### PR TITLE
Update declaration

### DIFF
--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -95,6 +95,8 @@ declare module '@finos/perspective' {
         on_delete(callback: Function): void;
         on_update(callback: UpdateCallback): void;
         schema(): Promise<Schema>;
+        to_arrow(options?: SerializeConfig & { data_slice: any }): Promise<ArrayBuffer>;
+        to_columns(options?: SerializeConfig): Promise<Array<object>>;
         to_csv(options?: SerializeConfig & { config: object }): Promise<string>;
         to_json(options?: SerializeConfig): Promise<Array<object>>;
     }

--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -85,11 +85,11 @@ declare module '@finos/perspective' {
         delete(): Promise<void>;
         num_columns(): Promise<number>;
         num_rows(): Promise<number>;
-        on_update(callback: UpdateCallback): void;
         on_delete(callback: Function): void;
+        on_update(callback: UpdateCallback): void;
         schema(): Promise<Schema>;
-        to_json(): Promise<Array<object>>;
         to_csv(): Promise<string>;
+        to_json(): Promise<Array<object>>;
     }
 
     /**** Table ****/

--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -95,8 +95,8 @@ declare module '@finos/perspective' {
         on_delete(callback: Function): void;
         on_update(callback: UpdateCallback): void;
         schema(): Promise<Schema>;
-        to_csv(): Promise<string>;
-        to_json(): Promise<Array<object>>;
+        to_csv(options?: SerializeConfig & { config: object }): Promise<string>;
+        to_json(options?: SerializeConfig): Promise<Array<object>>;
     }
 
     /**** Table ****/

--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -80,6 +80,13 @@ declare module '@finos/perspective' {
         [ key: string ]: TypeNames ;
     }
 
+    export interface SerializeConfig {
+        start_row: number,
+        end_row: number,
+        start_col: number,
+        end_col: number,
+    }
+
     /**** View ****/
     export type View = {
         delete(): Promise<void>;


### PR DESCRIPTION
This PR adds the `to_arrow` and `to_columns` methods to `View` and defines a config interface which is used by the various serialization methods. This is based on what's described in the API docs (I'm assuming that's more up to date than what is in the TS declaration).