### PR TITLE
Fixed webpack config error in webpack example

### DIFF
--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
         rules: [
             {
                 test: /\.less$/,
-                exclude: /packages/,
+                exclude: [/packages/, /node_modules/],
                 use: [{loader: "style-loader"}, {loader: "css-loader"}, {loader: "less-loader"}]
             }
         ]


### PR DESCRIPTION
When developing locally via yarn workspaces, `@finos/perspective` is in `~/packages`;  but without building yarn workspaces (from the top of the repo), it is in `~/node_modules`. 

Fixes #638 