### PR TITLE
Adjust setup.py for MacOS wheel dist

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -455,6 +455,10 @@ if (PSP_WASM_BUILD)
 	set_target_properties(perspective.async PROPERTIES OUTPUT_NAME "psp.async")
 elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 	if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+		# Look for the binary using @loader_path (relative to binary location) instead of @rpath
+		# and include arrow in @rpath so it can be found by libbinding/libpsp
+		set(PSP_INSTALL_PATH "@loader_path" ${PYTHON_PYARROW_LIBRARY_DIR})
+		set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 		set(CMAKE_SHARED_LIBRARY_SUFFIX .dylib)
 	endif()
 
@@ -471,9 +475,11 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 		# which means they use the old ABI: https://github.com/blue-yonder/turbodbc/issues/102#issuecomment-312222949
 		if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 			target_link_libraries(psp ${PYTHON_PYARROW_SHARED_LIBRARY})
+			set_target_properties(psp PROPERTIES INSTALL_RPATH "${PSP_INSTALL_PATH}")
 		else()
 			target_link_libraries(psp arrow)
 			target_link_libraries(psp ${Boost_FILESYSTEM_LIBRARY})
+			target_link_libraries(psp ${PYTHON_PYARROW_LIBRARIES})
 		endif()
 
 		target_link_libraries(psp ${PYTHON_LIBRARIES})
@@ -486,11 +492,12 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 		target_link_libraries(binding psp)
 		target_link_libraries(binding tbb)
 
-		# Link again libarrow from pyarrow
 		if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-			target_link_libraries(binding ${PYTHON_PYARROW_SHARED_LIBRARY})
+			# Add custom @rpath to binding
+			set_target_properties(binding PROPERTIES INSTALL_RPATH "${PSP_INSTALL_PATH}")
 		else()
-			target_link_libraries(psp ${PYTHON_PYARROW_LIBRARIES})
+			# Link binding code to pyarrow
+			target_link_libraries(binding ${PYTHON_PYARROW_LIBRARIES})
 		endif()
 		target_link_libraries(binding ${PYTHON_PYARROW_SHARED_LIBRARY})
 		target_link_libraries(binding ${PYTHON_LIBRARIES})

--- a/python/perspective/.bumpversion.cfg
+++ b/python/perspective/.bumpversion.cfg
@@ -15,5 +15,5 @@ values =
 
 [bumpversion:part:build]
 
-[bumpversion:file:perspective/_version.py]
+[bumpversion:file:perspective/core/_version.py]
 

--- a/python/perspective/MANIFEST.in
+++ b/python/perspective/MANIFEST.in
@@ -9,7 +9,8 @@ include pyproject.toml
 include .bumpversion.cfg
 include Makefile
 
-graft perspective/tests
+# Source files for perspective-python
+graft perspective
 
 # Documentation
 graft docs
@@ -26,8 +27,6 @@ include tsconfig.json
 include tslint.json
 graft src
 graft style
-graft ../../cpp
-graft ../../cmake
 
 # Patterns to exclude from any directory
 global-exclude *~

--- a/python/perspective/README.md
+++ b/python/perspective/README.md
@@ -10,6 +10,16 @@ Python APIs for [perspective](https://github.com/finos/perspective) front end
 
 ## Install
 
+### Dependencies
+
+You need to have [https://github.com/intel/tbb](TBB) installed as a system dependency:
+
+On MacOS:
+
+`brew install tbb`
+
+### Installation
+
 To install the base package from pip:
 
 `pip install perspective-python`

--- a/python/perspective/requirements.txt
+++ b/python/perspective/requirements.txt
@@ -2,6 +2,7 @@ ipywidgets>=7.4.2
 numpy>=1.13.1
 pandas>=0.22.0
 psutil>=5.4.8
+pyarrow==0.15.0
 six>=1.11.0
 traitlets>=4.3.2
 zerorpc>=0.6.1

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -10,7 +10,6 @@ from setuptools.command.build_ext import build_ext
 from distutils.version import LooseVersion
 from codecs import open
 import io
-import logging
 import os
 import os.path
 import re
@@ -90,21 +89,6 @@ class PSPBuild(build_ext):
 
         for ext in self.extensions:
             self.build_extension_cmake(ext)
-
-        # for MacOS, add the binary location as an rpath
-        if platform.system() == "Darwin":
-            install_name_tool = shutil.which("install_name_tool")
-            if install_name_tool:
-                logging.warning("Setting @rpath for shared libraries to @loader_path")
-                extdir = os.path.abspath(
-                    os.path.dirname(self.get_ext_fullpath("perspective")))
-                # shared library suffix always .so on Mac
-                subprocess.check_call([
-                    install_name_tool,
-                    "-change",
-                    "@rpath/libpsp.so",
-                    "@loader_path/libpsp.so",
-                    str(os.path.join(extdir, 'perspective', 'table', 'libbinding.so'))])
 
     def build_extension_node(self):
         env = os.environ.copy()

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -10,6 +10,7 @@ from setuptools.command.build_ext import build_ext
 from distutils.version import LooseVersion
 from codecs import open
 import io
+import logging
 import os
 import os.path
 import re
@@ -89,6 +90,21 @@ class PSPBuild(build_ext):
 
         for ext in self.extensions:
             self.build_extension_cmake(ext)
+
+        # for MacOS, add the binary location as an rpath
+        if platform.system() == "Darwin":
+            install_name_tool = shutil.which("install_name_tool")
+            if install_name_tool:
+                logging.warning("Setting @rpath for shared libraries to @loader_path")
+                extdir = os.path.abspath(
+                    os.path.dirname(self.get_ext_fullpath("perspective")))
+                # shared library suffix always .so on Mac
+                subprocess.check_call([
+                    install_name_tool,
+                    "-change",
+                    "@rpath/libpsp.so",
+                    "@loader_path/libpsp.so",
+                    str(os.path.join(extdir, 'perspective', 'table', 'libbinding.so'))])
 
     def build_extension_node(self):
         env = os.environ.copy()


### PR DESCRIPTION
This PR allows us to build a portable wheel distribution for OSX:

- Our binaries depend on @rpath, which is set relative to the build location of the binary. This causes a problem when distributing to PyPi/installing from pip. In `setup.py`, we adjust the install names of the built binary to reference `@loader_path`, i.e. relative to the actual location of the binary download.
- Pin pyarrow in our requirements. This means that `TBB` is the only system requirement that needs to be installed from brew/build from source.
- Fix bumpversion config
- Fix manifest - graft source files and not tests