### PR TITLE
Feature/treemap enhancements

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapControls.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapControls.js
@@ -14,6 +14,7 @@ export function parentControls(container) {
     let onClick = null;
     let text = null;
     let hide = true;
+    let deactivated = false;
 
     const parent = getOrCreateElement(container, ".parent-controls", () =>
         container
@@ -27,8 +28,25 @@ export function parentControls(container) {
         parent
             .style("display", hide ? "none" : "")
             .select("#goto-parent")
+            .style("pointer-events", deactivated ? "none" : null)
             .html(`⇪ ${text}`)
             .on("click", () => onClick());
+    };
+
+    controls.deactivate = (...args) => {
+        if (!args.length) {
+            return deactivated;
+        }
+        deactivated = args[0];
+
+        const button = parent.select("#goto-parent");
+        if (deactivated) {
+            button.style("pointer-events", "none");
+        } else {
+            button.style("pointer-events", null);
+        }
+
+        return controls;
     };
 
     controls.hide = (...args) => {

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLabel.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLabel.js
@@ -8,21 +8,37 @@
  */
 
 import {select} from "d3";
-import {isElementOverlapping} from "../../utils/utils";
+import {isElementOverlapping, isElementOverflowing} from "../../utils/utils";
+
+const minTextSize = 7;
+
+export const labelMapExists = d => (d.target && d.target.textAttributes ? true : false);
 
 export const toggleLabels = (nodes, treemapLevel, crossValues) => {
     nodes
         .selectAll("text")
-        .attr("dx", 0)
-        .attr("dy", 0)
+        .style("font-size", null)
         .attr("class", d => textLevelHelper(d, treemapLevel, crossValues));
-    nodes.selectAll("text").each((_, i, nodes) => centerText(nodes[i]));
-    preventTextCollisions(nodes);
+
+    const visibleNodes = selectVisibleNodes(nodes);
+    centerLabels(visibleNodes);
+    preventTextCollisions(visibleNodes);
+};
+
+export const restoreLabels = nodes => {
+    nodes.each((d, i, nodes) => {
+        const label = select(nodes[i]).selectAll("text");
+        label
+            .attr("dx", d.target.textAttributes.dx)
+            .attr("dy", d.target.textAttributes.dy)
+            .attr("class", d.target.textAttributes.class)
+            .style("font-size", d.target.textAttributes["font-size"]);
+    });
 };
 
 export const preventTextCollisions = nodes => {
     const textCollisionFuzzFactorPx = -2;
-    const textAdjustPx = 16;
+    const textAdjustPx = 19; // This should remain the same as the css value for .top => font-size in the chart.less
     const rect = element => element.getBoundingClientRect();
 
     const topNodes = [];
@@ -42,7 +58,57 @@ export const preventTextCollisions = nodes => {
         });
 };
 
-const centerText = node => select(node).attr("dx", select(node).attr("dx") - node.getBoundingClientRect().width / 2);
+export const lockTextOpacity = d => select(d).style("opacity", textOpacity[select(d).attr("class")]);
+
+export const unlockTextOpacity = d => select(d).style("opacity", null);
+
+export const textOpacity = {top: 1, mid: 0.7, lower: 0};
+
+export const selectVisibleNodes = nodes =>
+    nodes.filter(
+        (_, i, nodes) =>
+            select(nodes[i])
+                .selectAll("text")
+                .attr("class") !== textVisability.zero
+    );
+
+export const adjustLabelsThatOverflow = nodes => nodes.selectAll("text").each((_, i, nodes) => shrinkOrHideText(nodes[i]));
+
+const centerLabels = nodes => nodes.selectAll("text").each((_, i, nodes) => centerText(nodes[i]));
+
+const centerText = d => {
+    const nodeSelect = select(d);
+    const rect = d.getBoundingClientRect();
+    nodeSelect.attr("dx", 0 - rect.width / 2).attr("dy", 0 + rect.height / 4);
+};
+
+const shrinkOrHideText = d => {
+    const parent = d.parentNode;
+    const rect = parent.childNodes[0];
+
+    const textRect = d.getBoundingClientRect();
+    const rectRect = rect.getBoundingClientRect();
+
+    if (!needsToShrinkOrHide(d, rectRect, textRect, "left") && !needsToShrinkOrHide(d, rectRect, textRect, "bottom")) {
+        select(d).attr("class", select(d).attr("class"));
+    }
+};
+
+const needsToShrinkOrHide = (d, rectRect, textRect, direction) => {
+    if (isElementOverflowing(rectRect, textRect, direction)) {
+        const fontSize = parseInt(select(d).style("font-size"));
+        if (fontSize > minTextSize) {
+            select(d).style("font-size", `${fontSize - 1}px`);
+            centerText(d);
+            shrinkOrHideText(d);
+        } else {
+            select(d).style("font-size", null);
+            select(d).attr("class", textVisability.zero);
+        }
+        return true;
+    }
+    return false;
+};
 
 const textLevelHelper = (d, treemapLevel, crossValues) => {
     if (!crossValues.filter(x => x !== "").every(x => d.crossValue.split("|").includes(x))) return textVisability.zero;
@@ -56,8 +122,4 @@ const textLevelHelper = (d, treemapLevel, crossValues) => {
     }
 };
 
-const textVisability = {
-    high: "top",
-    low: "mid",
-    zero: "lower"
-};
+const textVisability = {high: "top", low: "mid", zero: "lower"};

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLevelCalculation.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLevelCalculation.js
@@ -8,8 +8,9 @@
  */
 
 import {calcWidth, calcHeight} from "./treemapSeries";
-import {hierarchy} from "d3";
+import {hierarchy, select} from "d3";
 import treemapLayout from "./treemapLayout";
+import {textOpacity} from "./treemapLabel";
 
 const includesAllCrossValues = (d, crossValues) => crossValues.every(val => d.crossValue.split("|").includes(val));
 
@@ -20,6 +21,8 @@ export function calculateSubTreeMap(d, crossValues, nodesMerge, treemapLevel, ro
     d.mapLevel[treemapLevel].levelRoot = true;
     // Use the pre-existing d3 mechanism to calculate the subtree for the viewable area.
     recalculateVisibleSubTreeCoordinates(d, rootNode.x1 - rootNode.x0, rootNode.y1 - rootNode.y0, treemapLevel);
+
+    calculateTextOpacities(nodesMerge, treemapLevel);
 }
 
 export function calculateRootLevelMap(nodesMerge, rootNode) {
@@ -35,7 +38,20 @@ export function calculateRootLevelMap(nodesMerge, rootNode) {
         };
     });
     rootNode.mapLevel[0].levelRoot = true;
+    calculateTextOpacities(nodesMerge, 0);
 }
+
+export const saveLabelMap = (nodes, treemapLevel) => {
+    nodes.each((d, i, nodes) => {
+        const label = select(nodes[i]).selectAll("text");
+        d.mapLevel[treemapLevel].textAttributes = {
+            dx: label.attr("dx"),
+            dy: label.attr("dy"),
+            class: label.attr("class"),
+            "font-size": label.style("font-size")
+        };
+    });
+};
 
 function approximateAttributesForAllNodes(d, crossValues, nodesMerge, treemapLevel, rootNode) {
     const oldDimensions = {x: d.x0, y: d.y0, width: d.x1 - d.x0, height: d.y1 - d.y0};
@@ -48,6 +64,7 @@ function approximateAttributesForAllNodes(d, crossValues, nodesMerge, treemapLev
         const width = calcWidth(d) * dimensionMultiplier.width;
         const height = calcHeight(d) * dimensionMultiplier.height;
         const visible = includesAllCrossValues(d, crossValues) && d.data.name != crossValues[treemapLevel - 1];
+
         d.mapLevel[treemapLevel] = {
             x0,
             x1: width + x0,
@@ -57,6 +74,7 @@ function approximateAttributesForAllNodes(d, crossValues, nodesMerge, treemapLev
             opacity: visible ? 1 : 0
         };
     });
+    d.mapLevel[treemapLevel].levelRoot = true;
 }
 
 function recalculateVisibleSubTreeCoordinates(subTreeRoot, treeRootWidth, treeRootHeight, treemapLevel) {
@@ -71,5 +89,14 @@ function recalculateVisibleSubTreeCoordinates(subTreeRoot, treeRootWidth, treeRo
         descendants[i].mapLevel[treemapLevel].x1 = dummiedDescendants[i].x1;
         descendants[i].mapLevel[treemapLevel].y0 = dummiedDescendants[i].y0;
         descendants[i].mapLevel[treemapLevel].y1 = dummiedDescendants[i].y1;
+    });
+}
+
+function calculateTextOpacities(nodesMerge, treemapLevel) {
+    nodesMerge.selectAll("text").each((_, i, nodes) => {
+        const text = select(nodes[i]);
+        const d = select(nodes[i]).datum();
+        const textVis = text.attr("class");
+        d.mapLevel[treemapLevel].textLockedAt = {opacity: textOpacity[textVis]};
     });
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLevelCalculation.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLevelCalculation.js
@@ -14,13 +14,13 @@ import {textOpacity} from "./treemapLabel";
 
 const includesAllCrossValues = (d, crossValues) => crossValues.every(val => d.crossValue.split("|").includes(val));
 
-export function calculateSubTreeMap(d, crossValues, nodesMerge, treemapLevel, rootNode) {
+export function calculateSubTreeMap(d, crossValues, nodesMerge, treemapLevel, rootNode, treemapDiv) {
     // We can approximate coordinates for most of the tree which will be shunted beyond the viewable area.
     // This approach alone results in excessive margins as one goes deeper into the treemap.
     approximateAttributesForAllNodes(d, crossValues, nodesMerge, treemapLevel, rootNode);
     d.mapLevel[treemapLevel].levelRoot = true;
     // Use the pre-existing d3 mechanism to calculate the subtree for the viewable area.
-    recalculateVisibleSubTreeCoordinates(d, rootNode.x1 - rootNode.x0, rootNode.y1 - rootNode.y0, treemapLevel);
+    recalculateVisibleSubTreeCoordinates(d, treemapDiv.node().getBoundingClientRect().width, treemapDiv.node().getBoundingClientRect().height, treemapLevel);
 
     calculateTextOpacities(nodesMerge, treemapLevel);
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapSeries.js
@@ -7,11 +7,11 @@
  *
  */
 
-import {toggleLabels} from "./treemapLabel";
+import {toggleLabels, adjustLabelsThatOverflow, selectVisibleNodes} from "./treemapLabel";
 import treemapLayout from "./treemapLayout";
 import {changeLevel, returnToLevel} from "./treemapTransitions";
 import {parentControls} from "./treemapControls";
-import {calculateRootLevelMap} from "./treemapLevelCalculation";
+import {calculateRootLevelMap, saveLabelMap} from "./treemapLevelCalculation";
 
 export const nodeLevel = {leaf: "leafnode", branch: "branchnode", root: "rootnode"};
 export const calcWidth = d => d.x1 - d.x0;
@@ -55,15 +55,19 @@ export function treemapSeries() {
         color && rects.style("fill", d => color(d.data.color));
 
         const labels = nodesMerge
+            .filter(d => d.value !== 0)
             .select("text")
             .attr("x", d => d.x0 + calcWidth(d) / 2)
             .attr("y", d => d.y0 + calcHeight(d) / 2)
             .text(d => d.data.name);
 
-        toggleLabels(nodesMerge, settings.treemapLevel, []);
-
         const rootNode = rects.filter(d => d.crossValue === "").datum();
         calculateRootLevelMap(nodesMerge, rootNode);
+
+        toggleLabels(nodesMerge, 0, []);
+        adjustLabelsThatOverflow(selectVisibleNodes(nodesMerge));
+        saveLabelMap(nodesMerge, 0);
+
         if (settings.treemapRoute.length === 0) settings.treemapRoute.push(rootNode.crossValue);
         rects.filter(d => d.children).on("click", d => changeLevel(d, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, parentCtrls));
 

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapTransitions.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapTransitions.js
@@ -9,24 +9,26 @@
 
 import * as d3 from "d3";
 import {calcWidth, calcHeight} from "./treemapSeries";
-import {toggleLabels, preventTextCollisions} from "./treemapLabel";
-import {calculateSubTreeMap} from "./treemapLevelCalculation";
+import {labelMapExists, toggleLabels, preventTextCollisions, lockTextOpacity, unlockTextOpacity, textOpacity, selectVisibleNodes, adjustLabelsThatOverflow, restoreLabels} from "./treemapLabel";
+import {calculateSubTreeMap, saveLabelMap} from "./treemapLevelCalculation";
 
 export function returnToLevel(rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, parentCtrls) {
     if (settings.treemapLevel > 0) {
         const crossValues = rootNode.crossValue.split("|");
-        executeTransition(rootNode, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, 0, crossValues, parentCtrls, 1);
+        executeTransition(rootNode, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, 0, crossValues, parentCtrls, 1, false);
 
         settings.treemapRoute.slice(1, settings.treemapRoute.length).forEach(cv => {
             const d = nodesMerge.filter(d => d.crossValue === cv).datum();
             const crossValues = d.crossValue.split("|");
             calculateSubTreeMap(d, crossValues, nodesMerge, d.depth, rootNode);
-            executeTransition(d, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, d.depth, crossValues, parentCtrls, 1);
+            executeTransition(d, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, d.depth, crossValues, parentCtrls, 1, false);
         });
     }
 }
 
 export function changeLevel(d, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, parentCtrls) {
+    if (!d.children) return;
+
     if (settings.treemapLevel < d.depth) {
         settings.treemapRoute.push(d.crossValue);
     } else {
@@ -43,40 +45,17 @@ export function changeLevel(d, rects, nodesMerge, labels, settings, treemapDiv, 
     executeTransition(d, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, settings.treemapLevel, crossValues, parentCtrls);
 }
 
-function executeTransition(d, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, treemapLevel, crossValues, parentCtrls, duration) {
-    const transitionDuration = !!duration ? duration : 350;
+function executeTransition(d, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, treemapLevel, crossValues, parentCtrls, duration = 500, recordLabelMap = true) {
     const parent = d.parent;
 
     const t = treemapSvg
-        .transition()
-        .duration(transitionDuration)
+        .transition("main transition")
+        .duration(duration)
         .ease(d3.easeCubicOut);
 
     nodesMerge.each(d => (d.target = d.mapLevel[treemapLevel]));
 
-    rects
-        .transition(t)
-        .filter(d => d.target.visible)
-        .tween("data", d => {
-            const i = d3.interpolate(d.current, d.target);
-            return t => (d.current = i(t));
-        })
-        .styleTween("x", d => () => `${d.current.x0}px`)
-        .styleTween("y", d => () => `${d.current.y0}px`)
-        .styleTween("width", d => () => `${d.current.x1 - d.current.x0}px`)
-        .styleTween("height", d => () => `${d.current.y1 - d.current.y0}px`);
-
-    labels
-        .transition(t)
-        .filter(d => d.target.visible)
-        .tween("data", d => {
-            const i = d3.interpolate(d.current, d.target);
-            return t => (d.current = i(t));
-        })
-        .attrTween("x", d => () => d.current.x0 + calcWidth(d.current) / 2)
-        .attrTween("y", d => () => d.current.y0 + calcHeight(d.current) / 2)
-        .end()
-        .then(() => preventTextCollisions(nodesMerge));
+    if (!labelMapExists(d)) preventUserInteraction(nodesMerge, parentCtrls);
 
     // hide hidden svgs
     nodesMerge
@@ -88,14 +67,91 @@ function executeTransition(d, rects, nodesMerge, labels, settings, treemapDiv, t
         .styleTween("opacity", d => () => d.current.opacity)
         .attrTween("pointer-events", d => () => (d.target.visible ? "all" : "none"));
 
-    toggleLabels(nodesMerge, treemapLevel, crossValues);
+    rects
+        .transition(t)
+        .filter(d => d.target.visible)
+        .styleTween("x", d => () => `${d.current.x0}px`)
+        .styleTween("y", d => () => `${d.current.y0}px`)
+        .styleTween("width", d => () => `${d.current.x1 - d.current.x0}px`)
+        .styleTween("height", d => () => `${d.current.y1 - d.current.y0}px`);
+
+    labels
+        .transition(t)
+        .filter(d => d.target.visible)
+        .attrTween("x", d => () => d.current.x0 + calcWidth(d.current) / 2)
+        .attrTween("y", d => () => d.current.y0 + calcHeight(d.current) / 2)
+        .end()
+        .catch(() => enableUserInteraction(nodesMerge))
+        .then(() => {
+            if (!labelMapExists(d)) {
+                preventTextCollisions(visibleLabelNodes);
+                adjustLabelsThatOverflow(visibleLabelNodes);
+                fadeTextTransition(labels, treemapSvg, duration);
+                if (recordLabelMap) saveLabelMap(nodesMerge, treemapLevel);
+                enableUserInteraction(nodesMerge, parentCtrls, parent);
+            }
+        })
+        .catch(ex => {
+            console.error("Exception completing promises after main transition", ex);
+            enableUserInteraction(nodesMerge, parentCtrls, parent);
+        });
+
+    if (!labelMapExists(d)) {
+        labels.each((_, i, labels) => lockTextOpacity(labels[i]));
+        toggleLabels(nodesMerge, treemapLevel, crossValues);
+    } else {
+        restoreLabels(nodesMerge);
+    }
+
+    const visibleLabelNodes = selectVisibleNodes(nodesMerge);
 
     if (parent) {
         parentCtrls
             .hide(false)
             .text(d.data.name)
-            .onClick(() => changeLevel(parent, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, parentCtrls))();
+            .onClick(() => changeLevel(parent, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, parentCtrls, duration))();
     } else {
         parentCtrls.hide(true)();
     }
 }
+
+async function fadeTextTransition(labels, treemapSvg, duration = 400) {
+    const t = treemapSvg
+        .transition("text fade transition")
+        .duration(duration)
+        .ease(d3.easeCubicOut);
+
+    await labels
+        .transition(t)
+        .filter(d => d.target.visible)
+        .tween("data", (d, i, labels) => {
+            const label = labels[i];
+            const interpolation = d3.interpolate(lockedOpacity(d), targetOpacity(label));
+            return t => (d.current.opacity = interpolation(t));
+        })
+        .styleTween("opacity", d => () => d.current.opacity)
+        .end()
+        .catch(ex => console.error("Exception in text fade transition", ex))
+        .then(() => labels.each((_, i, labels) => unlockTextOpacity(labels[i])));
+}
+
+const lockedOpacity = d => d.target.textLockedAt.opacity;
+const targetOpacity = d => textOpacity[d3.select(d).attr("class")];
+
+const preventUserInteraction = (nodes, parentCtrls) => {
+    parentCtrls.deactivate(true);
+
+    nodes.each((_, i, nodes) => {
+        const rect = d3.select(nodes[i]).selectAll("rect");
+        rect.attr("pointer-events", "none");
+    });
+};
+
+const enableUserInteraction = (nodes, parentCtrls) => {
+    if (parentCtrls) parentCtrls.deactivate(false);
+
+    nodes.each((_, i, nodes) => {
+        const rect = d3.select(nodes[i]).selectAll("rect");
+        rect.attr("pointer-events", null);
+    });
+};

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapTransitions.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapTransitions.js
@@ -20,7 +20,7 @@ export function returnToLevel(rects, nodesMerge, labels, settings, treemapDiv, t
         settings.treemapRoute.slice(1, settings.treemapRoute.length).forEach(cv => {
             const d = nodesMerge.filter(d => d.crossValue === cv).datum();
             const crossValues = d.crossValue.split("|");
-            calculateSubTreeMap(d, crossValues, nodesMerge, d.depth, rootNode);
+            calculateSubTreeMap(d, crossValues, nodesMerge, d.depth, rootNode, treemapDiv);
             executeTransition(d, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, d.depth, crossValues, parentCtrls, 1, false);
         });
     }
@@ -39,7 +39,7 @@ export function changeLevel(d, rects, nodesMerge, labels, settings, treemapDiv, 
 
     const crossValues = d.crossValue.split("|");
     if (!d.mapLevel[settings.treemapLevel] || !d.mapLevel[settings.treemapLevel].levelRoot) {
-        calculateSubTreeMap(d, crossValues, nodesMerge, settings.treemapLevel, rootNode);
+        calculateSubTreeMap(d, crossValues, nodesMerge, settings.treemapLevel, rootNode, treemapDiv);
     }
 
     executeTransition(d, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, settings.treemapLevel, crossValues, parentCtrls);

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
@@ -105,7 +105,7 @@ function showTooltip(containerNode, node, tooltipDiv, centered) {
 
     if (centered) [left, top] = centerTip(tooltipDiv, containerRect);
 
-    shiftIfOverflowingChartArea(tooltipDiv, containerRect, left, top);
+    shiftIfOverflowingChartArea(tooltipDiv, containerRect, left, top, centered);
 }
 
 function centerTip(tooltipDiv, containerRect) {
@@ -121,7 +121,7 @@ function centerTip(tooltipDiv, containerRect) {
     return [newLeft, newTop];
 }
 
-function shiftIfOverflowingChartArea(tooltipDiv, containerRect, left, top) {
+function shiftIfOverflowingChartArea(tooltipDiv, containerRect, left, top, centered = false) {
     const tooltipDivRect = tooltipDiv.node().getBoundingClientRect();
 
     if (isElementOverflowing(containerRect, tooltipDivRect)) {
@@ -131,6 +131,18 @@ function shiftIfOverflowingChartArea(tooltipDiv, containerRect, left, top) {
 
     if (isElementOverflowing(containerRect, tooltipDivRect, "bottom")) {
         const topAdjust = tooltipDivRect.bottom - containerRect.bottom;
+        tooltipDiv.style("top", `${top - topAdjust}px`);
+    }
+
+    if (!centered) return;
+
+    if (isElementOverflowing(containerRect, tooltipDivRect, "left")) {
+        const leftAdjust = tooltipDivRect.left - containerRect.left;
+        tooltipDiv.style("left", `${left - leftAdjust}px`);
+    }
+
+    if (isElementOverflowing(containerRect, tooltipDivRect, "top")) {
+        const topAdjust = tooltipDivRect.top - containerRect.top;
         tooltipDiv.style("top", `${top - topAdjust}px`);
     }
 }

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -123,7 +123,7 @@
                 }
 
                 & .top {
-                    font-size: 15px;
+                    font-size: 19px;
                     font-weight: bold;
                     z-index: 5;
                     pointer-events: none;
@@ -135,7 +135,7 @@
                     z-index: 4;
                 }
                 & .lower {
-                    font-size: 10px;
+                    font-size: 0px;
                     font-weight: bold;
                     opacity: 0;
                     z-index: 4;

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -65,6 +65,7 @@
 
         &.d3_treemap {
             padding: 0;
+            padding-right: 105px;
 
             & .treemap-container {
                 position: relative;


### PR DESCRIPTION
Enhancements:

1. Legend moved to a gutter down the right-hand side so it does not overlap any charts.
2. Text can be dynamically resized to be smaller where necessary to ensure display of as many labels as reasonably feasible.
3. Text specific transitions have been introduced to prevent jarring shifts between treemap layers. Once the text location and size has been calculated the first time, the map of this is retained so the slightly slower and more compute intensive transition does not have to be used again when returning to a level.
4. Tooltips cannot overflow off the chart on the top and left edges.