### PR TITLE
Fix #616: perspective-jupyterlab versioning

### DIFF
--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -26,7 +26,8 @@
         "test": "npm-run-all test:run",
         "test:run": "echo done",
         "build": "webpack --color --config src/config/plugin.config.js",
-        "clean": "rimraf dist"
+        "clean": "rimraf dist",
+        "version": "yarn build"
     },
     "dependencies": {
         "@finos/perspective-phosphor": "^0.3.6",


### PR DESCRIPTION
Adds a build in the `version` script, which `lerna publish` will run _after_ updating version numbers but _before_ pushing to the remote. This should update the disted Jupyterlab with the right version of Perspective. 

See comment on [Lerna issue #1275](https://github.com/lerna/lerna/issues/1275#issuecomment-367057638) for explanation of version lifecycle hook as it relates to Lerna.