### PR TITLE
Fixed grid performance when pivoted

### DIFF
--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -155,7 +155,7 @@ async function grid_create(div, view, task, max_rows, max_cols, force) {
     const window = {
         start_row: 0,
         end_row: Math.max(colPivots.length + 1, rowPivots.length + 1),
-        index: true
+        index: rowPivots.length === 0 && colPivots.length === 0
     };
 
     const [nrows, json, schema, tschema] = await Promise.all([view.num_rows(), view.to_columns(window), view.schema(), this._table.schema()]);
@@ -183,7 +183,7 @@ async function grid_create(div, view, task, max_rows, max_cols, force) {
     dataModel.pspFetch = async range => {
         range.end_row += this.hasAttribute("settings") ? 8 : 2;
         range.end_col += rowPivots && rowPivots.length > 0 ? 1 : 0;
-        range.index = true;
+        range.index = rowPivots.length === 0 && colPivots.length === 0;
         let next_page = await dataModel._view.to_columns(range);
         if (columns.length === 0) {
             columns = Object.keys(await view.to_columns(window));

--- a/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
@@ -48,7 +48,9 @@ function page2hypergrid(data, row_pivots, columns) {
             };
         }
 
-        dataRow["__INDEX__"] = data["__INDEX__"][ridx][0];
+        if (data.__INDEX__) {
+            dataRow["__INDEX__"] = data["__INDEX__"][ridx][0];
+        }
 
         rows.push(dataRow);
     }


### PR DESCRIPTION
Index support for `to_*` methods can generate extremely large payloads, so we now turn this feature off for pivoted grids where many index keys may be present, greatly improving pivot performance on large datasets.