### PR TITLE
Made drag/drop zones more generous

### DIFF
--- a/packages/perspective-viewer/src/less/viewer.less
+++ b/packages/perspective-viewer/src/less/viewer.less
@@ -269,6 +269,8 @@
     }
     #top_panel > .rrow > * {
         width: 100%;
+        padding: 12px 0px 12px 0px;
+        margin: -12px 0px -12px 0px;
     }
     .rrow #psp_row {
         white-space: nowrap;


### PR DESCRIPTION
Fixed "drop" zones on `<perspective-viewer>` to have much wider borders.