### PR TITLE
Add tornado handler for perspective-python

### DIFF
--- a/examples/remote/index.html
+++ b/examples/remote/index.html
@@ -47,7 +47,7 @@
             worker.initialize_profile_thread();
 
             // Get a proxy for a view named "data_source_one", registered on
-            // the server with a reciprcal call to `host_view()`.
+            // the server with a reciprocal call to `host_view()`.
             // No data is transferred, `view` is a virtual handle for data on
             // the server.
             const view = websocket.open_view('data_source_one');

--- a/packages/perspective-jupyterlab/src/ts/view.ts
+++ b/packages/perspective-jupyterlab/src/ts/view.ts
@@ -33,6 +33,7 @@ class PerspectiveView extends DOMWidgetView {
              plugin_config: this.model.get('plugin_config'),
              computed_columns: [],
              dark: this.model.get('dark'),
+             editable: this.model.get("editable"),
              bindto: this.el,
              view: this,
         });
@@ -95,6 +96,7 @@ class PerspectiveView extends DOMWidgetView {
         this.model.on('change:filters', this.filters_changed, this);
         this.model.on('change:plugin_config', this.plugin_config_changed, this);
         this.model.on('change:dark', this.dark_changed, this);
+        this.model.on('change:editable', this.editable_changed, this);
 
         // Watch the viewer DOM so that widget state is always synchronized with DOM attributes.
         const observer = new MutationObserver(this._synchronize_state.bind(this));
@@ -177,5 +179,9 @@ class PerspectiveView extends DOMWidgetView {
 
     dark_changed(){
         this.pWidget.dark = this.model.get('dark');
+    }
+
+    editable_changed() {
+        this.pWidget.editable = this.model.get("editable");
     }
 }

--- a/packages/perspective-jupyterlab/src/ts/widget.ts
+++ b/packages/perspective-jupyterlab/src/ts/widget.ts
@@ -28,7 +28,7 @@ export type PerspectiveJupyterWidgetOptions = {
 }
 
 /**
- * TODO: document
+ * PerspectiveJupyterWidget is the ipywidgets front-end for the Perspective Jupyterlab plugin.
  */
 export
 class PerspectiveJupyterWidget extends PerspectiveWidget {

--- a/packages/perspective-phosphor/src/ts/widget.ts
+++ b/packages/perspective-phosphor/src/ts/widget.ts
@@ -64,8 +64,10 @@ export
         let computed_columns: { [colname: string]: string }[] = options.computed_columns || [];
         let plugin_config: any = options.plugin_config || {};
         let dark: boolean = options.dark || false;
+        let editable: boolean = options.editable || false;
 
         this.dark = dark;
+        this.editable = editable;
         this.plugin = plugin;
         this.plugin_config = plugin_config;
         this.row_pivots = row_pivots;
@@ -273,11 +275,22 @@ export
         }
     }
 
+    get editable() { return this._editable }
+    set editable(editable: boolean) {
+        this._editable = editable;
+        if (this._editable) {
+            this.viewer.setAttribute("editable", "");
+        } else {
+            this.viewer.removeAttribute("editable");
+        }
+    }
+
     get displayed(){ return this._displayed; }
 
     private _viewer: PerspectiveViewer;
     private _plugin_config: any;
     private _dark: boolean;
+    private _editable: boolean;
     private _displayed: boolean;
 }
 

--- a/packages/perspective-viewer-hypergrid/src/js/editors.js
+++ b/packages/perspective-viewer-hypergrid/src/js/editors.js
@@ -38,7 +38,7 @@ function setEditorValueDate(x) {
     if (x === null) {
         return;
     }
-    const now = +new Date(x);
+    const now = new Date(x);
     const day = ("0" + now.getDate()).slice(-2);
     const month = ("0" + (now.getMonth() + 1)).slice(-2);
     this.input.value = `${now.getFullYear()}-${month}-${day}`;

--- a/python/perspective/examples/perspective_tornado_server.py
+++ b/python/perspective/examples/perspective_tornado_server.py
@@ -8,7 +8,7 @@ import tornado.ioloop
 import pandas as pd
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
-from perspective import PerspectiveViewer, PerspectiveTornadoHandler
+from perspective import Table, PerspectiveManager, PerspectiveTornadoHandler
 
 
 class MainHandler(tornado.web.RequestHandler):
@@ -25,19 +25,18 @@ class MainHandler(tornado.web.RequestHandler):
 def make_app():
     '''Create and return a Tornado app.
 
-    For `PerspectiveTornadoHandler` to work, it must be passed an instance of `PerspectiveViewer`.
+    For `PerspectiveTornadoHandler` to work, it must be passed an instance of `PerspectiveManager`.
 
-    Inside this function, we create a PerspectiveViewer and load data into it using its `load` method.
-
-    By passing a name into `load`, we guarantee the existence of a table with the name "data_source_one". This allows us to reference the Table
-    from the front-end with its known name. Without the `name` kwarg, the front-end has no way of knowing how to look up the Table on the backend.
+    The data is loaded into a new `Table`, which is passed to the manager through `host_table`.
+    The front-end is able to look up the table using the name provided to `host_table`.
     '''
-    VIEWER = PerspectiveViewer()
-    VIEWER.load(pd.read_csv("superstore.csv"), name="data_source_one")
+    MANAGER = PerspectiveManager()
+    TABLE = Table(pd.read_csv("superstore.csv"))
+    MANAGER.host_table("data_source_one", TABLE)
     return tornado.web.Application([
         (r"/", MainHandler),
         # create a websocket endpoint that the client Javascript can access
-        (r"/websocket", PerspectiveTornadoHandler, {"viewer": VIEWER, "check_origin": True})
+        (r"/websocket", PerspectiveTornadoHandler, {"manager": MANAGER, "check_origin": True})
     ])
 
 

--- a/python/perspective/examples/perspective_tornado_server.py
+++ b/python/perspective/examples/perspective_tornado_server.py
@@ -1,34 +1,14 @@
 import os
 import os.path
 import sys
-import json
 import logging
 import tornado.websocket
 import tornado.web
 import tornado.ioloop
 import pandas as pd
-from datetime import datetime
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
-from perspective import Table, PerspectiveManager
-
-'''
-Import the Table and PerspectiveManager classes.
-
-A Perspective `Table` is instantiated either with data or a `schema`.
-
-The `PerspectiveManager` class handles incoming messages from the client Perspective through a WebSocket connection.
-'''
-
-
-class DateTimeEncoder(json.JSONEncoder):
-    '''Create a custom JSON encoder that allows serialization of datetime and date objects.'''
-
-    def default(self, obj):
-        if isinstance(obj, datetime):
-            # Convert to milliseconds - perspective.js expects millisecond timestamps, but python generates them in seconds.
-            return obj.timestamp() * 1000
-        return super(DateTimeEncoder, self).default(obj)
+from perspective import PerspectiveViewer, PerspectiveTornadoHandler
 
 
 class MainHandler(tornado.web.RequestHandler):
@@ -42,63 +22,29 @@ class MainHandler(tornado.web.RequestHandler):
         self.render("perspective_tornado_client.html")
 
 
-class SimpleWebSocket(tornado.websocket.WebSocketHandler):
-
-    def check_origin(self, origin):
-        return True
-
-    def on_message(self, message):
-        '''When the websocket receives a message, send it to the `process` method of the `PerspectiveManager` with a reference to the `post` callback.'''
-        if message == "heartbeat":
-            return
-        message = json.loads(message)
-        MANAGER.process(message, self.post)
-
-    def post(self, message):
-        '''When `post` is called by `PerspectiveManager`, serialize the data to JSON and send it to the client.'''
-        message = json.dumps(message, cls=DateTimeEncoder)
-        self.write_message(message)
-
-
 def make_app():
+    '''Create and return a Tornado app.
+
+    For `PerspectiveTornadoHandler` to work, it must be passed an instance of `PerspectiveViewer`.
+
+    Inside this function, we create a PerspectiveViewer and load data into it using its `load` method.
+
+    By passing a name into `load`, we guarantee the existence of a table with the name "data_source_one". This allows us to reference the Table
+    from the front-end with its known name. Without the `name` kwarg, the front-end has no way of knowing how to look up the Table on the backend.
+    '''
+    VIEWER = PerspectiveViewer()
+    VIEWER.load(pd.read_csv("superstore.csv"), name="data_source_one")
     return tornado.web.Application([
         (r"/", MainHandler),
         # create a websocket endpoint that the client Javascript can access
-        (r"/websocket", SimpleWebSocket)
+        (r"/websocket", PerspectiveTornadoHandler, {"viewer": VIEWER, "check_origin": True})
     ])
 
 
 if __name__ == "__main__":
-    '''Create an instance of the `PerspectiveManager`.
-
-    The manager instance tracks tables and views, manages method calls on them, and parses messages from the client.
-    '''
-    MANAGER = PerspectiveManager()
-
-    '''Perspective can load data in row, column, and dataframe format.
-
-        - Row format (list[dict{string:value}]): [{"column_1": 1, "column_2": "abc", "column_3": True, "column_4": datetime.now(), "column_5": date.today()}]
-            * Each element in the list is a dict, which represents a row of data.
-        - Column format (dict{string: list}): {"column": [1, 2, 3]}
-            * The keys of the dict are string column names, and the values are lists that contain the value for each row.
-            * Numpy arrays can also be used in this format, i.e. {"a": numpy.arange(100)}
-        - DataFrame (pandas.DataFrame): Perspective has full support for dataframe loading, updating, and editing.
-
-    For this example, we'll load a sample dataframe from CSV, and provide it to the Table.
-    '''
-    tbl = Table(pd.read_csv("superstore.csv"))
-
-    '''Once the Table is created, pass it to the manager instance with a name.
-
-    Make sure that the name here is used in the client HTML when we call `open_table`.
-
-    Once the manager has the table, commands from the client will be tracked and applied.
-    '''
-    MANAGER.host_table("data_source_one", tbl)
-
-    # start the Tornado server
+    # Because we use `PerspectiveTornadoHandler`, all that needs to be done in `init` is to start the Tornado server.
     app = make_app()
     app.listen(8888)
-    logging.critical("Listending on http://localhost:8888")
+    logging.critical("Listening on http://localhost:8888")
     loop = tornado.ioloop.IOLoop.current()
     loop.start()

--- a/python/perspective/examples/streaming.py
+++ b/python/perspective/examples/streaming.py
@@ -2,34 +2,14 @@ import os
 import os.path
 import random
 import sys
-import json
 import logging
 import tornado.websocket
 import tornado.web
 import tornado.ioloop
 from datetime import datetime
-from functools import partial
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
-from perspective import Table, PerspectiveManager
-
-'''
-Import the Table and PerspectiveManager classes.
-
-A Perspective `Table` is instantiated either with data or a `schema`.
-
-The `PerspectiveManager` class handles incoming messages from the client Perspective through a WebSocket connection.
-'''
-
-
-class DateTimeEncoder(json.JSONEncoder):
-    '''Create a custom JSON encoder that allows serialization of datetime and date objects.'''
-
-    def default(self, obj):
-        if isinstance(obj, datetime):
-            # Convert to milliseconds - perspective.js expects millisecond timestamps, but python generates them in seconds.
-            return obj.timestamp() * 1000
-        return super(DateTimeEncoder, self).default(obj)
+from perspective import PerspectiveViewer, PerspectiveTornadoHandler
 
 
 class MainHandler(tornado.web.RequestHandler):
@@ -43,67 +23,30 @@ class MainHandler(tornado.web.RequestHandler):
         self.render("streaming.html")
 
 
-class SimpleWebSocket(tornado.websocket.WebSocketHandler):
+def data_source():
+    rows = []
+    modifier = random.random() * random.randint(1, 50)
+    for i in range(5):
+        rows.append({
+            "name": SECURITIES[random.randint(0, len(SECURITIES) - 1)],
+            "client": CLIENTS[random.randint(0, len(CLIENTS) - 1)],
+            "open": (random.random() * 75 + random.randint(0, 9)) * modifier,
+            "high": (random.random() * 105 + random.randint(1, 3)) * modifier,
+            "low": (random.random() * 85 + random.randint(1, 3)) * modifier,
+            "close": (random.random() * 90 + random.randint(1, 3)) * modifier,
+            "lastUpdate": datetime.now()
+        })
+    return rows
 
-    def on_message(self, message):
-        '''When the websocket receives a message, send it to the `process` method of the `PerspectiveManager` with a reference to the `post` callback.'''
-        if message == "heartbeat":
-            return
-        message = json.loads(message)
-        MANAGER.process(message, self.post)
 
-    def post(self, message):
-        '''When `post` is called by `PerspectiveManager`, serialize the data to JSON and send it to the client.'''
-        message = json.dumps(message, cls=DateTimeEncoder)
-        self.write_message(message)
+'''Set up our data for this example.'''
+SECURITIES = ["AAPL.N", "AMZN.N", "QQQ.N", "NVDA.N", "TSLA.N", "FB.N", "MSFT.N", "TLT.N", "XIV.N", "YY.N", "CSCO.N", "GOOGL.N", "PCLN.N"]
+CLIENTS = ["Homer", "Marge", "Bart", "Lisa", "Maggie", "Moe", "Lenny", "Carl", "Krusty"]
 
 
 def make_app():
-    return tornado.web.Application([
-        (r"/", MainHandler),
-        # create a websocket endpoint that the client Javascript can access
-        (r"/websocket", SimpleWebSocket)
-    ])
-
-
-if __name__ == "__main__":
-    '''Set up our data for this example.'''
-    SECURITIES = ["AAPL.N", "AMZN.N", "QQQ.N", "NVDA.N", "TSLA.N", "FB.N", "MSFT.N", "TLT.N", "XIV.N", "YY.N", "CSCO.N", "GOOGL.N", "PCLN.N"]
-    CLIENTS = ["Homer", "Marge", "Bart", "Lisa", "Maggie", "Moe", "Lenny", "Carl", "Krusty"]
-
-    def data_source():
-        rows = []
-        modifier = random.random() * random.randint(1, 50)
-        for i in range(5):
-            rows.append({
-                "name": SECURITIES[random.randint(0, len(SECURITIES) - 1)],
-                "client": CLIENTS[random.randint(0, len(CLIENTS) - 1)],
-                "open": (random.random() * 75 + random.randint(0, 9)) * modifier,
-                "high": (random.random() * 105 + random.randint(1, 3)) * modifier,
-                "low": (random.random() * 85 + random.randint(1, 3)) * modifier,
-                "close": (random.random() * 90 + random.randint(1, 3)) * modifier,
-                "lastUpdate": datetime.now()
-            })
-        return rows
-
-    '''Create an instance of the `PerspectiveManager`.
-
-    The manager instance tracks tables and views, manages method calls on them, and parses messages from the client.
-    '''
-    MANAGER = PerspectiveManager()
-
-    '''Perspective can load data in row, column, and dataframe format.
-
-        - Row format (list[dict{string:value}]): [{"column_1": 1, "column_2": "abc", "column_3": True, "column_4": datetime.now(), "column_5": date.today()}]
-            * Each element in the list is a dict, which represents a row of data.
-        - Column format (dict{string: list}): {"column": [1, 2, 3]}
-            * The keys of the dict are string column names, and the values are lists that contain the value for each row.
-            * Numpy arrays can also be used in this format, i.e. {"a": numpy.arange(100)}
-        - DataFrame (pandas.DataFrame): Perspective has full support for dataframe loading, updating, and editing.
-
-    For this example, we'll create a table from a schema, and use Tornado's event loop to push updates to it every 50 milliseconds.
-    '''
-    SCHEMA = {
+    VIEWER = PerspectiveViewer()
+    VIEWER.load({
         "name": str,
         "client": str,
         "open": float,
@@ -111,28 +54,25 @@ if __name__ == "__main__":
         "low": float,
         "close": float,
         "lastUpdate": datetime,
-    }
-    tbl = Table(SCHEMA, limit=2500)
+    }, name="data_source_one", limit=2500)
 
-    '''Once the Table is created, pass it to the manager instance with a name.
+    # update with new data every 50ms
+    def updater():
+        VIEWER.update(data_source())
 
-    Make sure that the name here is used in the client HTML when we call `open_table`.
+    callback = tornado.ioloop.PeriodicCallback(callback=updater, callback_time=50)
+    callback.start()
 
-    Once the manager has the table, commands from the client will be tracked and applied.
-    '''
-    MANAGER.host_table("data_source_one", tbl)
+    return tornado.web.Application([
+        (r"/", MainHandler),
+        # create a websocket endpoint that the client Javascript can access
+        (r"/websocket", PerspectiveTornadoHandler, {"viewer": VIEWER, "check_origin": True})
+    ])
 
-    # server setup
+
+if __name__ == "__main__":
     app = make_app()
     app.listen(8888)
     logging.critical("Listening on http://localhost:8888")
     loop = tornado.ioloop.IOLoop.current()
-
-    # update with new data every 50ms
-    def updater():
-        tbl.update(data_source())
-    callback = tornado.ioloop.PeriodicCallback(callback=updater, callback_time=50)
-    callback.start()
-
-    # begin our server
     loop.start()

--- a/python/perspective/perspective/core/__init__.py
+++ b/python/perspective/perspective/core/__init__.py
@@ -9,5 +9,7 @@ from ._version import __version__  # noqa: F401
 from .plugin import Plugin  # noqa: F401
 from .aggregate import Aggregate  # noqa: F401
 from .exception import PerspectiveError  # noqa: F401
+from .manager import PerspectiveManager  # noqa: F401
+from .tornado_handler import PerspectiveTornadoHandler  # noqa: F401
 from .viewer import PerspectiveViewer  # noqa: F401
 from .widget import PerspectiveWidget  # noqa: F401

--- a/python/perspective/perspective/core/data/__init__.py
+++ b/python/perspective/perspective/core/data/__init__.py
@@ -1,0 +1,9 @@
+# *****************************************************************************
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+from .pandas import deconstruct_pandas  # noqa: F401

--- a/python/perspective/perspective/core/manager.py
+++ b/python/perspective/perspective/core/manager.py
@@ -7,8 +7,8 @@
 #
 import logging
 from functools import partial
-from .table import Table
-from ..core.exception import PerspectiveError
+from ..table import Table
+from .exception import PerspectiveError
 
 
 class PerspectiveManager(object):
@@ -20,6 +20,10 @@ class PerspectiveManager(object):
     def host_table(self, name, table):
         '''Given a reference to a `Table`, manage it and allow operations on it to occur through the Manager.'''
         self._tables[name] = table
+
+    def host_view(self, name, view):
+        '''Given a reference to a `View`, add it to the manager's views container.'''
+        self._views[name] = view
 
     def process(self, msg, post_callback):
         '''Given a message from the client, process it through the Perspective engine.
@@ -145,3 +149,7 @@ class PerspectiveManager(object):
     def get_table(self, name):
         '''Return a table under management by name.'''
         return self._tables.get(name, None)
+
+    def get_view(self, name):
+        '''Return a view under management by name.'''
+        return self._views.get(name, None)

--- a/python/perspective/perspective/core/session.py
+++ b/python/perspective/perspective/core/session.py
@@ -1,0 +1,28 @@
+# *****************************************************************************
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+from random import random
+
+
+class PerspectiveSession(object):
+    '''Encapsulates the actions and resources of a single connection to Perspective.'''
+
+    def __init__(self, manager):
+        '''Create a new session object, keeping track of a unique client_id and the manager the session belongs to.
+
+        `PerspectiveSession` should not be constructed directly - use `PerspectiveManager.new_session()` to create.
+        '''
+        self.client_id = str(random())
+        self.manager = manager
+
+    def process(self, message, post_callback):
+        '''Pass a message to the manager's `process` method, which passes the result to `post_callback`.'''
+        self.manager.process(message, post_callback, client_id=self.client_id)
+
+    def close(self):
+        '''Remove the views created within this session when the session ends.'''
+        self.manager.clear_views(self.client_id)

--- a/python/perspective/perspective/core/tornado_handler.py
+++ b/python/perspective/perspective/core/tornado_handler.py
@@ -1,0 +1,69 @@
+# *****************************************************************************
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+import json
+import tornado.websocket
+from datetime import datetime
+from .exception import PerspectiveError
+
+
+class DateTimeEncoder(json.JSONEncoder):
+    '''Create a custom JSON encoder that allows serialization of datetime and date objects.'''
+
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            # Convert to milliseconds - perspective.js expects millisecond timestamps, but python generates them in seconds.
+            return obj.timestamp() * 1000
+        return super(DateTimeEncoder, self).default(obj)
+
+
+class PerspectiveTornadoHandler(tornado.websocket.WebSocketHandler):
+    '''PerspectiveTornadoHandler is a drop-in implementation of Perspective.
+
+    Use it inside Tornado routing to create a server-side Perspective that is ready to receive websocket messages from
+    the front-end `perspective-viewer`.
+
+    Examples:
+        >>> VIEWER = PerspectiveViewer()
+        >>> VIEWER.load(pd.read_csv("superstore.csv"), name="data_source_one")
+        >>> app = tornado.web.Application([
+                (r"/", MainHandler),
+                (r"/websocket", PerspectiveTornadoHandler, {"viewer": VIEWER, "check_origin": True})
+            ])
+    '''
+
+    def __init__(self, *args, **kwargs):
+        '''Create a new instance of the PerspectiveTornadoHandler with the given Viewer instance.
+
+        Args:
+            **kwargs (dict) : keyword arguments for the Tornado handler.
+                - viewer (PerspectiveViewer) : a `PerspectiveViewer` instance. Must be provided on initialization.
+                - check_origin (bool) : if True, all requests will be accepted regardless of origin. Defaults to False.
+        '''
+        self._viewer = kwargs.pop("viewer", None)
+        self._check_origin = kwargs.pop("check_origin", False)
+
+        if self._viewer is None:
+            raise PerspectiveError("A `PerspectiveViewer` instance must be provided to the tornado handler!")
+
+        super(PerspectiveTornadoHandler, self).__init__(*args, **kwargs)
+
+    def check_origin(self, origin):
+        '''Returns whether the handler allows requests from origins outside of the host URL.'''
+        return self._check_origin
+
+    def on_message(self, message):
+        '''When the websocket receives a message, send it to the `process` method of the `PerspectiveManager` with a reference to the `post` callback.'''
+        if message == "heartbeat":
+            return
+        message = json.loads(message)
+        self._viewer.manager.process(message, self.post)
+
+    def post(self, message):
+        '''When `post` is called by `PerspectiveManager`, serialize the data to JSON and send it to the client.'''
+        message = json.dumps(message, cls=DateTimeEncoder)
+        self.write_message(message)

--- a/python/perspective/perspective/core/validate.py
+++ b/python/perspective/perspective/core/validate.py
@@ -87,15 +87,14 @@ def validate_sort(sort):
             if isinstance(s, Sort):
                 s = s.value
             elif not isinstance(s, string_types) or s not in Sort.options():
-                raise PerspectiveError('Unrecognized Sort: %s', s)
+                raise PerspectiveError('Unrecognized sort direction: %s', s)
             ret.append([col, s])
         return ret
     else:
         raise PerspectiveError('Cannot parse sort type: %s', str(type(sort)))
 
 
-def validate_filters(filters, columns=None):
-    columns = columns or []
+def validate_filters(filters):
     if filters is None:
         return []
 
@@ -104,26 +103,20 @@ def validate_filters(filters, columns=None):
         filters = [filters]
 
     if isinstance(filters, list):
-        ret = []
-        for i, d in enumerate(filters):
-            if not isinstance(d, list):
+        for f in filters:
+            if not isinstance(f, list):
                 raise PerspectiveError('`filters` kwarg must be a list!')
 
-            if len(d) != 3:
-                raise PerspectiveError('Cannot parse filter - unrecognized function {}'.format(d['func']))
-
-            for i, l in enumerate(d):
-                # FIXME check if column exists?
-                # if columns and (l not in columns):
-                #     raise PerspectiveError('Cannot parse computed_columns - unrecognized column {}'.format(input))
+            for i, item in enumerate(f):
                 if i == 1:
-                    if l not in ALL_FILTERS:
-                        raise PerspectiveError('Unrecognized filter operator: {}'.format(l))
-                pass
-            ret.append(d)
-        return ret
+                    if item not in ALL_FILTERS:
+                        raise PerspectiveError('Unrecognized filter operator: {}'.format(item))
+                    elif item not in ("is null", "is not null"):
+                        if len(f) != 3:
+                            raise PerspectiveError('Cannot parse filter - {} operator must have a comparison value.'.format(item))
+        return filters
     else:
-        raise PerspectiveError('Cannot parse filters type: %s', str(type(filters)))
+        raise PerspectiveError('Cannot parse filters type: {}'.format(str(type(filters))))
 
 
 def validate_plugin_config(plugin_config):

--- a/python/perspective/perspective/core/viewer.py
+++ b/python/perspective/perspective/core/viewer.py
@@ -105,7 +105,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
             >>> viewer.load(tbl)
             >>> viewer.load(data, index="a") # kwargs are forwarded to the `Table` constructor.
         '''
-        name = options.pop("name", str(random()))  # TODO: is this too convoluted
+        name = options.pop("name", str(random()))
         if isinstance(table_or_data, Table):
             table = table_or_data
         else:

--- a/python/perspective/perspective/core/viewer.py
+++ b/python/perspective/perspective/core/viewer.py
@@ -10,7 +10,8 @@ from random import random
 from .validate import validate_plugin, validate_columns, validate_row_pivots, validate_column_pivots, \
     validate_aggregates, validate_sort, validate_filters, validate_plugin_config
 from .viewer_traitlets import PerspectiveTraitlets
-from ..table import PerspectiveManager, Table
+from .manager import PerspectiveManager
+from ..table import Table
 
 
 class PerspectiveViewer(PerspectiveTraitlets):
@@ -24,7 +25,8 @@ class PerspectiveViewer(PerspectiveTraitlets):
                  sort=None,
                  filters=None,
                  plugin_config=None,
-                 dark=False):
+                 dark=False,
+                 editable=False):
         '''Initialize an instance of `PerspectiveViewer` with the given viewer configuration.
 
         Do not pass a `Table` or data into the constructor — use the `load()` method to provide the viewer with data.
@@ -51,6 +53,7 @@ class PerspectiveViewer(PerspectiveTraitlets):
         # Create an instance of `PerspectiveManager`, which receives messages from the `PerspectiveJupyterClient` on the front-end.
         self.manager = PerspectiveManager()
         self.table_name = None  # not a traitlet - only used in the python side of the viewer
+        self.view_name = None
 
         # Viewer configuration
         self.plugin = validate_plugin(plugin)
@@ -62,11 +65,19 @@ class PerspectiveViewer(PerspectiveTraitlets):
         self.filters = validate_filters(filters) or []
         self.plugin_config = validate_plugin_config(plugin_config) or {}
         self.dark = dark
+        self.editable = editable
 
     @property
     def table(self):
         '''Returns the `perspective.Table` under management by the viewer.'''
         return self.manager.get_table(self.table_name)
+
+    @property
+    def view(self):
+        '''Returns the `perspective.View` currently shown by the viewer.
+
+        This property changes every time the viewer configuration changes.'''
+        return self.manager.get_view(self.view_name)
 
     def load(self, table_or_data, **options):
         '''Given a `perspective.Table` or data that can be handled by `perspective.Table`, pass it to the viewer.
@@ -81,6 +92,7 @@ class PerspectiveViewer(PerspectiveTraitlets):
         Args:
             table_or_data (Table|dict|list|pandas.DataFrame) : a `perspective.Table` instance or a dataset to be displayed in the viewer.
             **options : optional keyword arguments that will be parsed by the `perspective.Table` constructor if data is passed in.
+                - name (str) : an optional name to reference the table by so it can be accessed from the front-end.
                 - index (str) : the name of a column that will be the dataset's primary key. This sorts the dataset in ascending order based on primary key.
                 - limit (int) : cannot be applied at the same time as `index` - the total number of rows that will be loaded into Perspective.
                     If the table is updated and the number of rows is greater than `limit`, updates begin overwriting at row 0.
@@ -93,7 +105,7 @@ class PerspectiveViewer(PerspectiveTraitlets):
             >>> viewer.load(tbl)
             >>> viewer.load(data, index="a") # kwargs are forwarded to the `Table` constructor.
         '''
-        name = str(random())
+        name = options.pop("name", str(random()))  # TODO: is this too convoluted
         if isinstance(table_or_data, Table):
             table = table_or_data
         else:
@@ -101,11 +113,8 @@ class PerspectiveViewer(PerspectiveTraitlets):
 
         self.manager.host_table(name, table)
 
-        '''
-        if columns are different between the tables, then remove viewer state.
-
-        sorting is expensive, but it prevents errors from applying pivots, etc. on columns that don't exist in the dataset.
-        '''
+        # If columns are different between the tables, then remove viewer state.
+        # - sorting is expensive, but it prevents errors from applying pivots, etc. on columns that don't exist in the dataset.
         if self.table_name is not None:
             old_columns = sorted(self.manager.get_table(self.table_name).columns())
             new_columns = sorted(table.columns())
@@ -134,3 +143,25 @@ class PerspectiveViewer(PerspectiveTraitlets):
             data (dict|list|pandas.DataFrame) : the update data for the table.
         '''
         self.table.update(data)
+
+    def _new_view(self):
+        '''Create a new View, and assign its name to the viewer.
+
+        There should only be one View associated with the Viewer at any given time - when a new View is created, the old one is destroyed.
+
+        # TODO: fully implement
+        '''
+        if not self.table_name:
+            return
+        name = str(random())
+        table = self.manager.get_table(self.table_name)
+        view = table.view(
+            row_pivots=self.row_pivots,
+            column_pivots=self.column_pivots,
+            columns=self.columns,
+            aggregates=self.aggregates,
+            sort=self.sort,
+            filter=self.filters
+        )
+        self.manager.host_view(name, view)
+        self.view_name = name

--- a/python/perspective/perspective/core/viewer.py
+++ b/python/perspective/perspective/core/viewer.py
@@ -14,7 +14,7 @@ from .manager import PerspectiveManager
 from ..table import Table
 
 
-class PerspectiveViewer(PerspectiveTraitlets):
+class PerspectiveViewer(PerspectiveTraitlets, object):
     '''PerspectiveViewer wraps the `perspective.Table` API and exposes an API around creating views, loading data, and updating data.'''
     def __init__(self,
                  plugin='hypergrid',
@@ -147,12 +147,13 @@ class PerspectiveViewer(PerspectiveTraitlets):
     def _new_view(self):
         '''Create a new View, and assign its name to the viewer.
 
-        There should only be one View associated with the Viewer at any given time - when a new View is created, the old one is destroyed.
+        Do not call this function - it will be called automatically when the state of the viewer changes.
 
-        # TODO: fully implement
+        There should only be one View associated with the Viewer at any given time - when a new View is created, the old one is destroyed.
         '''
         if not self.table_name:
             return
+
         name = str(random())
         table = self.manager.get_table(self.table_name)
         view = table.view(
@@ -163,5 +164,6 @@ class PerspectiveViewer(PerspectiveTraitlets):
             sort=self.sort,
             filter=self.filters
         )
+
         self.manager.host_view(name, view)
         self.view_name = name

--- a/python/perspective/perspective/core/viewer_traitlets.py
+++ b/python/perspective/perspective/core/viewer_traitlets.py
@@ -16,7 +16,7 @@ class PerspectiveTraitlets(HasTraits):
     Properties that are set here are synchronized between the front-end and back-end.
 
     Examples:
-        >>> widget = perspective.PerspectiveWidget(row_pivots=["a", "b", "c"])
+        >>> widget = perspective.PerspectiveWidget(data, row_pivots=["a", "b", "c"])
         PerspectiveWidget(row_pivots=["a", "b", "c"])
         >>> widget.column_pivots=["b"]
         >>> widget
@@ -33,6 +33,7 @@ class PerspectiveTraitlets(HasTraits):
     filters = List(default_value=[]).tag(sync=True)
     plugin_config = Dict(default_value={}).tag(sync=True)
     dark = Bool(False).tag(sync=True)
+    editable = Bool(False).tag(sync=True)
 
     @validate('plugin')
     def _validate_plugin(self, proposal): return validate_plugin(proposal.value)
@@ -53,7 +54,7 @@ class PerspectiveTraitlets(HasTraits):
     def _validate_sort(self, proposal): return validate_sort(proposal.value)
 
     @validate('filters')
-    def _validate_filters(self, proposal): return validate_filters(proposal.value, self.columns)
+    def _validate_filters(self, proposal): return validate_filters(proposal.value)
 
     @validate('plugin_config')
     def _validate_plugin_config(self, proposal): return validate_plugin_config(proposal.value)

--- a/python/perspective/perspective/core/widget.py
+++ b/python/perspective/perspective/core/widget.py
@@ -12,7 +12,7 @@ from functools import wraps
 from time import mktime
 from ipywidgets import Widget
 from traitlets import observe, Unicode
-from .data.pandas import deconstruct_pandas
+from .data import deconstruct_pandas
 from .exception import PerspectiveError
 from .viewer import PerspectiveViewer
 

--- a/python/perspective/perspective/table/__init__.py
+++ b/python/perspective/perspective/table/__init__.py
@@ -6,6 +6,5 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 from .table import Table
-from .manager import PerspectiveManager
 
-__all__ = ["Table", "PerspectiveManager"]
+__all__ = ["Table"]

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -7,7 +7,7 @@
 #
 import pandas
 from math import isnan
-from perspective.table.libbinding import t_dtype
+from .libbinding import t_dtype
 from ._date_validator import _PerspectiveDateValidator
 
 
@@ -44,7 +44,7 @@ def _type_to_format(data_or_schema):
             # if pandas not installed or is not a dataframe or series
             raise NotImplementedError("Must be dict or list!")
         else:
-            from perspective.core.data.pandas import deconstruct_pandas
+            from perspective.core.data import deconstruct_pandas
 
             # flatten column/index multiindex
             df, _ = deconstruct_pandas(data_or_schema)
@@ -118,7 +118,7 @@ class _PerspectiveAccessor(object):
         Args:
             cidx (int)
             ridx (int)
-            type (perspective.table.libbinding.t_dtype)
+            type (.libbinding.t_dtype)
 
         Returns:
             object or None

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -44,7 +44,7 @@ def _type_to_format(data_or_schema):
             # if pandas not installed or is not a dataframe or series
             raise NotImplementedError("Must be dict or list!")
         else:
-            from perspective.core.data import deconstruct_pandas
+            from ..core.data import deconstruct_pandas
 
             # flatten column/index multiindex
             df, _ = deconstruct_pandas(data_or_schema)

--- a/python/perspective/perspective/table/_data_formatter.py
+++ b/python/perspective/perspective/table/_data_formatter.py
@@ -7,7 +7,7 @@
 #
 import numpy as np
 from math import trunc
-from perspective.table.libbinding import get_data_slice_zero, get_data_slice_one, get_data_slice_two, \
+from .libbinding import get_data_slice_zero, get_data_slice_one, get_data_slice_two, \
     get_from_data_slice_zero, get_from_data_slice_one, get_from_data_slice_two, \
     get_pkeys_from_data_slice_zero, get_pkeys_from_data_slice_one, get_pkeys_from_data_slice_two
 from ._constants import COLUMN_SEPARATOR_STRING

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -10,7 +10,7 @@ import numpy
 from datetime import datetime
 from re import search
 from dateutil.parser import parse
-from perspective.table.libbinding import t_dtype
+from .libbinding import t_dtype
 
 
 class _PerspectiveDateValidator(object):

--- a/python/perspective/perspective/table/_utils.py
+++ b/python/perspective/perspective/table/_utils.py
@@ -6,7 +6,7 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 from datetime import date, datetime
-from perspective.table.libbinding import t_dtype
+from .libbinding import t_dtype
 
 
 def _extract_type(type, typemap):

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -194,6 +194,7 @@ class Table(object):
 
         Args:
             **config (dict) : optional keyword arguments that configure and transform the view:
+            - "columns" (list[str]) : a list of column names to be shown
             - "row_pivots" (list[str]) : a list of column names to use as row pivots
             - "column_pivots" (list[str]) : a list of column names to use as column pivots
             - "aggregates" (dict[str:str]) : a dictionary of column names to aggregate types to specify aggregates for individual columns

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -6,7 +6,7 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 from datetime import date, datetime
-from perspective.table.libbinding import make_table, str_to_filter_op, t_filter_op, t_op, t_dtype
+from .libbinding import make_table, str_to_filter_op, t_filter_op, t_op, t_dtype
 from .view import View
 from ._accessor import _PerspectiveAccessor
 from ._callback_cache import _PerspectiveCallBackCache

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -8,7 +8,7 @@
 import pandas
 from functools import partial, wraps
 from random import random
-from perspective.table.libbinding import make_view_zero, make_view_one, make_view_two
+from .libbinding import make_view_zero, make_view_one, make_view_two
 from .view_config import ViewConfig
 from ._data_formatter import to_format
 from ._constants import COLUMN_SEPARATOR_STRING

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -44,6 +44,7 @@ class View(object):
         self._column_only = self._view.is_column_only()
         self._callbacks = self._table._callbacks
         self._delete_callbacks = _PerspectiveCallBackCache()
+        self._client_id = None
 
     def get_config(self):
         '''Returns the original dictionary config passed in by the user.'''

--- a/python/perspective/perspective/tests/core/test_manager.py
+++ b/python/perspective/perspective/tests/core/test_manager.py
@@ -85,6 +85,19 @@ class TestPerspectiveManager(object):
             "b": ["c"]
         }
 
+    def test_manager_host_view(self):
+        message = {"id": 1, "name": "view1", "cmd": "view_method", "method": "schema", "args": []}
+        manager = PerspectiveManager()
+        table = Table(data)
+        view = table.view()
+        manager.host_table("table1", table)
+        manager.host_view("view1", view)
+        manager.process(message, self.post)
+        assert manager.get_view("view1").schema() == {
+            "a": int,
+            "b": str
+        }
+
     def test_manager_create_view_zero(self):
         message = {"id": 1, "table_name": "table1", "view_name": "view1", "cmd": "view"}
         manager = PerspectiveManager()

--- a/python/perspective/perspective/tests/core/test_manager.py
+++ b/python/perspective/perspective/tests/core/test_manager.py
@@ -28,6 +28,13 @@ class TestPerspectiveManager(object):
             "b": str
         }
 
+    def test_manager_host_table_transitive(self):
+        manager = PerspectiveManager()
+        table = Table(data)
+        manager.host_table("table1", table)
+        table.update({"a": [4, 5, 6], "b": ["d", "e", "f"]})
+        assert manager.get_table("table1").size() == 6
+
     def test_manager_create_table(self):
         message = {"id": 1, "name": "table1", "cmd": "table", "args": [data]}
         manager = PerspectiveManager()

--- a/python/perspective/perspective/tests/core/test_validate.py
+++ b/python/perspective/perspective/tests/core/test_validate.py
@@ -24,3 +24,20 @@ class TestValidate:
     def test_validate_plugin_invalid_string(self):
         with raises(PerspectiveError):
             perspective.core.validate.validate_plugin("invalid")
+
+    def test_validate_filters_valid(self):
+        filters = [["a", ">", 1], ["b", "==", "abc"]]
+        assert perspective.core.validate.validate_filters(filters) == filters
+
+    def test_validate_filters_invalid(self):
+        with raises(PerspectiveError):
+            filters = [["a", ">"], ["b", "invalid" "abc"]]
+            perspective.core.validate.validate_filters(filters)
+
+    def test_validate_filters_is_null(self):
+        filters = [["a", "is null"]]
+        assert perspective.core.validate.validate_filters(filters) == filters
+
+    def test_validate_filters_is_not_null(self):
+        filters = [["a", "is not null"]]
+        assert perspective.core.validate.validate_filters(filters) == filters

--- a/python/perspective/perspective/tests/core/test_viewer.py
+++ b/python/perspective/perspective/tests/core/test_viewer.py
@@ -18,16 +18,64 @@ class TestViewer:
         viewer.load(table)
         assert viewer.table == table
 
+    # server-side view creation
+
+    def test_viewer_make_view(self):
+        table = Table({"a": [1, 2, 3]})
+        viewer = PerspectiveViewer(filters=[["a", "==", 2]])
+        viewer.load(table)
+        viewer._new_view()
+        assert viewer.view.to_dict() == {
+            "a": [2]
+        }
+
+    def test_viewer_make_view_none(self):
+        table = Table({"a": [1, 2, 3]})
+        viewer = PerspectiveViewer(filters=[["a", "==", 2]])
+        viewer.load(table)
+        assert viewer.view_name is None
+        assert viewer.view is None
+
+    def test_viewer_make_view_replace(self):
+        table = Table({"a": [1, 2, 3]})
+        viewer = PerspectiveViewer(filters=[["a", "==", 2]])
+        viewer.load(table)
+        viewer._new_view()
+        assert viewer.view.to_dict() == {
+            "a": [2]
+        }
+        viewer.filters = []
+        viewer._new_view()
+        assert viewer.view.to_dict() == {
+            "a": [1, 2, 3]
+        }
+
+    # loading
+
     def test_viewer_load_table(self):
         table = Table({"a": [1, 2, 3]})
         viewer = PerspectiveViewer()
         viewer.load(table)
         assert viewer.columns == ["a"]
 
+    def test_viewer_load_named_table(self):
+        table = Table({"a": [1, 2, 3]})
+        viewer = PerspectiveViewer()
+        viewer.load(table, name="data_1")
+        assert viewer.columns == ["a"]
+        assert viewer.table_name == "data_1"
+        assert viewer.table == table
+
     def test_viewer_load_data(self):
         viewer = PerspectiveViewer()
         viewer.load({"a": [1, 2, 3]})
         assert viewer.columns == ["a"]
+
+    def test_viewer_load_named_data(self):
+        viewer = PerspectiveViewer()
+        viewer.load({"a": [1, 2, 3]}, name="data_1")
+        assert viewer.columns == ["a"]
+        assert viewer.table_name == "data_1"
 
     def test_viewer_load_schema(self):
         viewer = PerspectiveViewer()
@@ -45,18 +93,14 @@ class TestViewer:
         # options should be disregarded when loading Table
         viewer.load(table, limit=1)
         assert viewer.columns == ["a"]
-        table_name = list(viewer.manager._tables.keys())[0]
-        table = viewer.manager._tables[table_name]
-        assert table.size() == 3
+        assert viewer.table.size() == 3
 
     def test_viewer_load_data_with_options(self):
         viewer = PerspectiveViewer()
         # options should be forwarded to the Table constructor
         viewer.load({"a": [1, 2, 3]}, limit=1)
         assert viewer.columns == ["a"]
-        table_name = list(viewer.manager._tables.keys())[0]
-        table = viewer.manager._tables[table_name]
-        assert table.size() == 1
+        assert viewer.table.size() == 1
 
     def test_viewer_load_clears_state(self):
         table = Table({"a": [1, 2, 3]})
@@ -72,6 +116,26 @@ class TestViewer:
         viewer = PerspectiveViewer()
         viewer.load(table)
         assert viewer.columns == ["a"]
+
+    def test_viewer_load_np_data(self):
+        viewer = PerspectiveViewer()
+        viewer.load({"a": np.arange(1, 100)})
+        assert viewer.columns == ["a"]
+        assert viewer.table.size() == 99
+
+    def test_viewer_load_df(self):
+        table = Table(pd.DataFrame({"a": np.arange(1, 100)}))
+        viewer = PerspectiveViewer()
+        viewer.load(table)
+        assert viewer.columns == ["index", "a"]
+        assert viewer.table.size() == 99
+
+    def test_viewer_load_df_data(self):
+        viewer = PerspectiveViewer()
+        viewer.load(pd.DataFrame({"a": np.arange(1, 100)}))
+        assert viewer.columns == ["index", "a"]
+
+    # update
 
     def test_viewer_update_dict(self):
         table = Table({"a": [1, 2, 3]})

--- a/python/perspective/perspective/tests/core/test_viewer.py
+++ b/python/perspective/perspective/tests/core/test_viewer.py
@@ -29,6 +29,16 @@ class TestViewer:
         viewer.load({"a": [1, 2, 3]})
         assert viewer.columns == ["a"]
 
+    def test_viewer_load_schema(self):
+        viewer = PerspectiveViewer()
+        viewer.load({
+            "a": str,
+            "b": int,
+            "c": bool,
+            "d": str
+        })
+        assert viewer.columns == ["a", "b", "c", "d"]
+
     def test_viewer_load_table_with_options(self):
         table = Table({"a": [1, 2, 3]})
         viewer = PerspectiveViewer()

--- a/python/perspective/perspective/tests/core/test_widget.py
+++ b/python/perspective/perspective/tests/core/test_widget.py
@@ -48,11 +48,9 @@ class TestWidget:
     def test_widget_load_table_ignore_limit(self):
         table = Table({"a": np.arange(0, 50)})
         widget = PerspectiveWidget(table, limit=1)
-        table_name = list(widget.manager._tables.keys())[0]
-        assert widget.manager.get_table(table_name).size() == 50
+        assert widget.table.size() == 50
 
     def test_widget_pass_options(self):
         data = {"a": np.arange(0, 50)}
         widget = PerspectiveWidget(data, limit=1)
-        table_name = list(widget.manager._tables.keys())[0]
-        assert widget.manager.get_table(table_name).size() == 1
+        assert widget.table.size() == 1

--- a/python/perspective/perspective/tests/table/test_manager.py
+++ b/python/perspective/perspective/tests/table/test_manager.py
@@ -5,7 +5,7 @@
 # This file is part of the Perspective library, distributed under the terms of
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
-from perspective.table import Table, PerspectiveManager
+from perspective import Table, PerspectiveManager
 
 data = {"a": [1, 2, 3], "b": ["a", "b", "c"]}
 


### PR DESCRIPTION
This PR cleans up the integration of Perspective with web servers in Python:

- Adds PerspectiveTornadoHandler, which encapsulates the manager and messaging abstractions for use within Tornado.
- Adds PerspectiveSession, which encapsulates the state of a single websocket connection and removes the wrangling around `client_id` we have on the JS side.
- Fixes a bug with date editing in hypergrid
- Does a little cleanup in the python source