### PR TITLE
Editing for `@finos/perspective-viewer-hypergrid`

### DIFF
--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1047,8 +1047,8 @@ namespace binding {
                 break;
             }
             case DTYPE_TIME: {
-                col->set_nth<std::int64_t>(
-                    idx, static_cast<std::int64_t>(value.as<double>()), STATUS_VALID);
+                auto elem = static_cast<std::int64_t>(value.call<t_val>("getTime").as<double>()); // dcol[i].as<T>();
+                col->set_nth(idx, elem, STATUS_VALID);
                 break;
             }
             case DTYPE_UINT8:

--- a/packages/perspective-viewer-d3fc/src/js/charts/candlestick.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/candlestick.js
@@ -19,7 +19,8 @@ candlestick.plugin = {
         type: "number",
         count: 4,
         names: ["Open", "Close", "High", "Low"]
-    }
+    },
+    selectMode: "toggle"
 };
 
 export default candlestick;

--- a/packages/perspective-viewer-d3fc/src/js/charts/ohlc.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/ohlc.js
@@ -19,7 +19,8 @@ ohlc.plugin = {
         type: "number",
         count: 4,
         names: ["Open", "Close", "High", "Low"]
-    }
+    },
+    selectMode: "toggle"
 };
 
 export default ohlc;

--- a/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
@@ -101,7 +101,8 @@ xyScatter.plugin = {
         type: "number",
         count: 2,
         names: ["X Axis", "Y Axis", "Color", "Size"]
-    }
+    },
+    selectMode: "toggle"
 };
 
 export default xyScatter;

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -135,6 +135,9 @@ module.exports = require("datasaur-local").extend("PerspectiveDataModel", {
     },
 
     getCellEditorAt: function(columnIndex, rowIndex, declaredEditorName, options) {
+        if (!declaredEditorName) {
+            return;
+        }
         const offset = this.grid.renderer.dataWindow.top;
         const row = this._view.to_json({
             start_row: rowIndex + offset - 1,
@@ -143,24 +146,19 @@ module.exports = require("datasaur-local").extend("PerspectiveDataModel", {
             end_col: columnIndex + 1,
             index: true
         });
-        const editor = this.grid.cellEditors.create("textfield", options);
-        editor.setEditorValue = function(old) {
-            return old;
-        };
+        const editor = this.grid.cellEditors.create(declaredEditorName, options);
+        editor.el.addEventListener("blur", () => setTimeout(() => editor.cancelEditing()));
         editor.getEditorValue = updated => {
             row.then(old => {
                 old = old[0];
                 const index = old.__INDEX__;
-                console.log(index);
                 delete old["__INDEX__"];
                 const colname = Object.keys(old)[0];
                 this._table.update([{__INDEX__: index, [colname]: updated}]);
-                console.log(old);
             });
             return updated;
         };
         return editor;
-        //this.grid.cellEditors.add("perspective-editor", editor);
     },
 
     getCell: function(config, rendererName) {

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -134,6 +134,35 @@ module.exports = require("datasaur-local").extend("PerspectiveDataModel", {
         }
     },
 
+    getCellEditorAt: function(columnIndex, rowIndex, declaredEditorName, options) {
+        const offset = this.grid.renderer.dataWindow.top;
+        const row = this._view.to_json({
+            start_row: rowIndex + offset - 1,
+            end_row: rowIndex + offset,
+            start_col: columnIndex,
+            end_col: columnIndex + 1,
+            index: true
+        });
+        const editor = this.grid.cellEditors.create("textfield", options);
+        editor.setEditorValue = function(old) {
+            return old;
+        };
+        editor.getEditorValue = updated => {
+            row.then(old => {
+                old = old[0];
+                const index = old.__INDEX__;
+                console.log(index);
+                delete old["__INDEX__"];
+                const colname = Object.keys(old)[0];
+                this._table.update([{__INDEX__: index, [colname]: updated}]);
+                console.log(old);
+            });
+            return updated;
+        };
+        return editor;
+        //this.grid.cellEditors.add("perspective-editor", editor);
+    },
+
     getCell: function(config, rendererName) {
         var nextRow, depthDelta;
         if (config.isUserDataArea) {

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -150,6 +150,7 @@ module.exports = require("datasaur-local").extend("PerspectiveDataModel", {
         editor._row = this._view.to_json(args);
         editor.el.addEventListener("blur", () => setTimeout(() => editor.cancelEditing()));
         editor._table = this._table;
+        editor._data = this.data;
         return editor;
     },
 

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -139,25 +139,17 @@ module.exports = require("datasaur-local").extend("PerspectiveDataModel", {
             return;
         }
         const offset = this.grid.renderer.dataWindow.top;
-        const row = this._view.to_json({
+        const editor = this.grid.cellEditors.create(declaredEditorName, options);
+        const args = {
             start_row: rowIndex + offset - 1,
             end_row: rowIndex + offset,
             start_col: columnIndex,
             end_col: columnIndex + 1,
             index: true
-        });
-        const editor = this.grid.cellEditors.create(declaredEditorName, options);
-        editor.el.addEventListener("blur", () => setTimeout(() => editor.cancelEditing()));
-        editor.getEditorValue = updated => {
-            row.then(old => {
-                old = old[0];
-                const index = old.__INDEX__;
-                delete old["__INDEX__"];
-                const colname = Object.keys(old)[0];
-                this._table.update([{__INDEX__: index, [colname]: updated}]);
-            });
-            return updated;
         };
+        editor._row = this._view.to_json(args);
+        editor.el.addEventListener("blur", () => setTimeout(() => editor.cancelEditing()));
+        editor._table = this._table;
         return editor;
     },
 

--- a/packages/perspective-viewer-hypergrid/src/js/editors.js
+++ b/packages/perspective-viewer-hypergrid/src/js/editors.js
@@ -76,6 +76,16 @@ function getEditorValueText(updated) {
     return this.localizer.format(updated);
 }
 
+function getEditorValueNumber(updated) {
+    this._row.then(([old]) => {
+        const index = old.__INDEX__;
+        delete old["__INDEX__"];
+        const colname = Object.keys(old)[0];
+        this._table.update([{__INDEX__: index, [colname]: Number(updated.replace(/,/g, ""))}]);
+    });
+    return this.localizer.format(updated);
+}
+
 function getEditorValueDate(updated) {
     updated = new Date(updated);
     this._row.then(([old]) => {
@@ -87,6 +97,13 @@ function getEditorValueDate(updated) {
     return this.localizer.format(updated);
 }
 
+function saveEditorValue(x) {
+    var save = !(x && x === this.initialValue) && this.grid.fireBeforeCellEdit(this.event.gridCell, this.initialValue, x, this);
+    if (save) {
+        this._data[this.event.gridCell.y - 1][this.event.gridCell.x] = x;
+    }
+}
+
 export function set_editors(grid) {
     const date = Textfield.extend("perspective-date", {
         localizer: grid.localization.get("chromeDate"),
@@ -95,7 +112,8 @@ export function set_editors(grid) {
         setEditorValue: setEditorValueDate,
         validateEditorValue: validateEditorValueDate,
         setBounds: setBoundsDate,
-        selectAll: () => {}
+        selectAll: () => {},
+        saveEditorValue
     });
 
     const datetime = Textfield.extend("perspective-datetime", {
@@ -105,23 +123,23 @@ export function set_editors(grid) {
         setEditorValue: setEditorValueDatetime,
         validateEditorValue: validateEditorValueDate,
         setBounds: setBoundsDate,
-        selectAll: () => {}
+        selectAll: () => {},
+        saveEditorValue
     });
 
     const text = Textfield.extend("perspective-text", {
         setBounds: setBoundsText,
         setEditorValue: setEditorValueText,
         getEditorValue: getEditorValueText,
-        validateEditorValue: function(str) {
-            return this.localizer.invalid && this.localizer.invalid(str || this.input.value);
-        }
+        saveEditorValue
     });
 
     const number = Textfield.extend("perspective-number", {
         setBounds: setBoundsText,
         setEditorValue: setEditorValueText,
-        getEditorValue: getEditorValueText,
-        validateEditorValue: x => isNaN(Number(x))
+        getEditorValue: getEditorValueNumber,
+        validateEditorValue: x => isNaN(Number(x.replace(/,/g, ""))),
+        saveEditorValue
     });
 
     grid.cellEditors.add(number);

--- a/packages/perspective-viewer-hypergrid/src/js/editors.js
+++ b/packages/perspective-viewer-hypergrid/src/js/editors.js
@@ -1,0 +1,85 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const Textfield = require("fin-hypergrid/src/cellEditors/Textfield");
+
+function px(n) {
+    return n + "px";
+}
+
+function validateEditorValueDate(x) {
+    const d = new Date(x);
+    return !(d instanceof Date && !isNaN(d));
+}
+
+function setBoundsDate(cellBounds) {
+    var style = this.el.style;
+    style.left = px(cellBounds.x + 4);
+    style.top = px(cellBounds.y - 3);
+    style.width = px(cellBounds.width + 50);
+    style.height = px(cellBounds.height);
+}
+
+function setBoundsText(cellBounds) {
+    var style = this.el.style;
+    style.left = px(cellBounds.x + 4);
+    style.top = px(cellBounds.y - 3);
+    style.width = px(cellBounds.width - 10);
+    style.height = px(cellBounds.height);
+}
+
+function setEditorValueDate(x) {
+    const now = +new Date(x);
+    const day = ("0" + now.getDate()).slice(-2);
+    const month = ("0" + (now.getMonth() + 1)).slice(-2);
+    this.input.value = `${now.getFullYear()}-${month}-${day}`;
+}
+
+function setEditorValueDatetime(x) {
+    const now = new Date(x);
+    const day = ("0" + now.getDate()).slice(-2);
+    const month = ("0" + (now.getMonth() + 1)).slice(-2);
+    const hour = ("0" + now.getHours()).slice(-2);
+    const minute = ("0" + now.getMinutes()).slice(-2);
+    const ss = ("0" + now.getSeconds()).slice(-2);
+    this.input.value = `${now.getFullYear()}-${month}-${day}T${hour}:${minute}:${ss}`;
+}
+
+export function set_editors(grid) {
+    const base_args = {
+        localizer: grid.localization.get("chromeDate"),
+        getEditorValue: x => new Date(x),
+        validateEditorValue: validateEditorValueDate,
+        setBounds: setBoundsDate,
+        selectAll: () => {}
+    };
+
+    const date = Textfield.extend("perspective-date", {
+        template: "<input class='hypergrid-textfield' type='date'>",
+        setEditorValue: setEditorValueDate,
+        setBounds: setBoundsDate,
+        ...base_args
+    });
+
+    const datetime = Textfield.extend("perspective-datetime", {
+        template: "<input class='hypergrid-textfield' type='datetime-local'>",
+        getEditorValue: x => +new Date(x),
+        setEditorValue: setEditorValueDatetime,
+        setBounds: setBoundsDate,
+        ...base_args
+    });
+
+    const text = Textfield.extend("perspective-text", {
+        setBounds: setBoundsText
+    });
+
+    grid.cellEditors.add(date);
+    grid.cellEditors.add(datetime);
+    grid.cellEditors.add(text);
+}

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -14,114 +14,16 @@ const groupedHeaderPlugin = require("fin-hypergrid-grouped-header-plugin");
 const perspectivePlugin = require("./perspective-plugin");
 const PerspectiveDataModel = require("./PerspectiveDataModel");
 const {psp2hypergrid, page2hypergrid} = require("./psp-to-hypergrid");
-const {cloneDeep} = require("lodash");
 
 import {bindTemplate} from "@finos/perspective-viewer/dist/esm/utils.js";
 
 const TEMPLATE = require("../html/hypergrid.html");
 
 import style from "../less/hypergrid.less";
-import {get_styles, clear_styles} from "./styles.js";
+import {get_styles, clear_styles, default_grid_properties} from "./styles.js";
 import {set_formatters} from "./formatters.js";
 import {set_editors} from "./editors.js";
 import {treeLineRendererPaint} from "./hypergrid-tree-cell-renderer";
-
-const COLUMN_HEADER_FONT = "12px Helvetica, sans-serif";
-const GROUP_LABEL_FONT = "12px Open Sans, sans-serif";
-
-const base_grid_properties = {
-    autoSelectRows: false,
-    cellPadding: 5,
-    cellSelection: false,
-    columnSelection: false,
-    rowSelection: false,
-    checkboxOnlyRowSelections: false,
-    columnClip: true,
-    columnHeaderFont: COLUMN_HEADER_FONT,
-    columnHeaderForegroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
-    columnsReorderable: false,
-    defaultRowHeight: 24,
-    editable: true,
-    editOnKeydown: true,
-    editorActivationKeys: ["alt", "esc"],
-    enableContinuousRepaint: false,
-    fixedColumnCount: 0,
-    fixedRowCount: 0,
-    fixedLinesHWidth: 1,
-    fixedLinesVWidth: 1,
-    font: '12px "Arial", Helvetica, sans-serif',
-    foregroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
-    gridLinesH: false,
-    gridLinesV: true, // except: due to groupedHeaderPlugin's `clipRuleLines: true` option, only header row displays these lines
-    gridLinesUserDataArea: false, // restricts vertical rule line rendering to header row only
-    halign: "left",
-    headerTextWrapping: false,
-    hoverColumnHighlight: {enabled: false},
-    hoverRowHighlight: {
-        enabled: true,
-        backgroundColor: "#555"
-    },
-    hoverCellHighlight: {
-        enabled: true,
-        backgroundColor: "#333"
-    },
-    noDataMessage: "",
-    minimumColumnWidth: 50,
-    multipleSelections: false,
-    renderFalsy: false,
-    rowHeaderFont: "12px Arial, Helvetica, sans-serif",
-    rowHeaderForegroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
-    rowResize: true,
-    scrollbarHoverOff: "visible",
-    rowHeaderCheckboxes: false,
-    rowHeaderNumbers: false,
-    showFilterRow: true,
-    showHeaderRow: true,
-    showTreeColumn: false,
-    singleRowSelectionMode: false,
-    sortColumns: [],
-    sortOnDoubleClick: true,
-    treeRenderer: "TreeCell",
-    treeHeaderFont: "12px Arial, Helvetica, sans-serif",
-    treeHeaderForegroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
-    useBitBlit: false,
-    vScrollbarClassPrefix: "",
-    voffset: 0
-};
-
-const light_theme_overrides = {
-    backgroundColor: "#ffffff",
-    color: "#666",
-    lineColor: "#AAA",
-    // font: '12px Arial, Helvetica, sans-serif',
-    font: '12px "Open Sans", Helvetica, sans-serif',
-    foregroundSelectionFont: "12px amplitude-regular, Helvetica, sans-serif",
-    foregroundSelectionColor: "#666",
-    backgroundSelectionColor: "rgba(162, 183, 206, 0.3)",
-    selectionRegionOutlineColor: "rgb(45, 64, 85)",
-    columnHeaderColor: "#666",
-    columnHeaderHalign: "left", // except: group header labels always 'center'; numbers always 'right' per `setPSP`
-    columnHeaderBackgroundColor: "#fff",
-    columnHeaderForegroundSelectionColor: "#333",
-    columnHeaderBackgroundSelectionColor: "#40536d",
-    rowHeaderForegroundSelectionFont: "12px Arial, Helvetica, sans-serif",
-    treeHeaderColor: "#666",
-    treeHeaderBackgroundColor: "#fff",
-    treeHeaderForegroundSelectionColor: "#333",
-    treeHeaderBackgroundSelectionColor: "#40536d",
-    hoverCellHighlight: {
-        enabled: true,
-        backgroundColor: "#eeeeee"
-    },
-    hoverRowHighlight: {
-        enabled: true,
-        backgroundColor: "#f6f6f6"
-    }
-};
-
-function generateGridProperties(overrides) {
-    return Object.assign({}, cloneDeep(base_grid_properties), cloneDeep(overrides));
-}
 
 bindTemplate(TEMPLATE, style)(
     class HypergridElement extends HTMLElement {
@@ -144,22 +46,8 @@ bindTemplate(TEMPLATE, style)(
                 host.removeAttribute("hidden");
                 this.grid.get_styles = () => get_styles(this);
 
-                this.grid.installPlugins([
-                    perspectivePlugin,
-                    [
-                        groupedHeaderPlugin,
-                        {
-                            paintBackground: null, // no group header label decoration
-                            columnHeaderLines: false, // only draw vertical rule lines between group labels
-                            groupConfig: [
-                                {
-                                    halign: "center", // center group labels
-                                    font: GROUP_LABEL_FONT
-                                }
-                            ]
-                        }
-                    ]
-                ]);
+                const grid_properties = default_grid_properties();
+                this.grid.installPlugins([perspectivePlugin, [groupedHeaderPlugin, grid_properties.groupedHeader]]);
 
                 // Broken in fin-hypergrid-grouped-header 0.1.2
                 let _old_paint = this.grid.cellRenderers.items.GroupedHeader.paint;
@@ -168,9 +56,6 @@ bindTemplate(TEMPLATE, style)(
                     return _old_paint.call(this, gc, config);
                 };
 
-                const grid_properties = generateGridProperties(light_theme_overrides);
-
-                grid_properties["showRowNumbers"] = grid_properties["showCheckboxes"] || grid_properties["showRowNumbers"];
                 this.grid.addProperties(grid_properties);
                 const styles = get_styles(this);
                 this.grid.addProperties(styles[""]);

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -15,6 +15,7 @@ const perspectivePlugin = require("./perspective-plugin");
 const PerspectiveDataModel = require("./PerspectiveDataModel");
 const {psp2hypergrid, page2hypergrid} = require("./psp-to-hypergrid");
 const {cloneDeep} = require("lodash");
+const Textfield = require("fin-hypergrid/src/cellEditors/Textfield");
 
 import {bindTemplate} from "@finos/perspective-viewer/dist/esm/utils.js";
 
@@ -40,9 +41,9 @@ const base_grid_properties = {
     columnHeaderForegroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
     columnsReorderable: false,
     defaultRowHeight: 24,
-    editable: false,
+    editable: true,
     editOnKeydown: true,
-    editor: "textfield",
+    editor: "perspective-editor",
     editorActivationKeys: ["alt", "esc"],
     enableContinuousRepaint: false,
     fixedColumnCount: 0,
@@ -203,6 +204,7 @@ async function grid_update(div, view, task) {
     const dataModel = this.hypergrid.behavior.dataModel;
     dataModel.setDirty(nrows);
     dataModel._view = view;
+    dataModel._table = this._table;
     this.hypergrid.canvas.paintNow();
 }
 
@@ -249,6 +251,7 @@ async function grid_create(div, view, task) {
     const hypergrid = this.hypergrid;
     if (hypergrid) {
         hypergrid.behavior.dataModel._view = undefined;
+        hypergrid.behavior.dataModel._table = undefined;
     }
 
     const config = await view.get_config();
@@ -282,6 +285,7 @@ async function grid_create(div, view, task) {
     dataModel.setIsTree(rowPivots.length > 0);
     dataModel.setDirty(nrows);
     dataModel._view = view;
+    dataModel._table = this._table;
     dataModel._config = config;
     dataModel._viewer = this;
 

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -103,11 +103,11 @@ function setColumnPropsByType(column) {
     const isEditable = this.grid.behavior.dataModel._viewer.hasAttribute("editable");
     if (isEditable && config.row_pivots.length === 0 && config.row_pivots.length === 0) {
         props.editor = {
-            integer: "perspective-text",
+            integer: "perspective-number",
             string: "perspective-text",
             date: "perspective-date",
             datetime: "perspective-datetime",
-            float: "perspective-text"
+            float: "perspective-number"
         }[column.type];
     }
     const styles = this.grid.get_styles();

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -15,7 +15,7 @@ const lodash = require("lodash");
  * @this {Behavior}
  * @param payload
  */
-function setPSP(payload) {
+function setPSP(payload, force = false) {
     const new_schema = [];
 
     if (payload.isTree) {
@@ -48,6 +48,7 @@ function setPSP(payload) {
     this.refreshColumns = refreshColumns;
 
     if (
+        !force &&
         this._memoized_schema &&
         lodash.isEqual(this._memoized_schema.slice(0, this._memoized_schema.length), new_schema.slice(0, new_schema.length)) &&
         lodash.isEqual(payload.rowPivots, this._memoized_pivots)
@@ -97,6 +98,17 @@ function setColumnPropsByType(column) {
         props.format = "FinanceTree";
     } else {
         props.format = `perspective-${column.type}`;
+    }
+    const config = this.grid.behavior.dataModel._config;
+    const isEditable = this.grid.behavior.dataModel._viewer.hasAttribute("editable");
+    if (isEditable && config.row_pivots.length === 0 && config.row_pivots.length === 0) {
+        props.editor = {
+            integer: "perspective-text",
+            string: "perspective-text",
+            date: "perspective-date",
+            datetime: "perspective-datetime",
+            float: "perspective-text"
+        }[column.type];
     }
     const styles = this.grid.get_styles();
     if (styles[column.type]) {

--- a/packages/perspective-viewer-hypergrid/src/js/styles.js
+++ b/packages/perspective-viewer-hypergrid/src/js/styles.js
@@ -8,6 +8,7 @@
  */
 
 import {PropsBuilder} from "@finos/perspective-viewer/dist/esm/custom_styles";
+import {cloneDeep} from "lodash";
 
 const properties = new PropsBuilder();
 const title = `--hypergrid`;
@@ -60,4 +61,114 @@ export function get_styles(elem) {
 
 export function clear_styles(elem) {
     return properties.clear_properties(elem);
+}
+
+const COLUMN_HEADER_FONT = "12px Helvetica, sans-serif";
+const GROUP_LABEL_FONT = "12px Open Sans, sans-serif";
+
+const base_grid_properties = {
+    autoSelectRows: false,
+    cellPadding: 5,
+    cellSelection: false,
+    columnSelection: false,
+    rowSelection: false,
+    checkboxOnlyRowSelections: false,
+    columnClip: true,
+    columnHeaderFont: COLUMN_HEADER_FONT,
+    columnHeaderForegroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
+    columnsReorderable: false,
+    defaultRowHeight: 24,
+    editable: true,
+    editOnKeydown: true,
+    editorActivationKeys: ["alt", "esc"],
+    enableContinuousRepaint: false,
+    feedbackCount: 1000000,
+    fixedColumnCount: 0,
+    fixedRowCount: 0,
+    fixedLinesHWidth: 1,
+    fixedLinesVWidth: 1,
+    font: '12px "Arial", Helvetica, sans-serif',
+    foregroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
+    gridLinesH: false,
+    gridLinesV: true, // except: due to groupedHeaderPlugin's `clipRuleLines: true` option, only header row displays these lines
+    gridLinesUserDataArea: false, // restricts vertical rule line rendering to header row only
+    groupedHeader: {
+        paintBackground: null, // no group header label decoration
+        columnHeaderLines: false, // only draw vertical rule lines between group labels
+        groupConfig: [
+            {
+                halign: "center", // center group labels
+                font: GROUP_LABEL_FONT
+            }
+        ]
+    },
+    halign: "left",
+    headerTextWrapping: false,
+    hoverColumnHighlight: {enabled: false},
+    hoverRowHighlight: {
+        enabled: true,
+        backgroundColor: "#555"
+    },
+    hoverCellHighlight: {
+        enabled: true,
+        backgroundColor: "#333"
+    },
+    noDataMessage: "",
+    minimumColumnWidth: 50,
+    multipleSelections: false,
+    renderFalsy: false,
+    rowHeaderFont: "12px Arial, Helvetica, sans-serif",
+    rowHeaderForegroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
+    rowResize: true,
+    scrollbarHoverOff: "visible",
+    rowHeaderCheckboxes: false,
+    rowHeaderNumbers: false,
+    showFilterRow: true,
+    showHeaderRow: true,
+    showTreeColumn: false,
+    showRowNumbers: false,
+    showCheckboxes: false,
+    singleRowSelectionMode: false,
+    sortColumns: [],
+    sortOnDoubleClick: true,
+    treeRenderer: "TreeCell",
+    treeHeaderFont: "12px Arial, Helvetica, sans-serif",
+    treeHeaderForegroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
+    useBitBlit: false,
+    vScrollbarClassPrefix: "",
+    voffset: 0
+};
+
+const light_theme_overrides = {
+    backgroundColor: "#ffffff",
+    color: "#666",
+    lineColor: "#AAA",
+    // font: '12px Arial, Helvetica, sans-serif',
+    font: '12px "Open Sans", Helvetica, sans-serif',
+    foregroundSelectionFont: "12px amplitude-regular, Helvetica, sans-serif",
+    foregroundSelectionColor: "#666",
+    backgroundSelectionColor: "rgba(162, 183, 206, 0.3)",
+    selectionRegionOutlineColor: "rgb(45, 64, 85)",
+    columnHeaderColor: "#666",
+    columnHeaderHalign: "left", // except: group header labels always 'center'; numbers always 'right' per `setPSP`
+    columnHeaderBackgroundColor: "#fff",
+    columnHeaderForegroundSelectionColor: "#333",
+    columnHeaderBackgroundSelectionColor: "#40536d",
+    rowHeaderForegroundSelectionFont: "12px Arial, Helvetica, sans-serif",
+    treeHeaderColor: "#666",
+    treeHeaderBackgroundColor: "#fff",
+    treeHeaderForegroundSelectionColor: "#333",
+    treeHeaderBackgroundSelectionColor: "#40536d",
+    hoverCellHighlight: {
+        enabled: true,
+        backgroundColor: "#eeeeee"
+    },
+    hoverRowHighlight: {
+        enabled: true,
+        backgroundColor: "#f6f6f6"
+    }
+};
+
+export function default_grid_properties(overrides = light_theme_overrides) {
+    return Object.assign({}, cloneDeep(base_grid_properties), cloneDeep(overrides));
 }

--- a/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
+++ b/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
@@ -33,6 +33,13 @@
         color: #de3838;
     }
 
+    input.hypergrid-textfield {
+        position: absolute;
+        outline: none;
+        border: 1px solid #ccc;
+        box-shadow: 2px 0px 5px tgba(0,0,0,0.5);
+    }
+
     #gridWrapper {
         box-sizing: border-box;
         width: 100%;

--- a/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
+++ b/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
@@ -37,8 +37,9 @@
         position: absolute;
         outline: none;
         border: none;
-        box-shadow: 0px 2px 5px rgba(0,0,0,0.2);
+        box-shadow: 0px 2px 3px rgba(0,0,0,0.2);
         color: var(--hypergrid--color, inherit);
+        background: var(--hypergrid--background, white);
         padding-right: 10px;
     }
 

--- a/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
+++ b/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
@@ -36,8 +36,10 @@
     input.hypergrid-textfield {
         position: absolute;
         outline: none;
-        border: 1px solid #ccc;
-        box-shadow: 2px 0px 5px tgba(0,0,0,0.5);
+        border: none;
+        box-shadow: 0px 2px 5px rgba(0,0,0,0.2);
+        color: var(--hypergrid--color, inherit);
+        padding-right: 10px;
     }
 
     #gridWrapper {

--- a/packages/perspective-viewer-hypergrid/test/html/editable.html
+++ b/packages/perspective-viewer-hypergrid/test/html/editable.html
@@ -1,0 +1,38 @@
+<!--
+   
+   Copyright (c) 2017, the Perspective Authors.
+   
+   This file is part of the Perspective library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon"> 
+        <script src="perspective-viewer.js"></script>
+        <script src="perspective-viewer-hypergrid.js"></script>
+
+        <link rel='stylesheet' href="demo.css">
+
+    </head>
+    <body>
+
+        <perspective-viewer columns='["Row ID","Order ID","Order Date","Sales"]' editable>
+  
+        </perspective-viewer>
+
+        <script>
+
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', 'superstore.csv', true);
+            xhr.onload = function () { 
+                document.getElementsByTagName('perspective-viewer')[0].load(xhr.response); 
+            }
+            xhr.send(null);
+
+        </script>
+
+    </body>
+</html>

--- a/packages/perspective-viewer-hypergrid/test/js/editing.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/editing.spec.js
@@ -1,0 +1,114 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const utils = require("@finos/perspective-test");
+const path = require("path");
+
+const {dblclick} = require("./utils.js");
+
+utils.with_server({}, () => {
+    describe.page(
+        "superstore.html",
+        () => {
+            describe("editing UI opens", () => {
+                test.capture("should not edit an immutable viewer", async page => {
+                    await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.waitForSelector("perspective-viewer[settings]");
+                    await dblclick(page);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                });
+            });
+        },
+        {reload_page: true, root: path.join(__dirname, "..", "..")}
+    );
+
+    describe.page(
+        "editable.html",
+        () => {
+            describe("editing UI opens", () => {
+                test.capture("should open an editor on a string column", async page => {
+                    await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.waitForSelector("perspective-viewer[settings]");
+                    await dblclick(page);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                });
+
+                test.capture("should open an editor on an integer column", async page => {
+                    await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.waitForSelector("perspective-viewer[settings]");
+                    await dblclick(page, 50);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                });
+
+                test.capture("should open an editor on a datetime column", async page => {
+                    await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.waitForSelector("perspective-viewer[settings]");
+                    await dblclick(page, 400);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                });
+            });
+
+            describe("editing UI saves", () => {
+                test.capture("should save edits to a string column", async page => {
+                    await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.waitForSelector("perspective-viewer[settings]");
+                    await dblclick(page);
+                    await page.keyboard.sendCharacter("a");
+                    await page.keyboard.sendCharacter("b");
+                    await page.keyboard.sendCharacter("c");
+                    await page.keyboard.sendCharacter("d");
+                    await page.keyboard.press("Enter");
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                });
+
+                test.capture("should save edits to an integer column", async page => {
+                    await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.waitForSelector("perspective-viewer[settings]");
+                    await dblclick(page, 50);
+                    await page.keyboard.sendCharacter("1");
+                    await page.keyboard.sendCharacter("2");
+                    await page.keyboard.press("Enter");
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                });
+
+                test.capture("should save edits of negative numbers to an integer column", async page => {
+                    await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.waitForSelector("perspective-viewer[settings]");
+                    await dblclick(page, 50);
+                    await page.keyboard.sendCharacter("-");
+                    await page.keyboard.sendCharacter("1");
+                    await page.keyboard.sendCharacter("2");
+                    await page.keyboard.press("Enter");
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                });
+
+                test.capture("should fail to save edits of invalid integers", async page => {
+                    await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.waitForSelector("perspective-viewer[settings]");
+                    await dblclick(page, 50);
+                    await page.keyboard.sendCharacter("1");
+                    await page.keyboard.sendCharacter("2");
+                    await page.keyboard.sendCharacter("A");
+                    await page.keyboard.press("Enter");
+                    await page.waitFor(100);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                });
+            });
+        },
+        {reload_page: true, root: path.join(__dirname, "..", "..")}
+    );
+});

--- a/packages/perspective-viewer-hypergrid/test/js/utils.js
+++ b/packages/perspective-viewer-hypergrid/test/js/utils.js
@@ -7,6 +7,22 @@
  *
  */
 
+exports.dblclick = async (page, x = 310, y = 300) => {
+    await page.evaluate(
+        ({x, y}) => {
+            const example = document
+                .querySelector("perspective-viewer")
+                .shadowRoot.querySelector("perspective-hypergrid")
+                .shadowRoot.querySelector("canvas");
+
+            const event = document.createEvent("MouseEvents");
+            event.initMouseEvent("dblclick", true, false, window, 0, x, y, x, y, false, false, false, false, 2, null);
+            example.dispatchEvent(event);
+        },
+        {x, y}
+    );
+};
+
 exports.click_details = async (page, x = 310, y = 300) => {
     const viewer = await page.$("perspective-viewer");
 

--- a/packages/perspective-viewer/src/js/computed_column.js
+++ b/packages/perspective-viewer/src/js/computed_column.js
@@ -30,10 +30,22 @@ const month_of_year = function(val) {
     return ["01 January", "02 February", "03 March", "04 April", "05 May", "06 June", "07 July", "08 August", "09 September", "10 October", "11 November", "12 December"][new Date(val).getMonth()];
 };
 
+const second_bucket = function(val) {
+    return new Date(Math.floor(new Date(val).getTime() / 1000) * 1000);
+};
+
+const minute_bucket = function(val) {
+    let date = new Date(val);
+    date.setSeconds(0);
+    date.setMilliseconds(0);
+    return date;
+};
+
 const hour_bucket = function(val) {
     let date = new Date(val);
     date.setMinutes(0);
     date.setSeconds(0);
+    date.setMilliseconds(0);
     return date;
 };
 
@@ -42,6 +54,7 @@ const day_bucket = function(val) {
     date.setHours(0);
     date.setMinutes(0);
     date.setSeconds(0);
+    date.setMilliseconds(0);
     return date;
 };
 
@@ -69,6 +82,8 @@ export const COMPUTATIONS = {
     hour_of_day: new Computation("hour_of_day", "datetime", "integer", hour_of_day),
     day_of_week: new Computation("day_of_week", "datetime", "string", day_of_week),
     month_of_year: new Computation("month_of_year", "datetime", "string", month_of_year),
+    second_bucket: new Computation("second_bucket", "datetime", "datetime", second_bucket),
+    minute_bucket: new Computation("minute_bucket", "datetime", "datetime", minute_bucket),
     hour_bucket: new Computation("hour_bucket", "datetime", "datetime", hour_bucket),
     day_bucket: new Computation("day_bucket", "datetime", "date", day_bucket),
     week_bucket: new Computation("week_bucket", "datetime", "date", week_bucket),

--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -39,7 +39,7 @@ polyfill({});
  * @module perspective-viewer
  */
 
-const PERSISTENT_ATTRIBUTES = ["plugin", "row-pivots", "column-pivots", "aggregates", "filters", "sort", "computed-columns", "columns"];
+const PERSISTENT_ATTRIBUTES = ["editable", "plugin", "row-pivots", "column-pivots", "aggregates", "filters", "sort", "computed-columns", "columns"];
 
 /**
  * HTMLElement class for `<perspective-viewer>` custom element.  This class is
@@ -370,6 +370,26 @@ class PerspectiveViewer extends ActionElement {
         this._update_column_list(pivots, inner, pivot => this._new_row(pivot));
         this.dispatchEvent(new Event("perspective-config-update"));
         this._debounce_update();
+    }
+
+    /**
+     * Determines whether this viewer is editable or not (though it is
+     * ultimately up to the plugin as to whether editing is implemented).
+     *
+     * @kind member
+     * @type {boolean} Is this viewer editable?
+     * @fires PerspectiveViewer#perspective-config-update
+     */
+    set editable(x) {
+        if (x === "null") {
+            if (this.hasAttribute("editable")) {
+                this.removeAttribute("editable");
+            }
+        } else {
+            this.toggleAttribute("editable", true);
+        }
+        this._debounce_update({force_update: true});
+        this.dispatchEvent(new Event("perspective-config-update"));
     }
 
     /**

--- a/packages/perspective-viewer/src/js/viewer/perspective_element.js
+++ b/packages/perspective-viewer/src/js/viewer/perspective_element.js
@@ -378,9 +378,9 @@ export class PerspectiveElement extends StateElement {
 
         try {
             if (limit_points) {
-                await this._plugin.create.call(this, this._datavis, this._view, task, max_cols, max_rows);
+                await this._plugin.create.call(this, this._datavis, this._view, task, max_cols, max_rows, force_update);
             } else {
-                await this._plugin.create.call(this, this._datavis, this._view, task);
+                await this._plugin.create.call(this, this._datavis, this._view, task, undefined, undefined, force_update);
             }
         } catch (err) {
             console.warn(err);


### PR DESCRIPTION
Adds the `editable` attribute to `<perspective-viewer>`, which allows cells to be edited.  Edits are treated as `update()` on the underlying `table`.

![date_edit](https://user-images.githubusercontent.com/60666/64375565-2585b400-cff4-11e9-9012-0f968350b468.gif)