### PR TITLE
Update Babel `preset-env`

### DIFF
--- a/packages/perspective-cli/babel.config.js
+++ b/packages/perspective-cli/babel.config.js
@@ -3,6 +3,14 @@ module.exports = {
         [
             "@babel/preset-env",
             {
+                targets: {
+                    chrome: "57",
+                    node: "8",
+                    ios: "11",
+                    safari: "11",
+                    edge: "16",
+                    firefox: "52"
+                },
                 modules: false,
                 useBuiltIns: "usage",
                 corejs: 2
@@ -10,16 +18,5 @@ module.exports = {
         ]
     ],
     sourceType: "unambiguous",
-    plugins: [
-        "lodash",
-        "@babel/transform-runtime",
-        ["@babel/plugin-proposal-decorators", {legacy: true}],
-        "transform-custom-element-classes",
-        [
-            "@babel/plugin-transform-for-of",
-            {
-                loose: true
-            }
-        ]
-    ]
+    plugins: ["lodash", ["@babel/plugin-proposal-decorators", {legacy: true}], "transform-custom-element-classes"]
 };

--- a/packages/perspective-viewer-d3fc/babel.config.js
+++ b/packages/perspective-viewer-d3fc/babel.config.js
@@ -3,6 +3,14 @@ module.exports = {
         [
             "@babel/preset-env",
             {
+                targets: {
+                    chrome: "57",
+                    node: "8",
+                    ios: "11",
+                    safari: "11",
+                    edge: "16",
+                    firefox: "52"
+                },
                 modules: false,
                 useBuiltIns: "usage",
                 corejs: 2
@@ -10,16 +18,5 @@ module.exports = {
         ]
     ],
     sourceType: "unambiguous",
-    plugins: [
-        "lodash",
-        "@babel/transform-runtime",
-        ["@babel/plugin-proposal-decorators", {legacy: true}],
-        "transform-custom-element-classes",
-        [
-            "@babel/plugin-transform-for-of",
-            {
-                loose: true
-            }
-        ]
-    ]
+    plugins: ["lodash", ["@babel/plugin-proposal-decorators", {legacy: true}], "transform-custom-element-classes"]
 };

--- a/packages/perspective-viewer-highcharts/babel.config.js
+++ b/packages/perspective-viewer-highcharts/babel.config.js
@@ -3,6 +3,14 @@ module.exports = {
         [
             "@babel/preset-env",
             {
+                targets: {
+                    chrome: "57",
+                    node: "8",
+                    ios: "11",
+                    safari: "11",
+                    edge: "16",
+                    firefox: "52"
+                },
                 modules: false,
                 useBuiltIns: "usage",
                 corejs: 2
@@ -10,16 +18,5 @@ module.exports = {
         ]
     ],
     sourceType: "unambiguous",
-    plugins: [
-        "lodash",
-        "@babel/transform-runtime",
-        ["@babel/plugin-proposal-decorators", {legacy: true}],
-        "transform-custom-element-classes",
-        [
-            "@babel/plugin-transform-for-of",
-            {
-                loose: true
-            }
-        ]
-    ]
+    plugins: ["lodash", ["@babel/plugin-proposal-decorators", {legacy: true}], "transform-custom-element-classes"]
 };

--- a/packages/perspective-viewer-hypergrid/babel.config.js
+++ b/packages/perspective-viewer-hypergrid/babel.config.js
@@ -3,6 +3,14 @@ module.exports = {
         [
             "@babel/preset-env",
             {
+                targets: {
+                    chrome: "57",
+                    node: "8",
+                    ios: "11",
+                    safari: "11",
+                    edge: "16",
+                    firefox: "52"
+                },
                 modules: false,
                 useBuiltIns: "usage",
                 corejs: 2
@@ -10,16 +18,5 @@ module.exports = {
         ]
     ],
     sourceType: "unambiguous",
-    plugins: [
-        "lodash",
-        "@babel/transform-runtime",
-        ["@babel/plugin-proposal-decorators", {legacy: true}],
-        "transform-custom-element-classes",
-        [
-            "@babel/plugin-transform-for-of",
-            {
-                loose: true
-            }
-        ]
-    ]
+    plugins: ["lodash", ["@babel/plugin-proposal-decorators", {legacy: true}], "transform-custom-element-classes"]
 };

--- a/packages/perspective-viewer/babel.config.js
+++ b/packages/perspective-viewer/babel.config.js
@@ -3,6 +3,14 @@ module.exports = {
         [
             "@babel/preset-env",
             {
+                targets: {
+                    chrome: "57",
+                    node: "8",
+                    ios: "11",
+                    safari: "11",
+                    edge: "16",
+                    firefox: "52"
+                },
                 modules: false,
                 useBuiltIns: "usage",
                 corejs: 2
@@ -10,16 +18,5 @@ module.exports = {
         ]
     ],
     sourceType: "unambiguous",
-    plugins: [
-        "lodash",
-        "@babel/transform-runtime",
-        ["@babel/plugin-proposal-decorators", {legacy: true}],
-        "transform-custom-element-classes",
-        [
-            "@babel/plugin-transform-for-of",
-            {
-                loose: true
-            }
-        ]
-    ]
+    plugins: ["lodash", ["@babel/plugin-proposal-decorators", {legacy: true}], "transform-custom-element-classes"]
 };

--- a/packages/perspective/babel.config.js
+++ b/packages/perspective/babel.config.js
@@ -3,6 +3,13 @@ module.exports = {
         [
             "@babel/preset-env",
             {
+                targets: {
+                    chrome: "70",
+                    node: "8",
+                    ios: "12",
+                    safari: "12",
+                    edge: "44"
+                },
                 modules: false,
                 useBuiltIns: "usage",
                 corejs: 2
@@ -10,16 +17,5 @@ module.exports = {
         ]
     ],
     sourceType: "unambiguous",
-    plugins: [
-        "lodash",
-        "@babel/transform-runtime",
-        ["@babel/plugin-proposal-decorators", {legacy: true}],
-        "transform-custom-element-classes",
-        [
-            "@babel/plugin-transform-for-of",
-            {
-                loose: true
-            }
-        ]
-    ]
+    plugins: ["lodash", ["@babel/plugin-proposal-decorators", {legacy: true}], "transform-custom-element-classes"]
 };

--- a/packages/perspective/src/config/perspective.node.config.js
+++ b/packages/perspective/src/config/perspective.node.config.js
@@ -5,7 +5,7 @@ const TerserPlugin = require("terser-webpack-plugin");
 module.exports = Object.assign({}, common(), {
     entry: "./cjs/js/perspective.node.js",
     target: "node",
-    externals: [/^([a-z0-9]|\@(?!apache\-arrow)).*?(?!wasm)$/g],
+    externals: [/^[a-z0-9].*?$/g],
     node: {
         __dirname: false,
         __filename: false


### PR DESCRIPTION
Now that we no longer build ASM.JS, remove polyfills for WASM-incompatible browsers.