### PR TITLE
Fix performance regression

### DIFF
--- a/packages/perspective/src/js/config/index.js
+++ b/packages/perspective/src/js/config/index.js
@@ -93,5 +93,5 @@ module.exports.get_config = function get_config() {
     if (!global.__PERSPECTIVE_CONFIG__) {
         global.__PERSPECTIVE_CONFIG__ = mergeDeep(DEFAULT_CONFIG, typeof window === "undefined" ? get_config_file() : global.__TEMPLATE_CONFIG__ || {});
     }
-    return JSON.parse(JSON.stringify(global.__PERSPECTIVE_CONFIG__));
+    return global.__PERSPECTIVE_CONFIG__;
 };


### PR DESCRIPTION
Removed extraneous object copy in perspective/config, which is called in tight loops and is expected to be memoized.