### PR TITLE
add restyle to type definitions, fix dark mode in jlab, fix CSS issue

### DIFF
--- a/packages/perspective-phosphor/src/less/index.less
+++ b/packages/perspective-phosphor/src/less/index.less
@@ -12,9 +12,10 @@
 @import (less) "../../../perspective-viewer/src/less/row.less";
 @import (less) "../../../perspective-viewer/src/less/variables.less";
 @import (less) "../../../perspective-viewer/src/less/viewer.less";
+@import (less) "../../../perspective-viewer/src/themes/material.less";
 
 div.PSPContainer {
-    @import (less) "../../../perspective-viewer/src/themes/material.less";
+
 }
 
 div.PSPContainer-dark {

--- a/packages/perspective-phosphor/src/less/index.less
+++ b/packages/perspective-phosphor/src/less/index.less
@@ -6,11 +6,17 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+@import (less) "../../../perspective-viewer/src/less/column_labels.less";
+@import (less) "../../../perspective-viewer/src/less/computed_column.less";
+@import (less) "../../../perspective-viewer/src/less/default.less";
+@import (less) "../../../perspective-viewer/src/less/row.less";
+@import (less) "../../../perspective-viewer/src/less/variables.less";
+@import (less) "../../../perspective-viewer/src/less/viewer.less";
 
-div.PSPContainer perspective-viewer {
-    @import (inline) "../../../perspective-viewer/build/material.css";
+div.PSPContainer {
+    @import (less) "../../../perspective-viewer/src/themes/material.less";
 }
 
-div.PSPContainer-dark perspective-viewer {
-    @import (inline) "../../../perspective-viewer/build/material.dark.css";
+div.PSPContainer-dark {
+    @import (less) "../../../perspective-viewer/src/themes/material.dark.less";
 }

--- a/packages/perspective-phosphor/src/ts/widget.ts
+++ b/packages/perspective-phosphor/src/ts/widget.ts
@@ -161,6 +161,7 @@ export
         this._key = key;
         this._wrap = wrap;
         this._delete = delete_;
+        this._displayed = false;
     }
 
     /**********************/
@@ -192,6 +193,7 @@ export
     onAfterShow(msg: Message): void {
         this.pspNode.notifyResize();
         super.onAfterShow(msg);
+        this._displayed = true;
     }
 
     /**
@@ -199,7 +201,9 @@ export
      *
      */
     onResize(msg: Widget.ResizeMessage): void {
-        this.pspNode.notifyResize();
+        if (this._displayed){
+            this.pspNode.notifyResize();
+        }
         super.onResize(msg);
     }
 
@@ -460,6 +464,9 @@ export
             this.node.classList.add(PSP_CONTAINER_CLASS);
             this.node.classList.remove(PSP_CONTAINER_CLASS_DARK);
         }
+        if (this._displayed){
+            this.pspNode.restyleElement();
+        }
     }
 
     private _data: any = [];
@@ -486,6 +493,7 @@ export
     private _key: string;
     private _wrap: boolean;
     private _delete: boolean;
+    private _displayed: boolean;
 }
 
 

--- a/packages/perspective-viewer/index.d.ts
+++ b/packages/perspective-viewer/index.d.ts
@@ -11,7 +11,7 @@ declare module '@finos/perspective-viewer' {
         toggleConfig(): void;
         save(): any;
         restore(x: any): Promise<void>;
-
+        restyleElement(): void;
 
         sort?: Array<string>;
         columns?: Array<string>;


### PR DESCRIPTION
This does 3 things
- Fixes CSS ugliness in phosphor/jlab:
<img width="115" alt="Screen Shot 2019-05-14 at 7 21 22 PM" src="https://user-images.githubusercontent.com/3105306/57738517-d0591780-767d-11e9-85ef-f90d7b4e2800.png">

- Adds restyle to type definitions for `perspective-viewer`
- Uses 1 and 2 to reenable dark mode:

<img width="581" alt="Screen Shot 2019-05-14 at 7 21 58 PM" src="https://user-images.githubusercontent.com/3105306/57738529-e1a22400-767d-11e9-9393-e2f52eeef9c1.png">

~~Though it looks like the wrench is there in dark mode for some reason...~~