### PR TITLE
add compute() to dynamically show/hide sidebar computation panel

### DIFF
--- a/packages/perspective-viewer/src/js/viewer/dom_element.js
+++ b/packages/perspective-viewer/src/js/viewer/dom_element.js
@@ -212,8 +212,11 @@ export class DomElement extends PerspectiveElement {
         this.shadowRoot.querySelector("#psp_styles").innerHTML = style;
     }
 
-    _show_column_selectors() {
+    _show_column_container() {
         this.shadowRoot.querySelector("#columns_container").style.visibility = "visible";
+    }
+
+    _show_side_panel_actions() {
         this.shadowRoot.querySelector("#side_panel__actions").style.visibility = "visible";
     }
 

--- a/packages/perspective-viewer/src/js/viewer/perspective_element.js
+++ b/packages/perspective-viewer/src/js/viewer/perspective_element.js
@@ -208,7 +208,11 @@ export class PerspectiveElement extends StateElement {
             this._inactive_columns.parentElement.classList.remove("collapse");
         }
 
-        this._show_column_selectors();
+        this._show_column_container();
+
+        if ((await this._table.compute()) === true) {
+            this._show_side_panel_actions();
+        }
 
         // Filters need type information to populate e.g. the operator dropdown,
         // so reset them.

--- a/packages/perspective/src/js/api/table_api.js
+++ b/packages/perspective/src/js/api/table_api.js
@@ -107,6 +107,8 @@ table.prototype.view = function(config) {
 
 // Dispatch table methods that do not create new objects (getters, setters etc.) to the queue for processing.
 
+table.prototype.compute = async_queue("compute", "table_method");
+
 table.prototype.schema = async_queue("schema", "table_method");
 
 table.prototype.computed_schema = async_queue("computed_schema", "table_method");

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -978,6 +978,10 @@ export default function(Module) {
         bindall(this);
     }
 
+    table.prototype.compute = function() {
+        return true;
+    };
+
     table.prototype.get_id = function() {
         return this._Table.get_id();
     };

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -38,6 +38,10 @@ class Table(object):
         self._views = []
         self._delete_callback = None
 
+    def compute(self):
+        '''Returns whether the computed column feature is enabled.'''
+        return False
+
     def clear(self):
         '''Removes all the rows in the Table, but preserves the schema and configuration.'''
         self._table.reset_gnode(self._gnode_id)


### PR DESCRIPTION
Because computed columns is not yet implemented in the Python API, make sure the viewer does not render the computation sidebar when `Table.compute()` returns false.