### PR TITLE
Enable update with __INDEX__ on explicit index column

### DIFF
--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -175,8 +175,6 @@ Table::set_data_types(const std::vector<t_dtype>& data_types) {
 
 void
 Table::validate_columns(const std::vector<std::string>& column_names) {
-    bool implicit_index =
-        std::find(column_names.begin(), column_names.end(), "__INDEX__") != column_names.end();
     if (m_index != "") {
         // Check if index is valid after getting column names
         bool explicit_index
@@ -184,10 +182,6 @@ Table::validate_columns(const std::vector<std::string>& column_names) {
         if (!explicit_index) {
             std::cout << "Specified index " << m_index << " does not exist in data." << std::endl;
             PSP_COMPLAIN_AND_ABORT("Specified index '" + m_index + "' does not exist in data.");
-        }
-        if (explicit_index && implicit_index) {
-            std::cout << "Specified index " << m_index << " twice - ignoring implicit __INDEX__" << std::endl;
-            PSP_COMPLAIN_AND_ABORT("Specified index '" + m_index + "' twice; ignoring implicit index.");
         }
     }
 }

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -1035,6 +1035,73 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("should apply updates using '__INDEX__' on a table with explicit index set", async function() {
+            let table = perspective.table(data, {index: "x"});
+            table.update([
+                {
+                    __INDEX__: 2,
+                    y: "new_string"
+                }
+            ]);
+            let view = table.view();
+            let result = await view.to_json();
+
+            let expected = JSON.parse(JSON.stringify(data));
+            expected[1]["y"] = "new_string";
+
+            expect(result).toEqual(expected);
+            view.delete();
+            table.delete();
+        });
+
+        it("should apply mulitple sequential updates using '__INDEX__' on a table with explicit index set", async function() {
+            let table = perspective.table(data, {index: "x"});
+            table.update([
+                {
+                    __INDEX__: 2,
+                    y: "new_string"
+                },
+                {
+                    __INDEX__: 3,
+                    y: "new_string"
+                }
+            ]);
+            let view = table.view();
+            let result = await view.to_json();
+
+            let expected = JSON.parse(JSON.stringify(data));
+            expected[1]["y"] = "new_string";
+            expected[2]["y"] = "new_string";
+
+            expect(result).toEqual(expected);
+            view.delete();
+            table.delete();
+        });
+
+        it("should apply mulitple nonsequential updates using '__INDEX__' on a table with explicit index set", async function() {
+            let table = perspective.table(data, {index: "x"});
+            table.update([
+                {
+                    __INDEX__: 2,
+                    y: "new_string"
+                },
+                {
+                    __INDEX__: 4,
+                    y: "new_string"
+                }
+            ]);
+            let view = table.view();
+            let result = await view.to_json();
+
+            let expected = JSON.parse(JSON.stringify(data));
+            expected[1]["y"] = "new_string";
+            expected[3]["y"] = "new_string";
+
+            expect(result).toEqual(expected);
+            view.delete();
+            table.delete();
+        });
+
         it("should apply multiple sequential partial updates on unindexed table using '__INDEX__'", async function() {
             let table = perspective.table(data);
             table.update([


### PR DESCRIPTION
This PR removes the `abort()` we previously added for updates using implicit index, thus updates using `__INDEX__` (which always shadows the primary key) now work on indexed tables.