### PR TITLE
Add core-js@2 dependency that is required by transpiled outputs of Babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "clean-css-loader": "^1.1.0",
         "codemirror": "^5.30.0",
         "codemirror-javascript": "^0.2.0",
-        "core-js": "^2.5.7",
+        "core-js": "^2.6.9",
         "cpx": "^1.5.0",
         "css-loader": "^0.28.7",
         "dotenv": "^8.1.0",

--- a/packages/perspective-cli/package.json
+++ b/packages/perspective-cli/package.json
@@ -31,6 +31,7 @@
         "@finos/perspective-viewer": "^0.3.9",
         "@finos/perspective-viewer-d3fc": "^0.3.9",
         "@finos/perspective-viewer-hypergrid": "^0.3.9",
-        "commander": "^2.19.0"
+        "commander": "^2.19.0",
+        "core-js": "^2.6.9"
     }
 }

--- a/packages/perspective-test/package.json
+++ b/packages/perspective-test/package.json
@@ -20,7 +20,8 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@babel/runtime": "^7.3.4",
-        "@finos/perspective": "^0.3.9"
+        "@finos/perspective": "^0.3.9",
+        "core-js": "^2.6.9"
     },
     "devDependencies": {
         "@finos/perspective-webpack-plugin": "^0.3.8"

--- a/packages/perspective-viewer-d3fc/package.json
+++ b/packages/perspective-viewer-d3fc/package.json
@@ -52,6 +52,7 @@
         "@finos/perspective-viewer": "^0.3.9",
         "babel-runtime": "^6.26.0",
         "chroma-js": "^1.3.4",
+        "core-js": "^2.6.9",
         "d3": "^5.7.0",
         "d3-svg-legend": "^2.25.6",
         "d3fc": "14.0.40",

--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -52,6 +52,7 @@
         "@finos/perspective": "^0.3.9",
         "@finos/perspective-viewer": "^0.3.9",
         "chroma-js": "^1.3.4",
+        "core-js": "^2.6.9",
         "detectie": "1.0.0",
         "gradient-parser": "0.1.5",
         "highcharts": "6.1.0",

--- a/packages/perspective-viewer-hypergrid/package.json
+++ b/packages/perspective-viewer-hypergrid/package.json
@@ -38,6 +38,7 @@
         "@babel/runtime": "^7.3.4",
         "@finos/perspective": "^0.3.9",
         "@finos/perspective-viewer": "^0.3.9",
+        "core-js": "^2.6.9",
         "datasaur-local": "3.0.0",
         "fin-hypergrid": "3.2.0",
         "fin-hypergrid-grouped-header-plugin": "^1.2.4",

--- a/packages/perspective-viewer/package.json
+++ b/packages/perspective-viewer/package.json
@@ -45,6 +45,7 @@
         "@webcomponents/shadycss": "^1.5.2",
         "@webcomponents/webcomponentsjs": "~2.0.4",
         "awesomplete": "^1.1.2",
+        "core-js": "^2.6.9",
         "d3-array": "^1.2.1",
         "detectie": "1.0.0",
         "lit-html": "^1.1.2",

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -53,6 +53,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@babel/runtime": "^7.3.4",
+        "core-js": "^2.6.9",
         "d3-array": "^1.2.1",
         "detectie": "1.0.0",
         "flatbuffers": "^1.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,10 +3925,10 @@ core-js-pure@3.1.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.2.tgz#62fc435f35b7374b9b782013cdcb2f97e9f6dffa"
   integrity sha512-5ckIdBF26B3ldK9PM177y2ZcATP2oweam9RskHSoqfZCrJ2As6wVg8zJ1zTriFsZf6clj/N1ThDFRGaomMsh9w==
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7, core-js@^2.6.5:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.8.tgz#dc3a1e633a04267944e0cb850d3880f340248139"
-  integrity sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg==
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5, core-js@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
 core-js@^3.0.0:
   version "3.1.2"


### PR DESCRIPTION
Many of the packages use [Babel configurations](https://github.com/finos/perspective/blob/2c19c5fa0046597e30ec780ae08655767c5253d4/packages/perspective/babel.config.js#L15) which create [various `core-js@2` imports in their transpiled outputs](https://babeljs.io/docs/en/babel-preset-env#corejs).

This dependency should be installed by these packages in order that they work at runtime. Also, while it is possible to recommend to consumers to manually install `core-js@2` themselves, this is fragile because if they depend on any libraries which use `core-js@3` it is likely that this could end up hoisted to the top of the `node_modules` directory, which would cause the wrong `core-js` to be picked up and the code to fail to execute.
