### PR TITLE
Type-on-edit

### DIFF
--- a/examples/simple/superstore-hypergrid.html
+++ b/examples/simple/superstore-hypergrid.html
@@ -27,7 +27,7 @@
 
 <body>
 
-    <perspective-viewer plugin='hypergrid' filters='[["State","==","Texas"]]' editable>
+    <perspective-viewer id="grid" plugin='hypergrid' filters='[["State","==","Texas"]]' editable>
 
     </perspective-viewer>
 

--- a/examples/simple/superstore-hypergrid.html
+++ b/examples/simple/superstore-hypergrid.html
@@ -1,0 +1,50 @@
+<!--
+   
+   Copyright (c) 2017, the Perspective Authors.
+   
+   This file is part of the Perspective library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+
+    <script src="perspective-viewer.js"></script>
+    <script src="perspective-viewer-hypergrid.js"></script>
+    <script src="perspective-viewer-d3fc.js"></script>
+
+    <script src="perspective.js"></script>
+
+    <link rel='stylesheet' href="index.css">
+    <link rel='stylesheet' href="material.css" is="custom-style">
+
+</head>
+
+<body>
+
+    <perspective-viewer plugin='hypergrid' filters='[["State","==","Texas"]]' editable>
+
+    </perspective-viewer>
+
+    <script>
+        window.addEventListener('WebComponentsReady', function() {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', 'superstore.arrow', true);
+            xhr.responseType = "arraybuffer"
+            xhr.onload = function() {
+                var el = document.getElementsByTagName('perspective-viewer')[0];
+                el.load(xhr.response);
+                el.toggleConfig();
+            }
+            xhr.send(null);
+        });
+    </script>
+
+</body>
+
+</html>

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -115,7 +115,6 @@ module.exports = require("datasaur-local").extend("PerspectiveDataModel", {
     _update_editor: function([rect]) {
         const editor = this.grid.cellEditor;
         let new_index;
-
         if (editor) {
             new_index = find_row(this.data, editor._index);
             editor.event.resetGridXY(editor.event.dataCell.x, new_index - rect.origin.y + 1);

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -151,6 +151,7 @@ module.exports = require("datasaur-local").extend("PerspectiveDataModel", {
         editor.el.addEventListener("blur", () => setTimeout(() => editor.cancelEditing()));
         editor._table = this._table;
         editor._data = this.data;
+        editor._canvas = this.grid.canvas.canvas;
         return editor;
     },
 

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -7,8 +7,12 @@
  *
  */
 
-const TREE_COLUMN_INDEX = require("fin-hypergrid/src/behaviors/Behavior").prototype.treeColumnIndex;
-const {get_type_config} = require("@finos/perspective/dist/esm/config/index.js");
+import Behavior from "fin-hypergrid/src/behaviors/Behavior";
+import {get_type_config} from "@finos/perspective/dist/esm/config/index.js";
+
+const {
+    prototype: {treeColumnIndex: TREE_COLUMN_INDEX}
+} = Behavior;
 
 function getSubrects(nrows) {
     if (!this.dataWindow) {
@@ -28,7 +32,7 @@ function find_row(rows, index) {
     return -1;
 }
 
-module.exports = require("datasaur-local").extend("PerspectiveDataModel", {
+export default require("datasaur-local").extend("PerspectiveDataModel", {
     isTreeCol: function(x) {
         return x === TREE_COLUMN_INDEX && this.isTree();
     },

--- a/packages/perspective-viewer-hypergrid/src/js/editors.js
+++ b/packages/perspective-viewer-hypergrid/src/js/editors.js
@@ -20,18 +20,18 @@ function validateEditorValueDate(x) {
 
 function setBoundsDate(cellBounds) {
     const style = this.el.style;
-    style.left = px(cellBounds.x);
-    style.top = px(cellBounds.y);
-    style.width = px(cellBounds.width + 50);
-    style.height = px(cellBounds.height - 1);
+    style.left = px(cellBounds.x - 1);
+    style.top = px(cellBounds.y - 1);
+    style.width = px(cellBounds.width + 52);
+    style.height = px(cellBounds.height + 2);
 }
 
 function setBoundsText(cellBounds) {
     const style = this.el.style;
-    style.left = px(cellBounds.x + 1);
-    style.top = px(cellBounds.y + 1);
-    style.width = px(cellBounds.width - 2);
-    style.height = px(cellBounds.height - 2);
+    style.left = px(cellBounds.x - 1);
+    style.top = px(cellBounds.y - 1);
+    style.width = px(cellBounds.width + 2);
+    style.height = px(cellBounds.height + 2);
 }
 
 function setEditorValueDate(x) {

--- a/packages/perspective-viewer-hypergrid/src/js/editors.js
+++ b/packages/perspective-viewer-hypergrid/src/js/editors.js
@@ -7,7 +7,7 @@
  *
  */
 
-const Textfield = require("fin-hypergrid/src/cellEditors/Textfield");
+import Textfield from "fin-hypergrid/src/cellEditors/Textfield";
 
 function px(n) {
     return n + "px";

--- a/packages/perspective-viewer-hypergrid/src/js/editors.js
+++ b/packages/perspective-viewer-hypergrid/src/js/editors.js
@@ -42,6 +42,7 @@ function setEditorValueDate(x) {
     const day = ("0" + now.getDate()).slice(-2);
     const month = ("0" + (now.getMonth() + 1)).slice(-2);
     this.input.value = `${now.getFullYear()}-${month}-${day}`;
+    this.input.addEventListener("keydown", keydown.bind(this));
 }
 
 function setEditorValueDatetime(x) {
@@ -55,6 +56,7 @@ function setEditorValueDatetime(x) {
     const minute = ("0" + now.getMinutes()).slice(-2);
     const ss = ("0" + now.getSeconds()).slice(-2);
     this.input.value = `${now.getFullYear()}-${month}-${day}T${hour}:${minute}:${ss}`;
+    this.input.addEventListener("keydown", keydown.bind(this));
 }
 
 function setEditorValueText(updated) {
@@ -182,7 +184,9 @@ function stopEditing(feedback) {
         this.grid.selectionModel.select(x, y + 1, 0, 0);
         this.hideEditor();
         this.grid.cellEditor = null;
+        this.grid._is_editing = true;
         this.el.remove();
+        this.grid._is_editing = false;
         this.grid.div.parentNode.parentNode.host.focus();
     } else if (feedback >= 0) {
         // false when `feedback` undefined
@@ -193,6 +197,18 @@ function stopEditing(feedback) {
     }
 
     return !error;
+}
+
+function cancelEditing() {
+    this.setEditorValue(this.initialValue);
+    this.hideEditor();
+    this.grid.cellEditor = null;
+    this.grid._is_editing = true;
+    this.el.remove();
+    this.grid._is_editing = false;
+    this.grid.takeFocus();
+
+    return true;
 }
 
 export function set_editors(grid) {
@@ -206,7 +222,8 @@ export function set_editors(grid) {
         selectAll: () => {},
         saveEditorValue,
         keyup,
-        stopEditing
+        stopEditing,
+        cancelEditing
     });
 
     const datetime = Textfield.extend("perspective-datetime", {
@@ -219,7 +236,8 @@ export function set_editors(grid) {
         selectAll: () => {},
         saveEditorValue,
         keyup,
-        stopEditing
+        stopEditing,
+        cancelEditing
     });
 
     const text = Textfield.extend("perspective-text", {
@@ -228,7 +246,8 @@ export function set_editors(grid) {
         getEditorValue: getEditorValueText,
         saveEditorValue,
         keyup,
-        stopEditing
+        stopEditing,
+        cancelEditing
     });
 
     const number = Textfield.extend("perspective-number", {
@@ -238,7 +257,8 @@ export function set_editors(grid) {
         validateEditorValue: x => isNaN(Number(x.replace(/,/g, ""))),
         saveEditorValue,
         keyup,
-        stopEditing
+        stopEditing,
+        cancelEditing
     });
 
     grid.cellEditors.add(number);

--- a/packages/perspective-viewer-hypergrid/src/js/editors.js
+++ b/packages/perspective-viewer-hypergrid/src/js/editors.js
@@ -134,6 +134,7 @@ function saveEditorValue(x) {
 function keyup() {}
 
 function keydown(e) {
+    e.stopPropagation();
     let grid = this.grid,
         cellProps = this.event.properties,
         feedbackCount = cellProps.feedbackCount,
@@ -177,6 +178,8 @@ function stopEditing(feedback) {
     }
 
     if (!error) {
+        const {x, y} = this.grid.selectionModel.getLastSelection().origin;
+        this.grid.selectionModel.select(x, y + 1, 0, 0);
         this.hideEditor();
         this.grid.cellEditor = null;
         this.el.remove();

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -83,7 +83,9 @@ async function grid_update(div, view, task) {
     if (task.cancelled) {
         return;
     }
-
+    if (this.hypergrid.cellEditor) {
+        this.hypergrid.cellEditor.cancelEditing();
+    }
     const dataModel = this.hypergrid.behavior.dataModel;
     dataModel.setDirty(nrows);
     dataModel._view = view;
@@ -112,6 +114,7 @@ async function getOrCreateHypergrid(div) {
     let perspectiveHypergridElement;
     if (!this.hypergrid) {
         perspectiveHypergridElement = this[PRIVATE].grid = document.createElement("perspective-hypergrid");
+        perspectiveHypergridElement.setAttribute("tabindex", 1);
         Object.defineProperty(this, "hypergrid", {
             configurable: true,
             get: () => (this[PRIVATE].grid ? this[PRIVATE].grid.grid : undefined)

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -7,17 +7,17 @@
  *
  */
 
-const Hypergrid = require("fin-hypergrid");
-const Base = require("fin-hypergrid/src/Base");
-const groupedHeaderPlugin = require("fin-hypergrid-grouped-header-plugin");
+import Hypergrid from "fin-hypergrid";
+import Base from "fin-hypergrid/src/Base";
+import groupedHeaderPlugin from "fin-hypergrid-grouped-header-plugin";
 
-const perspectivePlugin = require("./perspective-plugin");
-const PerspectiveDataModel = require("./PerspectiveDataModel");
-const {psp2hypergrid, page2hypergrid} = require("./psp-to-hypergrid");
+import * as perspectivePlugin from "./perspective-plugin";
+import PerspectiveDataModel from "./PerspectiveDataModel";
+import {psp2hypergrid, page2hypergrid} from "./psp-to-hypergrid";
 
 import {bindTemplate} from "@finos/perspective-viewer/dist/esm/utils.js";
 
-const TEMPLATE = require("../html/hypergrid.html");
+import TEMPLATE from "../html/hypergrid.html";
 
 import style from "../less/hypergrid.less";
 import {get_styles, clear_styles, default_grid_properties} from "./styles.js";

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -116,6 +116,12 @@ async function getOrCreateHypergrid(div) {
             configurable: true,
             get: () => (this[PRIVATE].grid ? this[PRIVATE].grid.grid : undefined)
         });
+        perspectiveHypergridElement.addEventListener("blur", () => {
+            if (perspectiveHypergridElement.grid && !perspectiveHypergridElement.grid._is_editing) {
+                perspectiveHypergridElement.grid.selectionModel.clear();
+                perspectiveHypergridElement.grid.paintNow();
+            }
+        });
     } else {
         perspectiveHypergridElement = this[PRIVATE].grid;
     }

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -348,7 +348,9 @@ exports.install = function(grid) {
         event.primitiveEvent.preventDefault();
         if (!grid.cellEditor) {
             const count = this.getAutoScrollAcceleration();
-            grid.moveSingleSelect(0, count);
+            const {x, y} = grid.selectionModel.getLastSelection().origin;
+            grid.selectionModel.select(x, y + count, 0, 0);
+            grid.repaint();
         }
     };
 

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -7,9 +7,9 @@
  *
  */
 
-const rectangular = require("rectangular");
-const superscript = require("superscript-number");
-const lodash = require("lodash");
+import rectangular from "rectangular";
+import superscript from "superscript-number";
+import lodash from "lodash";
 
 /**
  * @this {Behavior}
@@ -214,7 +214,7 @@ const right_click_handler = e => {
 };
 
 // `install` makes this a Hypergrid plug-in
-exports.install = function(grid) {
+export const install = function(grid) {
     addSortChars(grid.behavior.charMap);
 
     Object.getPrototypeOf(grid.behavior).setPSP = setPSP;

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -354,6 +354,34 @@ exports.install = function(grid) {
         }
     };
 
+    grid.lookupFeature("CellSelection").handleUP = function(grid, event) {
+        event.primitiveEvent.preventDefault();
+        if (!grid.cellEditor) {
+            const count = this.getAutoScrollAcceleration();
+            const {x, y} = grid.selectionModel.getLastSelection().origin;
+            grid.selectionModel.select(x, Math.max(0, y - count), 0, 0);
+            grid.repaint();
+        }
+    };
+
+    grid.lookupFeature("CellSelection").handleLEFT = function(grid, event) {
+        event.primitiveEvent.preventDefault();
+        if (!grid.cellEditor) {
+            const {x, y} = grid.selectionModel.getLastSelection().origin;
+            grid.selectionModel.select(Math.max(0, x - 1), y, 0, 0);
+            grid.repaint();
+        }
+    };
+
+    grid.lookupFeature("CellSelection").handleRIGHT = function(grid, event) {
+        event.primitiveEvent.preventDefault();
+        if (!grid.cellEditor) {
+            const {x, y} = grid.selectionModel.getLastSelection().origin;
+            grid.selectionModel.select(x + 1, y, 0, 0);
+            grid.repaint();
+        }
+    };
+
     grid.canvas.resize = async function(force, reset) {
         const width = (this.width = Math.floor(this.div.clientWidth));
         const height = (this.height = Math.floor(this.div.clientHeight));

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -348,8 +348,13 @@ export const install = function(grid) {
         event.primitiveEvent.preventDefault();
         if (!grid.cellEditor) {
             const count = this.getAutoScrollAcceleration();
-            const {x, y} = grid.selectionModel.getLastSelection().origin;
-            grid.selectionModel.select(x, y + count, 0, 0);
+            let {x, y} = grid.selectionModel.getLastSelection().origin;
+            const max = grid.renderer.dataWindow.origin.y + grid.renderer.dataWindow.extent.y - 2;
+            if (y + count > max) {
+                grid.sbVScroller.index++;
+            }
+            y = Math.min(grid.behavior.dataModel.getRowCount() - 1, y + count);
+            grid.selectionModel.select(x, y, 0, 0);
             grid.repaint();
         }
     };
@@ -358,8 +363,13 @@ export const install = function(grid) {
         event.primitiveEvent.preventDefault();
         if (!grid.cellEditor) {
             const count = this.getAutoScrollAcceleration();
-            const {x, y} = grid.selectionModel.getLastSelection().origin;
-            grid.selectionModel.select(x, Math.max(0, y - count), 0, 0);
+            let {x, y} = grid.selectionModel.getLastSelection().origin;
+            const min = grid.renderer.dataWindow.origin.y;
+            if (y - count < min) {
+                grid.sbVScroller.index--;
+            }
+            y = Math.max(0, y - count);
+            grid.selectionModel.select(x, y, 0, 0);
             grid.repaint();
         }
     };
@@ -367,8 +377,14 @@ export const install = function(grid) {
     grid.lookupFeature("CellSelection").handleLEFT = function(grid, event) {
         event.primitiveEvent.preventDefault();
         if (!grid.cellEditor) {
-            const {x, y} = grid.selectionModel.getLastSelection().origin;
-            grid.selectionModel.select(Math.max(0, x - 1), y, 0, 0);
+            const count = this.getAutoScrollAcceleration();
+            let {x, y} = grid.selectionModel.getLastSelection().origin;
+            const min = grid.renderer.dataWindow.origin.x;
+            if (x - count < min) {
+                grid.sbHScroller.index--;
+            }
+            x = Math.max(0, x - 1);
+            grid.selectionModel.select(x, y, 0, 0);
             grid.repaint();
         }
     };
@@ -376,10 +392,20 @@ export const install = function(grid) {
     grid.lookupFeature("CellSelection").handleRIGHT = function(grid, event) {
         event.primitiveEvent.preventDefault();
         if (!grid.cellEditor) {
-            const {x, y} = grid.selectionModel.getLastSelection().origin;
-            grid.selectionModel.select(x + 1, y, 0, 0);
+            const count = this.getAutoScrollAcceleration();
+            let {x, y} = grid.selectionModel.getLastSelection().origin;
+            const max = grid.renderer.dataWindow.origin.x + grid.renderer.dataWindow.extent.x - 1;
+            if (x + count > max) {
+                grid.sbHScroller.index++;
+            }
+            x = Math.min(grid.behavior.schema.length - 1, x + count);
+            grid.selectionModel.select(x, y, 0, 0);
             grid.repaint();
         }
+    };
+
+    grid.lookupFeature("CellSelection").moveShiftSelect = function(grid, offsetX, offsetY) {
+        grid.moveSingleSelect(offsetX, offsetY);
     };
 
     grid.canvas.resize = async function(force, reset) {

--- a/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
@@ -48,6 +48,8 @@ function page2hypergrid(data, row_pivots, columns) {
             };
         }
 
+        dataRow["__INDEX__"] = data["__INDEX__"][ridx][0];
+
         rows.push(dataRow);
     }
 

--- a/packages/perspective-viewer-hypergrid/src/js/styles.js
+++ b/packages/perspective-viewer-hypergrid/src/js/styles.js
@@ -16,6 +16,8 @@ const title = `--hypergrid`;
 properties.add_fonts({
     font: title,
     columnHeaderFont: `${title}-header`,
+    columnHeaderForegroundSelectionFont: `${title}-header`,
+    foregroundSelectionFont: `${title}-header`,
     rowHeaderFont: title,
     treeHeaderFont: title
 });
@@ -24,14 +26,20 @@ properties.add_styles({
     treeHeaderBackgroundColor: `${title}-tree-header--background`,
     backgroundColor: `${title}--background`,
     treeHeaderColor: `${title}-tree-header--color`,
+    treeHeaderForegroundSelectionColor: `${title}-tree-header--color`,
+    treeHeaderBackgroundSelectionColor: `${title}-tree-header--background`,
+    foregroundSelectionColor: [`${title}--color`, `color`],
     color: [`${title}--color`, `color`],
     columnHeaderBackgroundColor: `${title}-header--background`,
     columnHeaderSeparatorColor: `${title}-separator--color`,
     columnHeaderColor: `${title}-header--color`,
+    columnHeaderForegroundSelectionColor: `${title}-header--color`,
     columnColorNumberPositive: `${title}-positive--color`,
     columnColorNumberNegative: `${title}-negative--color`,
     columnBackgroundColorNumberPositive: `${title}-positive--background`,
     columnBackgroundColorNumberNegative: `${title}-negative--background`,
+    selectionRegionOverlayColor: `${title}-editor--background`,
+    selectionRegionOutlineColor: `${title}-editor--border-color`,
     halign: `${title}--text-align`,
     columnHeaderHalign: `${title}--text-align`,
     hoverCellHighlight: {
@@ -73,14 +81,13 @@ const base_grid_properties = {
     columnSelection: false,
     rowSelection: false,
     checkboxOnlyRowSelections: false,
+    backgroundSelectionColor: `#ffffff`,
     columnClip: true,
     columnHeaderFont: COLUMN_HEADER_FONT,
-    columnHeaderForegroundSelectionFont: '12px "Arial", Helvetica, sans-serif',
+    columnHeaderForegroundSelectionFont: COLUMN_HEADER_FONT,
+    columnHeaderBackgroundSelectionColor: undefined,
     columnsReorderable: false,
     defaultRowHeight: 24,
-    editable: true,
-    editOnKeydown: true,
-    editorActivationKeys: ["alt", "esc"],
     enableContinuousRepaint: false,
     feedbackCount: 1000000,
     fixedColumnCount: 0,
@@ -123,12 +130,15 @@ const base_grid_properties = {
     scrollbarHoverOff: "visible",
     rowHeaderCheckboxes: false,
     rowHeaderNumbers: false,
+    selectionRegionOverlayColor: "transparent",
+    selectionRegionOutlineColor: "rgba(0,0,0,0.2)",
     showFilterRow: true,
     showHeaderRow: true,
     showTreeColumn: false,
     showRowNumbers: false,
     showCheckboxes: false,
     singleRowSelectionMode: false,
+    //    navKeyMap: {},
     sortColumns: [],
     sortOnDoubleClick: true,
     treeRenderer: "TreeCell",
@@ -143,22 +153,14 @@ const light_theme_overrides = {
     backgroundColor: "#ffffff",
     color: "#666",
     lineColor: "#AAA",
-    // font: '12px Arial, Helvetica, sans-serif',
     font: '12px "Open Sans", Helvetica, sans-serif',
-    foregroundSelectionFont: "12px amplitude-regular, Helvetica, sans-serif",
-    foregroundSelectionColor: "#666",
-    backgroundSelectionColor: "rgba(162, 183, 206, 0.3)",
-    selectionRegionOutlineColor: "rgb(45, 64, 85)",
     columnHeaderColor: "#666",
     columnHeaderHalign: "left", // except: group header labels always 'center'; numbers always 'right' per `setPSP`
     columnHeaderBackgroundColor: "#fff",
     columnHeaderForegroundSelectionColor: "#333",
-    columnHeaderBackgroundSelectionColor: "#40536d",
     rowHeaderForegroundSelectionFont: "12px Arial, Helvetica, sans-serif",
     treeHeaderColor: "#666",
     treeHeaderBackgroundColor: "#fff",
-    treeHeaderForegroundSelectionColor: "#333",
-    treeHeaderBackgroundSelectionColor: "#40536d",
     hoverCellHighlight: {
         enabled: true,
         backgroundColor: "#eeeeee"
@@ -169,6 +171,7 @@ const light_theme_overrides = {
     }
 };
 
-export function default_grid_properties(overrides = light_theme_overrides) {
-    return Object.assign({}, cloneDeep(base_grid_properties), cloneDeep(overrides));
+export function default_grid_properties() {
+    const properties = Object.assign({}, cloneDeep(base_grid_properties), cloneDeep(light_theme_overrides));
+    return properties;
 }

--- a/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
+++ b/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
@@ -9,7 +9,7 @@
 
 :host {
     position: relative;
-
+    outline: none;
     width: 100%;
     height: 100%;
 
@@ -37,10 +37,10 @@
         position: absolute;
         outline: none;
         border: none;
-        box-shadow: 0px 2px 3px rgba(0,0,0,0.2);
         color: var(--hypergrid--color, inherit);
         background: var(--hypergrid--background, white);
-        padding-right: 10px;
+        box-sizing: border-box;
+        padding: 0px 4px 3px 4px;
     }
 
     #gridWrapper {

--- a/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
+++ b/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
@@ -36,11 +36,11 @@
     input.hypergrid-textfield {
         position: absolute;
         outline: none;
-        border: none;
+        border: 1px solid var(--hypergrid-editor--border-color, rgba(0,0,0,0.4));
         color: var(--hypergrid--color, inherit);
         background: var(--hypergrid--background, white);
         box-sizing: border-box;
-        padding: 0px 4px 3px 4px;
+        padding: 0px 4px 3px 5px;
     }
 
     #gridWrapper {
@@ -62,6 +62,9 @@
         height: 100%;
         margin: 0px;
         padding: 0px;
+    }
+
+    #mainGrid > div {
         overflow: hidden;
     }
 

--- a/packages/perspective-viewer-hypergrid/test/js/editing.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/editing.spec.js
@@ -32,32 +32,6 @@ utils.with_server({}, () => {
     describe.page(
         "editable.html",
         () => {
-            describe("editing UI opens", () => {
-                test.capture("should open an editor on a string column", async page => {
-                    await page.$("perspective-viewer");
-                    await page.shadow_click("perspective-viewer", "#config_button");
-                    await page.waitForSelector("perspective-viewer[settings]");
-                    await dblclick(page);
-                    await page.waitForSelector("perspective-viewer:not([updating])");
-                });
-
-                test.capture("should open an editor on an integer column", async page => {
-                    await page.$("perspective-viewer");
-                    await page.shadow_click("perspective-viewer", "#config_button");
-                    await page.waitForSelector("perspective-viewer[settings]");
-                    await dblclick(page, 50);
-                    await page.waitForSelector("perspective-viewer:not([updating])");
-                });
-
-                test.capture("should open an editor on a datetime column", async page => {
-                    await page.$("perspective-viewer");
-                    await page.shadow_click("perspective-viewer", "#config_button");
-                    await page.waitForSelector("perspective-viewer[settings]");
-                    await dblclick(page, 400);
-                    await page.waitForSelector("perspective-viewer:not([updating])");
-                });
-            });
-
             describe("editing UI saves", () => {
                 test.capture("should save edits to a string column", async page => {
                     await page.$("perspective-viewer");

--- a/packages/perspective-viewer-hypergrid/test/js/editing.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/editing.spec.js
@@ -78,8 +78,29 @@ utils.with_server({}, () => {
                     await page.keyboard.sendCharacter("2");
                     await page.keyboard.sendCharacter("A");
                     await page.keyboard.press("Enter");
-                    await page.waitFor(100);
+                    await page.waitFor(100); // wait for the invalid animation
+                    await page.keyboard.press("Escape");
+                });
+
+                test.capture("should follow the indexed row when the data updates", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.waitForSelector("perspective-viewer[settings]");
+                    await page.evaluate(async viewer => {
+                        viewer.setAttribute("sort", '[["Sales", "desc"]]');
+                        await viewer.flush();
+                    }, viewer);
                     await page.waitForSelector("perspective-viewer:not([updating])");
+                    await dblclick(page);
+                    await page.keyboard.sendCharacter("a");
+                    await page.keyboard.sendCharacter("b");
+                    await page.keyboard.sendCharacter("c");
+                    await page.keyboard.sendCharacter("d");
+                    await page.evaluate(async viewer => {
+                        const res = new Promise(x => viewer.addEventListener("perspective-view-update", () => x()));
+                        viewer.update([{Sales: 100000}]);
+                        await res;
+                    }, viewer);
                 });
             });
         },

--- a/packages/perspective-viewer-hypergrid/test/results/results.json
+++ b/packages/perspective-viewer-hypergrid/test/results/results.json
@@ -33,11 +33,8 @@
     "superstore.html/should reinterpret metadata when only row pivots are changed": "fb9c5cb1b9a4148023f6edf4bffd27db",
     "empty.html/perspective-click is fired when an empty dataset is loaded first": "7e5b653226145e1ab9f82e2417d89d7b",
     "superstore.html/should not edit an immutable viewer": "8d99c2bc8bf7450a5f2cc4f5b1ca7412",
-    "editable.html/should open an editor on a string column": "06ad5b1db4e71e41979fc11fa6291895",
-    "editable.html/should open an editor on an integer column": "e50abe7159914a7990be5505ff3db62b",
-    "editable.html/should open an editor on a datetime column": "15e1d52a2097f704d928207fbfac4f63",
     "editable.html/should save edits to a string column": "0f1e5aae7ca316d30e2926260fa4a049",
     "editable.html/should save edits to an integer column": "81ef9bcde6197a213fba59ee33152c72",
     "editable.html/should save edits of negative numbers to an integer column": "2007c3c6dc2b015f5e7e6223ad2c5be0",
-    "editable.html/should fail to save edits of invalid integers": "ffebbb0f4eac207176c26be89d072fba"
+    "editable.html/should fail to save edits of invalid integers": "a0b7759a6a79313c676e25ae1af2a08b"
 }

--- a/packages/perspective-viewer-hypergrid/test/results/results.json
+++ b/packages/perspective-viewer-hypergrid/test/results/results.json
@@ -37,5 +37,5 @@
     "editable.html/should save edits to an integer column": "0899c9636987608d306db60af44ec98f",
     "editable.html/should save edits of negative numbers to an integer column": "81721a50fa662cc15818005b9fb85cd4",
     "editable.html/should fail to save edits of invalid integers": "1f58c721fd26c7c71dae576f4a727de4",
-    "editable.html/should follow the indexed row when the data updates": "4028176406a2b3c43aa6e591056f7e9d"
+    "editable.html/should follow the indexed row when the data updates": "2b1aa9c3421e00e2bd547336a01e9f78"
 }

--- a/packages/perspective-viewer-hypergrid/test/results/results.json
+++ b/packages/perspective-viewer-hypergrid/test/results/results.json
@@ -33,8 +33,9 @@
     "superstore.html/should reinterpret metadata when only row pivots are changed": "fb9c5cb1b9a4148023f6edf4bffd27db",
     "empty.html/perspective-click is fired when an empty dataset is loaded first": "7e5b653226145e1ab9f82e2417d89d7b",
     "superstore.html/should not edit an immutable viewer": "8d99c2bc8bf7450a5f2cc4f5b1ca7412",
-    "editable.html/should save edits to a string column": "0f1e5aae7ca316d30e2926260fa4a049",
-    "editable.html/should save edits to an integer column": "81ef9bcde6197a213fba59ee33152c72",
-    "editable.html/should save edits of negative numbers to an integer column": "2007c3c6dc2b015f5e7e6223ad2c5be0",
-    "editable.html/should fail to save edits of invalid integers": "a0b7759a6a79313c676e25ae1af2a08b"
+    "editable.html/should save edits to a string column": "e1ccff5b0c2c15ee6363d1881f3a2754",
+    "editable.html/should save edits to an integer column": "0899c9636987608d306db60af44ec98f",
+    "editable.html/should save edits of negative numbers to an integer column": "81721a50fa662cc15818005b9fb85cd4",
+    "editable.html/should fail to save edits of invalid integers": "1f58c721fd26c7c71dae576f4a727de4",
+    "editable.html/should follow the indexed row when the data updates": "4028176406a2b3c43aa6e591056f7e9d"
 }

--- a/packages/perspective-viewer/src/js/viewer/dom_element.js
+++ b/packages/perspective-viewer/src/js/viewer/dom_element.js
@@ -35,40 +35,28 @@ export class DomElement extends PerspectiveElement {
         }
     }
 
-    _set_row_type(row, type) {
-        if (!type) {
-            let all = this._get_view_dom_columns("#inactive_columns perspective-row");
-            if (all.length > 0) {
-                type = all.find(x => x.getAttribute("name") === name);
-                if (type) {
-                    type = type.getAttribute("type");
-                } else {
-                    type = "integer";
-                }
+    _get_type(name) {
+        let all = this._get_view_dom_columns("#inactive_columns perspective-row");
+        if (all.length > 0) {
+            const type = all.find(x => x.getAttribute("name") === name);
+            if (type) {
+                return type.getAttribute("type");
             } else {
-                type = "";
+                return "integer";
             }
+        } else {
+            return "";
         }
-        row.setAttribute("type", type);
+    }
+
+    _set_row_type(row) {
+        row.setAttribute("type", this._get_type(row.getAttribute("name")));
     }
 
     // Generates a new row in state + DOM
     _new_row(name, type, aggregate, filter, sort, computed) {
         let row = document.createElement("perspective-row");
-
-        if (!type) {
-            let all = this._get_view_dom_columns("#inactive_columns perspective-row");
-            if (all.length > 0) {
-                type = all.find(x => x.getAttribute("name") === name);
-                if (type) {
-                    type = type.getAttribute("type");
-                } else {
-                    type = "integer";
-                }
-            } else {
-                type = "";
-            }
-        }
+        type = type || this._get_type(name);
 
         if (!aggregate) {
             let aggregates = this.get_aggregate_attribute();
@@ -259,7 +247,7 @@ export class DomElement extends PerspectiveElement {
     }
 
     _check_responsive_layout() {
-        if(this.shadowRoot){
+        if (this.shadowRoot) {
             if (this.clientHeight < 500 && this.clientWidth > 600 && this._get_view_columns({active: false}).length > this._get_view_columns().length) {
                 this.shadowRoot.querySelector("#app").classList.add("columns_horizontal");
             } else {

--- a/scripts/test_js.js
+++ b/scripts/test_js.js
@@ -41,9 +41,12 @@ function jest() {
     }
 
     if (args.indexOf("-t") > -1) {
-        const regex = args.slice(args.indexOf("-t") + 1).join(" ");
+        const regex = args
+            .slice(args.indexOf("-t") + 1)
+            .join(".")
+            .replace(/ /g, ".");
         console.log(`-- Qualifying search '${regex}'`);
-        cmd += ` -t '${regex}'`;
+        cmd += ` -t "${regex}"`;
     }
 
     return (IS_WRITE ? "WRITE_TESTS=1 " : "") + cmd;
@@ -96,7 +99,15 @@ try {
         }
         if (!IS_EMSDK) {
             execute(`yarn --silent clean --screenshots`);
-            execute(docker() + " " + args.join(" "));
+            execute(
+                docker() +
+                    " " +
+                    args
+                        .map(function(arg) {
+                            return "'" + arg.replace(/'/g, "'\\''") + "'";
+                        })
+                        .join(" ")
+            );
         }
     } else {
         if (IS_LOCAL_PUPPETEER) {
@@ -120,8 +131,11 @@ try {
             }
             cmd += " -- yarn --silent test:run";
             if (args.indexOf("-t") > -1) {
-                const regex = args.slice(args.indexOf("-t") + 1).join(" ");
-                console.log(`-- Qualifying search '${regex}'`);
+                let regex = args.slice(args.indexOf("-t") + 1);
+                const len = regex.findIndex(x => x.indexOf('"' > -1));
+                regex = regex.slice(0, len + 1);
+                console.log(`-- Qualifying search '${regex.join(" ")}'`);
+                regex = regex.join(".").replace(/ /g, ".");
                 cmd += ` -t "${regex}"`;
             }
             execute((IS_WRITE ? "WRITE_TESTS=1 " : "") + cmd);


### PR DESCRIPTION
Makes editing more excel-like;  single-click for selection and LF on save.

Also supports index pinning, so real-time data sets are now stable to edit as well.

![edit_on_type3](https://user-images.githubusercontent.com/60666/64774364-0f12b780-d522-11e9-92a1-4d1cdbfcfc57.gif)
