### PR TITLE
Get d3fc css directly from the package

### DIFF
--- a/packages/perspective-viewer-d3fc/src/config/d3fc.watch.config.js
+++ b/packages/perspective-viewer-d3fc/src/config/d3fc.watch.config.js
@@ -4,7 +4,10 @@ const rules = []; //pluginConfig.module.rules.slice(0);
 rules.push({
     test: /\.js$/,
     exclude: /node_modules/,
-    loader: "babel-loader"
+    loader: "babel-loader",
+    options: {
+        presets: ["@babel/preset-env"]
+    }
 });
 
 module.exports = Object.assign({}, pluginConfig, {

--- a/packages/perspective-viewer-d3fc/src/js/plugin/template.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/template.js
@@ -8,14 +8,17 @@
  */
 import * as d3 from "d3";
 
+import {css as chartCss} from "@d3fc/d3fc-chart/src/css";
+import {css as elementCss} from "@d3fc/d3fc-element/src/css";
 import style from "../../less/chart.less";
+
 import template from "../../html/d3fc-chart.html";
 import {areArraysEqualSimple} from "../utils/utils";
 import {initialiseStyles} from "../series/colorStyles";
 
 import {bindTemplate} from "@finos/perspective-viewer/cjs/js/utils";
 
-const styleWithD3FC = `${style}${getD3FCStyles()}`;
+const styleWithD3FC = `${style}${elementCss}${chartCss}`;
 
 @bindTemplate(template, styleWithD3FC) // eslint-disable-next-line no-unused-vars
 class D3FCChartElement extends HTMLElement {
@@ -105,15 +108,4 @@ class D3FCChartElement extends HTMLElement {
         this.remove();
         return newSettings;
     }
-}
-
-function getD3FCStyles() {
-    const headerStyles = document.querySelector("head").querySelectorAll("style");
-    const d3fcStyles = [];
-    headerStyles.forEach(s => {
-        if (s.innerText.indexOf("d3fc-") !== -1) {
-            d3fcStyles.push(s.innerText);
-        }
-    });
-    return d3fcStyles.join("");
 }


### PR DESCRIPTION
Instead of copying it from the *head*. The css of both the "element" and "chart" components are required.