### PR TITLE
Hypergrid renderer fixes

### DIFF
--- a/packages/perspective-test/src/js/index.js
+++ b/packages/perspective-test/src/js/index.js
@@ -328,7 +328,7 @@ test.capture = function capture(name, body, {timeout = 60000, viewport = null, w
                 }
 
                 if (process.env.PSP_PAUSE_ON_FAILURE) {
-                    if (hash !== results[_url + "/" + name]) {
+                    if (hash !== results[_url + "/" + name] || errors.length > 0) {
                         private_console.error(`Failed ${name}, pausing`);
                         await new Promise(f => setTimeout(f, 1000000));
                     }

--- a/packages/perspective-test/src/js/reporter.js
+++ b/packages/perspective-test/src/js/reporter.js
@@ -28,13 +28,15 @@ module.exports = class ImageViewerReporter {
     }
 
     write_img(title, ancestors, filename) {
-        process.stdout.write(`\n    ${ancestors.join(" > ")} > ${title}\n\n    `);
-        termimg(filename, {
-            width: "320px",
-            height: "240px",
-            fallback: () => this.write_img_fallback(filename)
-        });
-        process.stdout.write("\n");
+        if (fs.existsSync(filename)) {
+            process.stdout.write(`\n    ${ancestors.join(" > ")} > ${title}\n\n    `);
+            termimg(filename, {
+                width: "320px",
+                height: "240px",
+                fallback: () => this.write_img_fallback(filename)
+            });
+            process.stdout.write("\n");
+        }
     }
 
     /**

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -14,13 +14,12 @@ const {
     prototype: {treeColumnIndex: TREE_COLUMN_INDEX}
 } = Behavior;
 
-function getSubrects(nrows) {
+function get_rect(nrows) {
     if (!this.dataWindow) {
         return [];
     }
-    var dw = this.dataWindow;
-    var rect = this.grid.newRectangle(dw.left, dw.top, dw.width, nrows ? Math.min(nrows - dw.top, dw.height) : dw.height); // convert from InclusiveRect
-    return [rect];
+    const dw = this.dataWindow;
+    return this.grid.newRectangle(dw.left, dw.top, dw.width, nrows ? Math.min(nrows - dw.top, dw.height) : dw.height); // convert from InclusiveRect
 }
 
 function find_row(rows, index) {
@@ -62,17 +61,13 @@ export default require("datasaur-local").extend("PerspectiveDataModel", {
         this._isTree = isTree;
     },
 
-    isCached: function(rects) {
-        return !rects || !rects.find(uncachedRow, this);
-    },
-
     setDirty: function(nrows) {
         if (nrows !== this._nrows) {
-            this.grid.renderer.computeCellsBounds();
+            this._grid.renderer.computeCellsBounds();
         }
         this._dirty = true;
         this._nrows = nrows;
-        this.grid.behaviorChanged();
+        this._grid.behaviorChanged();
     },
 
     // Called when clicking on a row group expand
@@ -102,22 +97,22 @@ export default require("datasaur-local").extend("PerspectiveDataModel", {
             }
             let nrows = await this._view.num_rows();
             this.setDirty(nrows);
-            this.grid.canvas.paintNow();
+            this._grid.canvas.paintNow();
         }
     },
 
     _update_select_index: function() {
-        const has_selections = this.grid.selectionModel.hasSelections();
+        const has_selections = this._grid.selectionModel.hasSelections();
         if (has_selections) {
-            const row = this.data[this.grid.selectionModel.getLastSelection().origin.y];
+            const row = this.data[this._grid.selectionModel.getLastSelection().origin.y];
             if (row) {
                 this._select_index = row.__INDEX__;
             }
         }
     },
 
-    _update_editor: function([rect]) {
-        const editor = this.grid.cellEditor;
+    _update_editor: function(rect) {
+        const editor = this._grid.cellEditor;
         let new_index;
         if (editor) {
             new_index = find_row(this.data, editor._index);
@@ -128,59 +123,58 @@ export default require("datasaur-local").extend("PerspectiveDataModel", {
     },
 
     _update_selection: function(new_index) {
-        const has_selections = this.grid.selectionModel.hasSelections();
+        const has_selections = this._grid.selectionModel.hasSelections();
         if (has_selections) {
             new_index = new_index || find_row(this.data, this._select_index);
             if (new_index !== -1) {
-                const col = this.grid.selectionModel.getLastSelection().origin.x;
-                this.grid.selectionModel.select(col, new_index, 0, 0);
+                const col = this._grid.selectionModel.getLastSelection().origin.x;
+                this._grid.selectionModel.select(col, new_index, 0, 0);
             }
         }
     },
 
-    fetchData: async function(rectangles, resolve) {
-        rectangles = getSubrects.call(this.grid.renderer);
-
+    fetchData: async function(_, resolve) {
         if (this._view === undefined) {
             resolve(true);
             return;
         }
 
-        if (!this._dirty && !rectangles.find(uncachedRow, this)) {
+        let rect = get_rect.call(this._grid.renderer);
+
+        if (!this._dirty && !uncachedRow.call(this._data_window, rect)) {
             resolve(false);
             return;
         }
 
-        if (this._outstanding_requested_rects && rectangles[0].within(this._outstanding_requested_rects[0])) {
+        this._grid.renderer.needsComputeCellsBounds = true;
+
+        if (this._outstanding_rect && !uncachedRow.call(this._oustanding_rect, rect)) {
             resolve(true);
             return;
         }
 
+        this._outstanding_rect = rect;
         this._dirty = false;
-        this._outstanding_requested_rects = rectangles;
 
-        const promises = rectangles.map(rect =>
-            this.pspFetch({
-                start_row: rect.origin.y,
-                end_row: rect.corner.y,
-                start_col: rect.origin.x,
-                end_col: rect.corner.x + 1
-            })
-        );
+        const action = this.pspFetch({
+            start_row: rect.origin.y,
+            end_row: rect.corner.y,
+            start_col: rect.origin.x,
+            end_col: rect.corner.x + 1
+        });
 
         try {
             this._update_select_index();
-
-            await Promise.all(promises);
-
-            const new_index = this._update_editor(rectangles);
+            await action;
+            this._data_window = rect;
+            this._outstanding_rect = undefined;
+            const new_index = this._update_editor(rect);
             this._update_selection(new_index);
-            const rects = getSubrects.call(this.grid.renderer);
-            resolve(!!rects.find(uncachedRow, this));
+            rect = get_rect.call(this._grid.renderer);
+            this._grid.renderer.needsComputeCellsBounds = !!uncachedRow.call(this._data_window, rect);
+            resolve(this._grid.renderer.needsComputeCellsBounds);
         } catch (e) {
-            resolve(true);
-        } finally {
-            this._outstanding_requested_rects = undefined;
+            resolve(e);
         }
     },
 
@@ -188,9 +182,9 @@ export default require("datasaur-local").extend("PerspectiveDataModel", {
         if (!declaredEditorName) {
             return;
         }
-        const offset = this.grid.renderer.dataWindow.top;
-        const editor = this.grid.cellEditors.create(declaredEditorName, options);
-        this.grid.selectionModel.select(columnIndex, rowIndex + offset - 1);
+        const offset = this._grid.renderer.dataWindow.top;
+        const editor = this._grid.cellEditors.create(declaredEditorName, options);
+        this._grid.selectionModel.select(columnIndex, rowIndex + offset - 1);
         editor.el.addEventListener("blur", () => setTimeout(() => editor.cancelEditing()));
         const args = {
             start_row: rowIndex + offset - 1,
@@ -202,7 +196,7 @@ export default require("datasaur-local").extend("PerspectiveDataModel", {
         editor._row = this._view.to_json(args);
         editor._table = this._table;
         editor._data = this.data;
-        editor._canvas = this.grid.canvas.canvas;
+        editor._canvas = this._grid.canvas.canvas;
         editor._index = this.data[rowIndex + offset - 1].__INDEX__;
         return editor;
     },
@@ -225,9 +219,7 @@ export default require("datasaur-local").extend("PerspectiveDataModel", {
 });
 
 function uncachedRow(rect) {
-    let start_row = this.data[rect.origin.y];
-    let end_row = this.data[Math.min(rect.corner.y, this.getRowCount() - 1)];
-    return !(start_row && start_row[rect.origin.x] !== undefined && end_row && end_row[rect.corner.x - 1] !== undefined);
+    return !this || this.top !== rect.top || this.height !== rect.height || this.left !== rect.left || this.width !== rect.width;
 }
 
 function cellStyle(gridCellConfig) {

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -62,6 +62,9 @@ export default require("datasaur-local").extend("PerspectiveDataModel", {
     },
 
     setDirty: function(nrows) {
+        if (!this._grid) {
+            return;
+        }
         if (nrows !== this._nrows) {
             this._grid.renderer.computeCellsBounds();
         }

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -120,8 +120,8 @@ function setPSP(payload, force = false) {
             schema: new_schema
         });
         this.grid.selectionModel.clear();
-        this.grid.allowEvents(true);
     }
+    this.grid.allowEvents(true);
     this._memoized_schema = new_schema;
     this._memoized_pivots = payload.rowPivots;
 }
@@ -465,7 +465,7 @@ export const install = function(grid) {
         grid.moveSingleSelect(offsetX, offsetY);
     };
 
-    grid.canvas.resize = async function(force, reset) {
+    grid.canvas.resize = async function(force) {
         const width = (this.width = Math.floor(this.div.clientWidth));
         const height = (this.height = Math.floor(this.div.clientHeight));
 
@@ -486,27 +486,31 @@ export const install = function(grid) {
         this.component.setBounds(this.bounds);
         this.resizeNotification();
 
-        let render = false;
-        if (!reset && (height * ratio > this.canvas.height || force)) {
-            render = await new Promise(resolve => this.component.grid.behavior.dataModel.fetchData(undefined, resolve));
-        }
-
-        if (!render || reset) {
-            this.bounds = new rectangular.Rectangle(0, 0, width, height);
-            this.component.setBounds(this.bounds);
-
-            this.buffer.width = this.canvas.width = width * ratio;
-            this.buffer.height = this.canvas.height = height * ratio;
-
-            this.canvas.style.width = this.buffer.style.width = width + "px";
-            this.canvas.style.height = this.buffer.style.height = height + "px";
-
-            this.bc.scale(ratio, ratio);
-            if (isHIDPI && !this.component.properties.useBitBlit) {
-                this.gc.scale(ratio, ratio);
+        let render = true;
+        if (height * ratio !== this.canvas.height || width * ratio !== this.canvas.width || force) {
+            while (render) {
+                if (!this.component.grid.behavior.dataModel._view) {
+                    // If we are awaiting this grid's initialization, yield until it is ready.
+                    await new Promise(setTimeout);
+                }
+                render = await new Promise(resolve => this.component.grid.behavior.dataModel.fetchData(undefined, resolve));
             }
-
-            grid.canvas.paintNow();
         }
+
+        this.bounds = new rectangular.Rectangle(0, 0, width, height);
+        this.component.setBounds(this.bounds);
+
+        this.buffer.width = this.canvas.width = width * ratio;
+        this.buffer.height = this.canvas.height = height * ratio;
+
+        this.canvas.style.width = this.buffer.style.width = width + "px";
+        this.canvas.style.height = this.buffer.style.height = height + "px";
+
+        this.bc.scale(ratio, ratio);
+        if (isHIDPI && !this.component.properties.useBitBlit) {
+            this.gc.scale(ratio, ratio);
+        }
+        this.component.grid.renderer.needsComputeCellsBounds = false;
+        grid.canvas.paintNow();
     };
 };

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -121,7 +121,6 @@ function setPSP(payload, force = false) {
         });
         this.grid.selectionModel.clear();
     }
-    this.grid.allowEvents(true);
     this._memoized_schema = new_schema;
     this._memoized_pivots = payload.rowPivots;
 }

--- a/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
@@ -11,7 +11,6 @@ const utils = require("@finos/perspective-test");
 const path = require("path");
 
 const simple_tests = require("@finos/perspective-viewer/test/js/simple_tests.js");
-const {set_lazy} = require("./utils.js");
 
 utils.with_server({}, () => {
     describe.page(
@@ -95,25 +94,21 @@ utils.with_server({}, () => {
                 });
             });
 
-            describe("lazy render mode", () => {
-                test.capture("resets viewable area when the logical size expands.", async page => {
-                    await set_lazy(page);
-                    const viewer = await page.$("perspective-viewer");
-                    await page.shadow_click("perspective-viewer", "#config_button");
-                    await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
-                    await page.waitForSelector("perspective-viewer:not([updating])");
-                    await page.evaluate(element => element.setAttribute("row-pivots", '["City"]'), viewer);
-                });
+            test.capture("resets viewable area when the logical size expands.", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.evaluate(element => element.setAttribute("row-pivots", '["City"]'), viewer);
+            });
 
-                test.capture("resets viewable area when the physical size expands.", async page => {
-                    await set_lazy(page);
-                    const viewer = await page.$("perspective-viewer");
-                    await page.shadow_click("perspective-viewer", "#config_button");
-                    await page.evaluate(element => element.setAttribute("row-pivots", '["Category"]'), viewer);
-                    await page.waitForSelector("perspective-viewer:not([updating])");
-                    await page.evaluate(element => element.setAttribute("row-pivots", "[]"), viewer);
-                    await page.shadow_click("perspective-viewer", "#config_button");
-                });
+            test.capture("resets viewable area when the physical size expands.", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.evaluate(element => element.setAttribute("row-pivots", '["Category"]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.evaluate(element => element.setAttribute("row-pivots", "[]"), viewer);
+                await page.shadow_click("perspective-viewer", "#config_button");
             });
         },
         {reload_page: false, root: path.join(__dirname, "..", "..")}

--- a/packages/perspective-viewer-hypergrid/test/js/utils.js
+++ b/packages/perspective-viewer-hypergrid/test/js/utils.js
@@ -26,14 +26,15 @@ exports.dblclick = async (page, x = 310, y = 300) => {
 exports.click_details = async (page, x = 310, y = 300) => {
     const viewer = await page.$("perspective-viewer");
 
-    const click_event = page.evaluate(element => {
-        return new Promise(resolve => {
-            element.addEventListener("perspective-click", e => {
-                resolve(e.detail);
-            });
-        });
-    }, viewer);
-
+    const click_event = page.evaluate(
+        element =>
+            new Promise(resolve => {
+                element.addEventListener("perspective-click", e => {
+                    resolve(e.detail);
+                });
+            }),
+        viewer
+    );
     await page.mouse.click(x, y);
     return await click_event;
 };
@@ -51,17 +52,4 @@ exports.capture_update = async function capture_update(page, viewer, body) {
         console.error("Missing 'test-updated' attribute");
     }
     await page.evaluate(element => element.removeAttribute("test-updated"), viewer);
-};
-
-exports.set_lazy = async function set_lazy(page) {
-    const viewer = await page.$("perspective-viewer");
-    await page.evaluate(element => {
-        element.hypergrid.properties.repaintIntervalRate = 1;
-        if (!element.hypergrid._lazy_load) {
-            Object.defineProperty(element.hypergrid, "_lazy_load", {
-                set: () => {},
-                get: () => true
-            });
-        }
-    }, viewer);
 };

--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -317,7 +317,10 @@ class PerspectiveViewer extends ActionElement {
                     this.setAttribute("plugin", this._vis_selector.options[0].value);
                 }
             } else {
-                this._vis_selector.value = plugin;
+                if (this._vis_selector.value !== plugin) {
+                    this._vis_selector.value = plugin;
+                    this._vis_selector_changed();
+                }
                 this._set_row_styles();
                 this._set_column_defaults();
                 this.dispatchEvent(new Event("perspective-config-update"));

--- a/packages/perspective-viewer/src/js/viewer/action_element.js
+++ b/packages/perspective-viewer/src/js/viewer/action_element.js
@@ -231,6 +231,12 @@ export class ActionElement extends DomElement {
         document.addEventListener("mouseup", stop);
     }
 
+    _vis_selector_changed() {
+        this._plugin_information.classList.add("hidden");
+        this.setAttribute("plugin", this._vis_selector.value);
+        this._debounce_update();
+    }
+
     // most of these are drag and drop handlers - how to clean up?
     _register_callbacks() {
         this._sort.addEventListener("drop", drop.bind(this));
@@ -272,11 +278,7 @@ export class ActionElement extends DomElement {
         this._resize_bar.addEventListener("mousedown", this._resize_sidepanel.bind(this));
         this._resize_bar.addEventListener("dblclick", this._reset_sidepanel.bind(this));
 
-        this._vis_selector.addEventListener("change", () => {
-            this._plugin_information.classList.add("hidden");
-            this.setAttribute("plugin", this._vis_selector.value);
-            this._debounce_update();
-        });
+        this._vis_selector.addEventListener("change", this._vis_selector_changed.bind(this));
 
         this._plugin_information_action.addEventListener("click", () => {
             this._debounce_update({ignore_size_check: true, limit_points: false});


### PR DESCRIPTION
Fixes for `@finos/perspective-viewer-hypergrid`, which in sum greatly improve the user experience of using this plugin in the presence of slow interaciton with the core engine (e.g., when the engine is running on a remote server rather than a WebWorker).

* Fixed the plugin not appearing when the `plugin` attribute is toggled via `setAttribute()`.
* Fixed the viewer flashing when a hover event is triggered before the page can be loaded, e.g. due to large or frequent updates.
* Fixed various timing-related `console.error()`s.
