### PR TITLE
Calculate row offset in C++, refactor Table, remove implicit primary key mode

### DIFF
--- a/cpp/perspective/src/include/perspective/base.h
+++ b/cpp/perspective/src/include/perspective/base.h
@@ -254,7 +254,7 @@ enum t_ctx_type {
     GROUPED_COLUMNS_CONTEXT
 };
 
-enum t_op { OP_INSERT, OP_DELETE, OP_CLEAR, OP_UPDATE };
+enum t_op { OP_INSERT, OP_DELETE, OP_CLEAR };
 
 enum t_value_transition {
     VALUE_TRANSITION_EQ_FF,

--- a/cpp/perspective/src/include/perspective/base.h
+++ b/cpp/perspective/src/include/perspective/base.h
@@ -278,7 +278,6 @@ enum t_value_transition {
 
 enum t_gnode_type {
     GNODE_TYPE_PKEYED,         // Explicit user set pkey
-    GNODE_TYPE_IMPLICIT_PKEYED // pkey is row based
 };
 
 enum t_gnode_port {

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -184,13 +184,12 @@ namespace binding {
      * @param accessor
      * @param col_names
      * @param data_types
-     * @param offset
      * @param is_arrow
      * @param is_update
      */
     template <typename T>
     void _fill_data(t_data_table& tbl, T accessor, std::vector<std::string> col_names,
-        std::vector<t_dtype> data_types, std::uint32_t offset, bool is_arrow, bool is_update);
+        std::vector<t_dtype> data_types, bool is_arrow, bool is_update);
 
     /**
      * @brief Create and populate a table.
@@ -200,7 +199,6 @@ namespace binding {
      * @param gnode
      * @param accessor
      * @param computed
-     * @param offset
      * @param limit
      * @param index
      * @param is_update
@@ -208,7 +206,7 @@ namespace binding {
      * @return std::shared_ptr<t_gnode>
      */
     template <typename T>
-    std::shared_ptr<Table> make_table(T table, T accessor, T computed, std::uint32_t offset,
+    std::shared_ptr<Table> make_table(T table, T accessor, T computed,
         std::uint32_t limit, std::string index, t_op op, bool is_update, bool is_arrow);
 
     /**

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -204,13 +204,12 @@ namespace binding {
      * @param limit
      * @param index
      * @param is_update
-     * @param is_delete
      * @param is_arrow
      * @return std::shared_ptr<t_gnode>
      */
     template <typename T>
     std::shared_ptr<Table> make_table(T table, T accessor, T computed, std::uint32_t offset,
-        std::uint32_t limit, std::string index, t_op op, bool is_arrow);
+        std::uint32_t limit, std::string index, t_op op, bool is_update, bool is_arrow);
 
     /**
      * @brief Given an array-like container with new computed columns, add them to the

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -42,11 +42,10 @@ public:
      * @param limit
      * @param index
      * @param op
-     * @param is_arrow
      */
     Table(std::shared_ptr<t_pool> pool, std::vector<std::string> column_names,
         std::vector<t_dtype> data_types, std::uint32_t offset, std::uint32_t limit,
-        std::string index, t_op op, bool is_arrow);
+        std::string index);
 
     /**
      * @brief Register the given `t_data_table` with the underlying pool and gnode, thus
@@ -54,23 +53,7 @@ public:
      *
      * @param data_table
      */
-    void init(t_data_table& data_table);
-
-    /**
-     * @brief Given new metadata about the underlying data table, data format, index, limit
-     * etc., update the current object with this new metadata, allowing for reuse of `Table`
-     * instances.
-     *
-     * @param column_names
-     * @param data_types
-     * @param offset
-     * @param limit
-     * @param index
-     * @param op
-     * @param is_arrow
-     */
-    void update(std::vector<std::string> column_names, std::vector<t_dtype> data_types,
-        std::uint32_t offset, std::uint32_t limit, std::string index, t_op op, bool is_arrow);
+    void init(t_data_table& data_table, const t_op op);
 
     /**
      * @brief The size of the underlying `t_data_table`, i.e. a row count
@@ -144,12 +127,17 @@ public:
     std::uint32_t get_limit() const;
     const std::string& get_index() const;
 
+    // Setters
+    void set_column_names(const std::vector<std::string>& column_names);
+    void set_data_types(const std::vector<t_dtype>& data_types);
+    void set_offset(std::uint32_t offset);
+
 private:
     /**
      * @brief Create a column for the table operation - either insert or delete.
      *
      */
-    void process_op_column(t_data_table& data_table);
+    void process_op_column(t_data_table& data_table, const t_op op);
 
     /**
      * @brief Create the index column using a provided index or the row number.
@@ -164,10 +152,8 @@ private:
     std::vector<std::string> m_column_names;
     std::vector<t_dtype> m_data_types;
     std::uint32_t m_offset;
-    std::uint32_t m_limit;
-    std::string m_index;
-    t_op m_op;
-    bool m_is_arrow;
+    const std::uint32_t m_limit;
+    const std::string m_index;
     bool m_gnode_set;
 };
 

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -24,8 +24,6 @@ namespace perspective {
  *
  * By encapsulating business logic and the creation of internal structures,
  * the `Table` class handles data loading, table creation, and management of backend resources.
- *
- * @tparam T
  */
 class PERSPECTIVE_EXPORT Table {
 public:
@@ -35,16 +33,15 @@ public:
      * @brief Construct a `Table` object, which handles all operations related to `t_pool` and
      * `t_gnode`, effectively acting as an orchestrator between those underlying components.
      *
-     * @param pool
+     * @param pool - the `t_pool` which manages the Table.
      * @param column_names
      * @param data_types
-     * @param offset
-     * @param limit
-     * @param index
+     * @param limit - an upper bound on the number of rows in the Table (optional).
+     * @param index - a string column name to be used as a primary key. If not explicitly set, a primary key will be generated.
      * @param op
      */
     Table(std::shared_ptr<t_pool> pool, std::vector<std::string> column_names,
-        std::vector<t_dtype> data_types, std::uint32_t offset, std::uint32_t limit,
+        std::vector<t_dtype> data_types, std::uint32_t limit,
         std::string index);
 
     /**
@@ -52,8 +49,10 @@ public:
      * allowing operations on it.
      *
      * @param data_table
+     * @param row_count
+     * @param op
      */
-    void init(t_data_table& data_table, const t_op op);
+    void init(t_data_table& data_table, std::uint32_t row_count, const t_op op);
 
     /**
      * @brief The size of the underlying `t_data_table`, i.e. a row count
@@ -117,6 +116,14 @@ public:
      */
     void reset_gnode(t_uindex id);
 
+    /**
+     * @brief The offset determines where we begin to write data into the Table. 
+     * Using `m_offset`, `m_limit`, and the length of the dataset, calculate the new position at which we write data.
+     * 
+     * @param row_count - the number of rows to write into the table 
+     */
+    void calculate_offset(std::uint32_t row_count);
+
     // Getters
     t_uindex get_id() const;
     std::shared_ptr<t_pool> get_pool() const;
@@ -130,18 +137,23 @@ public:
     // Setters
     void set_column_names(const std::vector<std::string>& column_names);
     void set_data_types(const std::vector<t_dtype>& data_types);
-    void set_offset(std::uint32_t offset);
 
 private:
     /**
      * @brief Create a column for the table operation - either insert or delete.
      *
+     * @private
+     * @param data_table
+     * @param op
      */
     void process_op_column(t_data_table& data_table, const t_op op);
 
     /**
-     * @brief Create the index column using a provided index or the row number.
-     *
+     * @brief Create the index column using a provided index or the row number. 
+     * This serves as the primary key for the Table.
+     * 
+     * @private
+     * @param data_table
      */
     void process_index_column(t_data_table& data_table);
 
@@ -151,8 +163,25 @@ private:
     std::shared_ptr<t_gnode> m_gnode;
     std::vector<std::string> m_column_names;
     std::vector<t_dtype> m_data_types;
+
+    /**
+     * @brief The row number at which we start to write into the Table. Recalculated on updates, removes, and inserts.
+     * 
+     */
     std::uint32_t m_offset;
-    const std::uint32_t m_limit;
+
+    /**
+     * @brief an upper bound on the number of total rows in the Table. 
+     * 
+     * When limit is set, new data that exceeds the limit will overwrite starting at row 0.
+     * Otherwise, limit is set to the highest number at 32 bits.
+     */
+    const t_uindex m_limit;
+
+    /**
+     * @brief The name of a column that should be used as the Table's primary key.
+     * 
+     */
     const std::string m_index;
     bool m_gnode_set;
 };

--- a/cpp/perspective/test/cpp/simple.cpp
+++ b/cpp/perspective/test/cpp/simple.cpp
@@ -50,18 +50,6 @@ TEST(GNODE, explicit_pkey)
 }
 
 
-TEST(GNODE, implicit_pkey)
-{
-    t_gnode_options options;
-    options.m_gnode_type = GNODE_TYPE_IMPLICIT_PKEYED;
-    options.m_port_schema = t_schema{
-            {"psp_op", "psp_pkey", "x"}, {DTYPE_UINT8, DTYPE_INT64, DTYPE_INT64}};
-
-#ifndef WIN32
-	EXPECT_EXIT(t_gnode::build(options), ::testing::KilledBySignal(SIGINT), "");
-#endif
-}
-
 TEST(SCALAR, scalar_literal_test)
 {
     auto s1 = 1_ts;
@@ -492,29 +480,7 @@ protected:
     t_tscalar clear;
 };
 
-template <t_dtype DTYPE_T>
-class GNodeTestImplicit : public BaseTest
-{
-public:
-    GNodeTestImplicit()
-    {
-        m_ischema = t_schema{{"x"}, {DTYPE_T}};
-        m_oschema = {{"psp_pkey", "x"}, {DTYPE_INT64, DTYPE_T}};
-        t_gnode_options options;
-        options.m_gnode_type = GNODE_TYPE_IMPLICIT_PKEYED;
-        options.m_port_schema = m_ischema;
-        m_g = t_gnode::build(options);
-    }
-
-    virtual std::shared_ptr<t_data_table>
-    get_step_otable()
-    {
-        return m_g->get_sorted_pkeyed_table();
-    }
-};
-
 typedef GNodeTest<DTYPE_INT64> I64GnodeTest;
-typedef GNodeTestImplicit<DTYPE_INT64> I64GnodeTestImplicit;
 
 // clang-format off
 TEST_F(I64GnodeTest, test_1) {
@@ -656,27 +622,6 @@ TEST_F(I64GnodeTest, test_9) {
         {
             {{dop, 1_ts, null}},
             {}
-        }
-    };
-
-    run(data);
-}
-
-
-TEST_F(I64GnodeTestImplicit, test_1) {
-
-    t_testdata data{
-        {
-            {{1_ts}},
-            {{0_ts, 1_ts}}
-        },
-        {
-            {{2_ts}},
-            {{0_ts, 1_ts}, {1_ts, 2_ts}}
-        },
-        {
-            {{3_ts}},
-            {{0_ts, 1_ts}, {1_ts, 2_ts}, {2_ts, 3_ts}}
         }
     };
 

--- a/packages/perspective/src/js/data_accessor/index.js
+++ b/packages/perspective/src/js/data_accessor/index.js
@@ -43,7 +43,7 @@ export class DataAccessor {
         } else if (typeof data[Object.keys(data)[0]] === "string" || typeof data[Object.keys(data)[0]] === "function") {
             return this.data_formats.schema;
         } else {
-            throw "Unknown data format!";
+            throw `Could not determine data format for ${data}`;
         }
     }
 
@@ -61,10 +61,6 @@ export class DataAccessor {
         return this.format;
     }
 
-    get_row_count() {
-        return this.row_count;
-    }
-
     get(column_name, row_index) {
         let value = undefined;
 
@@ -80,7 +76,7 @@ export class DataAccessor {
         } else if (this.format === this.data_formats.schema) {
             value = undefined;
         } else {
-            throw "Unknown data format!";
+            throw `Could not get() from dataset - ${this.data} is poorly formatted.`;
         }
 
         return value;
@@ -182,7 +178,7 @@ export class DataAccessor {
                 }
             }
         } else {
-            throw "Unknown data format!";
+            throw `Could not initialize - failed to determine format for ${data}`;
         }
         return overridden_types;
     }

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -50,7 +50,8 @@ export default function(Module) {
      */
 
     /**
-     * Determines a table's limit index.
+     * Determines where in the table we should start to write data.
+     *
      * @private
      * @param {int} limit_index
      * @param {int} new_length

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -471,7 +471,7 @@ module.exports = perspective => {
             table.delete();
         });
 
-        it("Arrow (chunked) constructor", async function() {
+        it("Arrow (chunked format) constructor", async function() {
             var table = perspective.table(chunked.slice());
             var view = table.view();
             let result = await view.to_json();

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -388,6 +388,16 @@ module.exports = perspective => {
             view.delete();
             table.delete();
         });
+
+        it("{limit: 1} with arrow update", async function() {
+            var table = perspective.table(arrow.slice(), {limit: 1});
+            table.update(arrow.slice());
+            var view = table.view();
+            let result = await view.to_json();
+            expect(result).toEqual([arrow_result[arrow_result.length - 1]]);
+            view.delete();
+            table.delete();
+        });
     });
 
     describe("Indexed", function() {


### PR DESCRIPTION
This PR refactors the workings of the `Table` class and ports over some more functionality from JS to C++. Most importantly, the `limit_index`/`offset` property is now calculated within the `Table` class, which removes another chunk of state-dependent JS code. 

- Remove `GNODE_TYPE_IMPLICIT_PKEYED` which is not being used in the production codebase, and conflicts with features already present.
- Additional documentation added in JS and C++ for the table