### PR TITLE
Performance overhaul for `table.update()`

### DIFF
--- a/cmake/hopscotch.txt.in
+++ b/cmake/hopscotch.txt.in
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(hopscotch-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(hopscotch
+  GIT_REPOSITORY    https://github.com/Tessil/hopscotch-map.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/hopscotch-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/hopscotch-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+  CMAKE_ARGS        "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+)

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -33,7 +33,7 @@ function (psp_build_dep name cmake_file)
 		${CMAKE_BINARY_DIR}/${name}-build
 		EXCLUDE_FROM_ALL)
 
-	include_directories(${CMAKE_BINARY_DIR}/${name}-src/extras/gtest/include)
+	include_directories(${CMAKE_BINARY_DIR}/${name}-src/extras/${name}/include)
 	include_directories(${CMAKE_BINARY_DIR}/${name}-src/include)
 	include_directories(${CMAKE_BINARY_DIR}/${name}-src)
 endfunction()
@@ -143,6 +143,7 @@ if (PSP_WASM_BUILD)
 	####################
 	# EMSCRIPTEN BUILD #
 	####################
+	psp_build_dep("hopscotch" "../../cmake/hopscotch.txt.in")
 	set(CMAKE_C_COMPILER emcc)
 	set(CMAKE_CXX_COMPILER em++)
 	set(CMAKE_TOOLCHAIN_FILE "$ENV{EMSCRIPTEN_ROOT}/cmake/Modules/Platform/Emscripten.cmake")

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -143,9 +143,12 @@ if (PSP_WASM_BUILD)
 	####################
 	# EMSCRIPTEN BUILD #
 	####################
-	psp_build_dep("hopscotch" "../../cmake/hopscotch.txt.in")
-	set(CMAKE_C_COMPILER emcc)
-	set(CMAKE_CXX_COMPILER em++)
+	execute_process(COMMAND which emcc OUTPUT_VARIABLE EMCC)
+	execute_process(COMMAND which em++ OUTPUT_VARIABLE EMPP)
+	string(STRIP ${EMCC} EMCC)
+	string(STRIP ${EMPP} EMPP)
+	set(CMAKE_C_COMPILER ${EMCC})
+	set(CMAKE_CXX_COMPILER ${EMPP})
 	set(CMAKE_TOOLCHAIN_FILE "$ENV{EMSCRIPTEN_ROOT}/cmake/Modules/Platform/Emscripten.cmake")
 	set(CMAKE_AR emar)
 	set(CMAKE_RANLIB emranlib)
@@ -252,6 +255,9 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 		#####################
 	endif()
 endif()
+
+psp_build_dep("hopscotch" "../../cmake/hopscotch.txt.in")
+
 #####################
 
 
@@ -364,7 +370,6 @@ if (PSP_WASM_BUILD)
 	set_target_properties(perspective.sync PROPERTIES COMPILE_FLAGS "${SYNC_MODE_FLAGS}")
 	set_target_properties(perspective.sync PROPERTIES RUNTIME_OUTPUT_DIRECTORY "./build/")
 	set_target_properties(perspective.sync PROPERTIES OUTPUT_NAME "psp.sync")
-	add_dependencies(perspective.sync perspective.async)
 
 	if (NOT CMAKE_BUILD_TYPE_LOWER STREQUAL debug)
 		add_executable(perspective.asm src/cpp/emscripten.cpp)
@@ -373,7 +378,6 @@ if (PSP_WASM_BUILD)
 		set_target_properties(perspective.asm PROPERTIES COMPILE_FLAGS "${ASMJS_MODE_FLAGS}")
 		set_target_properties(perspective.asm PROPERTIES RUNTIME_OUTPUT_DIRECTORY "./build/")
 		set_target_properties(perspective.asm PROPERTIES OUTPUT_NAME "psp.asmjs")
-		add_dependencies(perspective.asm perspective.sync)
 	endif()
 elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 	if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/cpp/perspective/src/cpp/column.cpp
+++ b/cpp/perspective/src/cpp/column.cpp
@@ -14,7 +14,7 @@ SUPPRESS_WARNINGS_VC(4505)
 #include <perspective/defaults.h>
 #include <perspective/base.h>
 #include <perspective/sym_table.h>
-#include <unordered_set>
+#include <tsl/hopscotch_set.h>
 
 #ifdef PSP_ENABLE_PYTHON
 namespace py = boost::python;

--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -21,7 +21,7 @@
 #include <perspective/filter_utils.h>
 #include <queue>
 #include <tuple>
-#include <unordered_set>
+#include <tsl/hopscotch_set.h>
 
 namespace perspective {
 
@@ -308,7 +308,7 @@ t_ctx_grouped_pkey::get_pkeys(const std::vector<std::pair<t_uindex, t_uindex>>& 
 
     std::vector<t_tscalar> rval;
 
-    std::unordered_set<t_uindex> seen;
+    tsl::hopscotch_set<t_uindex> seen;
 
     for (const auto& c : cells) {
         auto ptidx = m_traversal->get_tree_index(c.first);
@@ -531,7 +531,7 @@ t_ctx_grouped_pkey::rebuild() {
     auto pkey_col = tbl->get_const_column("psp_pkey").get();
 
     std::vector<t_datum> data(nrows);
-    std::unordered_map<t_tscalar, t_uindex> child_ridx_map;
+    tsl::hopscotch_map<t_tscalar, t_uindex> child_ridx_map;
     std::vector<bool> self_pkey_eq(nrows);
 
     for (t_uindex idx = 0; idx < nrows; ++idx) {
@@ -575,7 +575,7 @@ t_ctx_grouped_pkey::rebuild() {
         ++nroot_children;
     }
 
-    std::unordered_map<t_tscalar, std::pair<t_uindex, t_uindex>> p_range_map;
+    tsl::hopscotch_map<t_tscalar, std::pair<t_uindex, t_uindex>> p_range_map;
 
     t_uindex brange = nroot_children;
     for (t_uindex idx = nroot_children; idx < nrows; ++idx) {
@@ -588,7 +588,7 @@ t_ctx_grouped_pkey::rebuild() {
     p_range_map[data.back().m_parent] = std::pair<t_uindex, t_uindex>(brange, nrows);
 
     // map from unsorted space to sorted space
-    std::unordered_map<t_uindex, t_uindex> sortidx_map;
+    tsl::hopscotch_map<t_uindex, t_uindex> sortidx_map;
 
     for (t_uindex idx = 0; idx < nrows; ++idx) {
         sortidx_map[data[idx].m_idx] = idx;

--- a/cpp/perspective/src/cpp/context_two.cpp
+++ b/cpp/perspective/src/cpp/context_two.cpp
@@ -579,7 +579,7 @@ t_ctx2::set_depth(t_header header, t_depth depth) {
 
 std::vector<t_tscalar>
 t_ctx2::get_pkeys(const std::vector<std::pair<t_uindex, t_uindex>>& cells) const {
-    std::unordered_set<t_tscalar> all_pkeys;
+    tsl::hopscotch_set<t_tscalar> all_pkeys;
 
     auto tree_info = resolve_cells(cells);
     for (t_index idx = 0, loop_end = tree_info.size(); idx < loop_end; ++idx) {

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -218,7 +218,7 @@ t_ctx0::get_cell_data(const std::vector<std::pair<t_uindex, t_uindex>>& cells) c
  */
 std::vector<t_cellupd>
 t_ctx0::get_cell_delta(t_index bidx, t_index eidx) const {
-    std::unordered_set<t_tscalar> pkeys;
+    tsl::hopscotch_set<t_tscalar> pkeys;
     t_tscalar prev_pkey;
     prev_pkey.set(t_none());
 
@@ -255,7 +255,7 @@ t_ctx0::get_cell_delta(t_index bidx, t_index eidx) const {
             }
         }
 
-        std::unordered_map<t_tscalar, t_index> r_indices;
+        tsl::hopscotch_map<t_tscalar, t_index> r_indices;
         m_traversal->get_row_indices(pkeys, r_indices);
 
         for (t_zcdeltas::index<by_zc_pkey_colidx>::type::iterator iter
@@ -307,7 +307,7 @@ t_ctx0::get_row_delta(t_index bidx, t_index eidx) {
     bool rows_changed = m_rows_changed || !m_traversal->empty_sort_by();
     std::vector<std::int32_t> rows;
 
-    std::unordered_set<t_tscalar> pkeys;
+    tsl::hopscotch_set<t_tscalar> pkeys;
     t_tscalar prev_pkey;
     prev_pkey.set(t_none());
 
@@ -337,7 +337,7 @@ t_ctx0::get_row_delta(t_index bidx, t_index eidx) {
         }
 
         // get row indices and assign into r_indices
-        std::unordered_map<t_tscalar, t_index> r_indices;
+        tsl::hopscotch_map<t_tscalar, t_index> r_indices;
         m_traversal->get_row_indices(pkeys, r_indices);
 
         for (t_zcdeltas::index<by_zc_pkey_colidx>::type::iterator iter

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1565,7 +1565,7 @@ namespace binding {
         }
 
         _fill_data(tbl, colnames, accessor, dtypes, offset, is_arrow,
-            !(is_new_gnode || new_gnode->mapping_size() == 0));
+            (is_update || new_gnode->mapping_size() > 0));
 
         // Set up pkey and op columns
         if (is_delete) {

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1601,8 +1601,6 @@ namespace binding {
         }
 
         pool->send(new_gnode->get_id(), 0, tbl);
-        pool->_process();
-
         return new_gnode;
     }
 
@@ -2148,6 +2146,7 @@ EMSCRIPTEN_BINDINGS(perspective) {
         .constructor<>()
         .smart_ptr<std::shared_ptr<t_pool>>("shared_ptr<t_pool>")
         .function<void>("unregister_gnode", &t_pool::unregister_gnode)
+        .function<void>("_process", &t_pool::_process)
         .function<void>("set_update_delegate", &t_pool::set_update_delegate);
 
     /******************************************************************************

--- a/cpp/perspective/src/cpp/flat_traversal.cpp
+++ b/cpp/perspective/src/cpp/flat_traversal.cpp
@@ -46,7 +46,7 @@ t_ftrav::get_all_pkeys(const std::vector<std::pair<t_uindex, t_uindex>>& cells) 
 
 std::vector<t_tscalar>
 t_ftrav::get_pkeys(const std::vector<std::pair<t_uindex, t_uindex>>& cells) const {
-    std::unordered_set<t_tscalar> all_pkeys;
+    tsl::hopscotch_set<t_tscalar> all_pkeys;
 
     std::set<t_index> all_rows;
 
@@ -145,8 +145,8 @@ t_ftrav::size() const {
 }
 
 void
-t_ftrav::get_row_indices(const std::unordered_set<t_tscalar>& pkeys,
-    std::unordered_map<t_tscalar, t_index>& out_map) const {
+t_ftrav::get_row_indices(const tsl::hopscotch_set<t_tscalar>& pkeys,
+    tsl::hopscotch_map<t_tscalar, t_index>& out_map) const {
     for (t_index idx = 0, loop_end = size(); idx < loop_end; ++idx) {
         const t_tscalar& pkey = (*m_index)[idx].m_pkey;
         if (pkeys.find(pkey) != pkeys.end()) {
@@ -156,8 +156,8 @@ t_ftrav::get_row_indices(const std::unordered_set<t_tscalar>& pkeys,
 }
 
 void
-t_ftrav::get_row_indices(t_index bidx, t_index eidx, const std::unordered_set<t_tscalar>& pkeys,
-    std::unordered_map<t_tscalar, t_index>& out_map) const {
+t_ftrav::get_row_indices(t_index bidx, t_index eidx, const tsl::hopscotch_set<t_tscalar>& pkeys,
+    tsl::hopscotch_map<t_tscalar, t_index>& out_map) const {
     for (t_index idx = bidx; idx < eidx; ++idx) {
         const t_tscalar& pkey = (*m_index)[idx].m_pkey;
         if (pkeys.find(pkey) != pkeys.end()) {
@@ -174,7 +174,7 @@ t_ftrav::reset() {
 
 void
 t_ftrav::check_size() {
-    std::unordered_set<t_tscalar> pkey_set;
+    tsl::hopscotch_set<t_tscalar> pkey_set;
     for (t_index idx = 0, loop_end = m_index->size(); idx < loop_end; ++idx) {
         if (pkey_set.find((*m_index)[idx].m_pkey) != pkey_set.end()) {
             std::cout << "Duplicate entry for " << (*m_index)[idx].m_pkey << std::endl;

--- a/cpp/perspective/src/cpp/sparse_tree.cpp
+++ b/cpp/perspective/src/cpp/sparse_tree.cpp
@@ -746,7 +746,7 @@ t_stree::update_aggs_from_static(const t_dtree_ctx& ctx, const t_gstate& gstate)
     static bool const enable_aggregate_reordering = true;
     static bool const enable_fix_double_calculation = true;
 
-    std::unordered_set<t_column*> dst_visited;
+    tsl::hopscotch_set<t_column*> dst_visited;
     auto push_column = [&](size_t idx) {
         if (enable_fix_double_calculation) {
             t_column* dst = agg_update_info.m_dst[idx];
@@ -1219,7 +1219,7 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 new_value.set(
                     gstate.reduce<std::function<std::uint32_t(std::vector<t_tscalar>&)>>(pkeys,
                         spec.get_dependencies()[0].name(), [](std::vector<t_tscalar>& values) {
-                            std::unordered_set<t_tscalar> vset;
+                            tsl::hopscotch_set<t_tscalar> vset;
                             for (const auto& v : values) {
                                 vset.insert(v);
                             }

--- a/cpp/perspective/src/cpp/sym_table.cpp
+++ b/cpp/perspective/src/cpp/sym_table.cpp
@@ -11,7 +11,7 @@
 #include <perspective/base.h>
 #include <perspective/sym_table.h>
 #include <perspective/column.h>
-#include <unordered_map>
+#include <tsl/hopscotch_map.h>
 #include <functional>
 #include <mutex>
 

--- a/cpp/perspective/src/cpp/tracing.cpp
+++ b/cpp/perspective/src/cpp/tracing.cpp
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <cxxabi.h>
 #include <fstream>
-#include <unordered_set>
+#include <tsl/hopscotch_set.h>
 #include <execinfo.h>
 #include <cstring>
 

--- a/cpp/perspective/src/cpp/tracing_impl_linux.cpp
+++ b/cpp/perspective/src/cpp/tracing_impl_linux.cpp
@@ -67,14 +67,14 @@ th_trace_fini() {
 
     t_instrec* irecs = static_cast<t_instrec*>(iptr);
 
-    std::unordered_set<void*> fptrs;
+    tsl::hopscotch_set<void*> fptrs;
 
     for (t_index idx = 0; idx < ndrecs; ++idx) {
         t_instrec* irec = irecs + idx;
         fptrs.emplace(irec->t_fntrace.m_fn);
     }
 
-    for (std::unordered_set<void*>::const_iterator iter = fptrs.begin(); iter != fptrs.end();
+    for (tsl::hopscotch_set<void*>::const_iterator iter = fptrs.begin(); iter != fptrs.end();
          ++iter) {
 
         of << *iter << " ";

--- a/cpp/perspective/src/cpp/tracing_impl_osx.cpp
+++ b/cpp/perspective/src/cpp/tracing_impl_osx.cpp
@@ -67,14 +67,14 @@ th_trace_fini() {
 
     t_instrec* irecs = static_cast<t_instrec*>(iptr);
 
-    std::unordered_set<void*> fptrs;
+    tsl::hopscotch_set<void*> fptrs;
 
     for (t_index idx = 0; idx < ndrecs; ++idx) {
         t_instrec* irec = irecs + idx;
         fptrs.emplace(irec->t_fntrace.m_fn);
     }
 
-    for (std::unordered_set<void*>::const_iterator iter = fptrs.begin(); iter != fptrs.end();
+    for (tsl::hopscotch_set<void*>::const_iterator iter = fptrs.begin(); iter != fptrs.end();
          ++iter) {
 
         of << *iter << " ";

--- a/cpp/perspective/src/cpp/tree_context_common.cpp
+++ b/cpp/perspective/src/cpp/tree_context_common.cpp
@@ -17,7 +17,7 @@
 #include <perspective/env_vars.h>
 #include <perspective/dense_tree.h>
 #include <perspective/dense_tree_context.h>
-#include <unordered_set>
+#include <tsl/hopscotch_set.h>
 
 namespace perspective {
 

--- a/cpp/perspective/src/cpp/vocab.cpp
+++ b/cpp/perspective/src/cpp/vocab.cpp
@@ -9,7 +9,7 @@
 
 #include <perspective/first.h>
 #include <perspective/vocab.h>
-#include <unordered_set>
+#include <tsl/hopscotch_set.h>
 
 namespace perspective {
 
@@ -139,7 +139,7 @@ t_vocab::verify() const {
     PSP_VERBOSE_ASSERT(std::string(zero->second), == "", "0 mapped to unknown");
 #endif
 
-    std::unordered_set<std::string> seen;
+    tsl::hopscotch_set<std::string> seen;
 #ifndef PSP_ENABLE_WASM
     seen.insert(std::string(""));
 #endif

--- a/cpp/perspective/src/include/perspective/column.h
+++ b/cpp/perspective/src/include/perspective/column.h
@@ -20,7 +20,7 @@
 #include <functional>
 #include <limits>
 #include <cmath>
-#include <unordered_map>
+#include <tsl/hopscotch_map.h>
 
 #ifdef PSP_ENABLE_PYTHON
 namespace py = boost::python;

--- a/cpp/perspective/src/include/perspective/flat_traversal.h
+++ b/cpp/perspective/src/include/perspective/flat_traversal.h
@@ -22,13 +22,13 @@
 #include <perspective/exports.h>
 #include <perspective/sym_table.h>
 #include <set>
-#include <unordered_map>
+#include <tsl/hopscotch_map.h>
 
 namespace perspective {
 
 class PERSPECTIVE_EXPORT t_ftrav {
-    typedef std::unordered_map<t_tscalar, t_index> t_pkeyidx_map;
-    typedef std::unordered_map<t_tscalar, t_mselem> t_pkmselem_map;
+    typedef tsl::hopscotch_map<t_tscalar, t_index> t_pkeyidx_map;
+    typedef tsl::hopscotch_map<t_tscalar, t_mselem> t_pkmselem_map;
 
 public:
     t_ftrav(bool handle_nan_sort);
@@ -57,11 +57,11 @@ public:
 
     t_index size() const;
 
-    void get_row_indices(const std::unordered_set<t_tscalar>& pkeys,
-        std::unordered_map<t_tscalar, t_index>& out_map) const;
+    void get_row_indices(const tsl::hopscotch_set<t_tscalar>& pkeys,
+        tsl::hopscotch_map<t_tscalar, t_index>& out_map) const;
 
-    void get_row_indices(t_index bidx, t_index eidx, const std::unordered_set<t_tscalar>& pkeys,
-        std::unordered_map<t_tscalar, t_index>& out_map) const;
+    void get_row_indices(t_index bidx, t_index eidx, const tsl::hopscotch_set<t_tscalar>& pkeys,
+        tsl::hopscotch_map<t_tscalar, t_index>& out_map) const;
 
     void reset();
 

--- a/cpp/perspective/src/include/perspective/gnode_state.h
+++ b/cpp/perspective/src/include/perspective/gnode_state.h
@@ -12,18 +12,19 @@
 #include <perspective/first.h>
 #include <perspective/base.h>
 #include <perspective/table.h>
-#include <boost/unordered_map.hpp>
+#include <tsl/hopscotch_map.h>
 #include <boost/unordered_set.hpp>
 #include <perspective/mask.h>
 #include <perspective/sym_table.h>
 #include <perspective/rlookup.h>
+#include <tsl/hopscotch_map.h>
 
 namespace perspective {
 
 std::pair<t_tscalar, t_tscalar> get_vec_min_max(const std::vector<t_tscalar>& vec);
 
 class PERSPECTIVE_EXPORT t_gstate {
-    typedef boost::unordered_map<t_tscalar, t_uindex> t_mapping;
+    typedef tsl::hopscotch_map<t_tscalar, t_uindex> t_mapping;
 
     typedef boost::unordered_set<t_uindex> t_free_items;
 

--- a/cpp/perspective/src/include/perspective/scalar.h
+++ b/cpp/perspective/src/include/perspective/scalar.h
@@ -20,8 +20,8 @@
 #include <functional>
 #include <cstdint>
 #include <vector>
-#include <unordered_set>
-#include <unordered_map>
+#include <tsl/hopscotch_set.h>
+#include <tsl/hopscotch_map.h>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <sstream>
 #include <functional> //std::hash
@@ -365,7 +365,7 @@ namespace std {
 
 template <>
 struct hash<perspective::t_tscalar> {
-    // Enable the use of std::unordered_map
+    // Enable the use of tsl::hopscotch_map
     size_t
     operator()(const perspective::t_tscalar& key) const {
         return perspective::hash_value(key);

--- a/cpp/perspective/src/include/perspective/sym_table.h
+++ b/cpp/perspective/src/include/perspective/sym_table.h
@@ -10,12 +10,12 @@
 #pragma once
 #include <perspective/first.h>
 #include <perspective/scalar.h>
-#include <unordered_map>
+#include <tsl/hopscotch_map.h>
 
 namespace perspective {
 
 class t_symtable {
-    typedef std::unordered_map<const char*, const char*, t_cchar_umap_hash, t_cchar_umap_cmp>
+    typedef tsl::hopscotch_map<const char*, const char*, t_cchar_umap_hash, t_cchar_umap_cmp>
         t_mapping;
 
 public:

--- a/cpp/perspective/src/include/perspective/vocab.h
+++ b/cpp/perspective/src/include/perspective/vocab.h
@@ -17,12 +17,12 @@
 #include <functional>
 #include <limits>
 #include <cmath>
-#include <unordered_map>
+#include <tsl/hopscotch_map.h>
 
 namespace perspective {
 
 class PERSPECTIVE_EXPORT t_vocab {
-    typedef std::unordered_map<const char*, t_uindex, t_cchar_umap_hash, t_cchar_umap_cmp>
+    typedef tsl::hopscotch_map<const char*, t_uindex, t_cchar_umap_hash, t_cchar_umap_cmp>
         t_sidxmap;
 
 public:

--- a/packages/perspective/bench/js/bench.js
+++ b/packages/perspective/bench/js/bench.js
@@ -17,6 +17,7 @@ const LIMIT = args.indexOf("--limit");
 const multi_template = (xs, ...ys) => ys[0].map((y, i) => [y, xs.reduce((z, x, ix) => (ys[ix] ? z + x + ys[ix][i] : z + x), "")]);
 
 const UNPKG_VERSIONS = [
+    "0.2.23",
     "0.2.22",
     "0.2.21",
     "0.2.20",

--- a/packages/perspective/bench/js/bench.js
+++ b/packages/perspective/bench/js/bench.js
@@ -16,8 +16,8 @@ const LIMIT = args.indexOf("--limit");
 
 const multi_template = (xs, ...ys) => ys[0].map((y, i) => [y, xs.reduce((z, x, ix) => (ys[ix] ? z + x + ys[ix][i] : z + x), "")]);
 
-const UNPKG_VERSIONS = [
-    "0.2.23",
+const JPMC_VERSIONS = [
+    //"0.2.23", /* memory leak */
     "0.2.22",
     "0.2.21",
     "0.2.20",
@@ -39,12 +39,17 @@ const UNPKG_VERSIONS = [
     "0.2.0"
 ];
 
-const UNPKG_URLS = multi_template`https://unpkg.com/@jpmorganchase/perspective@${UNPKG_VERSIONS}/build/perspective.js`;
+const FINOS_VERSIONS = [
+    "0.3.0-rc.1"
+]
 
-const OLD_FORMAT_UNPKG_VERSIONS = ["0.2.0-beta.3"];
-const OLD_FORMAT_UNPKG_URLS = multi_template`https://unpkg.com/@jpmorganchase/perspective-examples@${OLD_FORMAT_UNPKG_VERSIONS}/build/perspective.js`;
+const JPMC_URLS = multi_template`https://unpkg.com/@jpmorganchase/perspective@${JPMC_VERSIONS}/build/perspective.js`;
+const FINOS_URLS = multi_template`https://unpkg.com/@finos/perspective@${FINOS_VERSIONS}/build/perspective.js`
 
-const URLS = [].concat([["master", `http://host.docker.internal:8080/perspective.js`]], UNPKG_URLS, OLD_FORMAT_UNPKG_URLS);
+const OLD_FORMAT_JPMC_VERSIONS = ["0.2.0-beta.3"];
+const OLD_FORMAT_JPMC_URLS = multi_template`https://unpkg.com/@jpmorganchase/perspective-examples@${OLD_FORMAT_JPMC_VERSIONS}/build/perspective.js`;
+
+const URLS = [].concat([["master", `http://localhost:8080/perspective.js`]], FINOS_URLS, JPMC_URLS, OLD_FORMAT_JPMC_URLS);
 
 const RUN_TEST = fs.readFileSync(path.join(__dirname, "browser_runtime.js")).toString();
 

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -258,6 +258,7 @@ export default function(Module) {
             this._View = __MODULE__.make_view_two(pool, gnode, name, defaults.COLUMN_SEPARATOR_STRING, this.config, this.date_parser);
         }
 
+        this.pool = pool;
         this.ctx = this._View.get_context();
         this.column_only = this._View.is_column_only();
         this.callbacks = callbacks;
@@ -713,6 +714,7 @@ export default function(Module) {
      *     - "rows": The callback is invoked with the changed rows.
      */
     view.prototype.on_update = function(callback, {mode = "none"} = {}) {
+        _clear_process(this.pool);
         if (["none", "rows", "pkey"].indexOf(mode) === -1) {
             throw new Error(`Invalid update mode "${mode}" - valid modes are "none", "rows" and "pkey".`);
         }
@@ -745,6 +747,7 @@ export default function(Module) {
     };
 
     view.prototype.remove_update = function(callback) {
+        _clear_process(this.pool);
         this.callbacks = this.callbacks.filter(x => x.callback !== callback);
     };
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -111,6 +111,11 @@ try {
                 cmd += " --scope=@finos/${PACKAGE}";
             }
             cmd += " -- yarn --silent test:run";
+            if (args.indexOf("-t") > -1) {
+                const regex = args.slice(args.indexOf("-t") + 1).join(" ");
+                console.log(`-- Qualifying search '${regex}'`);
+                cmd += ` -t "${regex}"`;
+            }
             execute((IS_WRITE ? "WRITE_TESTS=1 " : "") + cmd);
             execute(slow_jest());
         } else {


### PR DESCRIPTION
This PR contains a number of fixes applied as a result of some runtime profiling of the `table.update()` mechanism:

* Removed `std::unordered_map` in favor of `tsl::hopscotch_map`, which improves primary key lookup performance, and overall update processing time is improved by 50%.
* Added throttling to this method.  This means that `on_update()` is no longer called 1:1 with calls to `update()` (though the final `on_update()` will always be consistent with `table` state).  As a result, `update()` calls will no longer stack up and overwhelm other API calls, which leads to drastic improvement in perceived performance, and much smarter interleaving of `update()` and other calls which reflect the `view()` to the `<perspective-viewer>` element.

Additionally, a few other enhancements have been made which facilitated these principal fixes:

* Benchmarks now mark outlier observations (more accurate benchmarks).
* CMake executable builds are now parallelized (faster builds).
* `yarn test` now respects `-t` in focus mode (faster test iteration).