### PR TITLE
Fixed tooltip value when split_values and multiple main values

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
@@ -37,7 +37,7 @@ export function getDataValues(data, settings) {
             return [
                 {
                     name: data.key,
-                    value: data.mainValue
+                    value: data.mainValue - (data.baseValue || 0)
                 }
             ];
         }


### PR DESCRIPTION
We previously showing the "mainValue" number, without subtracting "baseValue".
This affects Area and Column/Bar charts when there are both multiple aggregate values, and a split-by.