### PR TITLE
Link `lerna version` to `bumpversion`

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
         "fix_python": "node scripts/lint_python.js --fix",
         "fix": "npm-run-all --silent fix:*",
         "toggle_puppeteer": "node scripts/toggle_puppeteer.js",
-        "version": "bumpversion"
+        "version": "node scripts/version_python.js"
     }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "fix:json": "prettier --tab-width 4 --write **/package.json",
         "fix_python": "node scripts/lint_python.js --fix",
         "fix": "npm-run-all --silent fix:*",
-        "toggle_puppeteer": "node scripts/toggle_puppeteer.js"
+        "toggle_puppeteer": "node scripts/toggle_puppeteer.js",
+        "version": "bumpversion"
     }
 }

--- a/python/perspective/.bumpversion.cfg
+++ b/python/perspective/.bumpversion.cfg
@@ -15,5 +15,5 @@ values =
 
 [bumpversion:part:build]
 
-[bumpversion:file:perspective/_version.py]
+[bumpversion:file:perspective/core/_version.py]
 

--- a/scripts/version_python.js
+++ b/scripts/version_python.js
@@ -50,4 +50,4 @@ const parse_version = function(version) {
 console.log(`Bumping \`perspective-python\` version to ${VERSION}`);
 const python_path = resolve(__dirname, "..", "python", "perspective");
 const version_path = resolve(__dirname, "..", "python", "perspective", "perspective", "core", "_version.py");
-execute(`cd ${python_path} && bumpversion --new-version "${parse_version(VERSION)}" ${version_path}`);
+execute(`cd ${python_path} && bumpversion --allow-dirty --new-version "${parse_version(VERSION)}" ${version_path}`);

--- a/scripts/version_python.js
+++ b/scripts/version_python.js
@@ -1,0 +1,53 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+const resolve = require("path").resolve;
+const execute = require("./script_utils").execute;
+const VERSION = require("../packages/perspective/package.json").version;
+const ENDINGS = ["alpha", "beta", "rc"];
+
+/**
+ * Converts a npm-spec version string into a bumpversion-spec version string.
+ *
+ * Example:
+ * - "1.0.0" => "1, 0, 0"
+ * - "0.3.0-alpha.1" => "0, 3, 0, alpha, 1"
+ * - "0.3.5-rc.3" => "0, 3, 5, rc, 3"
+ *
+ * @param {string} version
+ */
+const parse_version = function(version) {
+    let release_level = "final";
+    let serial = 0;
+    let has_ending = false;
+
+    for (let e of ENDINGS) {
+        if (version.includes(e)) {
+            has_ending = true;
+        }
+    }
+
+    // "0.3.0-rc.1" => ["0", "3", "0-rc", "1"]
+    let split = version.split(".");
+    let patch = split[2];
+
+    // remove dash from alpha/beta/rc
+    if (has_ending) {
+        let optional_versions = split[split.length - 2].split("-");
+        patch = optional_versions[0];
+        release_level = optional_versions[1];
+        serial = split[split.length - 1];
+    }
+
+    return `${split[0]}, ${split[1]}, ${patch}, '${release_level}', ${serial}`;
+};
+
+console.log(`Bumping \`perspective-python\` version to ${VERSION}`);
+const python_path = resolve(__dirname, "..", "python", "perspective");
+const version_path = resolve(__dirname, "..", "python", "perspective", "perspective", "core", "_version.py");
+execute(`cd ${python_path} && bumpversion --new-version "${parse_version(VERSION)}" ${version_path}`);


### PR DESCRIPTION
This PR adds `version_python.js` to the `version` script, which will run after Lerna increases the version number but before pushing to the remote.