### PR TITLE
0-sided Performance Fix

### DIFF
--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -55,7 +55,7 @@ t_ctx0::step_end() {
     }
 
     m_traversal->step_end();
-
+#ifndef BUILD_WASM
     t_uindex ncols = m_config.get_num_columns();
     std::vector<t_minmax> rval(ncols);
 
@@ -84,6 +84,7 @@ t_ctx0::step_end() {
 #endif
 
     m_minmax = rval;
+#endif
 }
 
 // ASGGrid data interface

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -55,7 +55,7 @@ t_ctx0::step_end() {
     }
 
     m_traversal->step_end();
-#ifndef BUILD_WASM
+#ifndef PSP_ENABLE_WASM
     t_uindex ncols = m_config.get_num_columns();
     std::vector<t_minmax> rval(ncols);
 

--- a/cpp/perspective/src/cpp/flat_traversal.cpp
+++ b/cpp/perspective/src/cpp/flat_traversal.cpp
@@ -253,7 +253,7 @@ t_ftrav::step_end() {
     std::vector<t_mselem> new_rows;
 
     for (t_pkmselem_map::const_iterator pkelem_iter = m_new_elems.begin();
-        pkelem_iter != m_new_elems.end(); ++pkelem_iter) {
+         pkelem_iter != m_new_elems.end(); ++pkelem_iter) {
         new_rows.push_back(pkelem_iter->second);
     }
     std::sort(new_rows.begin(), new_rows.end(), sorter);
@@ -276,11 +276,11 @@ t_ftrav::step_end() {
         } else {
             i++;
         }
-                
+
         m_pkeyidx[elem.m_pkey] = new_index->size();
         new_index->push_back(elem);
     }
-    
+
     while (i < m_index->size()) {
         const t_mselem& new_elem = (*m_index)[i++];
         if (new_elem.m_deleted) {
@@ -291,7 +291,7 @@ t_ftrav::step_end() {
         }
     }
 
-    std::swap(new_index, m_index);  
+    std::swap(new_index, m_index);
     m_new_elems.clear();
 }
 

--- a/cpp/perspective/src/cpp/multi_sort.cpp
+++ b/cpp/perspective/src/cpp/multi_sort.cpp
@@ -19,30 +19,35 @@ namespace perspective {
 t_mselem::t_mselem()
     : m_pkey(mknone())
     , m_order(0)
-    , m_deleted(false) {}
+    , m_deleted(false)
+    , m_updated(false) {}
 
 t_mselem::t_mselem(const std::vector<t_tscalar>& row)
     : m_row(row)
     , m_pkey(mknone())
     , m_order(0)
-    , m_deleted(false) {}
+    , m_deleted(false)
+    , m_updated(false) {}
 
 t_mselem::t_mselem(const std::vector<t_tscalar>& row, t_uindex order)
     : m_row(row)
     , m_pkey(mknone())
     , m_order(order)
-    , m_deleted(false) {}
+    , m_deleted(false)
+    , m_updated(false) {}
 
 t_mselem::t_mselem(const t_tscalar& pkey, const std::vector<t_tscalar>& row)
     : m_row(row)
     , m_pkey(pkey)
     , m_order(0)
-    , m_deleted(false) {}
+    , m_deleted(false)
+    , m_updated(false) {}
 
 t_mselem::t_mselem(const t_mselem& other) {
     m_pkey = other.m_pkey;
     m_row = other.m_row;
     m_deleted = other.m_deleted;
+    m_updated = other.m_updated;
     m_order = other.m_order;
 }
 
@@ -50,6 +55,7 @@ t_mselem::t_mselem(t_mselem&& other) {
     m_pkey = other.m_pkey;
     m_row = std::move(other.m_row);
     m_deleted = other.m_deleted;
+    m_updated = other.m_updated;
     m_order = other.m_order;
 }
 
@@ -59,6 +65,7 @@ t_mselem::operator=(const t_mselem& other) {
     m_row = other.m_row;
     m_deleted = other.m_deleted;
     m_order = other.m_order;
+    m_updated = other.m_updated;
     return *this;
 }
 
@@ -67,6 +74,7 @@ t_mselem::operator=(t_mselem&& other) {
     m_pkey = other.m_pkey;
     m_row = std::move(other.m_row);
     m_deleted = other.m_deleted;
+    m_updated = other.m_updated;
     m_order = other.m_order;
     return *this;
 }

--- a/cpp/perspective/src/cpp/storage.cpp
+++ b/cpp/perspective/src/cpp/storage.cpp
@@ -519,7 +519,9 @@ void
 t_lstore::clear() {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+#ifndef BUILD_WASM
     memset(m_base, 0, size_t(capacity()));
+#endif
     {
         t_unlock_store tmp(this);
         m_size = 0;

--- a/cpp/perspective/src/cpp/storage.cpp
+++ b/cpp/perspective/src/cpp/storage.cpp
@@ -519,7 +519,7 @@ void
 t_lstore::clear() {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-#ifndef BUILD_WASM
+#ifndef PSP_ENABLE_WASM
     memset(m_base, 0, size_t(capacity()));
 #endif
     {

--- a/cpp/perspective/src/include/perspective/multi_sort.h
+++ b/cpp/perspective/src/include/perspective/multi_sort.h
@@ -96,6 +96,8 @@ cmp_mselem(const t_mselem& a, const t_mselem& b, const std::vector<t_sorttype>& 
         const t_tscalar& second = b.m_row[idx];
 
         t_sorttype order = sort_order[idx];
+
+#ifndef BUILD_WASM
         t_nancmp nancmp = nan_compare(order, first, second);
 
         if (first.is_floating_point() && nancmp.m_active) {
@@ -110,6 +112,7 @@ cmp_mselem(const t_mselem& a, const t_mselem& b, const std::vector<t_sorttype>& 
                 default: { continue; } break;
             }
         }
+#endif
 
         if (first == second)
             continue;

--- a/cpp/perspective/src/include/perspective/multi_sort.h
+++ b/cpp/perspective/src/include/perspective/multi_sort.h
@@ -31,6 +31,7 @@ struct PERSPECTIVE_EXPORT t_mselem {
     t_tscalar m_pkey;
     t_uindex m_order;
     bool m_deleted;
+    bool m_updated;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/multi_sort.h
+++ b/cpp/perspective/src/include/perspective/multi_sort.h
@@ -97,7 +97,7 @@ cmp_mselem(const t_mselem& a, const t_mselem& b, const std::vector<t_sorttype>& 
 
         t_sorttype order = sort_order[idx];
 
-#ifndef BUILD_WASM
+#ifndef PSP_ENABLE_WASM
         t_nancmp nancmp = nan_compare(order, first, second);
 
         if (first.is_floating_point() && nancmp.m_active) {


### PR DESCRIPTION
This change improves CPU utilization for processing updates on 0-sided contexts by ~20x.  It is currently only implemented for WASM.
* Rewrote flat_traversal to take advantage of sorted-ness
* Removed min/max calculation
* Removed `memset(0)` for gnode ports