### PR TITLE
`index` column support

### DIFF
--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -11,13 +11,22 @@
 #include <perspective/base.h>
 #include <cstdint>
 #include <limits>
+#ifdef PSP_ENABLE_WASM
+#include <emscripten.h>
+#endif
 
 namespace perspective {
 
 void
 psp_abort() {
     std::cerr << "abort()" << std::endl;
+#ifdef PSP_ENABLE_WASM
+    EM_ASM({
+        throw new Error("abort()");
+    });
+#else
     std::raise(SIGINT);
+#endif
 }
 
 bool

--- a/cpp/perspective/src/cpp/column.cpp
+++ b/cpp/perspective/src/cpp/column.cpp
@@ -695,7 +695,7 @@ t_column::clear() {
 void
 t_column::pprint() const {
     for (t_uindex idx = 0, loop_end = size(); idx < loop_end; ++idx) {
-        std::cout << idx << " => " << get_scalar(idx) << std::endl;
+        std::cout << idx << ": " << get_scalar(idx) << std::endl;
     }
 }
 

--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -516,20 +516,25 @@ t_data_table::clone() const {
     return rval;
 }
 
-t_column*
-t_data_table::add_column(const std::string& name, t_dtype dtype, bool status_enabled) {
+std::shared_ptr<t_column>
+t_data_table::add_column_sptr(const std::string& name, t_dtype dtype, bool status_enabled) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
 
     if (m_schema.has_column(name)) {
-        return m_columns.at(m_schema.get_colidx(name)).get();
+        return m_columns.at(m_schema.get_colidx(name));
     }
     m_schema.add_column(name, dtype);
     m_columns.push_back(make_column(name, dtype, status_enabled));
     m_columns.back()->init();
     m_columns.back()->reserve(std::max(size(), std::max(static_cast<t_uindex>(8), m_capacity)));
     m_columns.back()->set_size(size());
-    return m_columns.back().get();
+    return m_columns.back();
+}
+
+t_column*
+t_data_table::add_column(const std::string& name, t_dtype dtype, bool status_enabled) {
+    return add_column_sptr(name, dtype, status_enabled).get();
 }
 
 void
@@ -598,7 +603,7 @@ t_data_table::clone_column(const std::string& existing_col, const std::string& n
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
 
     if (!m_schema.has_column(existing_col)) {
-        std::cout << "Cannot clone non existing column";
+        std::cout << "Cannot clone non existing column: " << existing_col << std::endl;
         return 0;
     }
 

--- a/cpp/perspective/src/cpp/gnode.cpp
+++ b/cpp/perspective/src/cpp/gnode.cpp
@@ -339,7 +339,6 @@ t_gnode::_process_table() {
     }
 
     m_was_updated = true;
-
     std::shared_ptr<t_data_table> flattened(iport->get_table()->flatten());
     PSP_GNODE_VERIFY_TABLE(flattened);
     PSP_GNODE_VERIFY_TABLE(get_table());

--- a/cpp/perspective/src/cpp/gnode_state.cpp
+++ b/cpp/perspective/src/cpp/gnode_state.cpp
@@ -82,7 +82,6 @@ t_gstate::erase(const t_tscalar& pkey) {
 t_uindex
 t_gstate::lookup_or_create(const t_tscalar& pkey) {
     auto pkey_ = m_symtable.get_interned_tscalar(pkey);
-
     t_mapping::const_iterator iter = m_mapping.find(pkey_);
 
     if (iter != m_mapping.end()) {
@@ -122,10 +121,6 @@ t_gstate::update_history(const t_data_table* tbl) {
     auto stable = m_table.get();
 
     std::vector<t_uindex> col_translation(stable->num_columns());
-
-    std::string opname("psp_op");
-    std::string pkeyname("psp_pkey");
-
     std::vector<const t_column*> fcolumns(tbl->num_columns());
 
     t_uindex count = 0;
@@ -143,6 +138,7 @@ t_gstate::update_history(const t_data_table* tbl) {
         scolumns[idx] = stable->get_column(cname).get();
     }
 
+    // insert into new table
     if (size() == 0) {
         m_free.clear();
         m_mapping.clear();

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -176,20 +176,23 @@ namespace binding {
     template <typename T>
     void table_add_computed_column(t_data_table& table, T computed_defs);
 
+    template <typename T>
+    void _fill_data_helper(T accessor, t_data_table& tbl,
+        std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type,
+        bool is_arrow, bool is_update);
+
     /**
      * @brief Given a table, iterate through each column and fill it with data.
      *
      * @tparam T
      * @param tbl
      * @param accessor
-     * @param col_names
-     * @param data_types
+     * @param input_schema 
      * @param is_arrow
      * @param is_update
      */
     template <typename T>
-    void _fill_data(t_data_table& tbl, T accessor, std::vector<std::string> col_names,
-        std::vector<t_dtype> data_types, bool is_arrow, bool is_update);
+    void _fill_data(t_data_table& tbl, T accessor, std::vector<std::string> col_names, const t_schema& input_schema, const std::string& index, std::uint32_t offset, std::uint32_t limit, bool is_arrow, bool is_update);
 
     /**
      * @brief Create and populate a table.

--- a/cpp/perspective/src/include/perspective/data_table.h
+++ b/cpp/perspective/src/include/perspective/data_table.h
@@ -114,6 +114,7 @@ public:
 
     void set_column(t_uindex idx, std::shared_ptr<t_column> col);
     void set_column(const std::string& name, std::shared_ptr<t_column> col);
+    std::shared_ptr<t_column> add_column_sptr(const std::string& cname, t_dtype dtype, bool status_enabled);
     t_column* add_column(const std::string& cname, t_dtype dtype, bool status_enabled);
     void promote_column(
         const std::string& cname, t_dtype new_dtype, std::int32_t iter_limit, bool fill);
@@ -232,6 +233,7 @@ t_data_table::flatten_helper_2(ROWPACK_VEC_T& sorted, std::vector<t_flatten_reco
 template <typename FLATTENED_T, typename PKEY_T>
 void
 t_data_table::flatten_helper_1(FLATTENED_T flattened) const {
+
     t_uindex frags_size = size();
 
     PSP_VERBOSE_ASSERT(is_same_shape(*flattened), "Misaligned shaped found");

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -157,6 +157,8 @@ private:
      */
     void process_index_column(t_data_table& data_table);
 
+    void validate_columns(const std::vector<std::string>& column_names);
+
     bool m_init;
     t_uindex m_id;
     std::shared_ptr<t_pool> m_pool;

--- a/examples/simple/schema.html
+++ b/examples/simple/schema.html
@@ -1,0 +1,63 @@
+<!--
+   
+   Copyright (c) 2017, the Perspective Authors.
+   
+   This file is part of the Perspective library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+    <head>
+
+        <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon"> 
+        <script src="perspective-viewer.js"></script>
+        <script src="perspective-viewer-hypergrid.js"></script>
+        <script src="perspective-viewer-d3fc.js"></script>
+
+        <script src="perspective.js"></script>
+        
+        <link rel='stylesheet' href="index.css">
+        <link rel='stylesheet' href="material.css" is="custom-style">
+    </head>
+    <body>
+
+        <perspective-viewer>
+        </perspective-viewer>
+
+        <script>
+            window.addEventListener("WebComponentsReady", async function() {
+                const data = [{int: 1, string: "abc", datetime: new Date()}, {int: 2, string: "abcd", datetime: new Date()}];
+                var el = document.getElementsByTagName('perspective-viewer')[0];
+                const worker = perspective.shared_worker();
+                let table = worker.table(data);
+                let view = table.view();
+                table.update([
+                {
+                    __INDEX__: 0,
+                    string: "abcbbb",
+                },
+                {
+                    __INDEX__: 1,
+                    string: "xxx",
+                },
+                {
+                    __INDEX__: 2,
+                    string: "abcyyybbb",
+                }]);
+                table.update([
+                    {int: 5},
+                    {int: 6},
+                    {int: 7},
+                    {int: 8},
+                    {int: 10},
+                    {int: 9},
+                ]);
+                let json = await view.to_json();
+                console.log(json);
+            })
+        </script>
+
+    </body>
+</html>

--- a/examples/simple/test.html
+++ b/examples/simple/test.html
@@ -1,0 +1,54 @@
+<!--
+   
+   Copyright (c) 2017, the Perspective Authors.
+   
+   This file is part of the Perspective library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+
+    <script src="perspective-viewer.js"></script>
+    <script src="perspective-viewer-hypergrid.js"></script>
+    <script src="perspective-viewer-d3fc.js"></script>
+
+    <script src="perspective.js"></script>
+
+    <link rel='stylesheet' href="index.css">
+    <link rel='stylesheet' href="material.css" is="custom-style">
+    
+
+</head>
+
+<body>
+
+    <perspective-viewer >
+
+    </perspective-viewer>
+
+    <script>
+        window.addEventListener('WebComponentsReady', async function() {
+            // var xhr = new XMLHttpRequest();
+            // xhr.open('GET', 'superstore.arrow', true);
+            // xhr.responseType = "arraybuffer"
+            // xhr.onload = function() {
+                var el = document.getElementsByTagName('perspective-viewer')[0];
+                const table = perspective.shared_worker().table([{x: 1, y: "a", z: 2.5}]);
+                el.load(table);
+                table.update([{__INDEX__:1, y:"b"}]);
+                
+                el.toggleConfig();
+            // }
+            // xhr.send(null);
+        });
+    </script>
+
+</body>
+
+</html>

--- a/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
@@ -88,7 +88,7 @@ utils.with_server({}, () => {
                 test.capture("should reinterpret metadata when only row pivots are changed", async page => {
                     const viewer = await page.$("perspective-viewer");
                     await page.shadow_click("perspective-viewer", "#config_button");
-                    await page.evaluate(element => element.setAttribute("row-pivots", '["Region","OrderDate"]'), viewer);
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["Region","Order Date"]'), viewer);
                     await page.waitForSelector("perspective-viewer:not([updating])");
                     await page.evaluate(element => element.setAttribute("row-pivots", '["Order Date"]'), viewer);
                     await page.waitForSelector("perspective-viewer:not([updating])");

--- a/packages/perspective/README.md
+++ b/packages/perspective/README.md
@@ -38,7 +38,6 @@ The main API module for Perspective.
         * [.remove(data)](#module_perspective..table+remove)
         * [.add_computed(computed)](#module_perspective..table+add_computed)
         * [.columns(computed)](#module_perspective..table+columns) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
-        * [.column_metadata()](#module_perspective..table+column_metadata) ⇒ <code>Promise.&lt;Array.&lt;object&gt;&gt;</code>
 
 
 * * *
@@ -151,6 +150,8 @@ to serialize.
 to serialize.
     - .end_col <code>number</code> - The ending column index from which
 to serialize.
+    - [.index] <code>boolean</code> <code> = false</code> - Should the index from the underlying
+[table](#module_perspective..table) be in the output (as `"__INDEX__"`).
 
 
 * * *
@@ -379,7 +380,6 @@ is deleted, this callback will be invoked.
     * [.remove(data)](#module_perspective..table+remove)
     * [.add_computed(computed)](#module_perspective..table+add_computed)
     * [.columns(computed)](#module_perspective..table+columns) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
-    * [.column_metadata()](#module_perspective..table+column_metadata) ⇒ <code>Promise.&lt;Array.&lt;object&gt;&gt;</code>
 
 
 * * *
@@ -599,23 +599,6 @@ The column names of this table.
 - computed <code>boolean</code> - Should computed columns be included?
 (default false)
 
-
-* * *
-
-<a name="module_perspective..table+column_metadata"></a>
-
-#### table.column\_metadata() ⇒ <code>Promise.&lt;Array.&lt;object&gt;&gt;</code>
-Column metadata for this table.
-
-If the column is computed, the `computed` property is an Object containing:
- - Array `input_columns`
- - String `input_type`
- - Object `computation`.
-
- Otherwise, `computed` is `undefined`.
-
-**Kind**: instance method of [<code>table</code>](#module_perspective..table)  
-**Returns**: <code>Promise.&lt;Array.&lt;object&gt;&gt;</code> - An array of Objects containing metadata for each column.  
 
 * * *
 

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -500,6 +500,8 @@ export default function(Module) {
      * to serialize.
      * @param {number} options.end_col The ending column index from which
      * to serialize.
+     * @param {boolean} [config.index=false] Should the index from the underlying
+     * {@link module:perspective~table} be in the output (as `"__INDEX__"`).
      *
      * @returns {Promise<Array>} A Promise resolving to An array of Objects
      * representing the rows of this {@link module:perspective~view}.  If this {@link module:perspective~view} had a
@@ -884,9 +886,10 @@ export default function(Module) {
 
     /**
      * Transform configuration items into `std::vector` objects for interface with C++.
-     *
      * `this.aggregates` is not transformed into a C++ map, as the use of `ordered_map` in the engine
      * makes binding more difficult.
+     *
+     * @private
      */
     view_config.prototype.get_row_pivots = function() {
         let vector = __MODULE__.make_string_vector();

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -430,6 +430,7 @@ export default function(Module) {
                 const keys = slice.get_pkeys(ridx, 0);
                 formatter.initColumnValue(data, row, "__INDEX__");
                 for (let i = 0; i < keys.size(); i++) {
+                    // TODO: if __INDEX__ and set index have the same value, don't we need to make sure that it only emits one?
                     const value = __MODULE__.scalar_vec_to_val(keys, i);
                     formatter.addColumnValue(data, row, "__INDEX__", value);
                 }
@@ -865,7 +866,7 @@ export default function(Module) {
      * Javascript `Object`s in the {@link module:perspective~table#view} method, which has an `options` parameter.
      *
      * @param {Object} config the configuration `Object` passed by the user to the {@link module:perspective~table#view} method.
-     *
+     * @private
      * @class
      * @hideconstructor
      */
@@ -1268,15 +1269,17 @@ export default function(Module) {
                 data = "_" + data;
             }
             accessor.init(papaparse.parse(data.trim(), {header: true}).data);
-            accessor.names = cols;
-            accessor.types = accessor.extract_typevec(types).slice(0, cols.length);
+            accessor.names = cols.concat(accessor.names.filter(x => x === "__INDEX__"));
+            accessor.types = accessor.extract_typevec(types).slice(0, accessor.names.length);
+
             if (meter) {
                 meter(accessor.row_count);
             }
         } else {
             accessor.init(data);
-            accessor.names = cols;
-            accessor.types = accessor.extract_typevec(types).slice(0, cols.length);
+            accessor.names = cols.concat(accessor.names.filter(x => x === "__INDEX__"));
+            accessor.types = accessor.extract_typevec(types).slice(0, accessor.names.length);
+
             if (meter) {
                 meter(accessor.row_count);
             }
@@ -1285,6 +1288,19 @@ export default function(Module) {
         if (pdata.row_count === 0) {
             console.warn("table.update called with no data - ignoring");
             return;
+        }
+
+        // process implicit index column
+        const has_index = accessor.names.indexOf("__INDEX__");
+        if (has_index != -1) {
+            const explicit_index = !!this.index;
+            if (explicit_index) {
+                // find the type of the index column
+                accessor.types.push(accessor.types[accessor.names.indexOf(this.index)]);
+            } else {
+                // default index is an integer
+                accessor.types.push(__MODULE__.t_dtype.DTYPE_INT32);
+            }
         }
 
         try {

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -125,9 +125,9 @@ module.exports = perspective => {
 
                 it("w > date as string", async function() {
                     var table = perspective.table(schema);
-                    table.update(date_range_data);
+                    table.update(date_results);
                     var view = table.view({
-                        filter: [["w", ">", "10/01/2018"]]
+                        filter: [["w", ">", "10/02/2018"]]
                     });
                     let json = await view.to_json();
                     expect(json).toEqual(date_results.slice(2, 4));
@@ -137,12 +137,12 @@ module.exports = perspective => {
 
                 it("w < date as string", async function() {
                     var table = perspective.table(schema);
-                    table.update(date_range_data);
+                    table.update(date_results);
                     var view = table.view({
-                        filter: [["w", "<", "10/01/2018"]]
+                        filter: [["w", "<", "10/02/2018"]]
                     });
                     let json = await view.to_json();
-                    expect(json).toEqual([date_results[0]]);
+                    expect(json).toEqual(date_results.slice(0, 2));
                     view.delete();
                     table.delete();
                 });


### PR DESCRIPTION
Added support for generating & reading the special `__INDEX__`column, which allows access to this field even when an explicit `index` was not declared with the `table`.