### PR TITLE
Allow partial updates on computed column source columns

### DIFF
--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -262,6 +262,24 @@ dtype_to_str(t_dtype dtype) {
     return str_dtype.str();
 }
 
+t_dtype
+str_to_dtype(const std::string& typestring) {
+    // returns most commonly used types in the JS/python public APIs.
+    if (typestring == "integer") {
+        return DTYPE_INT32;
+    } else if (typestring == "float") {
+        return DTYPE_FLOAT64;
+    } else if (typestring == "boolean") {
+        return DTYPE_BOOL;
+    } else if (typestring == "date") {
+        return DTYPE_DATE;
+    } else if (typestring == "datetime") {
+        return DTYPE_TIME;
+    } else {
+        return DTYPE_STR;
+    }
+}
+
 std::string
 filter_op_to_str(t_filter_op op) {
     switch (op) {

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1076,31 +1076,18 @@ namespace binding {
         t_val type = computed_def["type"];
         t_val computed_func = computed_def["func"];
         
-        std::string stype;
+        std::string typestring;
 
         if (type.isUndefined()) {
-            stype = "string";
+            typestring = "string";
         } else {
-            stype = type.as<std::string>();
+            typestring = type.as<std::string>();
         }
 
-        // TODO: refactor into C++
-        t_dtype output_column_dtype;
-        if (stype == "integer") {
-            output_column_dtype = DTYPE_INT32;
-        } else if (stype == "float") {
-            output_column_dtype = DTYPE_FLOAT64;
-        } else if (stype == "boolean") {
-            output_column_dtype = DTYPE_BOOL;
-        } else if (stype == "date") {
-            output_column_dtype = DTYPE_DATE;
-        } else if (stype == "datetime") {
-            output_column_dtype = DTYPE_TIME;
-        } else {
-            output_column_dtype = DTYPE_STR;
-        }
+        t_dtype output_column_dtype = str_to_dtype(typestring);
 
         std::vector<std::shared_ptr<t_column>> input_columns;
+
         for (const auto& column_name : input_column_names) {
             input_columns.push_back(table->get_column(column_name));
         }
@@ -1182,9 +1169,9 @@ namespace binding {
     }
 
     template <>
-    std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>>
+    std::vector<t_computed_column_def>
     make_computed_lambdas(std::vector<t_val> computed) {
-        std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> converted;
+        std::vector<t_computed_column_def> converted;
         for (const auto& j_computed_def : computed) {
             converted.push_back(
                 [j_computed_def](std::shared_ptr<t_data_table> table, const std::vector<t_uindex>& row_indices) {
@@ -1389,7 +1376,7 @@ namespace binding {
         for (const auto lambda : computed_lambdas) {
             lambda(pkeyed_table, {});
         }
-        table->replace_data_table(pkeyed_table, computed_lambdas);
+        table->add_computed_columns(pkeyed_table, computed_lambdas);
         return table;
     }
 

--- a/cpp/perspective/src/cpp/pool.cpp
+++ b/cpp/perspective/src/cpp/pool.cpp
@@ -90,6 +90,17 @@ t_pool::unregister_gnode(t_uindex idx) {
 }
 
 void
+t_pool::send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table, const std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>>& computed_lambdas) {
+   {
+        std::lock_guard<std::mutex> lg(m_mtx);
+        m_data_remaining.store(true);
+        if (m_gnodes[gnode_id]) {
+            m_gnodes[gnode_id]->_send(port_id, table, computed_lambdas);
+        }
+    } 
+}
+
+void
 t_pool::send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table) {
     {
         std::lock_guard<std::mutex> lg(m_mtx);

--- a/cpp/perspective/src/cpp/pool.cpp
+++ b/cpp/perspective/src/cpp/pool.cpp
@@ -90,7 +90,7 @@ t_pool::unregister_gnode(t_uindex idx) {
 }
 
 void
-t_pool::send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table, const std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>>& computed_lambdas) {
+t_pool::send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table, const std::vector<t_computed_column_def>& computed_lambdas) {
    {
         std::lock_guard<std::mutex> lg(m_mtx);
         m_data_remaining.store(true);

--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -64,7 +64,7 @@ Table::get_schema() const {
 }
 
 void
-Table::replace_data_table(std::shared_ptr<t_data_table> data_table, std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> computed_lambdas) {
+Table::add_computed_columns(std::shared_ptr<t_data_table> data_table, std::vector<t_computed_column_def> computed_lambdas) {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     t_uindex prev_gnode_id = m_gnode->get_id();
     
@@ -74,10 +74,14 @@ Table::replace_data_table(std::shared_ptr<t_data_table> data_table, std::vector<
 
     auto new_gnode = make_gnode(data_table->get_schema());
     set_gnode(new_gnode);
+
     m_pool->register_gnode(m_gnode.get());
     m_pool->send(m_gnode->get_id(), 0, *data_table, lambdas);
     m_pool->_process();
+
     unregister_gnode(prev_gnode_id);
+
+    // need to unregister contexts linked back to table
 }
 
 std::shared_ptr<t_gnode>

--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -64,13 +64,20 @@ Table::get_schema() const {
 }
 
 void
-Table::replace_data_table(t_data_table* data_table) {
+Table::replace_data_table(std::shared_ptr<t_data_table> data_table, std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> computed_lambdas) {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    t_uindex prev_gnode_id = m_gnode->get_id();
+    
+    // transfer computed lambdas across to the new gnode and recalculate
+    auto lambdas = m_gnode->get_computed_lambdas();
+    lambdas.insert(lambdas.end(), computed_lambdas.begin(), computed_lambdas.end());
+
     auto new_gnode = make_gnode(data_table->get_schema());
     set_gnode(new_gnode);
     m_pool->register_gnode(m_gnode.get());
-    m_pool->send(m_gnode->get_id(), 0, *data_table);
+    m_pool->send(m_gnode->get_id(), 0, *data_table, lambdas);
     m_pool->_process();
+    unregister_gnode(prev_gnode_id);
 }
 
 std::shared_ptr<t_gnode>

--- a/cpp/perspective/src/include/perspective/base.h
+++ b/cpp/perspective/src/include/perspective/base.h
@@ -366,6 +366,7 @@ PERSPECTIVE_EXPORT bool is_floating_point(t_dtype dtype);
 PERSPECTIVE_EXPORT bool is_linear_order_type(t_dtype dtype);
 PERSPECTIVE_EXPORT std::string get_dtype_descr(t_dtype dtype);
 PERSPECTIVE_EXPORT std::string dtype_to_str(t_dtype dtype);
+PERSPECTIVE_EXPORT t_dtype str_to_dtype(const std::string& typestring);
 PERSPECTIVE_EXPORT std::string get_status_descr(t_status dtype);
 PERSPECTIVE_EXPORT t_uindex get_dtype_size(t_dtype dtype);
 PERSPECTIVE_EXPORT bool is_vlen_dtype(t_dtype dtype);

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -187,11 +187,24 @@ namespace binding {
      * 
      * @tparam T 
      * @param computed 
-     * @return std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> 
+     * @return std::vector<t_computed_column_def> 
      */
     template <typename T>
-    std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> make_computed_lambdas(std::vector<T> computed);
+    std::vector<t_computed_column_def> make_computed_lambdas(std::vector<T> computed);
 
+    /**
+     * @brief Utility function for accessing columns and adding data.
+     * 
+     * @tparam T 
+     * @param accessor 
+     * @param tbl 
+     * @param col 
+     * @param name 
+     * @param cidx 
+     * @param type 
+     * @param is_arrow 
+     * @param is_update 
+     */
     template <typename T>
     void _fill_data_helper(T accessor, t_data_table& tbl,
         std::shared_ptr<t_column> col, const std::string& name, std::int32_t cidx, t_dtype type,

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -168,13 +168,29 @@ namespace binding {
      * @brief Change a value at a given index inside the column.
      */
     template <typename T>
-    void set_column_nth(t_column* col, t_uindex idx, T value);
+    void set_column_nth(std::shared_ptr<t_column> col, t_uindex idx, T value);
 
     /**
-     * @brief Create a new computed column.
+     * @brief Create a computed column.
+     * 
+     * @tparam T 
+     * @param table 
+     * @param row_indices 
+     * @param computed_def 
      */
     template <typename T>
-    void table_add_computed_column(t_data_table& table, T computed_defs);
+    void add_computed_column(std::shared_ptr<t_data_table> table, const std::vector<t_uindex>& row_indices, T computed_def);
+
+    /**
+     * @brief Given a list of computed column declarations in the binding language, convert them to C++ lambdas that allow
+     * access from deeper inside the engine without importing the semantics of t_val. 
+     * 
+     * @tparam T 
+     * @param computed 
+     * @return std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> 
+     */
+    template <typename T>
+    std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> make_computed_lambdas(std::vector<T> computed);
 
     template <typename T>
     void _fill_data_helper(T accessor, t_data_table& tbl,

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -28,6 +28,8 @@
 
 namespace perspective {
 
+typedef std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)> t_computed_column_def;
+
 PERSPECTIVE_EXPORT t_tscalar calc_delta(
     t_value_transition trans, t_tscalar oval, t_tscalar nval);
 
@@ -77,7 +79,7 @@ public:
     // send data to input port with at index idx
     // schema should match port schema
     void _send(t_uindex idx, const t_data_table& fragments);
-    void _send(t_uindex idx, const t_data_table& fragments, const std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>>& computed_lambdas);
+    void _send(t_uindex idx, const t_data_table& fragments, const std::vector<t_computed_column_def>& computed_lambdas);
     void _send_and_process(const t_data_table& fragments);
     void _process();
     void _process_self();
@@ -147,11 +149,11 @@ public:
     void register_context(const std::string& name, std::shared_ptr<t_ctx2> ctx);
     void register_context(const std::string& name, std::shared_ptr<t_ctx_grouped_pkey> ctx);
 
-    std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> get_computed_lambdas() const;
+    std::vector<t_computed_column_def> get_computed_lambdas() const;
 
 protected:
     void recompute_columns(std::shared_ptr<t_data_table> flattened, const std::vector<t_uindex>& updated_ridxs);
-    void append_computed_lambdas(std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> new_lambdas);
+    void append_computed_lambdas(std::vector<t_computed_column_def> new_lambdas);
 
     bool have_context(const std::string& name) const;
     void notify_contexts(const t_data_table& flattened);
@@ -189,7 +191,7 @@ private:
 
     std::shared_ptr<t_data_table> _process_table();
     
-    std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> m_computed_lambdas;
+    std::vector<t_computed_column_def> m_computed_lambdas;
     t_gnode_processing_mode m_mode;
     t_gnode_type m_gnode_type;
     t_schema m_tblschema;

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -77,6 +77,7 @@ public:
     // send data to input port with at index idx
     // schema should match port schema
     void _send(t_uindex idx, const t_data_table& fragments);
+    void _send(t_uindex idx, const t_data_table& fragments, const std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>>& computed_lambdas);
     void _send_and_process(const t_data_table& fragments);
     void _process();
     void _process_self();
@@ -114,6 +115,7 @@ public:
     void clear_output_ports();
 
     t_data_table* _get_pkeyed_table() const;
+    std::shared_ptr<t_data_table> get_pkeyed_table_sptr() const;
     std::shared_ptr<t_data_table> get_sorted_pkeyed_table() const;
 
     bool has_pkey(t_tscalar pkey) const;
@@ -145,7 +147,12 @@ public:
     void register_context(const std::string& name, std::shared_ptr<t_ctx2> ctx);
     void register_context(const std::string& name, std::shared_ptr<t_ctx_grouped_pkey> ctx);
 
+    std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> get_computed_lambdas() const;
+
 protected:
+    void recompute_columns(std::shared_ptr<t_data_table> flattened, const std::vector<t_uindex>& updated_ridxs);
+    void append_computed_lambdas(std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> new_lambdas);
+
     bool have_context(const std::string& name) const;
     void notify_contexts(const t_data_table& flattened);
 
@@ -181,6 +188,8 @@ private:
         const std::vector<t_rlookup>& lkup, std::shared_ptr<t_data_table>& flat) const;
 
     std::shared_ptr<t_data_table> _process_table();
+    
+    std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> m_computed_lambdas;
     t_gnode_processing_mode m_mode;
     t_gnode_type m_gnode_type;
     t_schema m_tblschema;

--- a/cpp/perspective/src/include/perspective/pool.h
+++ b/cpp/perspective/src/include/perspective/pool.h
@@ -59,6 +59,8 @@ public:
 
     void send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table);
 
+    void send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table, const std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>>& computed_lambdas);
+
     void _process();
     void _process_helper();
     void init();

--- a/cpp/perspective/src/include/perspective/pool.h
+++ b/cpp/perspective/src/include/perspective/pool.h
@@ -59,7 +59,7 @@ public:
 
     void send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table);
 
-    void send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table, const std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>>& computed_lambdas);
+    void send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table, const std::vector<t_computed_column_def>& computed_lambdas);
 
     void _process();
     void _process_helper();

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -80,7 +80,7 @@ public:
      *
      * @param data_table
      */
-    void replace_data_table(t_data_table* data_table);
+    void replace_data_table(std::shared_ptr<t_data_table> data_table, std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> computed_lambdas);
 
     /**
      * @brief Given a schema, create a `t_gnode` that manages the `t_data_table`.

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -72,15 +72,19 @@ public:
     t_schema get_schema() const;
 
     /**
-     * @brief Given a new `t_data_table`, replace this instance's `m_data_table` with the new
-     * object, and perform registration operations so the new table is recognized.
+     * @brief Add computed columns to the `Table` by replacing `m_gnode` and the `t_data_table` that it tracks.
+     * 
+     * Given the new `computed_lambdas` property, which is a vector of lambdas that contain computed column functions
+     * to execute, append the new computed lambdas to the ones from the old `m_gnode` so as to maintain multiple
+     * computed columns.
      *
      * Used during construction of computed columns, as we don't need to create a new `Table`
      * object each time.
      *
      * @param data_table
+     * @param computed_lambdas
      */
-    void replace_data_table(std::shared_ptr<t_data_table> data_table, std::vector<std::function<void(std::shared_ptr<t_data_table>, const std::vector<t_uindex>&)>> computed_lambdas);
+    void add_computed_columns(std::shared_ptr<t_data_table> data_table, std::vector<t_computed_column_def> computed_lambdas);
 
     /**
      * @brief Given a schema, create a `t_gnode` that manages the `t_data_table`.

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -842,7 +842,7 @@ module.exports = perspective => {
                 table.delete();
             });
 
-            it("Computed column of arity 2 with updates on non-dependent columns", async function() {
+            it("Computed column of arity 2 with updates on non-dependent columns, construct from schema", async function() {
                 var meta = {
                     w: "float",
                     x: "float",

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -16,6 +16,8 @@ const partial_missing_rows_arrow = fs.readFileSync(path.join(__dirname, "..", "a
 
 var data = [{x: 1, y: "a", z: true}, {x: 2, y: "b", z: false}, {x: 3, y: "c", z: true}, {x: 4, y: "d", z: false}];
 
+let computed_data = [{x: 1, y: 2}, {x: 2, y: 4}, {x: 3, y: 6}, {x: 4, y: 8}];
+
 var col_data = {
     x: [1, 2, 3, 4],
     y: ["a", "b", "c", "d"],
@@ -744,6 +746,129 @@ module.exports = perspective => {
             expect(result2).toEqual(result.slice(1, 3));
             view.delete();
             table.delete();
+        });
+    });
+
+    describe("computed updates", function() {
+        it("partial update on single computed source column", async function() {
+            let table = perspective.table(computed_data);
+            let table2 = table.add_computed([
+                {
+                    column: "multiply",
+                    type: "float",
+                    func: (a, b) => a * b,
+                    inputs: ["x", "y"]
+                }
+            ]);
+            table2.update([{__INDEX__: 0, x: 10}, {__INDEX__: 2, x: 10}]);
+            let view = table2.view();
+            let json = await view.to_json();
+            expect(json).toEqual([{x: 10, y: 2, multiply: 20}, {x: 2, y: 4, multiply: 8}, {x: 10, y: 6, multiply: 60}, {x: 4, y: 8, multiply: 32}]);
+        });
+
+        it("partial update on non-contiguous computed source columns", async function() {
+            let table = perspective.table(computed_data);
+            let table2 = table.add_computed([
+                {
+                    column: "multiply",
+                    type: "float",
+                    func: (a, b) => a * b,
+                    inputs: ["x", "y"]
+                }
+            ]);
+            table2.update([{__INDEX__: 0, x: 1, y: 10}, {__INDEX__: 2, x: 3, y: 20}]);
+            let view = table2.view();
+            let json = await view.to_json();
+            expect(json).toEqual([{x: 1, y: 10, multiply: 10}, {x: 2, y: 4, multiply: 8}, {x: 3, y: 20, multiply: 60}, {x: 4, y: 8, multiply: 32}]);
+        });
+
+        it("multiple partial update on single computed source column", async function() {
+            let table = perspective.table(computed_data);
+            let table2 = table.add_computed([
+                {
+                    column: "multiply",
+                    type: "float",
+                    func: (a, b) => a * b,
+                    inputs: ["x", "y"]
+                }
+            ]);
+
+            table2.update([{__INDEX__: 0, x: 10}, {__INDEX__: 2, x: 10}]);
+            table2.update([{__INDEX__: 0, x: 20}, {__INDEX__: 2, x: 20}]);
+            table2.update([{__INDEX__: 0, x: 30}, {__INDEX__: 2, x: 30}]);
+
+            let view = table2.view();
+            let json = await view.to_json();
+            expect(json).toEqual([{x: 30, y: 2, multiply: 60}, {x: 2, y: 4, multiply: 8}, {x: 30, y: 6, multiply: 180}, {x: 4, y: 8, multiply: 32}]);
+        });
+
+        it("multiple computed columns with updates on source columns", async function() {
+            let table = perspective.table(computed_data);
+
+            let table2 = table.add_computed([
+                {
+                    column: "multiply",
+                    type: "float",
+                    func: (a, b) => a * b,
+                    inputs: ["x", "y"]
+                }
+            ]);
+
+            let table3 = table2.add_computed([
+                {
+                    column: "add",
+                    type: "float",
+                    func: (a, b) => a + b,
+                    inputs: ["x", "y"]
+                }
+            ]);
+
+            table3.update([{__INDEX__: 0, x: 5}, {__INDEX__: 2, x: 10}]);
+
+            let view = table2.view({
+                columns: ["add", "multiply"]
+            });
+
+            let json = await view.to_json();
+            expect(json).toEqual([{add: 7, multiply: 10}, {add: 6, multiply: 8}, {add: 16, multiply: 60}, {add: 12, multiply: 32}]);
+        });
+
+        it("maintain previous computed columns when creating new ones", async function() {
+            let table = perspective.table(computed_data);
+
+            let table2 = table.add_computed([
+                {
+                    column: "multiply",
+                    type: "float",
+                    func: (a, b) => a * b,
+                    inputs: ["x", "y"]
+                }
+            ]);
+
+            let table3 = table2.add_computed([
+                {
+                    column: "add",
+                    type: "float",
+                    func: (a, b) => a + b,
+                    inputs: ["x", "y"]
+                }
+            ]);
+
+            let table4 = table3.add_computed([
+                {
+                    column: "subtract",
+                    type: "float",
+                    func: (a, b) => a - b,
+                    inputs: ["y", "x"]
+                }
+            ]);
+
+            let view = table4.view({
+                columns: ["add", "subtract", "multiply"]
+            });
+
+            let json = await view.to_json();
+            expect(json).toEqual([{add: 3, subtract: 1, multiply: 2}, {add: 6, subtract: 2, multiply: 8}, {add: 9, subtract: 3, multiply: 18}, {add: 12, subtract: 4, multiply: 32}]);
         });
     });
 

--- a/python/table/perspective/include/perspective/python/fill.h
+++ b/python/table/perspective/include/perspective/python/fill.h
@@ -22,36 +22,36 @@ namespace binding {
  * Fill columns with data
  */
 
-// void
-// _fill_col_time(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name,
-//     std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update) {
-
-// void
-// _fill_col_date(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name,
-//     std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update) {
-
+void _fill_col_time(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
+void _fill_col_date(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 void _fill_col_bool(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 void _fill_col_string(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 void _fill_col_int64(t_data_accessor accessor, t_data_table& tbl, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
-
-
-template <>
-void set_column_nth(t_column* col, t_uindex idx, t_val value);
-
-// TODO
-// template <>
-// void
-// table_add_computed_column(t_data_table& table, t_val computed_defs) {
-
 void _fill_col_numeric(t_data_accessor accessor, t_data_table& tbl, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 void _fill_data_helper(t_data_accessor accessor, t_data_table& tbl, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
 
+
+template <>
+void set_column_nth(std::shared_ptr<t_column> col, t_uindex idx, t_val value);
 /******************************************************************************
  *
  * Fill tables with data
  */
 
 void _fill_data(t_data_table& tbl, t_data_accessor accessor, const t_schema& input_schema, const std::string& index, std::uint32_t offset, std::uint32_t limit, bool is_arrow, bool is_update);
+
+/******************************************************************************
+ *
+ * Add computed columns
+ */
+
+/*
+template <>
+void add_computed_column(std::shared_ptr<t_data_table> table, const std::vector<t_uindex>& row_indices, t_val computed_def);
+
+template <>
+void make_computed_lambdas(std::vector<t_val> computed)
+*/
 
 } //namespace binding
 } //namespace perspective

--- a/python/table/perspective/src/fill.cpp
+++ b/python/table/perspective/src/fill.cpp
@@ -263,9 +263,7 @@ _fill_col_int64(t_data_accessor accessor, t_data_table& tbl, std::shared_ptr<t_c
 
 template <>
 void
-set_column_nth(t_column* col, t_uindex idx, t_val value) {
-
-    // Check if the value is a javascript null
+set_column_nth(std::shared_ptr<t_column> col, t_uindex idx, t_val value) {
     if (value.is_none()) {
         col->unset(idx);
         return;
@@ -411,113 +409,17 @@ _fill_col_numeric(t_data_accessor accessor, t_data_table& tbl,
     }
 }
 
-// TODO
-// template <>
-// void
-// table_add_computed_column(t_data_table& table, t_val computed_defs) {
-//     auto vcomputed_defs = vecFromArray<t_val, t_val>(computed_defs);
-//     for (auto i = 0; i < vcomputed_defs.size(); ++i) {
-//         t_val coldef = vcomputed_defs[i];
-//         std::string name = coldef["column"].cast<std::string>();
-//         t_val inputs = coldef["inputs"];
-//         t_val func = coldef["func"];
-//         t_val type = coldef["type"];
+/*
+void
+add_computed_column(std::shared_ptr<t_data_table> table, const std::vector<t_uindex>& row_indices, t_val computed_def) {
+    // TODO: implement
+}
 
-//         std::string stype;
-
-//         if (type.isUndefined()) {
-//             stype = "string";
-//         } else {
-//             stype = type.cast<std::string>();
-//         }
-
-//         t_dtype dtype;
-//         if (stype == "integer") {
-//             dtype = DTYPE_INT32;
-//         } else if (stype == "float") {
-//             dtype = DTYPE_FLOAT64;
-//         } else if (stype == "boolean") {
-//             dtype = DTYPE_BOOL;
-//         } else if (stype == "date") {
-//             dtype = DTYPE_DATE;
-//         } else if (stype == "datetime") {
-//             dtype = DTYPE_TIME;
-//         } else {
-//             dtype = DTYPE_STR;
-//         }
-
-//         // Get list of input column names
-//         auto icol_names = vecFromArray<t_val, std::string>(inputs);
-
-//         // Get t_column* for all input columns
-//         std::vector<const t_column*> icols;
-//         for (const auto& cc : icol_names) {
-//             icols.push_back(table._get_column(cc));
-//         }
-
-//         int arity = icols.size();
-
-//         // Add new column
-//         t_column* out = table.add_column(name, dtype, true);
-
-//         t_val i1 = t_val::undefined(), i2 = t_val::undefined(), i3 = t_val::undefined(),
-//               i4 = t_val::undefined();
-
-//         t_uindex size = table.size();
-//         for (t_uindex ridx = 0; ridx < size; ++ridx) {
-//             t_val value = t_val::undefined();
-
-//             switch (arity) {
-//                 case 0: {
-//                     value = func();
-//                     break;
-//                 }
-//                 case 1: {
-//                     i1 = scalar_to_val(icols[0]->get_scalar(ridx));
-//                     if (!i1.isNull()) {
-//                         value = func(i1);
-//                     }
-//                     break;
-//                 }
-//                 case 2: {
-//                     i1 = scalar_to_val(icols[0]->get_scalar(ridx));
-//                     i2 = scalar_to_val(icols[1]->get_scalar(ridx));
-//                     if (!i1.isNull() && !i2.isNull()) {
-//                         value = func(i1, i2);
-//                     }
-//                     break;
-//                 }
-//                 case 3: {
-//                     i1 = scalar_to_val(icols[0]->get_scalar(ridx));
-//                     i2 = scalar_to_val(icols[1]->get_scalar(ridx));
-//                     i3 = scalar_to_val(icols[2]->get_scalar(ridx));
-//                     if (!i1.isNull() && !i2.isNull() && !i3.isNull()) {
-//                         value = func(i1, i2, i3);
-//                     }
-//                     break;
-//                 }
-//                 case 4: {
-//                     i1 = scalar_to_val(icols[0]->get_scalar(ridx));
-//                     i2 = scalar_to_val(icols[1]->get_scalar(ridx));
-//                     i3 = scalar_to_val(icols[2]->get_scalar(ridx));
-//                     i4 = scalar_to_val(icols[3]->get_scalar(ridx));
-//                     if (!i1.isNull() && !i2.isNull() && !i3.isNull() && !i4.isNull()) {
-//                         value = func(i1, i2, i3, i4);
-//                     }
-//                     break;
-//                 }
-//                 default: {
-//                     // Don't handle other arity values
-//                     break;
-//                 }
-//             }
-
-//             if (!value.isUndefined()) {
-//                 set_column_nth(out, ridx, value);
-//             }
-//         }
-//     }
-// }
+void
+make_computed_lambdas(std::vector<t_val> computed) {
+    // TODO: implement
+}
+*/
 
 void
 _fill_data_helper(t_data_accessor accessor, t_data_table& tbl,


### PR DESCRIPTION
This PR refactors logic around constructing computed columns in order to move operations to the `t_gnode`'s `_process` method. 

Instead of constructing computed columns before the table is sent to `_process()`, use the metadata of the `_process` method to allow for partial updates (implicit and explicit index) on underlying columns for computed columns, which automatically propagates changes to computed columns. 

Previous iterations would recalculate each computed column for the total number of rows on the table; this allows computed column recalculation to happen ONLY for rows that were updated within `_process()`.