### PR TITLE
Refactor C++

### DIFF
--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -322,7 +322,7 @@ filter_op_to_str(t_filter_op op) {
 }
 
 t_filter_op
-str_to_filter_op(std::string str) {
+str_to_filter_op(const std::string& str) {
     if (str == "<") {
         return t_filter_op::FILTER_OP_LT;
     } else if (str == "<=") {
@@ -347,7 +347,7 @@ str_to_filter_op(std::string str) {
         return t_filter_op::FILTER_OP_NOT_IN;
     } else if (str == "&" || str == "and") {
         return t_filter_op::FILTER_OP_AND;
-    } else if (str == "|") {
+    } else if (str == "|" || str == "or") {
         return t_filter_op::FILTER_OP_OR;
     } else if (str == "is null") {
         return t_filter_op::FILTER_OP_IS_NULL;
@@ -365,7 +365,7 @@ str_to_filter_op(std::string str) {
 }
 
 t_sorttype
-str_to_sorttype(std::string str) {
+str_to_sorttype(const std::string& str) {
     if (str == "none") {
         return SORTTYPE_NONE;
     } else if (str == "asc" || str == "col asc") {
@@ -383,7 +383,7 @@ str_to_sorttype(std::string str) {
 }
 
 t_aggtype
-str_to_aggtype(std::string str) {
+str_to_aggtype(const std::string& str) {
     if (str == "distinct count" || str == "distinctcount" || str == "distinct"
         || str == "distinct_count") {
         return t_aggtype::AGGTYPE_DISTINCT_COUNT;

--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -19,33 +19,14 @@ Table::Table(std::shared_ptr<t_pool> pool, std::vector<std::string> column_names
     : m_init(false)
     , m_id(GLOBAL_TABLE_ID++)
     , m_pool(pool)
-    , m_column_names(column_names)
-    , m_data_types(data_types)
+    , m_column_names(std::move(column_names))
+    , m_data_types(std::move(data_types))
     , m_offset(0)
     , m_limit(limit)
-    , m_index(index)
+    , m_index(std::move(index))
     , m_gnode_set(false) {
-        validate_columns(column_names);
+        validate_columns(m_column_names);
     }
-
-void
-Table::validate_columns(const std::vector<std::string>& column_names) {
-    bool implicit_index =
-        std::find(column_names.begin(), column_names.end(), "__INDEX__") != column_names.end();
-    if (m_index != "") {
-        // Check if index is valid after getting column names
-        bool explicit_index
-            = std::find(column_names.begin(), column_names.end(), m_index) != column_names.end();
-        if (!explicit_index) {
-            std::cout << "Specified index " << m_index << " does not exist in data." << std::endl;
-            PSP_COMPLAIN_AND_ABORT("Specified index '" + m_index + "' does not exist in data.");
-        }
-        if (explicit_index && implicit_index) {
-            std::cout << "Specified index " << m_index << " twice - ignoring implicit __INDEX__" << std::endl;
-            PSP_COMPLAIN_AND_ABORT("Specified index '" + m_index + "' twice; ignoring implicit index.");
-        }
-    }
-}
 
 void
 Table::init(t_data_table& data_table, std::uint32_t row_count, const t_op op) {
@@ -179,6 +160,25 @@ Table::set_column_names(const std::vector<std::string>& column_names) {
 void 
 Table::set_data_types(const std::vector<t_dtype>& data_types) {
     m_data_types = data_types;
+}
+
+void
+Table::validate_columns(const std::vector<std::string>& column_names) {
+    bool implicit_index =
+        std::find(column_names.begin(), column_names.end(), "__INDEX__") != column_names.end();
+    if (m_index != "") {
+        // Check if index is valid after getting column names
+        bool explicit_index
+            = std::find(column_names.begin(), column_names.end(), m_index) != column_names.end();
+        if (!explicit_index) {
+            std::cout << "Specified index " << m_index << " does not exist in data." << std::endl;
+            PSP_COMPLAIN_AND_ABORT("Specified index '" + m_index + "' does not exist in data.");
+        }
+        if (explicit_index && implicit_index) {
+            std::cout << "Specified index " << m_index << " twice - ignoring implicit __INDEX__" << std::endl;
+            PSP_COMPLAIN_AND_ABORT("Specified index '" + m_index + "' twice; ignoring implicit index.");
+        }
+    }
 }
 
 void

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -17,10 +17,10 @@ View<CTX_T>::View(std::shared_ptr<Table> table, std::shared_ptr<CTX_T> ctx, std:
     std::string separator, t_view_config view_config)
     : m_table(table)
     , m_ctx(ctx)
-    , m_name(name)
-    , m_separator(separator)
+    , m_name(std::move(name))
+    , m_separator(std::move(separator))
     , m_col_offset(0)
-    , m_view_config(view_config) {
+    , m_view_config(std::move(view_config)) {
 
     m_row_pivots = m_view_config.get_row_pivots();
     m_column_pivots = m_view_config.get_column_pivots();

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -17,15 +17,15 @@ t_view_config::t_view_config(std::vector<std::string> row_pivots,
     std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> filter,
     std::vector<std::vector<std::string>> sort, std::string filter_op, bool column_only)
     : m_init(false)
-    , m_row_pivots(row_pivots)
-    , m_column_pivots(column_pivots)
-    , m_aggregates(aggregates)
-    , m_columns(columns)
-    , m_filter(filter)
-    , m_sort(sort)
+    , m_row_pivots(std::move(row_pivots))
+    , m_column_pivots(std::move(column_pivots))
+    , m_aggregates(std::move(aggregates))
+    , m_columns(std::move(columns))
+    , m_filter(std::move(filter))
+    , m_sort(std::move(sort))
     , m_row_pivot_depth(-1)
     , m_column_pivot_depth(-1)
-    , m_filter_op(filter_op)
+    , m_filter_op(std::move(filter_op))
     , m_column_only(column_only) {}
 
 void

--- a/cpp/perspective/src/include/perspective/base.h
+++ b/cpp/perspective/src/include/perspective/base.h
@@ -190,7 +190,7 @@ enum t_filter_op {
 };
 
 PERSPECTIVE_EXPORT std::string filter_op_to_str(t_filter_op op);
-PERSPECTIVE_EXPORT t_filter_op str_to_filter_op(std::string str);
+PERSPECTIVE_EXPORT t_filter_op str_to_filter_op(const std::string& str);
 
 enum t_header { HEADER_ROW, HEADER_COLUMN };
 
@@ -202,7 +202,7 @@ enum t_sorttype {
     SORTTYPE_DESCENDING_ABS
 };
 
-PERSPECTIVE_EXPORT t_sorttype str_to_sorttype(std::string str);
+PERSPECTIVE_EXPORT t_sorttype str_to_sorttype(const std::string& str);
 PERSPECTIVE_EXPORT std::string sorttype_to_str(t_sorttype type);
 
 enum t_aggtype {
@@ -239,7 +239,7 @@ enum t_aggtype {
     AGGTYPE_PCT_SUM_GRAND_TOTAL
 };
 
-PERSPECTIVE_EXPORT t_aggtype str_to_aggtype(std::string str);
+PERSPECTIVE_EXPORT t_aggtype str_to_aggtype(const std::string& str);
 PERSPECTIVE_EXPORT t_aggtype _get_default_aggregate(t_dtype dtype);
 PERSPECTIVE_EXPORT std::string _get_default_aggregate_string(t_dtype dtype);
 

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -142,26 +142,26 @@ namespace binding {
      */
     template <typename T>
     void _fill_col_numeric(T accessor, t_data_table& tbl, std::shared_ptr<t_column> col,
-        std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
+        const std::string& name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 
     template <typename T>
-    void _fill_col_int64(T accessor, std::shared_ptr<t_column> col, std::string name,
+    void _fill_col_int64(T accessor, std::shared_ptr<t_column> col, const std::string& name,
         std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 
     template <typename T>
-    void _fill_col_time(T accessor, std::shared_ptr<t_column> col, std::string name,
+    void _fill_col_time(T accessor, std::shared_ptr<t_column> col, const std::string& name,
         std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 
     template <typename T>
-    void _fill_col_date(T accessor, std::shared_ptr<t_column> col, std::string name,
+    void _fill_col_date(T accessor, std::shared_ptr<t_column> col, const std::string& name,
         std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 
     template <typename T>
-    void _fill_col_bool(T accessor, std::shared_ptr<t_column> col, std::string name,
+    void _fill_col_bool(T accessor, std::shared_ptr<t_column> col, const std::string& name,
         std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 
     template <typename T>
-    void _fill_col_string(T accessor, std::shared_ptr<t_column> col, std::string name,
+    void _fill_col_string(T accessor, std::shared_ptr<t_column> col, const std::string& name,
         std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 
     /**
@@ -178,7 +178,7 @@ namespace binding {
 
     template <typename T>
     void _fill_data_helper(T accessor, t_data_table& tbl,
-        std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type,
+        std::shared_ptr<t_column> col, const std::string& name, std::int32_t cidx, t_dtype type,
         bool is_arrow, bool is_update);
 
     /**
@@ -192,7 +192,7 @@ namespace binding {
      * @param is_update
      */
     template <typename T>
-    void _fill_data(t_data_table& tbl, T accessor, std::vector<std::string> col_names, const t_schema& input_schema, const std::string& index, std::uint32_t offset, std::uint32_t limit, bool is_arrow, bool is_update);
+    void _fill_data(t_data_table& tbl, T accessor, const t_schema& input_schema, const std::string& index, std::uint32_t offset, std::uint32_t limit, bool is_arrow, bool is_update);
 
     /**
      * @brief Create and populate a table.
@@ -210,7 +210,7 @@ namespace binding {
      */
     template <typename T>
     std::shared_ptr<Table> make_table(T table, T accessor, T computed,
-        std::uint32_t limit, std::string index, t_op op, bool is_update, bool is_arrow);
+        std::uint32_t limit, const std::string& index, t_op op, bool is_update, bool is_arrow);
 
     /**
      * @brief Given an array-like container with new computed columns, add them to the
@@ -238,28 +238,30 @@ namespace binding {
      * the filter term is not null/undefined.
      *
      * @tparam T
-     * @param type
+     * @param column_type
      * @param date_parser
      * @param filter_term
-     * @param filter_operand
+     * @param filter_operator
      * @return true
      * @return false
      */
     template <typename T>
-    bool is_valid_filter(t_dtype type, T date_parser, T filter_term, T filter_operand);
+    bool is_valid_filter(t_dtype column_type, T date_parser, t_filter_op filter_operator, T filter_term);
 
     /**
-     * @brief Create a filter by parsing the filter term from the binding language.
-     *
-     * @tparam T
-     * @param schema
-     * @param date_parser
-     * @param filter
-     * @return std::tuple<std::string, std::string, std::vector<t_tscalar>>
-     */
+    * @brief Create a filter by parsing the filter term from the binding language.
+    * 
+    * @tparam T 
+    * @param column_type 
+    * @param date_parser 
+    * @param column_name 
+    * @param filter_op_str 
+    * @param filter_term 
+    * @return std::tuple<std::string, std::string, std::vector<t_tscalar>> 
+    */
     template <typename T>
     std::tuple<std::string, std::string, std::vector<t_tscalar>> make_filter_term(
-        t_dtype type, T date_parser, std::vector<T> filter);
+        t_dtype column_type, T date_parser, const std::string column_name, const std::string& filter_op_str, T filter_term);
     /**
      * @brief Create a `t_view_config` object from the binding language's `view_config` object.
      *
@@ -293,8 +295,8 @@ namespace binding {
      * @return std::shared_ptr<View<CTX_T>>
      */
     template <typename T, typename CTX_T>
-    std::shared_ptr<View<CTX_T>> make_view(std::shared_ptr<Table> table, std::string name,
-        std::string separator, T view_config, T date_parser);
+    std::shared_ptr<View<CTX_T>> make_view(std::shared_ptr<Table> table, const std::string& name,
+        const std::string& separator, T view_config, T date_parser);
 
     /**
      * @brief Create a new context of type `CTX_T`, which will be one of 3 types:
@@ -309,7 +311,7 @@ namespace binding {
      */
     template <typename CTX_T>
     std::shared_ptr<CTX_T> make_context(std::shared_ptr<Table> table, const t_schema& schema,
-        const t_view_config& view_config, std::string name);
+        const t_view_config& view_config, const std::string& name);
 
     /**
      * @brief Get a slice of data for a single column, serialized to t_val.
@@ -320,7 +322,7 @@ namespace binding {
      * @return t_val
      */
     template <typename T>
-    T get_column_data(std::shared_ptr<t_data_table> table, std::string colname);
+    T get_column_data(std::shared_ptr<t_data_table> table, const std::string& colname);
 
     /**
      * @brief Get the t_data_slice object, which contains an underlying slice of data and

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -140,6 +140,12 @@ public:
 
 private:
     /**
+     * @brief Make sure that the table does not have an explicit index AND an implicit index (with the `__INDEX__` column in data).
+     * 
+     * @param column_names 
+     */
+    void validate_columns(const std::vector<std::string>& column_names);
+    /**
      * @brief Create a column for the table operation - either insert or delete.
      *
      * @private
@@ -147,17 +153,6 @@ private:
      * @param op
      */
     void process_op_column(t_data_table& data_table, const t_op op);
-
-    /**
-     * @brief Create the index column using a provided index or the row number. 
-     * This serves as the primary key for the Table.
-     * 
-     * @private
-     * @param data_table
-     */
-    void process_index_column(t_data_table& data_table);
-
-    void validate_columns(const std::vector<std::string>& column_names);
 
     bool m_init;
     t_uindex m_id;

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -172,9 +172,9 @@ private:
     std::int32_t m_column_pivot_depth;
 
     /**
-     * @brief the `t_filter_op` used to combine values inside the engine, stored as a string.
+     * @brief the `t_filter_op` used to return data in the case of multiple filters being applied.
      *
-     * Defaults to "and" unless specified.
+     * Defaults to "and", which returns data that satisfies all the filters provided by the user. 
      */
     std::string m_filter_op;
 

--- a/packages/perspective-viewer-hypergrid/test/js/regressions.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/regressions.spec.js
@@ -35,6 +35,7 @@ utils.with_server({}, () => {
                     await page.shadow_click("perspective-viewer", "#config_button");
                     await page.evaluate(element => element.setAttribute("column-pivots", '["y"]'), viewer);
                 });
+
                 test.capture("regular updates", async page => {
                     const viewer = await page.$("perspective-viewer");
                     await page.shadow_click("perspective-viewer", "#config_button");

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -290,10 +290,11 @@ module.exports = perspective => {
                 table.delete();
             });
 
-            it("y contains 'a' | y contains 'b'", async function() {
+            it("y contains 'a' OR y contains 'b'", async function() {
                 var table = perspective.table(data);
+                // when `filter_op` is provided, perspective returns data differently. In this case, returned data should satisfy either/or of the filter conditions.
                 var view = table.view({
-                    filter_op: "|",
+                    filter_op: "or",
                     filter: [["y", "contains", "a"], ["y", "contains", "b"]]
                 });
                 let json = await view.to_json();


### PR DESCRIPTION
- Removes unnecessary string copies in `emscripten.cpp`
- Use `std::move` when possible in constructors for `Table`, `View`, and `t_view_config`
- Clarify purpose of `filter_op` in the view config, and refactor base methods to accept "or" as a valid filter op
- clean up filter parsing in `emscripten.cpp`