### PR TITLE
Add view config class in C++

### DIFF
--- a/cmake/ordered-map.txt.in
+++ b/cmake/ordered-map.txt.in
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(ordered-map-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(ordered-map
+  GIT_REPOSITORY    https://github.com/Tessil/ordered-map.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/ordered-map-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/ordered-map-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+  CMAKE_ARGS        "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+)

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -346,6 +346,7 @@ set (SOURCE_FILES
 	src/cpp/utils.cpp
 	src/cpp/update_task.cpp
 	src/cpp/view.cpp
+	src/cpp/view_config.cpp
 	src/cpp/vocab.cpp
 	)
 

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -259,6 +259,7 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 endif()
 
 psp_build_dep("hopscotch" "../../cmake/hopscotch.txt.in")
+psp_build_dep("ordered-map" "../../cmake/ordered-map.txt.in")
 
 #####################
 

--- a/cpp/perspective/src/cpp/aggspec.cpp
+++ b/cpp/perspective/src/cpp/aggspec.cpp
@@ -23,27 +23,6 @@ t_col_name_type::t_col_name_type(const std::string& name, t_dtype type)
 
 t_aggspec::t_aggspec() {}
 
-t_aggspec::t_aggspec(const t_aggspec_recipe& v) {
-    m_name = v.m_name;
-    m_disp_name = v.m_name;
-    m_agg = v.m_agg;
-
-    for (const auto& d : v.m_dependencies) {
-        m_dependencies.push_back(d);
-    }
-
-    for (const auto& d : v.m_odependencies) {
-        m_odependencies.push_back(d);
-    }
-
-    m_sort_type = v.m_sort_type;
-    m_agg_one_idx = v.m_agg_one_idx;
-    m_agg_two_idx = v.m_agg_two_idx;
-    m_agg_one_weight = v.m_agg_one_weight;
-    m_agg_two_weight = v.m_agg_two_weight;
-    m_invmode = v.m_invmode;
-}
-
 t_aggspec::t_aggspec(
     const std::string& name, t_aggtype agg, const std::vector<t_dep>& dependencies)
     : m_name(name)
@@ -405,31 +384,6 @@ t_aggspec::get_first_depname() const {
         return "";
 
     return m_dependencies[0].name();
-}
-
-t_aggspec_recipe
-t_aggspec::get_recipe() const {
-    t_aggspec_recipe rv;
-    rv.m_name = m_name;
-    rv.m_disp_name = m_name;
-    rv.m_agg = m_agg;
-
-    for (const auto& d : m_dependencies) {
-        rv.m_dependencies.push_back(d.get_recipe());
-    }
-
-    for (const auto& d : m_odependencies) {
-        rv.m_odependencies.push_back(d.get_recipe());
-    }
-
-    rv.m_sort_type = m_sort_type;
-    rv.m_agg_one_idx = m_agg_one_idx;
-    rv.m_agg_two_idx = m_agg_two_idx;
-    rv.m_agg_one_weight = m_agg_one_weight;
-    rv.m_agg_two_weight = m_agg_two_weight;
-    rv.m_invmode = m_invmode;
-
-    return rv;
 }
 
 } // end namespace perspective

--- a/cpp/perspective/src/cpp/config.cpp
+++ b/cpp/perspective/src/cpp/config.cpp
@@ -42,33 +42,39 @@ t_config::t_config(const std::vector<std::string>& detail_columns, t_filter_op c
     , m_fmode(FMODE_SIMPLE_CLAUSES) {}
 
 // t_ctx1
-t_config::t_config(const std::vector<t_pivot>& row_pivots,
+t_config::t_config(const std::vector<std::string>& row_pivots,
     const std::vector<t_aggspec>& aggregates, t_filter_op combiner,
     const std::vector<t_fterm>& fterms)
-    : m_row_pivots(row_pivots)
-    , m_aggregates(aggregates)
+    : m_aggregates(aggregates)
     , m_totals(TOTALS_BEFORE)
     , m_combiner(combiner)
     , m_fterms(fterms)
     , m_handle_nan_sort(true)
     , m_fmode(FMODE_SIMPLE_CLAUSES) {
+    for (const auto& p : row_pivots) {
+        m_row_pivots.push_back(t_pivot(p));
+    }
     setup(m_detail_columns, std::vector<std::string>{}, std::vector<std::string>{});
 }
 
 // t_ctx2
-t_config::t_config(const std::vector<t_pivot>& row_pivots,
-    const std::vector<t_pivot>& col_pivots, const std::vector<t_aggspec>& aggregates,
+t_config::t_config(const std::vector<std::string>& row_pivots,
+    const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates,
     const t_totals totals, t_filter_op combiner, const std::vector<t_fterm>& fterms,
     bool column_only)
-    : m_row_pivots(row_pivots)
-    , m_col_pivots(col_pivots)
-    , m_column_only(column_only)
+    : m_column_only(column_only)
     , m_aggregates(aggregates)
     , m_totals(totals)
     , m_combiner(combiner)
     , m_fterms(fterms)
     , m_handle_nan_sort(true)
     , m_fmode(FMODE_SIMPLE_CLAUSES) {
+    for (const auto& p : row_pivots) {
+        m_row_pivots.push_back(t_pivot(p));
+    }
+    for (const auto& p : col_pivots) {
+        m_col_pivots.push_back(t_pivot(p));
+    }
     setup(m_detail_columns, std::vector<std::string>{}, std::vector<std::string>{});
 }
 

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -139,9 +139,9 @@ namespace binding {
 
     template <>
     std::vector<t_sortspec>
-    _get_sort(const std::vector<std::string>& columns, bool is_column_sort,
-        const std::vector<t_val>& sortbys) {
-        std::vector<t_sortspec> svec{};
+    _get_sort(const std::vector<std::string>& columns, const std::vector<t_val>& sortbys,
+        bool is_column_sort) {
+        std::vector<t_sortspec> svec;
 
         auto _is_valid_sort = [is_column_sort](t_val sort_item) {
             /**
@@ -1570,8 +1570,8 @@ namespace binding {
         }
 
         if (sortbys.size() > 0) {
-            sorts = _get_sort(aggregate_names, false, sortbys);
-            col_sorts = _get_sort(aggregate_names, true, sortbys);
+            sorts = _get_sort(aggregate_names, sortbys, false);
+            col_sorts = _get_sort(aggregate_names, sortbys, true);
         }
 
         auto view_config = t_config(row_pivots, column_pivots, aggregates, sorts, col_sorts,

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -25,12 +25,6 @@ namespace binding {
         return std::vector<T>{};
     }
 
-    template <typename K, typename V>
-    std::map<K, V>
-    make_map() {
-        return std::map<K, V>{};
-    }
-
     template <>
     bool
     has_value(t_val item) {
@@ -42,151 +36,6 @@ namespace binding {
      * Data Loading
      */
 
-    t_index
-    _get_aggregate_index(const std::vector<std::string>& agg_names, std::string name) {
-        auto it = std::find(agg_names.begin(), agg_names.end(), name);
-        if (it != agg_names.end()) {
-            return t_index(std::distance(agg_names.begin(), it));
-        }
-        return t_index();
-    }
-
-    std::vector<std::string>
-    _get_aggregate_names(const std::vector<t_aggspec>& aggs) {
-        std::vector<std::string> names;
-        for (const t_aggspec& agg : aggs) {
-            names.push_back(agg.name());
-        }
-        return names;
-    }
-
-    template <>
-    std::vector<t_aggspec>
-    _get_aggspecs(const t_schema& schema, const std::vector<std::string>& row_pivots,
-        const std::vector<std::string>& column_pivots, bool column_only,
-        const std::vector<std::string>& columns, const std::vector<t_val>& sortbys,
-        t_val j_aggs) {
-        std::vector<t_aggspec> aggspecs;
-        t_val agg_columns = t_val::global("Object").call<t_val>("keys", j_aggs);
-        std::vector<std::string> aggs = vecFromArray<t_val, std::string>(agg_columns);
-
-        /**
-         * Provide aggregates for columns that are shown but NOT specified in
-         * the `j_aggs` object.
-         */
-        for (const std::string& column : columns) {
-            if (std::find(aggs.begin(), aggs.end(), column) != aggs.end()) {
-                continue;
-            }
-
-            t_dtype dtype = schema.get_dtype(column);
-            std::vector<t_dep> dependencies{t_dep(column, DEPTYPE_COLUMN)};
-            t_aggtype agg_op
-                = t_aggtype::AGGTYPE_ANY; // use aggtype here since we are not parsing aggs
-
-            if (!column_only) {
-                agg_op = _get_default_aggregate(dtype);
-            }
-
-            aggspecs.push_back(t_aggspec(column, agg_op, dependencies));
-        }
-
-        // Construct aggregates from config object
-        for (const std::string& agg_column : aggs) {
-            if (std::find(columns.begin(), columns.end(), agg_column) == columns.end()) {
-                continue;
-            }
-
-            std::string agg_op = j_aggs[agg_column].as<std::string>();
-            std::vector<t_dep> dependencies;
-
-            if (column_only) {
-                agg_op = "any";
-            }
-
-            dependencies.push_back(t_dep(agg_column, DEPTYPE_COLUMN));
-
-            t_aggtype aggtype = str_to_aggtype(agg_op);
-
-            if (aggtype == AGGTYPE_FIRST || aggtype == AGGTYPE_LAST) {
-                if (dependencies.size() == 1) {
-                    dependencies.push_back(t_dep("psp_pkey", DEPTYPE_COLUMN));
-                }
-                aggspecs.push_back(t_aggspec(
-                    agg_column, agg_column, aggtype, dependencies, SORTTYPE_ASCENDING));
-            } else {
-                aggspecs.push_back(t_aggspec(agg_column, aggtype, dependencies));
-            }
-        }
-
-        // construct aggspecs for hidden sorts
-        for (auto sortby : sortbys) {
-            std::string column = sortby[0].as<std::string>();
-
-            bool is_hidden_column
-                = std::find(columns.begin(), columns.end(), column) == columns.end();
-
-            if (is_hidden_column) {
-                bool is_pivot = (std::find(row_pivots.begin(), row_pivots.end(), column)
-                                    != row_pivots.end())
-                    || (std::find(column_pivots.begin(), column_pivots.end(), column)
-                           != column_pivots.end());
-
-                std::vector<t_dep> dependencies{t_dep(column, DEPTYPE_COLUMN)};
-                t_aggtype agg_op;
-
-                if (is_pivot || row_pivots.size() == 0 || column_only) {
-                    agg_op = t_aggtype::AGGTYPE_ANY;
-                } else {
-                    t_dtype dtype = schema.get_dtype(column);
-                    agg_op = _get_default_aggregate(dtype);
-                }
-
-                aggspecs.push_back(t_aggspec(column, agg_op, dependencies));
-            }
-        }
-
-        return aggspecs;
-    }
-
-    template <>
-    std::vector<t_sortspec>
-    _get_sort(const std::vector<std::string>& columns, const std::vector<t_val>& sortbys,
-        bool is_column_sort) {
-        std::vector<t_sortspec> svec;
-
-        auto _is_valid_sort = [is_column_sort](t_val sort_item) {
-            /**
-             * If column sort, make sure string matches. Otherwise make
-             * sure string is *not* a column sort.
-             */
-            std::string op = sort_item[1].as<std::string>();
-            bool is_col_sortop = op.find("col") != std::string::npos;
-            return (is_column_sort && is_col_sortop) || (!is_col_sortop && !is_column_sort);
-        };
-
-        for (auto idx = 0; idx < sortbys.size(); ++idx) {
-            t_val sort_item = sortbys[idx];
-            t_index agg_index;
-            std::string column;
-            t_sorttype sorttype;
-
-            std::string sort_op_str;
-            if (!_is_valid_sort(sort_item)) {
-                continue;
-            }
-
-            column = sort_item[0].as<std::string>();
-            sort_op_str = sort_item[1].as<std::string>();
-            sorttype = str_to_sorttype(sort_op_str);
-
-            agg_index = _get_aggregate_index(columns, column);
-
-            svec.push_back(t_sortspec(column, agg_index, sorttype));
-        }
-        return svec;
-    }
-
     template <>
     bool
     is_valid_filter(t_dtype type, t_val date_parser, t_val filter_term) {
@@ -197,71 +46,6 @@ namespace binding {
             return has_value(filter_term);
         }
     };
-
-    template <>
-    std::vector<t_fterm>
-    _get_fterms(const t_schema& schema, t_val j_date_parser, t_val j_filters) {
-        std::vector<t_fterm> fvec{};
-        std::vector<t_val> filters = vecFromArray<t_val, t_val>(j_filters);
-
-        for (auto fidx = 0; fidx < filters.size(); ++fidx) {
-            std::vector<t_val> filter = vecFromArray<t_val, t_val>(filters[fidx]);
-            std::string col = filter[0].as<std::string>();
-            t_filter_op comp = str_to_filter_op(filter[1].as<std::string>());
-
-            // check validity and if_date
-            t_dtype col_type = schema.get_dtype(col);
-            bool is_valid = is_valid_filter(col_type, j_date_parser, filter[2]);
-
-            if (!is_valid) {
-                continue;
-            }
-
-            switch (comp) {
-                case FILTER_OP_NOT_IN:
-                case FILTER_OP_IN: {
-                    std::vector<t_tscalar> terms{};
-                    std::vector<std::string> j_terms
-                        = vecFromArray<t_val, std::string>(filter[2]);
-                    for (auto jidx = 0; jidx < j_terms.size(); ++jidx) {
-                        terms.push_back(mktscalar(get_interned_cstr(j_terms[jidx].c_str())));
-                    }
-                    fvec.push_back(t_fterm(col, comp, mktscalar(0), terms));
-                } break;
-                default: {
-                    t_tscalar term;
-                    switch (col_type) {
-                        case DTYPE_INT32: {
-                            term = mktscalar(filter[2].as<std::int32_t>());
-                        } break;
-                        case DTYPE_INT64:
-                        case DTYPE_FLOAT64: {
-                            term = mktscalar(filter[2].as<double>());
-                        } break;
-                        case DTYPE_BOOL: {
-                            term = mktscalar(filter[2].as<bool>());
-                        } break;
-                        case DTYPE_DATE: {
-                            t_val parsed_date = j_date_parser.call<t_val>("parse", filter[2]);
-                            term = mktscalar(jsdate_to_t_date(parsed_date));
-                        } break;
-                        case DTYPE_TIME: {
-                            t_val parsed_date = j_date_parser.call<t_val>("parse", filter[2]);
-                            term = mktscalar(t_time(static_cast<std::int64_t>(
-                                parsed_date.call<t_val>("getTime").as<double>())));
-                        } break;
-                        default: {
-                            term = mktscalar(
-                                get_interned_cstr(filter[2].as<std::string>().c_str()));
-                        }
-                    }
-
-                    fvec.push_back(t_fterm(col, comp, term, std::vector<t_tscalar>()));
-                }
-            }
-        }
-        return fvec;
-    }
 
     /******************************************************************************
      *
@@ -1580,71 +1364,6 @@ namespace binding {
     }
 
     template <>
-    t_config
-    make_config(
-        const t_schema& schema, std::string separator, t_val date_parser, t_val config) {
-        t_val j_row_pivots = config["row_pivots"];
-        t_val j_column_pivots = config["column_pivots"];
-        t_val j_aggregates = config["aggregates"];
-        t_val j_columns = config["columns"];
-        t_val j_filter = config["filter"];
-        t_val j_sort = config["sort"];
-
-        std::vector<std::string> row_pivots;
-        std::vector<std::string> column_pivots;
-        std::vector<t_aggspec> aggregates;
-        std::vector<std::string> aggregate_names;
-        std::vector<std::string> columns;
-        std::vector<t_fterm> filters;
-        std::vector<t_val> sortbys;
-        std::vector<t_sortspec> sorts;
-        std::vector<t_sortspec> col_sorts;
-
-        t_filter_op filter_op = t_filter_op::FILTER_OP_AND;
-
-        if (has_value(j_row_pivots)) {
-            row_pivots = vecFromArray<t_val, std::string>(j_row_pivots);
-        }
-
-        if (has_value(j_column_pivots)) {
-            column_pivots = vecFromArray<t_val, std::string>(j_column_pivots);
-        }
-
-        bool column_only = false;
-
-        if (row_pivots.size() == 0 && column_pivots.size() > 0) {
-            row_pivots.push_back("psp_okey");
-            column_only = true;
-        }
-
-        if (has_value(j_sort)) {
-            sortbys = vecFromArray<t_val, t_val>(j_sort);
-        }
-
-        columns = vecFromArray<t_val, std::string>(j_columns);
-        aggregates = _get_aggspecs(
-            schema, row_pivots, column_pivots, column_only, columns, sortbys, j_aggregates);
-        aggregate_names = _get_aggregate_names(aggregates);
-
-        if (has_value(j_filter)) {
-            filters = _get_fterms(schema, date_parser, j_filter);
-            if (has_value(config["filter_op"])) {
-                filter_op = str_to_filter_op(config["filter_op"].as<std::string>());
-            }
-        }
-
-        if (sortbys.size() > 0) {
-            sorts = _get_sort(aggregate_names, sortbys, false);
-            col_sorts = _get_sort(aggregate_names, sortbys, true);
-        }
-
-        auto view_config = t_config(row_pivots, column_pivots, aggregates, sorts, col_sorts,
-            filter_op, filters, aggregate_names, column_only);
-
-        return view_config;
-    }
-
-    template <>
     t_view_config
     make_view_config(const t_schema& schema, t_val date_parser, t_val config) {
         // extract vectors from JS, where they were created
@@ -1655,12 +1374,11 @@ namespace binding {
         auto filter_op = config["filter_op"].as<std::string>();
 
         // aggregates require manual parsing - std::maps read from JS are empty
-        std::map<std::string, std::string> aggregates;
         t_val j_aggregate_keys
             = t_val::global("Object").call<t_val>("keys", config["aggregates"]);
         auto aggregate_names = vecFromArray<t_val, std::string>(j_aggregate_keys);
 
-        std::cout << aggregate_names << std::endl;
+        tsl::ordered_map<std::string, std::string> aggregates;
         for (const auto& name : aggregate_names) {
             aggregates[name] = config["aggregates"][name].as<std::string>();
         };
@@ -1672,18 +1390,30 @@ namespace binding {
             column_only = true;
         }
 
-        t_view_config view_config(
-            row_pivots, column_pivots, aggregates, columns, {}, sort, filter_op, column_only);
+        // construct filters with filter terms, and fill the vector of tuples
+        auto js_filter = config.call<std::vector<std::vector<t_val>>>("get_filter");
+        std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> filter;
 
-        // construct filters with filter terms
-        auto filter = config.call<std::vector<std::vector<t_val>>>("get_filter");
-        for (auto f : filter) {
+        for (auto f : js_filter) {
             t_dtype type = schema.get_dtype(f[0].as<std::string>());
             if (is_valid_filter(type, date_parser, f[2])) {
-                view_config.add_filter_term(make_filter_term(type, date_parser, f));
+                filter.push_back(make_filter_term(type, date_parser, f));
             }
         }
 
+        t_view_config view_config(row_pivots, column_pivots, aggregates, columns, filter, sort,
+            filter_op, column_only);
+
+        // set pivot depths if provided
+        if (has_value(config["row_pivot_depth"])) {
+            view_config.set_row_pivot_depth(config["row_pivot_depth"].as<std::int32_t>());
+        }
+
+        if (has_value(config["column_pivot_depth"])) {
+            view_config.set_column_pivot_depth(config["column_pivot_depth"].as<std::int32_t>());
+        }
+
+        // transform primitive values into abstractions that the engine can use
         view_config.init(schema);
 
         return view_config;
@@ -1692,19 +1422,13 @@ namespace binding {
     template <>
     std::shared_ptr<View<t_ctx0>>
     make_view_zero(std::shared_ptr<Table> table, std::string name, std::string separator,
-        t_val j_view_config, t_val date_parser) {
+        t_val view_config, t_val date_parser) {
         auto schema = table->get_schema();
-        t_view_config view_config = make_view_config<t_val>(schema, date_parser, j_view_config);
+        t_view_config config = make_view_config<t_val>(schema, date_parser, view_config);
 
-        auto columns = view_config.get_columns();
-        auto filter_op = view_config.get_filter_op();
-        auto filter = view_config.get_fterm();
-        auto sort = view_config.get_sortspec();
+        auto ctx = make_context_zero(table, schema, config, name);
 
-        auto ctx = make_context_zero(table, schema, filter_op, columns, filter, sort, name);
-
-        auto view_ptr
-            = std::make_shared<View<t_ctx0>>(table, ctx, name, separator, view_config);
+        auto view_ptr = std::make_shared<View<t_ctx0>>(table, ctx, name, separator, config);
 
         return view_ptr;
     }
@@ -1712,28 +1436,13 @@ namespace binding {
     template <>
     std::shared_ptr<View<t_ctx1>>
     make_view_one(std::shared_ptr<Table> table, std::string name, std::string separator,
-        t_val config, t_val j_view_config, t_val date_parser) {
+        t_val view_config, t_val date_parser) {
         auto schema = table->get_schema();
-        // FIXME: temp workaround
-        t_config v_config = make_config<t_val>(schema, separator, date_parser, config);
-        t_view_config view_config = make_view_config<t_val>(schema, date_parser, j_view_config);
+        t_view_config config = make_view_config<t_val>(schema, date_parser, view_config);
 
-        auto aggregates = v_config.get_aggregates();
-        auto row_pivots = v_config.get_row_pivots();
-        auto filter_op = v_config.get_combiner();
-        auto filters = v_config.get_fterms();
-        auto sorts = v_config.get_sortspecs();
+        auto ctx = make_context_one(table, schema, config, name);
 
-        std::int32_t pivot_depth = -1;
-        if (has_value(config["row_pivot_depth"])) {
-            pivot_depth = config["row_pivot_depth"].as<std::int32_t>();
-        }
-
-        auto ctx = make_context_one(table, schema, row_pivots, filter_op, filters, aggregates,
-            sorts, pivot_depth, name);
-
-        auto view_ptr
-            = std::make_shared<View<t_ctx1>>(table, ctx, name, separator, view_config);
+        auto view_ptr = std::make_shared<View<t_ctx1>>(table, ctx, name, separator, config);
 
         return view_ptr;
     }
@@ -1741,40 +1450,13 @@ namespace binding {
     template <>
     std::shared_ptr<View<t_ctx2>>
     make_view_two(std::shared_ptr<Table> table, std::string name, std::string separator,
-        t_val config, t_val j_view_config, t_val date_parser) {
+        t_val view_config, t_val date_parser) {
         auto schema = table->get_schema();
-        // FIXME: temp workaround
-        t_config v_config = make_config<t_val>(schema, separator, date_parser, config);
-        t_view_config view_config = make_view_config<t_val>(schema, date_parser, j_view_config);
+        t_view_config config = make_view_config<t_val>(schema, date_parser, view_config);
 
-        bool column_only = v_config.is_column_only();
-        auto column_names = v_config.get_column_names();
-        auto row_pivots = v_config.get_row_pivots();
-        auto column_pivots = v_config.get_column_pivots();
-        auto aggregates = v_config.get_aggregates();
-        auto filter_op = v_config.get_combiner();
-        auto filters = v_config.get_fterms();
-        auto sorts = v_config.get_sortspecs();
-        auto col_sorts = v_config.get_col_sortspecs();
+        auto ctx = make_context_two(table, schema, config, name);
 
-        std::int32_t rpivot_depth = -1;
-        std::int32_t cpivot_depth = -1;
-
-        // TODO: implement in `t_view_config`?
-        if (has_value(config["row_pivot_depth"])) {
-            rpivot_depth = config["row_pivot_depth"].as<std::int32_t>();
-        }
-
-        if (has_value(config["column_pivot_depth"])) {
-            cpivot_depth = config["column_pivot_depth"].as<std::int32_t>();
-        }
-
-        auto ctx
-            = make_context_two(table, schema, row_pivots, column_pivots, filter_op, filters,
-                aggregates, sorts, col_sorts, rpivot_depth, cpivot_depth, column_only, name);
-
-        auto view_ptr
-            = std::make_shared<View<t_ctx2>>(table, ctx, name, separator, view_config);
+        auto view_ptr = std::make_shared<View<t_ctx2>>(table, ctx, name, separator, config);
 
         return view_ptr;
     }
@@ -1785,13 +1467,17 @@ namespace binding {
      */
 
     std::shared_ptr<t_ctx0>
-    make_context_zero(std::shared_ptr<Table> table, t_schema schema, t_filter_op combiner,
-        std::vector<std::string> columns, std::vector<t_fterm> filters,
-        std::vector<t_sortspec> sorts, std::string name) {
-        auto cfg = t_config(columns, combiner, filters);
+    make_context_zero(std::shared_ptr<Table> table, const t_schema& schema,
+        const t_view_config& view_config, std::string name) {
+        auto columns = view_config.get_columns();
+        auto filter_op = view_config.get_filter_op();
+        auto fterm = view_config.get_fterm();
+        auto sortspec = view_config.get_sortspec();
+
+        auto cfg = t_config(columns, filter_op, fterm);
         auto ctx0 = std::make_shared<t_ctx0>(schema, cfg);
         ctx0->init();
-        ctx0->sort_by(sorts);
+        ctx0->sort_by(sortspec);
 
         auto pool = table->get_pool();
         auto gnode = table->get_gnode();
@@ -1802,40 +1488,53 @@ namespace binding {
     }
 
     std::shared_ptr<t_ctx1>
-    make_context_one(std::shared_ptr<Table> table, t_schema schema, std::vector<t_pivot> pivots,
-        t_filter_op combiner, std::vector<t_fterm> filters, std::vector<t_aggspec> aggregates,
-        std::vector<t_sortspec> sorts, std::int32_t pivot_depth, std::string name) {
-        auto cfg = t_config(pivots, aggregates, combiner, filters);
+    make_context_one(std::shared_ptr<Table> table, const t_schema& schema,
+        const t_view_config& view_config, std::string name) {
+        auto row_pivots = view_config.get_row_pivots();
+        auto aggspecs = view_config.get_aggspecs();
+        auto filter_op = view_config.get_filter_op();
+        auto fterm = view_config.get_fterm();
+        auto sortspec = view_config.get_sortspec();
+        auto row_pivot_depth = view_config.get_row_pivot_depth();
+
+        auto cfg = t_config(row_pivots, aggspecs, filter_op, fterm);
         auto ctx1 = std::make_shared<t_ctx1>(schema, cfg);
 
         ctx1->init();
-        ctx1->sort_by(sorts);
+        ctx1->sort_by(sortspec);
 
         auto pool = table->get_pool();
         auto gnode = table->get_gnode();
         pool->register_context(gnode->get_id(), name, ONE_SIDED_CONTEXT,
             reinterpret_cast<std::uintptr_t>(ctx1.get()));
 
-        if (pivot_depth > -1) {
-            ctx1->set_depth(pivot_depth - 1);
+        if (row_pivot_depth > -1) {
+            ctx1->set_depth(row_pivot_depth - 1);
         } else {
-            ctx1->set_depth(pivots.size());
+            ctx1->set_depth(row_pivots.size());
         }
 
         return ctx1;
     }
 
     std::shared_ptr<t_ctx2>
-    make_context_two(std::shared_ptr<Table> table, t_schema schema,
-        std::vector<t_pivot> rpivots, std::vector<t_pivot> cpivots, t_filter_op combiner,
-        std::vector<t_fterm> filters, std::vector<t_aggspec> aggregates,
-        std::vector<t_sortspec> sorts, std::vector<t_sortspec> col_sorts,
-        std::int32_t rpivot_depth, std::int32_t cpivot_depth, bool column_only,
-        std::string name) {
-        t_totals total = sorts.size() > 0 ? TOTALS_BEFORE : TOTALS_HIDDEN;
+    make_context_two(std::shared_ptr<Table> table, const t_schema& schema,
+        const t_view_config& view_config, std::string name) {
+        bool column_only = view_config.is_column_only();
+        auto row_pivots = view_config.get_row_pivots();
+        auto column_pivots = view_config.get_column_pivots();
+        auto aggspecs = view_config.get_aggspecs();
+        auto filter_op = view_config.get_filter_op();
+        auto fterm = view_config.get_fterm();
+        auto sortspec = view_config.get_sortspec();
+        auto col_sortspec = view_config.get_col_sortspec();
+        auto row_pivot_depth = view_config.get_row_pivot_depth();
+        auto column_pivot_depth = view_config.get_column_pivot_depth();
 
-        auto cfg
-            = t_config(rpivots, cpivots, aggregates, total, combiner, filters, column_only);
+        t_totals total = sortspec.size() > 0 ? TOTALS_BEFORE : TOTALS_HIDDEN;
+
+        auto cfg = t_config(
+            row_pivots, column_pivots, aggspecs, total, filter_op, fterm, column_only);
         auto ctx2 = std::make_shared<t_ctx2>(schema, cfg);
 
         ctx2->init();
@@ -1845,24 +1544,24 @@ namespace binding {
         pool->register_context(gnode->get_id(), name, TWO_SIDED_CONTEXT,
             reinterpret_cast<std::uintptr_t>(ctx2.get()));
 
-        if (rpivot_depth > -1) {
-            ctx2->set_depth(t_header::HEADER_ROW, rpivot_depth - 1);
+        if (row_pivot_depth > -1) {
+            ctx2->set_depth(t_header::HEADER_ROW, row_pivot_depth - 1);
         } else {
-            ctx2->set_depth(t_header::HEADER_ROW, rpivots.size());
+            ctx2->set_depth(t_header::HEADER_ROW, row_pivots.size());
         }
 
-        if (cpivot_depth > -1) {
-            ctx2->set_depth(t_header::HEADER_COLUMN, cpivot_depth - 1);
+        if (column_pivot_depth > -1) {
+            ctx2->set_depth(t_header::HEADER_COLUMN, column_pivot_depth - 1);
         } else {
-            ctx2->set_depth(t_header::HEADER_COLUMN, cpivots.size());
+            ctx2->set_depth(t_header::HEADER_COLUMN, column_pivots.size());
         }
 
-        if (sorts.size() > 0) {
-            ctx2->sort_by(sorts);
+        if (sortspec.size() > 0) {
+            ctx2->sort_by(sortspec);
         }
 
-        if (col_sorts.size() > 0) {
-            ctx2->column_sort_by(col_sorts);
+        if (col_sortspec.size() > 0) {
+            ctx2->column_sort_by(col_sortspec);
         }
 
         return ctx2;
@@ -2037,7 +1736,7 @@ EMSCRIPTEN_BINDINGS(perspective) {
      */
     class_<t_view_config>("t_view_config")
         .constructor<std::vector<std::string>, std::vector<std::string>,
-            std::map<std::string, std::string>, std::vector<std::string>,
+            tsl::ordered_map<std::string, std::string>, std::vector<std::string>,
             std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>>,
             std::vector<std::vector<std::string>>, std::string, bool>()
         .function("add_filter_term", &t_view_config::add_filter_term);
@@ -2227,13 +1926,12 @@ EMSCRIPTEN_BINDINGS(perspective) {
 
     /******************************************************************************
      *
-     * Construct data structures
+     * Construct `std::vector`s
      */
     function("make_string_vector", &make_vector<std::string>);
     function("make_val_vector", &make_vector<t_val>);
     function("make_2d_string_vector", &make_vector<std::vector<std::string>>);
     function("make_2d_val_vector", &make_vector<std::vector<t_val>>);
-    function("make_string_map", &make_map<std::string, std::string>);
 
     /******************************************************************************
      *

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1515,6 +1515,7 @@ namespace binding {
      *
      * View API
      */
+
     template <>
     t_config
     make_view_config(
@@ -1918,6 +1919,16 @@ EMSCRIPTEN_BINDINGS(perspective) {
 
     /******************************************************************************
      *
+     * t_view_config
+     */
+    class_<t_view_config>("t_view_config")
+        .constructor<std::vector<std::string>, std::vector<std::string>,
+            std::vector<std::string>, std::map<std::string, std::string>,
+            std::vector<std::tuple<std::string, std::string, t_tscalar>>,
+            std::vector<std::vector<std::string>>, bool>();
+
+    /******************************************************************************
+     *
      * t_data_table
      */
     class_<t_data_table>("t_data_table")
@@ -2043,13 +2054,14 @@ EMSCRIPTEN_BINDINGS(perspective) {
      * vector
      */
     register_vector<std::int32_t>("std::vector<std::int32_t>");
+    register_vector<std::string>("std::vector<std::string>");
     register_vector<t_dtype>("std::vector<t_dtype>");
     register_vector<t_cellupd>("std::vector<t_cellupd>");
     register_vector<t_tscalar>("std::vector<t_tscalar>");
-    register_vector<std::vector<t_tscalar>>("std::vector<std::vector<t_tscalar>>");
-    register_vector<std::string>("std::vector<std::string>");
     register_vector<t_updctx>("std::vector<t_updctx>");
     register_vector<t_uindex>("std::vector<t_uindex>");
+    register_vector<std::vector<t_tscalar>>("std::vector<std::vector<t_tscalar>>");
+    register_vector<std::vector<std::string>>("std::vector<std::vector<std::string>>");
 
     /******************************************************************************
      *

--- a/cpp/perspective/src/cpp/filter.cpp
+++ b/cpp/perspective/src/cpp/filter.cpp
@@ -14,15 +14,6 @@ namespace perspective {
 
 t_fterm::t_fterm() {}
 
-t_fterm::t_fterm(const t_fterm_recipe& v) {
-    m_colname = v.m_colname;
-    m_op = v.m_op;
-    m_threshold = v.m_threshold;
-    m_bag = v.m_bag;
-    m_use_interned
-        = (m_op == FILTER_OP_EQ || m_op == FILTER_OP_NE) && m_threshold.m_type == DTYPE_STR;
-}
-
 t_fterm::t_fterm(const std::string& colname, t_filter_op op, t_tscalar threshold,
     const std::vector<t_tscalar>& bag, bool negated, bool is_primary)
     : m_colname(colname)
@@ -53,16 +44,6 @@ t_fterm::coerce_numeric(t_dtype dtype) {
     for (auto& f : m_bag) {
         f.set(f.coerce_numeric_dtype(dtype));
     }
-}
-
-t_fterm_recipe
-t_fterm::get_recipe() const {
-    t_fterm_recipe rv;
-    rv.m_colname = m_colname;
-    rv.m_op = m_op;
-    rv.m_threshold = m_threshold;
-    rv.m_bag = m_bag;
-    return rv;
 }
 
 std::string

--- a/cpp/perspective/src/cpp/flat_traversal.cpp
+++ b/cpp/perspective/src/cpp/flat_traversal.cpp
@@ -102,10 +102,15 @@ t_ftrav::fill_sort_elem(std::shared_ptr<const t_gstate> state, const t_config& c
     out_elem.m_pkey = pkey;
     t_index sortby_size = m_sortby.size();
     out_elem.m_row.reserve(sortby_size);
-    for (t_index idx = 0; idx < sortby_size; ++idx) {
-        t_index sortby_idx = m_sortby[idx].m_agg_index;
-        const std::string& colname = config.col_at(sortby_idx);
-        const std::string sortby_colname = config.get_sort_by(colname);
+    for (const t_sortspec& sort : m_sortby) {
+        // maintain backwards compatibility
+        std::string colname;
+        if (sort.m_colname != "") {
+            colname = config.get_sort_by(sort.m_colname);
+        } else {
+            colname = config.col_at(sort.m_agg_index);
+        }
+        const std::string& sortby_colname = config.get_sort_by(colname);
         out_elem.m_row.push_back(
             m_symtable.get_interned_tscalar(state->get(pkey, sortby_colname)));
     }
@@ -117,10 +122,14 @@ t_ftrav::fill_sort_elem(std::shared_ptr<const t_gstate> state, const t_config& c
     out_elem.m_pkey = mknone();
     t_index sortby_size = m_sortby.size();
     out_elem.m_row.reserve(sortby_size);
-    for (t_index idx = 0; idx < sortby_size; ++idx) {
-        t_index sortby_idx = m_sortby[idx].m_agg_index;
-        const std::string& colname = config.col_at(sortby_idx);
-        const std::string sortby_colname = config.get_sort_by(colname);
+    for (const t_sortspec& sort : m_sortby) {
+        std::string colname;
+        if (sort.m_colname != "") {
+            colname = config.get_sort_by(sort.m_colname);
+        } else {
+            colname = config.col_at(sort.m_agg_index);
+        }
+        const std::string& sortby_colname = config.get_sort_by(colname);
         out_elem.m_row.push_back(
             get_interned_tscalar(row.at(config.get_colidx(sortby_colname))));
     }

--- a/cpp/perspective/src/cpp/sort_specification.cpp
+++ b/cpp/perspective/src/cpp/sort_specification.cpp
@@ -13,6 +13,12 @@
 
 namespace perspective {
 
+t_sortspec::t_sortspec(const std::string& column_name, t_index agg_index, t_sorttype sort_type)
+    : m_colname(column_name)
+    , m_agg_index(agg_index)
+    , m_sort_type(sort_type)
+    , m_sortspec_type(SORTSPEC_TYPE_IDX) {}
+
 t_sortspec::t_sortspec(t_index agg_index, t_sorttype sort_type)
     : m_agg_index(agg_index)
     , m_sort_type(sort_type)

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -16,7 +16,8 @@ t_view_config::t_view_config(std::vector<std::string> row_pivots,
     tsl::ordered_map<std::string, std::string> aggregates, std::vector<std::string> columns,
     std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> filter,
     std::vector<std::vector<std::string>> sort, std::string filter_op, bool column_only)
-    : m_row_pivots(row_pivots)
+    : m_init(false)
+    , m_row_pivots(row_pivots)
     , m_column_pivots(column_pivots)
     , m_aggregates(aggregates)
     , m_columns(columns)
@@ -32,76 +33,92 @@ t_view_config::init(const t_schema& schema) {
     fill_aggspecs(schema);
     fill_fterm();
     fill_sortspec();
+
+    m_init = true;
 }
 
 void
 t_view_config::add_filter_term(
     std::tuple<std::string, std::string, std::vector<t_tscalar>> term) {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     m_filter.push_back(term);
 }
 
 void
 t_view_config::set_row_pivot_depth(std::int32_t depth) {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     m_row_pivot_depth = depth;
 }
 
 void
 t_view_config::set_column_pivot_depth(std::int32_t depth) {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     m_column_pivot_depth = depth;
 }
 
 std::vector<std::string>
 t_view_config::get_row_pivots() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_row_pivots;
 }
 
 std::vector<std::string>
 t_view_config::get_column_pivots() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_column_pivots;
 }
 
 std::vector<t_aggspec>
 t_view_config::get_aggspecs() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_aggspecs;
 }
 
 std::vector<std::string>
 t_view_config::get_columns() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_columns;
 }
 
 std::vector<t_fterm>
 t_view_config::get_fterm() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_fterm;
 }
 
 std::vector<t_sortspec>
 t_view_config::get_sortspec() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_sortspec;
 }
 
 std::vector<t_sortspec>
 t_view_config::get_col_sortspec() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_col_sortspec;
 }
 
 t_filter_op
 t_view_config::get_filter_op() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return str_to_filter_op(m_filter_op);
 }
 
 bool
 t_view_config::is_column_only() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_column_only;
 }
 
 std::int32_t
 t_view_config::get_row_pivot_depth() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_row_pivot_depth;
 }
 
 std::int32_t
 t_view_config::get_column_pivot_depth() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_column_pivot_depth;
 }
 
@@ -234,11 +251,3 @@ t_view_config::get_aggregate_index(const std::string& column) const {
 }
 
 } // end namespace perspective
-
-namespace std {
-std::ostream&
-operator<<(std::ostream& os, const perspective::t_view_config& vc) {
-    os << "t_view_config"; // TODO: finish
-    return os;
-}
-} // end namespace std

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -1,0 +1,34 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+#include <perspective/view_config.h>
+
+namespace perspective {
+
+t_view_config::t_view_config(std::vector<std::string> row_pivots,
+    std::vector<std::string> column_pivots, std::vector<std::string> columns,
+    std::map<std::string, std::string> aggregates,
+    std::vector<std::tuple<std::string, std::string, t_tscalar>> filter,
+    std::vector<std::vector<std::string>> sort, bool column_only)
+    : m_row_pivots(row_pivots)
+    , m_column_pivots(column_pivots)
+    , m_columns(columns)
+    , m_aggregates(aggregates)
+    , m_filter(filter)
+    , m_sort(sort)
+    , m_column_only(column_only) {}
+
+void
+t_view_config::add_filter_term(
+    std::string col_name, std::string filter_op, t_tscalar filter_term) {
+    auto term = std::make_tuple(col_name, filter_op, filter_term);
+    m_filter.push_back(term);
+}
+
+} // namespace perspective

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -12,23 +12,206 @@
 namespace perspective {
 
 t_view_config::t_view_config(std::vector<std::string> row_pivots,
-    std::vector<std::string> column_pivots, std::vector<std::string> columns,
-    std::map<std::string, std::string> aggregates,
-    std::vector<std::tuple<std::string, std::string, t_tscalar>> filter,
-    std::vector<std::vector<std::string>> sort, bool column_only)
+    std::vector<std::string> column_pivots, std::map<std::string, std::string> aggregates,
+    std::vector<std::string> columns,
+    std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> filter,
+    std::vector<std::vector<std::string>> sort, std::string filter_op, bool column_only)
     : m_row_pivots(row_pivots)
     , m_column_pivots(column_pivots)
-    , m_columns(columns)
     , m_aggregates(aggregates)
+    , m_columns(columns)
     , m_filter(filter)
     , m_sort(sort)
+    , m_filter_op(filter_op)
     , m_column_only(column_only) {}
 
 void
 t_view_config::add_filter_term(
-    std::string col_name, std::string filter_op, t_tscalar filter_term) {
-    auto term = std::make_tuple(col_name, filter_op, filter_term);
+    std::tuple<std::string, std::string, std::vector<t_tscalar>> term) {
     m_filter.push_back(term);
 }
 
-} // namespace perspective
+std::vector<std::string>
+t_view_config::get_row_pivots() {
+    return m_row_pivots;
+}
+
+std::vector<std::string>
+t_view_config::get_column_pivots() {
+    return m_column_pivots;
+}
+
+std::vector<t_aggspec>
+t_view_config::get_aggregates(const t_schema& schema) {
+    std::vector<t_aggspec> aggspecs;
+
+    /**
+     * Provide aggregates for columns that are shown but NOT specified in `m_aggregates`.
+     */
+    for (const std::string& column : m_columns) {
+        if (m_aggregates.count(column) != 0) {
+            continue;
+        }
+
+        t_dtype dtype = schema.get_dtype(column);
+        std::vector<t_dep> dependencies{t_dep(column, DEPTYPE_COLUMN)};
+        t_aggtype agg_op
+            = t_aggtype::AGGTYPE_ANY; // use aggtype here since we are not parsing aggs
+
+        if (!m_column_only) {
+            agg_op = _get_default_aggregate(dtype);
+        }
+
+        aggspecs.push_back(t_aggspec(column, agg_op, dependencies));
+    }
+
+    // Construct aggregates from config object
+    // FIXME: this will NOT be in the right order unless we use `tsl::ordered_map`
+    for (auto const& iter : m_aggregates) {
+        auto column = iter.first;
+        auto aggregate = iter.second;
+        if (std::find(m_columns.begin(), m_columns.end(), column) == m_columns.end()) {
+            continue;
+        }
+
+        std::vector<t_dep> dependencies;
+        t_aggtype agg_type;
+
+        if (m_column_only) {
+            agg_type = t_aggtype::AGGTYPE_ANY;
+        } else {
+            agg_type = str_to_aggtype(aggregate);
+        }
+
+        dependencies.push_back(t_dep(column, DEPTYPE_COLUMN));
+
+        if (agg_type == AGGTYPE_FIRST || agg_type == AGGTYPE_LAST) {
+            if (dependencies.size() == 1) {
+                dependencies.push_back(t_dep("psp_pkey", DEPTYPE_COLUMN));
+            }
+            aggspecs.push_back(
+                t_aggspec(column, column, agg_type, dependencies, SORTTYPE_ASCENDING));
+        } else {
+            aggspecs.push_back(t_aggspec(column, agg_type, dependencies));
+        }
+    }
+
+    // construct aggspecs for hidden sorts
+    for (auto sort : m_sort) {
+        std::string column = sort[0];
+
+        bool is_hidden_column
+            = std::find(m_columns.begin(), m_columns.end(), column) == m_columns.end();
+
+        if (is_hidden_column) {
+            bool is_pivot = (std::find(m_row_pivots.begin(), m_row_pivots.end(), column)
+                                != m_row_pivots.end())
+                || (std::find(m_column_pivots.begin(), m_column_pivots.end(), column)
+                       != m_column_pivots.end());
+
+            std::vector<t_dep> dependencies{t_dep(column, DEPTYPE_COLUMN)};
+            t_aggtype agg_op;
+
+            // use the `any` agg for columns used as pivots/column_only views
+            if (is_pivot || m_row_pivots.size() == 0 || m_column_only) {
+                agg_op = t_aggtype::AGGTYPE_ANY;
+            } else {
+                t_dtype dtype = schema.get_dtype(column);
+                agg_op = _get_default_aggregate(dtype);
+            }
+
+            aggspecs.push_back(t_aggspec(column, agg_op, dependencies));
+        }
+    }
+
+    return aggspecs;
+}
+
+std::vector<std::string>
+t_view_config::get_columns() {
+    return m_columns;
+}
+
+std::vector<t_fterm>
+t_view_config::get_filter() {
+    std::vector<t_fterm> rval;
+
+    for (auto filter : m_filter) {
+        t_filter_op op = str_to_filter_op(std::get<1>(filter));
+        switch (op) {
+            case FILTER_OP_NOT_IN:
+            case FILTER_OP_IN: {
+                rval.push_back(
+                    t_fterm(std::get<0>(filter), op, mktscalar(0), std::get<2>(filter)));
+            } break;
+            default: {
+                t_tscalar filter_term = std::get<2>(filter)[0];
+                rval.push_back(
+                    t_fterm(std::get<0>(filter), op, filter_term, std::vector<t_tscalar>()));
+            }
+        }
+    }
+
+    return rval;
+}
+
+std::tuple<std::vector<t_sortspec>, std::vector<t_sortspec>>
+t_view_config::get_sort(const std::vector<std::string>& aggregate_names) {
+    std::vector<t_sortspec> sort;
+    std::vector<t_sortspec> column_sort;
+
+    for (auto s : m_sort) {
+        t_index agg_index = get_aggregate_index(aggregate_names, s[0]);
+        t_sorttype sort_type = str_to_sorttype(s[1]);
+
+        auto spec = t_sortspec(agg_index, sort_type);
+
+        bool is_column_sort = s[1].find("col") != std::string::npos;
+        if (is_column_sort) {
+            column_sort.push_back(spec);
+        } else {
+            sort.push_back(spec);
+        }
+    }
+
+    return std::make_tuple(sort, column_sort);
+}
+
+t_index
+t_view_config::get_aggregate_index(
+    const std::vector<std::string>& aggregate_names, const std::string& column) const {
+    auto it = std::find(aggregate_names.begin(), aggregate_names.end(), column);
+    if (it != aggregate_names.end()) {
+        return t_index(std::distance(aggregate_names.begin(), it));
+    }
+    return t_index();
+}
+
+std::vector<std::string>
+t_view_config::get_aggregate_names(const std::vector<t_aggspec>& aggs) const {
+    std::vector<std::string> names;
+    for (const t_aggspec& agg : aggs) {
+        names.push_back(agg.name());
+    }
+    return names;
+}
+
+t_filter_op
+t_view_config::get_filter_op() const {
+    return str_to_filter_op(m_filter_op);
+}
+
+bool
+t_view_config::is_column_only() const {
+    return m_column_only;
+}
+
+} // end namespace perspective
+
+namespace std {
+std::ostream&
+operator<<(std::ostream& os, const perspective::t_view_config& vc) {
+    os << "t_view_config"; // TODO: finish
+    return os;
+}
+} // end namespace std

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -26,23 +26,70 @@ t_view_config::t_view_config(std::vector<std::string> row_pivots,
     , m_column_only(column_only) {}
 
 void
+t_view_config::init(const t_schema& schema) {
+    m_aggspecs = make_aggspecs(schema);
+    m_fterm = make_fterm();
+
+    const auto sortspecs = make_sortspec();
+    m_sortspec = std::get<0>(sortspecs);
+    m_col_sortspec = std::get<1>(sortspecs);
+}
+
+void
 t_view_config::add_filter_term(
     std::tuple<std::string, std::string, std::vector<t_tscalar>> term) {
     m_filter.push_back(term);
 }
 
 std::vector<std::string>
-t_view_config::get_row_pivots() {
+t_view_config::get_row_pivots() const {
     return m_row_pivots;
 }
 
 std::vector<std::string>
-t_view_config::get_column_pivots() {
+t_view_config::get_column_pivots() const {
     return m_column_pivots;
 }
 
+// TODO: remove these eventually as after they point to non-abstracted structures
 std::vector<t_aggspec>
-t_view_config::get_aggregates(const t_schema& schema) {
+t_view_config::get_aggspecs() const {
+    return m_aggspecs;
+}
+
+std::vector<std::string>
+t_view_config::get_columns() const {
+    return m_columns;
+}
+
+std::vector<t_fterm>
+t_view_config::get_fterm() const {
+    return m_fterm;
+}
+
+std::vector<t_sortspec>
+t_view_config::get_sortspec() const {
+    return m_sortspec;
+}
+
+std::vector<t_sortspec>
+t_view_config::get_col_sortspec() const {
+    return m_col_sortspec;
+}
+
+t_filter_op
+t_view_config::get_filter_op() const {
+    return str_to_filter_op(m_filter_op);
+}
+
+bool
+t_view_config::is_column_only() const {
+    return m_column_only;
+}
+
+// PRIVATE
+std::vector<t_aggspec>
+t_view_config::make_aggspecs(const t_schema& schema) {
     std::vector<t_aggspec> aggspecs;
 
     /**
@@ -55,14 +102,15 @@ t_view_config::get_aggregates(const t_schema& schema) {
 
         t_dtype dtype = schema.get_dtype(column);
         std::vector<t_dep> dependencies{t_dep(column, DEPTYPE_COLUMN)};
-        t_aggtype agg_op
+        t_aggtype agg_type
             = t_aggtype::AGGTYPE_ANY; // use aggtype here since we are not parsing aggs
 
         if (!m_column_only) {
-            agg_op = _get_default_aggregate(dtype);
+            agg_type = _get_default_aggregate(dtype);
         }
 
-        aggspecs.push_back(t_aggspec(column, agg_op, dependencies));
+        aggspecs.push_back(t_aggspec(column, agg_type, dependencies));
+        m_aggregate_names.push_back(column);
     }
 
     // Construct aggregates from config object
@@ -74,7 +122,7 @@ t_view_config::get_aggregates(const t_schema& schema) {
             continue;
         }
 
-        std::vector<t_dep> dependencies;
+        std::vector<t_dep> dependencies{t_dep(column, DEPTYPE_COLUMN)};
         t_aggtype agg_type;
 
         if (m_column_only) {
@@ -83,17 +131,15 @@ t_view_config::get_aggregates(const t_schema& schema) {
             agg_type = str_to_aggtype(aggregate);
         }
 
-        dependencies.push_back(t_dep(column, DEPTYPE_COLUMN));
-
         if (agg_type == AGGTYPE_FIRST || agg_type == AGGTYPE_LAST) {
-            if (dependencies.size() == 1) {
-                dependencies.push_back(t_dep("psp_pkey", DEPTYPE_COLUMN));
-            }
+            dependencies.push_back(t_dep("psp_pkey", DEPTYPE_COLUMN));
             aggspecs.push_back(
                 t_aggspec(column, column, agg_type, dependencies, SORTTYPE_ASCENDING));
         } else {
             aggspecs.push_back(t_aggspec(column, agg_type, dependencies));
         }
+
+        m_aggregate_names.push_back(column); // FIXME: side effects should be avoided
     }
 
     // construct aggspecs for hidden sorts
@@ -110,30 +156,26 @@ t_view_config::get_aggregates(const t_schema& schema) {
                        != m_column_pivots.end());
 
             std::vector<t_dep> dependencies{t_dep(column, DEPTYPE_COLUMN)};
-            t_aggtype agg_op;
+            t_aggtype agg_type;
 
             // use the `any` agg for columns used as pivots/column_only views
             if (is_pivot || m_row_pivots.size() == 0 || m_column_only) {
-                agg_op = t_aggtype::AGGTYPE_ANY;
+                agg_type = t_aggtype::AGGTYPE_ANY;
             } else {
                 t_dtype dtype = schema.get_dtype(column);
-                agg_op = _get_default_aggregate(dtype);
+                agg_type = _get_default_aggregate(dtype);
             }
 
-            aggspecs.push_back(t_aggspec(column, agg_op, dependencies));
+            aggspecs.push_back(t_aggspec(column, agg_type, dependencies));
+            m_aggregate_names.push_back(column);
         }
     }
 
     return aggspecs;
 }
 
-std::vector<std::string>
-t_view_config::get_columns() {
-    return m_columns;
-}
-
 std::vector<t_fterm>
-t_view_config::get_filter() {
+t_view_config::make_fterm() {
     std::vector<t_fterm> rval;
 
     for (auto filter : m_filter) {
@@ -156,15 +198,15 @@ t_view_config::get_filter() {
 }
 
 std::tuple<std::vector<t_sortspec>, std::vector<t_sortspec>>
-t_view_config::get_sort(const std::vector<std::string>& aggregate_names) {
+t_view_config::make_sortspec() {
     std::vector<t_sortspec> sort;
     std::vector<t_sortspec> column_sort;
 
     for (auto s : m_sort) {
-        t_index agg_index = get_aggregate_index(aggregate_names, s[0]);
+        t_index agg_index = get_aggregate_index(s[0]);
         t_sorttype sort_type = str_to_sorttype(s[1]);
 
-        auto spec = t_sortspec(agg_index, sort_type);
+        auto spec = t_sortspec(s[0], agg_index, sort_type);
 
         bool is_column_sort = s[1].find("col") != std::string::npos;
         if (is_column_sort) {
@@ -178,32 +220,12 @@ t_view_config::get_sort(const std::vector<std::string>& aggregate_names) {
 }
 
 t_index
-t_view_config::get_aggregate_index(
-    const std::vector<std::string>& aggregate_names, const std::string& column) const {
-    auto it = std::find(aggregate_names.begin(), aggregate_names.end(), column);
-    if (it != aggregate_names.end()) {
-        return t_index(std::distance(aggregate_names.begin(), it));
+t_view_config::get_aggregate_index(const std::string& column) const {
+    auto it = std::find(m_aggregate_names.begin(), m_aggregate_names.end(), column);
+    if (it != m_aggregate_names.end()) {
+        return t_index(std::distance(m_aggregate_names.begin(), it));
     }
     return t_index();
-}
-
-std::vector<std::string>
-t_view_config::get_aggregate_names(const std::vector<t_aggspec>& aggs) const {
-    std::vector<std::string> names;
-    for (const t_aggspec& agg : aggs) {
-        names.push_back(agg.name());
-    }
-    return names;
-}
-
-t_filter_op
-t_view_config::get_filter_op() const {
-    return str_to_filter_op(m_filter_op);
-}
-
-bool
-t_view_config::is_column_only() const {
-    return m_column_only;
 }
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/aggspec.h
+++ b/cpp/perspective/src/include/perspective/aggspec.h
@@ -25,28 +25,11 @@ struct PERSPECTIVE_EXPORT t_col_name_type {
     t_dtype m_type;
 };
 
-struct PERSPECTIVE_EXPORT t_aggspec_recipe {
-    t_aggspec_recipe() {}
-    std::string m_name;
-    std::string m_disp_name;
-    t_aggtype m_agg;
-    std::vector<t_dep_recipe> m_dependencies;
-    std::vector<t_dep_recipe> m_odependencies;
-    t_sorttype m_sort_type;
-    t_uindex m_agg_one_idx;
-    t_uindex m_agg_two_idx;
-    double m_agg_one_weight;
-    double m_agg_two_weight;
-    t_invmode m_invmode;
-};
-
 class PERSPECTIVE_EXPORT t_aggspec {
 public:
     t_aggspec();
 
     ~t_aggspec();
-
-    t_aggspec(const t_aggspec_recipe& v);
 
     t_aggspec(
         const std::string& aggname, t_aggtype agg, const std::vector<t_dep>& dependencies);
@@ -64,6 +47,7 @@ public:
     t_aggspec(const std::string& aggname, const std::string& disp_aggname, t_aggtype agg,
         t_uindex agg_one_idx, t_uindex agg_two_idx, double agg_one_weight,
         double agg_two_weight);
+
     std::string name() const;
     t_tscalar name_scalar() const;
     std::string disp_name() const;
@@ -92,8 +76,6 @@ public:
     bool is_non_delta() const;
 
     std::string get_first_depname() const;
-
-    t_aggspec_recipe get_recipe() const;
 
 private:
     std::string m_name;

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -20,6 +20,7 @@
 #include <perspective/sym_table.h>
 #include <perspective/table.h>
 #include <perspective/view.h>
+#include <perspective/view_config.h>
 #include <random>
 #include <cmath>
 #include <sstream>
@@ -270,6 +271,10 @@ namespace binding {
      */
     template <typename T>
     std::shared_ptr<Table> make_computed_table(std::shared_ptr<Table> table, T computed);
+
+    template <typename T>
+    t_view_config make_view_config2(
+        const t_schema& schema, std::string separator, T date_parser, T config);
 
     /**
      * @brief Extracts and validates the config from the binding language,

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -283,7 +283,22 @@ namespace binding {
      */
     template <typename T>
     std::tuple<std::string, std::string, std::vector<t_tscalar>> make_filter_term(
-        const t_schema& schema, T date_parser, std::vector<T> filter);
+        t_dtype type, T date_parser, std::vector<T> filter);
+
+    /**
+     * @brief For date/datetime values, is the filter term a valid date?
+     *
+     * Otherwise, make sure the filter term is not null/undefined
+     *
+     * @tparam T
+     * @param type
+     * @param date_parser
+     * @param filter
+     * @return true
+     * @return false
+     */
+    template <typename T>
+    bool is_valid_filter(t_dtype type, T date_parser, T filter_term);
 
     /**
      * @brief Extracts and validates the config from the binding language,
@@ -327,7 +342,7 @@ namespace binding {
      */
     template <typename T>
     std::shared_ptr<View<t_ctx0>> make_view_zero(std::shared_ptr<Table> table, std::string name,
-        std::string separator, T config, T j_view_config, T date_parser);
+        std::string separator, T j_view_config, T date_parser);
 
     /**
      * @brief Create a new one-sided view.

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -94,7 +94,7 @@ namespace binding {
      */
     template <typename T>
     std::vector<t_sortspec> _get_sort(const std::vector<std::string>& columns,
-        bool is_column_sort, const std::vector<T>& sortbys);
+        const std::vector<T>& sortbys, bool is_column_sort);
 
     /**
      * @brief From the binding language, retrieve what we need to filter the dataset by.

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -59,23 +59,8 @@ namespace binding {
 
     /******************************************************************************
      *
-     * Data Loading
+     * Manipulate scalar values
      */
-
-    /**
-     * @brief For date/datetime values, is the filter term a valid date?
-     *
-     * Otherwise, make sure the filter term is not null/undefined
-     *
-     * @tparam T
-     * @param type
-     * @param date_parser
-     * @param filter
-     * @return true
-     * @return false
-     */
-    template <typename T>
-    bool is_valid_filter(t_dtype type, T date_parser, T filter_term);
 
     /**
      * @brief Converts a `t_scalar` to a value in the binding language.
@@ -240,6 +225,26 @@ namespace binding {
     template <typename T>
     std::shared_ptr<Table> make_computed_table(std::shared_ptr<Table> table, T computed);
 
+    /******************************************************************************
+     *
+     * View API
+     */
+
+    /**
+     * @brief For date/datetime values, is the filter term a valid date?
+     *
+     * Otherwise, make sure the filter term is not null/undefined.
+     *
+     * @tparam T
+     * @param type
+     * @param date_parser
+     * @param filter
+     * @return true
+     * @return false
+     */
+    template <typename T>
+    bool is_valid_filter(t_dtype type, T date_parser, T filter_term);
+
     /**
      * @brief Create a filter by parsing the filter term from the binding language.
      *
@@ -265,41 +270,13 @@ namespace binding {
     t_view_config make_view_config(const t_schema& schema, T date_parser, T config);
 
     /**
-     * @brief Create a new zero-sided view.
+     * @brief Create a new view.
      *
-     * Zero-sided views have no aggregates applied.
+     * Zero-sided views have no pivots or aggregates applied.
      *
-     * @tparam T
-     * @param table
-     * @param name
-     * @param separator
-     * @param config
-     * @param date_parser
-     * @return std::shared_ptr<View<t_ctx0>>
-     */
-    template <typename T>
-    std::shared_ptr<View<t_ctx0>> make_view_zero(std::shared_ptr<Table> table, std::string name,
-        std::string separator, T view_config, T date_parser);
-
-    /**
-     * @brief Create a new one-sided view.
+     * Views are backed by an underlying `t_ctx_*` object, represented by the `CTX_T` template.
      *
-     * One-sided views have one or more `row-pivots` applied,
-     *
-     * @tparam T
-     * @param table
-     * @param name
-     * @param separator
-     * @param config
-     * @param date_parser
-     * @return std::shared_ptr<View<t_ctx1>>
-     */
-    template <typename T>
-    std::shared_ptr<View<t_ctx1>> make_view_one(std::shared_ptr<Table> table, std::string name,
-        std::string separator, T view_config, T date_parser);
-
-    /**
-     * @brief Create a new two-sided view.
+     * One-sided views have one or more `row-pivots` applied.
      *
      * Two sided views have one or more `row-pivots` and `column-pivots` applied, or they have
      * one or more `column-pivots` applied without any row pivots, hence the term `column_only`.
@@ -310,38 +287,26 @@ namespace binding {
      * @param separator
      * @param config
      * @param date_parser
-     * @return std::shared_ptr<View<t_ctx2>>
+     * @return std::shared_ptr<View<CTX_T>>
      */
-    template <typename T>
-    std::shared_ptr<View<t_ctx2>> make_view_two(std::shared_ptr<Table> table, std::string name,
+    template <typename T, typename CTX_T>
+    std::shared_ptr<View<CTX_T>> make_view(std::shared_ptr<Table> table, std::string name,
         std::string separator, T view_config, T date_parser);
 
     /**
-     * @brief Create a new zero-sided context.
+     * @brief Create a new context of type `CTX_T`, which will be one of 3 types:
+     *
+     * `t_ctx0`, `t_ctx1`, `t_ctx2`.
+     *
      *
      * Contexts contain the underlying aggregates, sort specifications, filter terms, and other
      * metadata allowing for data manipulation and view creation.
      *
-     * @return std::shared_ptr<t_ctx0>
+     * @return std::shared_ptr<CTX_T>
      */
-    std::shared_ptr<t_ctx0> make_context_zero(std::shared_ptr<Table> table,
-        const t_schema& schema, const t_view_config& view_config, std::string name);
-
-    /**
-     * @brief Create a new one-sided context.
-     *
-     * @return std::shared_ptr<t_ctx1>
-     */
-    std::shared_ptr<t_ctx1> make_context_one(std::shared_ptr<Table> table,
-        const t_schema& schema, const t_view_config& view_config, std::string name);
-
-    /**
-     * @brief Create a new two-sided context.
-     *
-     * @return std::shared_ptr<t_ctx2>
-     */
-    std::shared_ptr<t_ctx2> make_context_two(std::shared_ptr<Table> table,
-        const t_schema& schema, const t_view_config& view_config, std::string name);
+    template <typename CTX_T>
+    std::shared_ptr<CTX_T> make_context(std::shared_ptr<Table> table, const t_schema& schema,
+        const t_view_config& view_config, std::string name);
 
     /**
      * @brief Get a slice of data for a single column, serialized to t_val.

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -272,9 +272,18 @@ namespace binding {
     template <typename T>
     std::shared_ptr<Table> make_computed_table(std::shared_ptr<Table> table, T computed);
 
+    /**
+     * @brief Create a filter by parsing the filter term from the binding language.
+     *
+     * @tparam T
+     * @param schema
+     * @param date_parser
+     * @param filter
+     * @return std::tuple<std::string, std::string, std::vector<t_tscalar>>
+     */
     template <typename T>
-    t_view_config make_view_config2(
-        const t_schema& schema, std::string separator, T date_parser, T config);
+    std::tuple<std::string, std::string, std::vector<t_tscalar>> make_filter_term(
+        const t_schema& schema, T date_parser, std::vector<T> filter);
 
     /**
      * @brief Extracts and validates the config from the binding language,
@@ -288,8 +297,20 @@ namespace binding {
      * @return t_config
      */
     template <typename T>
-    t_config make_view_config(
+    t_config make_config(
         const t_schema& schema, std::string separator, T date_parser, T config);
+
+    /**
+     * @brief Create a `t_view_config` object from the binding language's `view_config` object.
+     *
+     * @tparam T
+     * @param schema
+     * @param date_parser
+     * @param config
+     * @return t_config
+     */
+    template <typename T>
+    t_view_config make_view_config(const t_schema& schema, T date_parser, T config);
 
     /**
      * @brief Create a new zero-sided view.
@@ -306,7 +327,7 @@ namespace binding {
      */
     template <typename T>
     std::shared_ptr<View<t_ctx0>> make_view_zero(std::shared_ptr<Table> table, std::string name,
-        std::string separator, T config, T date_parser);
+        std::string separator, T config, T j_view_config, T date_parser);
 
     /**
      * @brief Create a new one-sided view.
@@ -323,7 +344,7 @@ namespace binding {
      */
     template <typename T>
     std::shared_ptr<View<t_ctx1>> make_view_one(std::shared_ptr<Table> table, std::string name,
-        std::string separator, T config, T date_parser);
+        std::string separator, T config, T j_view_config, T date_parser);
 
     /**
      * @brief Create a new two-sided view.
@@ -341,7 +362,7 @@ namespace binding {
      */
     template <typename T>
     std::shared_ptr<View<t_ctx2>> make_view_two(std::shared_ptr<Table> table, std::string name,
-        std::string separator, T config, T date_parser);
+        std::string separator, T config, T j_view_config, T date_parser);
 
     /**
      * @brief Create a new zero-sided context.

--- a/cpp/perspective/src/include/perspective/config.h
+++ b/cpp/perspective/src/include/perspective/config.h
@@ -66,8 +66,9 @@ public:
      * @param combiner
      * @param fterms
      */
-    t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_aggspec>& aggregates,
-        t_filter_op combiner, const std::vector<t_fterm>& fterms);
+    t_config(const std::vector<std::string>& row_pivots,
+        const std::vector<t_aggspec>& aggregates, t_filter_op combiner,
+        const std::vector<t_fterm>& fterms);
 
     /**
      * @brief Construct a new config for a `t_ctx2` object, which has 1 or more `row_pivot`s and
@@ -81,9 +82,10 @@ public:
      * @param fterms
      * @param column_only
      */
-    t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_pivot>& col_pivots,
-        const std::vector<t_aggspec>& aggregates, const t_totals totals, t_filter_op combiner,
-        const std::vector<t_fterm>& fterms, bool column_only);
+    t_config(const std::vector<std::string>& row_pivots,
+        const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates,
+        const t_totals totals, t_filter_op combiner, const std::vector<t_fterm>& fterms,
+        bool column_only);
 
     // Constructors used for C++ tests, not exposed to other parts of the engine
     t_config(const std::vector<std::string>& row_pivots,

--- a/cpp/perspective/src/include/perspective/config.h
+++ b/cpp/perspective/src/include/perspective/config.h
@@ -20,83 +20,89 @@
 
 namespace perspective {
 
-struct PERSPECTIVE_EXPORT t_config_recipe {
-    t_config_recipe();
-
-    std::vector<t_pivot_recipe> m_row_pivots;
-    std::vector<t_pivot_recipe> m_col_pivots;
-    std::vector<std::pair<std::string, std::string>> m_sortby;
-    std::vector<std::pair<std::string, std::string>> m_col_sortby;
-    std::vector<t_aggspec_recipe> m_aggregates;
-    std::vector<std::string> m_detail_columns;
-    t_totals m_totals;
-    t_filter_op m_combiner;
-    std::vector<t_fterm_recipe> m_fterms;
-    bool m_handle_nan_sort;
-    std::string m_parent_pkey_column;
-    std::string m_child_pkey_column;
-    std::string m_grouping_label_column;
-    t_fmode m_fmode;
-    std::vector<std::string> m_filter_exprs;
-};
-
+/**
+ * @brief `t_config` contains metadata for the `View` and `t_ctx*` structures, containing
+ * specifications for how pivots, columns, filters, and sorts should be constructed.
+ *
+ */
 class PERSPECTIVE_EXPORT t_config {
 public:
-    t_config();
-    t_config(const t_config_recipe& r);
-    t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_aggspec>& aggregates);
-    t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_pivot>& col_pivots,
-        const std::vector<t_aggspec>& aggregates,
-        const std::vector<std::string>& detail_columns, const t_totals totals,
-        const std::vector<std::string>& sort_pivot,
-        const std::vector<std::string>& sort_pivot_by, t_filter_op combiner,
-        const std::vector<t_fterm>& fterms, bool handle_nan_sort,
-        const std::string& parent_pkey_column, const std::string& child_pkey_column,
-        const std::string& grouping_label_column, t_fmode fmode,
-        const std::vector<std::string>& filter_exprs, const std::string& grand_agg_str);
-
-    // view config
+    /**
+     * @brief Construct a config for a `View` object. Pivots are passed in as vectors of
+     * strings, which are converted to `t_pivot` objects.
+     *
+     * @param row_pivots
+     * @param column_pivots
+     * @param aggregates
+     * @param sortspecs
+     * @param col_sortspecs
+     * @param combiner
+     * @param fterms
+     * @param col_names
+     * @param column_only
+     */
     t_config(const std::vector<std::string>& row_pivots,
         const std::vector<std::string>& column_pivots, const std::vector<t_aggspec>& aggregates,
         const std::vector<t_sortspec>& sortspecs, const std::vector<t_sortspec>& col_sortspecs,
         t_filter_op combiner, const std::vector<t_fterm>& fterms,
         const std::vector<std::string>& col_names, bool column_only);
 
-    // grouped_pkeys
-    t_config(const std::vector<std::string>& row_pivots,
-        const std::vector<std::string>& detail_columns, t_filter_op combiner,
-        const std::vector<t_fterm>& fterms, const std::string& parent_pkey_column,
-        const std::string& child_pkey_column, const std::string& grouping_label_column);
+    /**
+     * @brief Construct a new config for a `t_ctx0` object.
+     *
+     * @param detail_columns the columns to be displayed in the context
+     * @param combiner
+     * @param fterms specifications for filtering down the context
+     */
+    t_config(const std::vector<std::string>& detail_columns, t_filter_op combiner,
+        const std::vector<t_fterm>& fterms);
 
-    // ctx2
-    t_config(const std::vector<std::string>& row_pivots,
-        const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates);
+    /**
+     * @brief Construct a new config for a `t_ctx1` object, which has 1 or more `row_pivot`s
+     * applied.
+     *
+     * @param row_pivots
+     * @param aggregates
+     * @param combiner
+     * @param fterms
+     */
+    t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_aggspec>& aggregates,
+        t_filter_op combiner, const std::vector<t_fterm>& fterms);
 
+    /**
+     * @brief Construct a new config for a `t_ctx2` object, which has 1 or more `row_pivot`s and
+     * 1 or more `col_pivot`s applied.
+     *
+     * @param row_pivots
+     * @param col_pivots
+     * @param aggregates
+     * @param totals
+     * @param combiner
+     * @param fterms
+     * @param column_only
+     */
     t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_pivot>& col_pivots,
         const std::vector<t_aggspec>& aggregates, const t_totals totals, t_filter_op combiner,
         const std::vector<t_fterm>& fterms, bool column_only);
+
+    // Constructors used for C++ tests, not exposed to other parts of the engine
+    t_config(const std::vector<std::string>& row_pivots,
+        const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates);
 
     t_config(const std::vector<std::string>& row_pivots,
         const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates,
         const t_totals totals, t_filter_op combiner, const std::vector<t_fterm>& fterms);
 
-    // t_ctx1
+    t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_aggspec>& aggregates);
+
     t_config(
         const std::vector<std::string>& row_pivots, const std::vector<t_aggspec>& aggregates);
 
     t_config(const std::vector<std::string>& row_pivots, const t_aggspec& agg);
 
-    t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_aggspec>& aggregates,
-        t_filter_op combiner, const std::vector<t_fterm>& fterms);
-
-    t_config(const std::vector<std::string>& row_pivots,
-        const std::vector<t_aggspec>& aggregates, t_filter_op combiner,
-        const std::vector<t_fterm>& fterms);
-
-    // t_ctx0
     t_config(const std::vector<std::string>& detail_columns);
-    t_config(const std::vector<std::string>& detail_columns, t_filter_op combiner,
-        const std::vector<t_fterm>& fterms);
+
+    t_config();
 
     void setup(const std::vector<std::string>& detail_columns,
         const std::vector<std::string>& sort_pivot,
@@ -149,8 +155,6 @@ public:
     std::string get_child_pkey_column() const;
 
     const std::string& get_grouping_label_column() const;
-
-    t_config_recipe get_recipe() const;
 
     std::string unity_get_column_name(t_uindex idx) const;
     std::string unity_get_column_display_name(t_uindex idx) const;

--- a/cpp/perspective/src/include/perspective/emscripten.h
+++ b/cpp/perspective/src/include/perspective/emscripten.h
@@ -22,6 +22,24 @@ typedef emscripten::val t_val;
 
 namespace perspective {
 namespace binding {
+    /**
+     * @brief Helper function for creating `std::vector`s for use in Javascript.
+     *
+     * @tparam T
+     * @return std::vector<T>
+     */
+    template <typename T>
+    std::vector<T> make_vector();
+
+    /**
+     * @brief Helper function for creating `std::vector`s for use in Javascript.
+     *
+     * @tparam K
+     * @tparam V
+     * @return std::map<K, V>
+     */
+    template <typename K, typename V>
+    std::map<K, V> make_map();
 
     /**
      * @brief namespace `js_typed_array` contains utility bindings that initialize typed arrays

--- a/cpp/perspective/src/include/perspective/emscripten.h
+++ b/cpp/perspective/src/include/perspective/emscripten.h
@@ -32,16 +32,6 @@ namespace binding {
     std::vector<T> make_vector();
 
     /**
-     * @brief Helper function for creating `std::vector`s for use in Javascript.
-     *
-     * @tparam K
-     * @tparam V
-     * @return std::map<K, V>
-     */
-    template <typename K, typename V>
-    std::map<K, V> make_map();
-
-    /**
      * @brief namespace `js_typed_array` contains utility bindings that initialize typed arrays
      * using Emscripten.
      *

--- a/cpp/perspective/src/include/perspective/filter.h
+++ b/cpp/perspective/src/include/perspective/filter.h
@@ -125,19 +125,8 @@ struct t_operator_contains<t_uindex, DTYPE_STR> {
     }
 };
 
-struct PERSPECTIVE_EXPORT t_fterm_recipe {
-    t_fterm_recipe() {}
-
-    std::string m_colname;
-    t_filter_op m_op;
-    t_tscalar m_threshold;
-    std::vector<t_tscalar> m_bag;
-};
-
 struct PERSPECTIVE_EXPORT t_fterm {
     t_fterm();
-
-    t_fterm(const t_fterm_recipe& v);
 
     t_fterm(const std::string& colname, t_filter_op op, t_tscalar threshold,
         const std::vector<t_tscalar>& bag);
@@ -164,7 +153,6 @@ struct PERSPECTIVE_EXPORT t_fterm {
     std::string get_expr() const;
 
     void coerce_numeric(t_dtype dtype);
-    t_fterm_recipe get_recipe() const;
 
     std::string m_colname;
     t_filter_op m_op;

--- a/cpp/perspective/src/include/perspective/slice.h
+++ b/cpp/perspective/src/include/perspective/slice.h
@@ -30,7 +30,6 @@ public:
     const std::vector<t_data>& column_data() const;
     const std::vector<t_uindex>& row_depth() const;
     const std::vector<t_uindex>& column_depth() const;
-    const t_config_recipe& config_recipe() const;
     const std::vector<t_uindex>& is_row_expanded() const;
     const std::vector<t_uindex>& is_column_expanded() const;
 
@@ -57,7 +56,6 @@ private:
     std::vector<t_uindex> m_is_root;
     std::vector<t_uindex> m_is_row_expanded;
     std::vector<t_uindex> m_is_column_expanded;
-    t_config_recipe m_config_recipe;
     std::vector<t_uindex> m_row_depth;
     std::vector<t_uindex> m_column_depth;
 };

--- a/cpp/perspective/src/include/perspective/sort_specification.h
+++ b/cpp/perspective/src/include/perspective/sort_specification.h
@@ -20,15 +20,16 @@ enum t_sortspec_type { SORTSPEC_TYPE_IDX, SORTSPEC_TYPE_COLNAME, SORTSPEC_TYPE_P
 
 struct PERSPECTIVE_EXPORT t_sortspec {
     t_sortspec();
+    t_sortspec(const std::string& column_name, t_index agg_index, t_sorttype sort_type);
     t_sortspec(t_index agg_index, t_sorttype sort_type);
     t_sortspec(const std::vector<t_tscalar>& path, t_index agg_index, t_sorttype sort_type);
 
     bool operator==(const t_sortspec& s2) const;
     bool operator!=(const t_sortspec& s2) const;
 
+    std::string m_colname;
     t_index m_agg_index;
     t_sorttype m_sort_type;
-    bool m_colname;
     t_sortspec_type m_sortspec_type;
     std::vector<t_tscalar> m_path;
 };

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -12,12 +12,12 @@
 #include <perspective/exports.h>
 #include <perspective/base.h>
 #include <perspective/raw_types.h>
-#include <perspective/config.h>
 #include <perspective/context_zero.h>
 #include <perspective/context_one.h>
 #include <perspective/context_two.h>
 #include <perspective/data_slice.h>
 #include <perspective/table.h>
+#include <perspective/view_config.h>
 #include <cstddef>
 #include <memory>
 #include <map>
@@ -28,9 +28,15 @@ template <typename CTX_T>
 class PERSPECTIVE_EXPORT View {
 public:
     View(std::shared_ptr<Table> table, std::shared_ptr<CTX_T> ctx, std::string name,
-        std::string separator, t_config config);
-
+        std::string separator, t_view_config view_config);
     ~View();
+
+    /**
+     * @brief The `t_view_config` object that created this `View`.
+     *
+     * @return t_view_config
+     */
+    t_view_config get_view_config() const;
 
     /**
      * @brief The number of pivoted sides of this View.
@@ -179,6 +185,6 @@ private:
     t_uindex m_row_offset;
     t_uindex m_col_offset;
 
-    t_config m_config;
+    t_view_config m_view_config;
 };
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -1,0 +1,35 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+#pragma once
+
+#include <perspective/first.h>
+#include <perspective/config.h>
+#include <perspective/raw_types.h>
+#include <perspective/scalar.h>
+#include <boost/optional.hpp>
+#include <tuple>
+
+namespace perspective {
+struct t_view_config {
+    t_view_config(std::vector<std::string> row_pivots, std::vector<std::string> column_pivots,
+        std::vector<std::string> columns, std::map<std::string, std::string> aggregates,
+        std::vector<std::tuple<std::string, std::string, t_tscalar>> filter,
+        std::vector<std::vector<std::string>> sort, bool column_only);
+
+    void add_filter_term(std::string col_name, std::string filter_op, t_tscalar filter_term);
+
+    std::vector<std::string> m_row_pivots;
+    std::vector<std::string> m_column_pivots;
+    std::vector<std::string> m_columns;
+    std::map<std::string, std::string> m_aggregates;
+    std::vector<std::tuple<std::string, std::string, t_tscalar>> m_filter;
+    std::vector<std::vector<std::string>> m_sort;
+    bool m_column_only;
+};
+} // namespace perspective

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -41,6 +41,12 @@ public:
         std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> filter,
         std::vector<std::vector<std::string>> sort, std::string filter_op, bool column_only);
 
+    /**
+     * @brief Given a `t_schema` specifying the underlying `Table`'s columns, construct the
+     * abstractions necessary for the core engine.
+     *
+     * @param schema
+     */
     void init(const t_schema& schema);
 
     /**
@@ -81,6 +87,8 @@ public:
     std::int32_t get_column_pivot_depth() const;
 
 private:
+    bool m_init;
+
     /**
      * @brief Fill the `m_aggspecs` vector with `t_aggspec` objects which define the view's
      * aggregate settings.
@@ -119,6 +127,13 @@ private:
      */
     void fill_sortspec();
 
+    /**
+     * @brief Given a column name, find its position in `m_aggregate_names`. Used for
+     * determining sort specifications.
+     *
+     * @param column
+     * @return t_index
+     */
     t_index get_aggregate_index(const std::string& column) const;
 
     // containers for primitive data that does not need transformation into abstractions
@@ -171,7 +186,3 @@ private:
     bool m_column_only;
 };
 } // end namespace perspective
-
-namespace std {
-std::ostream& operator<<(std::ostream& os, const perspective::t_view_config& vc);
-} // end namespace std

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <perspective/first.h>
+#include <perspective/base.h>
 #include <perspective/config.h>
 #include <perspective/raw_types.h>
 #include <perspective/scalar.h>
@@ -16,20 +17,101 @@
 #include <tuple>
 
 namespace perspective {
-struct t_view_config {
+
+/**
+ * @brief The `t_view_config` API provides a unified view configuration object, which specifies
+ * how the `View` transforms the underlying `Table`. By storing configuration values in native
+ * C++ types, we allow easy integration with binding languages.
+ *
+ */
+class t_view_config {
+public:
+    /**
+     * @brief Construct a `t_view_config` object.
+     *
+     * @param row_pivots
+     * @param column_pivots
+     * @param aggregates
+     * @param columns
+     * @param filter
+     * @param sort
+     */
     t_view_config(std::vector<std::string> row_pivots, std::vector<std::string> column_pivots,
-        std::vector<std::string> columns, std::map<std::string, std::string> aggregates,
-        std::vector<std::tuple<std::string, std::string, t_tscalar>> filter,
-        std::vector<std::vector<std::string>> sort, bool column_only);
+        std::map<std::string, std::string> aggregates, std::vector<std::string> columns,
+        std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> filter,
+        std::vector<std::vector<std::string>> sort, std::string filter_op, bool column_only);
 
-    void add_filter_term(std::string col_name, std::string filter_op, t_tscalar filter_term);
+    /**
+     * @brief Add filter terms manually, as the filter term must be calculated from the value
+     * passed through the binding.
+     *
+     * @param term
+     */
+    void add_filter_term(std::tuple<std::string, std::string, std::vector<t_tscalar>> term);
 
+    std::vector<std::string> get_row_pivots();
+
+    std::vector<std::string> get_column_pivots();
+
+    /**
+     * @brief Construct a vector of `t_aggspec` for use in the engine, where configs stored as
+     * built-in types are not yet supported.
+     *
+     * @param schema
+     * @return std::vector<t_aggspec>
+     */
+    std::vector<t_aggspec> get_aggregates(const t_schema& schema); // FIXME: reduce deps
+
+    std::vector<std::string> get_columns();
+
+    std::vector<t_fterm> get_filter();
+
+    /**
+     * @brief Return how the `View` should be sorted. The first member of the tuple is the
+     * regular sort specification, and the second member is the column sort specification. //
+     * FIXME: cleanup
+     *
+     * FIXME: what's the point of column sorts
+     *
+     * @param aggregate_names `t_sortspec` requires the aggregate index
+     * @return std::tuple<std::vector<t_sortspec>, std::vector<t_sortspec>>
+     */
+    std::tuple<std::vector<t_sortspec>, std::vector<t_sortspec>> get_sort(
+        const std::vector<std::string>& aggregate_names);
+
+    // FIXME: we should not need this
+    t_index get_aggregate_index(
+        const std::vector<std::string>& agg_names, const std::string& column) const;
+
+    // FIXME: we should not need this
+    std::vector<std::string> get_aggregate_names(const std::vector<t_aggspec>& aggs) const;
+
+    t_filter_op get_filter_op() const;
+    bool is_column_only() const;
+
+private:
     std::vector<std::string> m_row_pivots;
     std::vector<std::string> m_column_pivots;
-    std::vector<std::string> m_columns;
     std::map<std::string, std::string> m_aggregates;
-    std::vector<std::tuple<std::string, std::string, t_tscalar>> m_filter;
+    std::vector<std::string> m_columns;
+    std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> m_filter;
     std::vector<std::vector<std::string>> m_sort;
+
+    /**
+     * @brief If a `filter_op` is specified - TODO: finish
+     *
+     */
+    std::string m_filter_op;
+
+    /**
+     * @brief should the `View` be `column_only`, that is, pivoted by 1+ columns without a row
+     * pivot?
+     *
+     */
     bool m_column_only;
 };
-} // namespace perspective
+} // end namespace perspective
+
+namespace std {
+std::ostream& operator<<(std::ostream& os, const perspective::t_view_config& vc);
+} // end namespace std

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -41,6 +41,8 @@ public:
         std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> filter,
         std::vector<std::vector<std::string>> sort, std::string filter_op, bool column_only);
 
+    void init(const t_schema& schema);
+
     /**
      * @brief Add filter terms manually, as the filter term must be calculated from the value
      * passed through the binding.
@@ -49,47 +51,32 @@ public:
      */
     void add_filter_term(std::tuple<std::string, std::string, std::vector<t_tscalar>> term);
 
-    std::vector<std::string> get_row_pivots();
+    std::vector<std::string> get_row_pivots() const;
 
-    std::vector<std::string> get_column_pivots();
+    std::vector<std::string> get_column_pivots() const;
 
-    /**
-     * @brief Construct a vector of `t_aggspec` for use in the engine, where configs stored as
-     * built-in types are not yet supported.
-     *
-     * @param schema
-     * @return std::vector<t_aggspec>
-     */
-    std::vector<t_aggspec> get_aggregates(const t_schema& schema); // FIXME: reduce deps
+    std::vector<t_aggspec> get_aggspecs() const;
 
-    std::vector<std::string> get_columns();
+    std::vector<std::string> get_columns() const;
 
-    std::vector<t_fterm> get_filter();
+    std::vector<t_fterm> get_fterm() const;
 
-    /**
-     * @brief Return how the `View` should be sorted. The first member of the tuple is the
-     * regular sort specification, and the second member is the column sort specification. //
-     * FIXME: cleanup
-     *
-     * FIXME: what's the point of column sorts
-     *
-     * @param aggregate_names `t_sortspec` requires the aggregate index
-     * @return std::tuple<std::vector<t_sortspec>, std::vector<t_sortspec>>
-     */
-    std::tuple<std::vector<t_sortspec>, std::vector<t_sortspec>> get_sort(
-        const std::vector<std::string>& aggregate_names);
+    std::vector<t_sortspec> get_sortspec() const;
 
-    // FIXME: we should not need this
-    t_index get_aggregate_index(
-        const std::vector<std::string>& agg_names, const std::string& column) const;
-
-    // FIXME: we should not need this
-    std::vector<std::string> get_aggregate_names(const std::vector<t_aggspec>& aggs) const;
+    std::vector<t_sortspec> get_col_sortspec() const;
 
     t_filter_op get_filter_op() const;
     bool is_column_only() const;
 
 private:
+    std::vector<t_aggspec> make_aggspecs(const t_schema& schema);
+
+    std::vector<t_fterm> make_fterm();
+
+    std::tuple<std::vector<t_sortspec>, std::vector<t_sortspec>> make_sortspec();
+
+    t_index get_aggregate_index(const std::string& column) const;
+
     std::vector<std::string> m_row_pivots;
     std::vector<std::string> m_column_pivots;
     std::map<std::string, std::string> m_aggregates;
@@ -98,17 +85,25 @@ private:
     std::vector<std::vector<std::string>> m_sort;
 
     /**
-     * @brief If a `filter_op` is specified - TODO: finish
+     * @brief The ordered list of aggregate columns:
+     *
+     * 1. all columns marked as "shown" by the user in `m_columns`
+     * 2. all specified aggregates from `m_aggregates`
+     * 3. all "hidden sorts", i.e. columns to sort by that do not appear in `m_columns`
      *
      */
+    std::vector<std::string> m_aggregate_names;
     std::string m_filter_op;
-
-    /**
-     * @brief should the `View` be `column_only`, that is, pivoted by 1+ columns without a row
-     * pivot?
-     *
-     */
     bool m_column_only;
+
+    // store abstractions, for now
+    std::vector<t_aggspec> m_aggspecs;
+
+    std::vector<t_fterm> m_fterm;
+
+    std::vector<t_sortspec> m_sortspec;
+
+    std::vector<t_sortspec> m_col_sortspec;
 };
 } // end namespace perspective
 

--- a/cpp/perspective/test/cpp/simple.cpp
+++ b/cpp/perspective/test/cpp/simple.cpp
@@ -2250,7 +2250,7 @@ TEST(GNODE_TEST, get_registered_contexts)
     std::vector<t_tscalar> expected_ctx0_pkeys{1_ts};
     EXPECT_EQ(ctx0_pkeys, expected_ctx0_pkeys);
 
-    ctx0->sort_by(std::vector<t_sortspec>{{0, SORTTYPE_DESCENDING}});
+    ctx0->sort_by(std::vector<t_sortspec>{{"i", 0, SORTTYPE_DESCENDING}});
     EXPECT_EQ(ctx0->get_cell_data({{0, 0}}), std::vector<t_tscalar>{"b"_ts});
 
     auto trees = gn->get_trees();

--- a/packages/perspective/src/js/emscripten.js
+++ b/packages/perspective/src/js/emscripten.js
@@ -51,18 +51,3 @@ export const fill_vector = function(vector, arr) {
     }
     return vector;
 };
-
-/**
- * Given a C++ map created in Emscripten, fill it with data. Assume that data types are already validated.
- *
- * @param {*} map the `std::map` to be filled
- * @param {Object} obj the `Object` from which to draw data
- *
- * @private
- */
-export const fill_map = function(map, obj) {
-    for (const key in obj) {
-        map[key] = obj[key];
-    }
-    return map;
-};

--- a/packages/perspective/src/js/emscripten.js
+++ b/packages/perspective/src/js/emscripten.js
@@ -35,3 +35,34 @@ export const extract_map = function(map) {
     keys.delete();
     return extracted;
 };
+
+/**
+ * Given a C++ vector constructed in Emscripten, fill it with data. Assume that data types are already validated,
+ * thus Emscripten will throw an error if the vector is filled with the wrong type of data.
+ *
+ * @param {*} vector the `std::vector` to be filled
+ * @param {Array} arr the `Array` from which to draw data
+ *
+ * @private
+ */
+export const fill_vector = function(vector, arr) {
+    for (const elem of arr) {
+        vector.push_back(elem);
+    }
+    return vector;
+};
+
+/**
+ * Given a C++ map created in Emscripten, fill it with data. Assume that data types are already validated.
+ *
+ * @param {*} map the `std::map` to be filled
+ * @param {Object} obj the `Object` from which to draw data
+ *
+ * @private
+ */
+export const fill_map = function(map, obj) {
+    for (const key in obj) {
+        map[key] = obj[key];
+    }
+    return map;
+};

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -262,9 +262,9 @@ export default function(Module) {
         if (sides === 0) {
             this._View = __MODULE__.make_view_zero(table._Table, name, defaults.COLUMN_SEPARATOR_STRING, this.view_config, this.date_parser);
         } else if (sides === 1) {
-            this._View = __MODULE__.make_view_one(table._Table, name, defaults.COLUMN_SEPARATOR_STRING, this.config, this.view_config, this.date_parser);
+            this._View = __MODULE__.make_view_one(table._Table, name, defaults.COLUMN_SEPARATOR_STRING, this.view_config, this.date_parser);
         } else if (sides === 2) {
-            this._View = __MODULE__.make_view_two(table._Table, name, defaults.COLUMN_SEPARATOR_STRING, this.config, this.view_config, this.date_parser);
+            this._View = __MODULE__.make_view_two(table._Table, name, defaults.COLUMN_SEPARATOR_STRING, this.view_config, this.date_parser);
         }
 
         this.table = table;
@@ -846,15 +846,16 @@ export default function(Module) {
     };
 
     /**
-     * A view config object is a set of options that transforms the underlying {@link module:perspective~table}.
-     * The user passes in an `Object` containing configuration options, and the `view_config` transforms it into a
+     * A view config is a set of options that configures the underlying {@link module:perspective~view}, specifying
+     * its pivots, columns to show, aggregates, filters, and sorts.
+     *
+     * The view config receives an `Object` containing configuration options, and the `view_config` transforms it into a
      * canonical format for interfacing with the core engine.
      *
      * <strong>Note</strong> This constructor is not public - view config objects should be created using standard
-     * Javascript `Object`s in the {@link module:perspective~table#view} method. Configuration fields are documented in
-     * the {@link module:perspective~table#View} method.
+     * Javascript `Object`s in the {@link module:perspective~table#view} method, which has an `options` parameter.
      *
-     * @param {Object} config the configuration object passed by the user to the {@link module:perspective~table#view} method.
+     * @param {Object} config the configuration `Object` passed by the user to the {@link module:perspective~table#view} method.
      *
      * @class
      * @hideconstructor
@@ -867,10 +868,15 @@ export default function(Module) {
         this.filter = config.filter || [];
         this.sort = config.sort || [];
         this.filter_op = config.filter_op || "and";
+        this.row_pivot_depth = config.row_pivot_depth;
+        this.column_pivot_depth = config.column_pivot_depth;
     }
 
     /**
-     * Transform configuration items into `std::vector` and `std::map` objects for interface with C++.
+     * Transform configuration items into `std::vector` objects for interface with C++.
+     *
+     * `this.aggregates` is not transformed into a C++ map, as the use of `ordered_map` in the engine
+     * makes binding more difficult.
      */
     view_config.prototype.get_row_pivots = function() {
         let vector = __MODULE__.make_string_vector();

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -10,7 +10,7 @@
 import * as defaults from "./config/constants.js";
 import {DataAccessor} from "./data_accessor";
 import {DateParser} from "./data_accessor/date_parser.js";
-import {extract_map, fill_vector, fill_map} from "./emscripten.js";
+import {extract_map, fill_vector} from "./emscripten.js";
 import {bindall, get_column_type} from "./utils.js";
 import {Server} from "./api/server.js";
 
@@ -260,7 +260,7 @@ export default function(Module) {
         this.view_config = view_config || new view_config();
 
         if (sides === 0) {
-            this._View = __MODULE__.make_view_zero(table._Table, name, defaults.COLUMN_SEPARATOR_STRING, this.config, this.view_config, this.date_parser);
+            this._View = __MODULE__.make_view_zero(table._Table, name, defaults.COLUMN_SEPARATOR_STRING, this.view_config, this.date_parser);
         } else if (sides === 1) {
             this._View = __MODULE__.make_view_one(table._Table, name, defaults.COLUMN_SEPARATOR_STRING, this.config, this.view_config, this.date_parser);
         } else if (sides === 2) {
@@ -880,11 +880,6 @@ export default function(Module) {
     view_config.prototype.get_column_pivots = function() {
         let vector = __MODULE__.make_string_vector();
         return fill_vector(vector, this.column_pivots);
-    };
-
-    view_config.prototype.get_aggregates = function() {
-        let map = __MODULE__.make_string_map();
-        return fill_map(map, this.aggregates);
     };
 
     view_config.prototype.get_columns = function() {

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -110,7 +110,7 @@ export default function(Module) {
 
         const pool = _Table.get_pool();
         const table_id = _Table.get_id();
-        console.log(table_id);
+
         if (op == __MODULE__.t_op.OP_UPDATE || op == __MODULE__.t_op.OP_DELETE) {
             _set_process(pool, table_id);
         } else {

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -341,7 +341,7 @@ module.exports = perspective => {
                 table.delete();
             });
 
-            it("x > null", async function() {
+            it("x > null should be an invalid filter", async function() {
                 var table = perspective.table({x: "float", y: "integer"});
                 const dataSet = [{x: 3.5, y: 1}, {x: 2.5, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4.5, y: 2}, {x: null, y: 2}];
                 table.update(dataSet);


### PR DESCRIPTION
This PR builds on top of the `Table` class in C++, defining `t_view_config`: a unified declaration of what a view configuration object looks like, codified in C++ and then implemented in the binding language. 

By storing configuration variables (pivots, aggregates, filters, sorts, etc.) as primitive values, we can implement `view_config` in binding languages without having to construct abstractions that are only used in the engine (such as `t_aggspec` and `t_fterm`). This also encapsulates the primitive-to-abstraction conversion code inside `t_view_config`, reducing the amount of binding code required to construct a view.

### C++ changes

- Adds `t_view_config` and associated logic
- Use `t_view_config` for all `View` objects, instead of `t_config`
- refactors `make_view` and `make_context` into templated functions, as their signatures are now much less complex
-  Add `[tsl::ordered_map](https://github.com/Tessil/ordered-map)` in order to maintain aggregate ordering in the view config
- Remove unused `t_config` constructors, reorganize the `t_config` header, remove `t_aggspec_recipe`

### JS changes

- Add `view_config` definition in `perspective.js`
- Add utilities to create vectors from Emscripten