### PR TITLE
Add `to_csv` to Python API

### DIFF
--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -289,11 +289,18 @@ class View(object):
                 - end_col: defaults to the total columns in the view
                 - index: whether to return an implicit pkey for each row. Defaults to False
                 - leaves_only: whether to return only the data at the end of the tree. Defaults to False
+                - date_format: how `date` and `datetime` objects should be formatted in the CSV. Must be a valid date formatting string.
 
         Returns:
             str : a CSV-formatted string containing the serialized data.
         '''
-        return self.to_df(**options).to_csv(date_format='%Y/%m/%d %H:%M:%S')
+        if options.get("date_format", None):
+            date_format = options["date_format"]
+            options.pop("date_format")
+        else:
+            date_format = '%Y/%m/%d %H:%M:%S'
+
+        return self.to_df(**options).to_csv(date_format=date_format)
 
     @wraps(to_records)
     def to_json(self, **options):

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -277,6 +277,24 @@ class View(object):
         cols = self.to_numpy(**options)
         return pandas.DataFrame(cols)
 
+    def to_csv(self, **options):
+        '''Serialize the view's dataset into a CSV string.
+
+        Args:
+            options (dict) :
+                user-provided options that specifies what data to return:
+                - start_row: defaults to 0
+                - end_row: defaults to the number of total rows in the view
+                - start_col: defaults to 0
+                - end_col: defaults to the total columns in the view
+                - index: whether to return an implicit pkey for each row. Defaults to False
+                - leaves_only: whether to return only the data at the end of the tree. Defaults to False
+
+        Returns:
+            str : a CSV-formatted string containing the serialized data.
+        '''
+        return self.to_df(**options).to_csv(date_format='%Y/%m/%d %H:%M:%S')
+
     @wraps(to_records)
     def to_json(self, **options):
         return self.to_records(**options)

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -294,13 +294,7 @@ class View(object):
         Returns:
             str : a CSV-formatted string containing the serialized data.
         '''
-        if options.get("date_format", None):
-            date_format = options["date_format"]
-            options.pop("date_format")
-        else:
-            date_format = '%Y/%m/%d %H:%M:%S'
-
-        return self.to_df(**options).to_csv(date_format=date_format)
+        return self.to_df(**options).to_csv(date_format=options.pop("date_format", "%Y/%m/%d %H:%M:%S"))
 
     @wraps(to_records)
     def to_json(self, **options):

--- a/python/perspective/perspective/tests/table/test_to_format.py
+++ b/python/perspective/perspective/tests/table/test_to_format.py
@@ -565,6 +565,15 @@ class TestToFormat(object):
         view = tbl.view()
         assert view.to_csv() == ",a,b\n0,{},2\n1,{},4\n".format(dt_str, dt_str)
 
+    def test_to_csv_date_custom_format(self):
+        today = date.today()
+        dt = datetime(today.year, today.month, today.day)
+        dt_str = dt.strftime("%Y")
+        data = [{"a": today, "b": 2}, {"a": today, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv(date_format="%Y") == ",a,b\n0,{},2\n1,{},4\n".format(dt_str, dt_str)
+
     def test_to_csv_datetime(self):
         dt = datetime(2019, 3, 15, 20, 30, 59, 6000)
         dt_str = dt.strftime("%Y/%m/%d %H:%M:%S")
@@ -572,6 +581,14 @@ class TestToFormat(object):
         tbl = Table(data)
         view = tbl.view()
         assert view.to_csv() == ",a,b\n0,{},2\n1,{},4\n".format(dt_str, dt_str)
+
+    def test_to_csv_datetime_custom_format(self):
+        dt = datetime(2019, 3, 15, 20, 30, 59, 6000)
+        dt_str = dt.strftime("%H:%M:%S")
+        data = [{"a": dt, "b": 2}, {"a": dt, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv(date_format="%H:%M:%S") == ",a,b\n0,{},2\n1,{},4\n".format(dt_str, dt_str)
 
     def test_to_csv_bool(self):
         data = [{"a": True, "b": False}, {"a": True, "b": False}]
@@ -590,6 +607,24 @@ class TestToFormat(object):
         tbl = Table(data)
         view = tbl.view()
         assert view.to_csv() == ",a,b\n0,,\n1,,\n"
+
+    def test_to_csv_custom_rows(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv(start_row=1) == ",a,b\n0,3,4\n"
+
+    def test_to_csv_custom_cols(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv(start_col=1) == ",b\n0,2\n1,4\n"
+
+    def test_to_csv_custom_rows_cols(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv(start_row=1, start_col=1) == ",b\n0,4\n"
 
     def test_to_csv_one(self):
         data = [{"a": 1, "b": 2}, {"a": 1, "b": 2}]
@@ -642,7 +677,7 @@ class TestToFormat(object):
             column_pivots=["b"],
             columns=[]
         )
-        assert view.to_csv() == '""\n' 
+        assert view.to_csv() == '""\n'
 
     # implicit index
 

--- a/python/perspective/perspective/tests/table/test_to_format.py
+++ b/python/perspective/perspective/tests/table/test_to_format.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytz
+from io import StringIO
 from datetime import date, datetime
 from perspective.table import Table
 
@@ -533,6 +534,115 @@ class TestToFormat(object):
             end_col=2
         )
         assert records == [{"b": 2}, {"b": 4}]
+
+    # to csv
+
+    def test_to_csv_symmetric(self):
+        csv = "a,b\n1,2\n3,4"
+        df = pd.read_csv(StringIO(csv))
+        tbl = Table(df)
+        view = tbl.view()
+        assert view.to_csv() == ",index,a,b\n0,0,1,2\n1,1,3,4\n"
+
+    def test_to_csv_int(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv() == ",a,b\n0,1,2\n1,3,4\n"
+
+    def test_to_csv_float(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv() == ",a,b\n0,1.5,2.5\n1,3.5,4.5\n"
+
+    def test_to_csv_date(self):
+        today = date.today()
+        dt = datetime(today.year, today.month, today.day)
+        dt_str = dt.strftime("%Y/%m/%d %H:%M:%S")
+        data = [{"a": today, "b": 2}, {"a": today, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv() == ",a,b\n0,{},2\n1,{},4\n".format(dt_str, dt_str)
+
+    def test_to_csv_datetime(self):
+        dt = datetime(2019, 3, 15, 20, 30, 59, 6000)
+        dt_str = dt.strftime("%Y/%m/%d %H:%M:%S")
+        data = [{"a": dt, "b": 2}, {"a": dt, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv() == ",a,b\n0,{},2\n1,{},4\n".format(dt_str, dt_str)
+
+    def test_to_csv_bool(self):
+        data = [{"a": True, "b": False}, {"a": True, "b": False}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv() == ",a,b\n0,True,False\n1,True,False\n"
+
+    def test_to_csv_string(self):
+        data = [{"a": "string1", "b": "string2"}, {"a": "string3", "b": "string4"}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv() == ",a,b\n0,string1,string2\n1,string3,string4\n"
+
+    def test_to_csv_none(self):
+        data = [{"a": None, "b": None}, {"a": None, "b": None}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_csv() == ",a,b\n0,,\n1,,\n"
+
+    def test_to_csv_one(self):
+        data = [{"a": 1, "b": 2}, {"a": 1, "b": 2}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"]
+        )
+        assert view.to_csv() == ",__ROW_PATH__,a,b\n0,[],2,4\n1,['1'],2,4\n"
+
+    def test_to_csv_two(self):
+        data = [{"a": 1, "b": 2}, {"a": 1, "b": 2}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            column_pivots=["b"]
+        )
+        assert view.to_csv() == ",__ROW_PATH__,2|a,2|b\n0,[],2,4\n1,['1'],2,4\n"
+
+    def test_to_csv_column_only(self):
+        data = [{"a": 1, "b": 2}, {"a": 1, "b": 2}]
+        tbl = Table(data)
+        view = tbl.view(
+            column_pivots=["b"]
+        )
+        assert view.to_csv() == ",2|a,2|b\n0,1,2\n1,1,2\n"
+
+    def test_to_csv_one_no_columns(self):
+        data = [{"a": 1, "b": 2}, {"a": 1, "b": 2}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            columns=[]
+        )
+        assert view.to_csv() == ",__ROW_PATH__\n0,[]\n1,['1']\n"
+
+    def test_to_csv_two_no_columns(self):
+        data = [{"a": 1, "b": 2}, {"a": 1, "b": 2}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            column_pivots=["b"],
+            columns=[]
+        )
+        assert view.to_csv() == ",__ROW_PATH__\n0,[]\n1,['1']\n"
+
+    def test_to_csv_column_only_no_columns(self):
+        data = [{"a": 1, "b": 2}, {"a": 1, "b": 2}]
+        tbl = Table(data)
+        view = tbl.view(
+            column_pivots=["b"],
+            columns=[]
+        )
+        assert view.to_csv() == '""\n' 
 
     # implicit index
 


### PR DESCRIPTION
This PR adds and tests `to_csv` for the perspective-python API. The method itself uses `pandas.DataFrame.to_csv`, so it includes the index columns that come as part of dataframe construction.