### PR TITLE
Use MODULARIZE emscripten option instead of a custom one

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -166,6 +166,9 @@ if (PSP_WASM_BUILD)
 		-s NO_EXIT_RUNTIME=1 \
 		-s NO_FILESYSTEM=1 \
 		-s ALLOW_MEMORY_GROWTH=1 \
+		-s MODULARIZE=1 \
+		-s EXPORT_NAME=\"load_perspective\" \
+		-s EXPORT_ES6=1 \
 		-s EXPORTED_FUNCTIONS=\"['_main']\" \
 		")
 
@@ -173,6 +176,7 @@ if (PSP_WASM_BUILD)
 		set(OPT_FLAGS " \
 			-O0 \
 			-g4 \
+			--profiling 1 \
 			-s SAFE_HEAP=1 \
 			-s DISABLE_EXCEPTION_CATCHING=0 \
 			-s ASSERTIONS=2 \

--- a/packages/perspective/src/js/perspective.node.js
+++ b/packages/perspective/src/js/perspective.node.js
@@ -18,7 +18,7 @@ const process = require("process");
 
 const path = require("path");
 
-const load_perspective = require("../../obj/psp.async.js").load_perspective;
+const load_perspective = require("../../obj/psp.async.js").default;
 
 // eslint-disable-next-line no-undef
 const RESOLVER = typeof __non_webpack_require__ !== "undefined" ? __non_webpack_require__.resolve : module.require.resolve;

--- a/packages/perspective/src/js/perspective.wasm.js
+++ b/packages/perspective/src/js/perspective.wasm.js
@@ -7,11 +7,13 @@
  *
  */
 
-const load_perspective = require("../../obj/psp.async.js").load_perspective;
-const perspective = require("./perspective.js").default;
+import load_perspective from "../../obj/psp.async.js";
+import perspective from "./perspective.js";
+
+let _perspective_instance;
 
 if (global.document !== undefined && typeof WebAssembly !== "undefined") {
-    module.exports = global.perspective = perspective(
+    _perspective_instance = global.perspective = perspective(
         load_perspective({
             wasmJSMethod: "native-wasm",
             printErr: x => console.error(x),
@@ -19,5 +21,7 @@ if (global.document !== undefined && typeof WebAssembly !== "undefined") {
         })
     );
 } else {
-    module.exports = global.perspective = perspective(load_perspective);
+    _perspective_instance = global.perspective = perspective(load_perspective);
 }
+
+export default _perspective_instance;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -42,14 +42,6 @@ const getBaseDir = packageName => path.join(__dirname, "..", "cpp", packageName,
 const getBuildDir = packageName => path.join(getBaseDir(packageName), "build");
 const getOuputDir = packageName => path.join(__dirname, "..", "packages", packageName);
 
-const templateSource = source => `
-var window = window || {};
-
-exports.load_perspective = function (Module) {
-    ${source};
-    return Module;
-};`;
-
 function compileRuntime({inputFile, inputWasmFile, format, packageName}) {
     console.log("-- Building %s", inputFile);
 
@@ -71,7 +63,7 @@ function compileRuntime({inputFile, inputWasmFile, format, packageName}) {
         })
     );
 
-    let source = templateSource(runtimeText);
+    let source = runtimeText;
     if (format) {
         console.debug("Formatting code");
         source = prettier.format(source, {


### PR DESCRIPTION
Removes a hacky step of the build which wraps the JS output from Emscripten in a function.