### PR TITLE
Change: Add title to perspective rows

### DIFF
--- a/packages/perspective-viewer/src/js/row.js
+++ b/packages/perspective-viewer/src/js/row.js
@@ -39,7 +39,9 @@ function get_text_width(text, max = 0) {
 class Row extends HTMLElement {
     set name(n) {
         let elem = this.shadowRoot.querySelector("#name");
-        elem.innerHTML = this.getAttribute("name");
+        let name = this.getAttribute("name");
+        elem.innerHTML = name;
+        elem.title = name;
     }
 
     set type(t) {


### PR DESCRIPTION
Very long column names (which you might get from a join) tend to be cut off in the column view. Currently there isn't a way to see what the full column name is, without adding it to a grid view and looking at the column header.

Example:

![image](https://user-images.githubusercontent.com/20070398/59886907-15641e00-938f-11e9-9c9e-4ea0e6489281.png)

With this change, they will now display a browser-native tooltip on mouse hover. This is more a stopgap/workaround than a solution, but it's not disruptive.