### PR TITLE
`perspective-click` fix

### DIFF
--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -57,11 +57,11 @@ function setPSP(payload) {
     } else {
         this.grid.sbVScroller.index = 0;
         this.grid.sbHScroller.index = 0;
-
         this.grid.setData({
             data: payload.rows,
             schema: new_schema
         });
+        this.grid.allowEvents(true);
     }
     this._memoized_schema = new_schema;
     this._memoized_pivots = payload.rowPivots;

--- a/packages/perspective-viewer-hypergrid/test/js/hypergrid.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/hypergrid.spec.js
@@ -9,23 +9,24 @@
 
 const utils = require("@finos/perspective-viewer/test/js/utils.js");
 const path = require("path");
-
-const click_details = async (page, x = 310) => {
-    const viewer = await page.$("perspective-viewer");
-
-    const click_event = page.evaluate(element => {
-        return new Promise(resolve => {
-            element.addEventListener("perspective-click", e => {
-                resolve(e.detail);
-            });
-        });
-    }, viewer);
-
-    await page.mouse.click(x, 300);
-    return await click_event;
-};
+const {click_details, capture_update} = require("./utils.js");
 
 utils.with_server({}, () => {
+    describe.page(
+        "empty.html",
+        () => {
+            test.capture("perspective-click is fired when an empty dataset is loaded first", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.waitFor("perspective-viewer:not([updating])");
+                await capture_update(page, viewer, () => page.evaluate(element => element.update([{x: 3000}, {x: 3000}, {x: 3000}, {x: 3000}, {x: 3000}, {x: 3000}]), viewer));
+                await page.waitFor("perspective-viewer:not([updating])");
+                const detail = await click_details(page, 30, 60);
+                expect(detail.row).toEqual({x: 3000});
+            });
+        },
+        {root: path.join(__dirname, "..", "..")}
+    );
+
     describe.page(
         "hypergrid.html",
         () => {

--- a/packages/perspective-viewer-hypergrid/test/js/regressions.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/regressions.spec.js
@@ -9,21 +9,7 @@
 
 const utils = require("@finos/perspective-viewer/test/js/utils.js");
 const path = require("path");
-
-async function capture_update(page, viewer, body) {
-    await page.evaluate(element => {
-        element.addEventListener("perspective-view-update", () => {
-            element.setAttribute("test-updated", true);
-        });
-    }, viewer);
-    await body();
-    try {
-        await page.waitFor(element => element.hasAttribute("test-updated"), {timeout: 3000}, viewer);
-    } catch (e) {
-        console.error("Missing 'test-updated' attribute");
-    }
-    await page.evaluate(element => element.removeAttribute("test-updated"), viewer);
-}
+const {capture_update} = require("./utils.js");
 
 utils.with_server({}, () => {
     describe.page(

--- a/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
@@ -11,19 +11,7 @@ const utils = require("@finos/perspective-viewer/test/js/utils.js");
 const path = require("path");
 
 const simple_tests = require("@finos/perspective-viewer/test/js/simple_tests.js");
-
-async function set_lazy(page) {
-    const viewer = await page.$("perspective-viewer");
-    await page.evaluate(element => {
-        element.hypergrid.properties.repaintIntervalRate = 1;
-        if (!element.hypergrid._lazy_load) {
-            Object.defineProperty(element.hypergrid, "_lazy_load", {
-                set: () => {},
-                get: () => true
-            });
-        }
-    }, viewer);
-}
+const {set_lazy} = require("./utils.js");
 
 utils.with_server({}, () => {
     describe.page(

--- a/packages/perspective-viewer-hypergrid/test/js/utils.js
+++ b/packages/perspective-viewer-hypergrid/test/js/utils.js
@@ -1,0 +1,51 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+exports.click_details = async (page, x = 310, y = 300) => {
+    const viewer = await page.$("perspective-viewer");
+
+    const click_event = page.evaluate(element => {
+        return new Promise(resolve => {
+            element.addEventListener("perspective-click", e => {
+                resolve(e.detail);
+            });
+        });
+    }, viewer);
+
+    await page.mouse.click(x, y);
+    return await click_event;
+};
+
+exports.capture_update = async function capture_update(page, viewer, body) {
+    await page.evaluate(element => {
+        element.addEventListener("perspective-view-update", () => {
+            element.setAttribute("test-updated", true);
+        });
+    }, viewer);
+    await body();
+    try {
+        await page.waitFor(element => element.hasAttribute("test-updated"), {timeout: 3000}, viewer);
+    } catch (e) {
+        console.error("Missing 'test-updated' attribute");
+    }
+    await page.evaluate(element => element.removeAttribute("test-updated"), viewer);
+};
+
+exports.set_lazy = async function set_lazy(page) {
+    const viewer = await page.$("perspective-viewer");
+    await page.evaluate(element => {
+        element.hypergrid.properties.repaintIntervalRate = 1;
+        if (!element.hypergrid._lazy_load) {
+            Object.defineProperty(element.hypergrid, "_lazy_load", {
+                set: () => {},
+                get: () => true
+            });
+        }
+    }, viewer);
+};

--- a/packages/perspective-viewer-hypergrid/test/results/results.json
+++ b/packages/perspective-viewer-hypergrid/test/results/results.json
@@ -29,6 +29,7 @@
     "superstore.html/shows a sort indicator": "5f4aae968d2dac96781c954e05d34303",
     "superstore.html/shows multiple sort indicators": "b6f6bd22638f550ee07cadc46c1c37c0",
     "superstore.html/shows a sort indicator on column split": "5391f996d29f1144d87ddc5f802e8c52",
-    "__GIT_COMMIT__": "e516798564eb956c7eae5cb02f81610c08071d6f",
-    "superstore.html/should reinterpret metadata when only row pivots are changed": "fb9c5cb1b9a4148023f6edf4bffd27db"
+    "__GIT_COMMIT__": "683a607ac1fbf5c842eac333a3fb5ab0f8ff7386",
+    "superstore.html/should reinterpret metadata when only row pivots are changed": "fb9c5cb1b9a4148023f6edf4bffd27db",
+    "empty.html/perspective-click is fired when an empty dataset is loaded first": "c9858679937200d7748610c312d7dee8"
 }


### PR DESCRIPTION
When the default `@finos/perspective-viewer-hypergrid` plugin is selected and an empty dataset is loaded (or when the element's `load()` method is called with a schema), Hypergrid's default click event handlers were not previously registered correctly, causing click events to not fire until the plugin was de-and-re-selected.