### PR TITLE
Dataframe/Numpy Array Loader

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -449,6 +449,7 @@ set (PYTHON_SOURCE_FILES
 	${PSP_PYTHON_SRC}/src/accessor.cpp
 	${PSP_PYTHON_SRC}/src/context.cpp
 	${PSP_PYTHON_SRC}/src/fill.cpp
+	${PSP_PYTHON_SRC}/src/numpy.cpp
 	${PSP_PYTHON_SRC}/src/python.cpp
 	${PSP_PYTHON_SRC}/src/serialization.cpp
 	${PSP_PYTHON_SRC}/src/table.cpp

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -290,7 +290,6 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 		find_package( Python ${PSP_PYTHON_VERSION} REQUIRED Interpreter Development )
 		include_directories( ${Python_INCLUDE_DIRS} )
 
-
 		find_package(Boost)
 		if(NOT Boost_FOUND)
 			message("${Red}Boost could not be located${ColorReset}")

--- a/cpp/perspective/src/cpp/arrow.cpp
+++ b/cpp/perspective/src/cpp/arrow.cpp
@@ -322,8 +322,8 @@ namespace arrow {
     }
 
     std::uint32_t
-    ArrowLoader::num_rows() const {
-        return  m_table->num_rows();
+    ArrowLoader::row_count() const {
+        return m_table->num_rows();
     }
 
     std::vector<std::string>

--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -234,34 +234,41 @@ get_dtype_descr(t_dtype dtype) {
 
 std::string
 dtype_to_str(t_dtype dtype) {
-    std::stringstream str_dtype;
+    std::stringstream ss;
     switch (dtype) {
         case DTYPE_FLOAT32:
         case DTYPE_FLOAT64: {
-            str_dtype << "float";
+            ss << "float";
         } break;
+        case DTYPE_UINT8:
+        case DTYPE_UINT16:
+        case DTYPE_UINT32:
+        case DTYPE_UINT64:
         case DTYPE_INT8:
         case DTYPE_INT16:
         case DTYPE_INT32:
         case DTYPE_INT64: {
-            str_dtype << "integer";
+            ss << "integer";
         } break;
         case DTYPE_BOOL: {
-            str_dtype << "boolean";
+            ss << "boolean";
         } break;
         case DTYPE_DATE: {
-            str_dtype << "date";
+            ss << "date";
         } break;
         case DTYPE_TIME: {
-            str_dtype << "datetime";
+            ss << "datetime";
         } break;
         case DTYPE_STR: {
-            str_dtype << "string";
+            ss << "string";
+        } break;
+        case DTYPE_NONE: {
+            ss << "none";
         } break;
         default: { PSP_COMPLAIN_AND_ABORT("Cannot convert unknown dtype to string!"); }
     }
 
-    return str_dtype.str();
+    return ss.str();
 }
 
 t_dtype

--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -238,9 +238,11 @@ std::string
 dtype_to_str(t_dtype dtype) {
     std::stringstream ss;
     switch (dtype) {
-        case DTYPE_FLOAT32:
-        case DTYPE_FLOAT64: {
+        case DTYPE_FLOAT32: {
             ss << "float";
+        } break;
+        case DTYPE_FLOAT64: {
+            ss << "float64";
         } break;
         case DTYPE_UINT8:
         case DTYPE_UINT16:
@@ -248,9 +250,12 @@ dtype_to_str(t_dtype dtype) {
         case DTYPE_UINT64:
         case DTYPE_INT8:
         case DTYPE_INT16:
-        case DTYPE_INT32:
-        case DTYPE_INT64: {
+        case DTYPE_INT32:{
             ss << "integer";
+        } break;
+        case DTYPE_INT64: {
+            // TODO: undo
+            ss << "int64";
         } break;
         case DTYPE_BOOL: {
             ss << "boolean";

--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -229,6 +229,9 @@ get_dtype_descr(t_dtype dtype) {
         case DTYPE_F64PAIR: {
             return "f64pair";
         } break;
+        case DTYPE_OBJECT: {
+            return "object";
+        }
         default: { PSP_COMPLAIN_AND_ABORT("Encountered unknown dtype"); }
     }
     return std::string("dummy");
@@ -238,11 +241,9 @@ std::string
 dtype_to_str(t_dtype dtype) {
     std::stringstream ss;
     switch (dtype) {
-        case DTYPE_FLOAT32: {
-            ss << "float";
-        } break;
+        case DTYPE_FLOAT32:
         case DTYPE_FLOAT64: {
-            ss << "float64";
+            ss << "float";
         } break;
         case DTYPE_UINT8:
         case DTYPE_UINT16:
@@ -250,12 +251,9 @@ dtype_to_str(t_dtype dtype) {
         case DTYPE_UINT64:
         case DTYPE_INT8:
         case DTYPE_INT16:
-        case DTYPE_INT32:{
-            ss << "integer";
-        } break;
+        case DTYPE_INT32: 
         case DTYPE_INT64: {
-            // TODO: undo
-            ss << "int64";
+            ss << "integer";
         } break;
         case DTYPE_BOOL: {
             ss << "boolean";

--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -80,6 +80,7 @@ is_floating_point(t_dtype dtype) {
 bool
 is_deterministic_sized(t_dtype dtype) {
     switch (dtype) {
+        case DTYPE_OBJECT:
         case DTYPE_PTR:
         case DTYPE_INT64:
         case DTYPE_UINT64:
@@ -108,6 +109,7 @@ is_deterministic_sized(t_dtype dtype) {
 t_uindex
 get_dtype_size(t_dtype dtype) {
     switch (dtype) {
+        case DTYPE_OBJECT:
         case DTYPE_PTR: {
             return sizeof(void*);
         }
@@ -261,6 +263,9 @@ dtype_to_str(t_dtype dtype) {
         } break;
         case DTYPE_STR: {
             ss << "string";
+        } break;
+        case DTYPE_OBJECT: {
+            ss << "object";
         } break;
         case DTYPE_NONE: {
             ss << "none";

--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -360,9 +360,15 @@ t_data_table::append(const t_data_table& other) {
     std::set<std::string> incoming;
 
     for (const auto& cname : other.m_schema.m_columns) {
-        PSP_VERBOSE_ASSERT(
-            other.get_const_column(cname)->get_dtype() == get_column(cname)->get_dtype(),
-            "Mismatched column dtypes");
+        t_dtype col_dtype = get_column(cname)->get_dtype();
+        t_dtype other_col_dtype = other.get_const_column(cname)->get_dtype();
+        if (col_dtype != other_col_dtype) {
+            std::stringstream ss; 
+            ss << "Mismatched column dtypes: attempted to append column of dtype `" 
+               << dtype_to_str(other_col_dtype) << "` to existing column of dtype `" 
+               << dtype_to_str(col_dtype) << std::endl;
+            PSP_COMPLAIN_AND_ABORT(ss.str())
+        }
         src_cols.push_back(other.get_const_column(cname).get());
         dst_cols.push_back(get_column(cname).get());
         incoming.insert(cname);

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1219,7 +1219,7 @@ namespace binding {
 
         std::uint32_t row_count = 0;
         if (is_arrow) {
-            row_count = loader.num_rows();
+            row_count = loader.row_count();
         } else {
             row_count = accessor["row_count"].as<std::int32_t>();
         }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1876,7 +1876,8 @@ EMSCRIPTEN_BINDINGS(perspective) {
         .value("DTYPE_STR", DTYPE_STR)
         .value("DTYPE_USER_VLEN", DTYPE_USER_VLEN)
         .value("DTYPE_LAST_VLEN", DTYPE_LAST_VLEN)
-        .value("DTYPE_LAST", DTYPE_LAST);
+        .value("DTYPE_LAST", DTYPE_LAST)
+        .value("DTYPE_OBJECT", DTYPE_OBJECT);
 
     /******************************************************************************
      *

--- a/cpp/perspective/src/include/perspective/arrow.h
+++ b/cpp/perspective/src/include/perspective/arrow.h
@@ -33,7 +33,7 @@ namespace arrow {
 
         std::vector<std::string> names() const;
         std::vector<t_dtype> types() const;
-        std::uint32_t num_rows() const;
+        std::uint32_t row_count() const;
 
     private:
         void fill_column(t_data_table& tbl, std::shared_ptr<t_column> col,

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -204,7 +204,6 @@ namespace binding {
      * @param name 
      * @param cidx 
      * @param type 
-     * @param is_arrow 
      * @param is_update 
      */
     template <typename T>
@@ -219,7 +218,6 @@ namespace binding {
      * @param tbl
      * @param accessor
      * @param input_schema 
-     * @param is_arrow
      * @param is_update
      */
     template <typename T>

--- a/cpp/perspective/src/include/perspective/raw_types.h
+++ b/cpp/perspective/src/include/perspective/raw_types.h
@@ -46,7 +46,8 @@ enum t_dtype {
     DTYPE_STR,
     DTYPE_USER_VLEN,
     DTYPE_LAST_VLEN,
-    DTYPE_LAST
+    DTYPE_LAST,
+    DTYPE_OBJECT
 };
 
 #ifdef PSP_ENABLE_WASM

--- a/python/perspective/perspective/core/data/__init__.py
+++ b/python/perspective/perspective/core/data/__init__.py
@@ -6,4 +6,5 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
+from .np import deconstruct_numpy   # noqa: F401
 from .pd import deconstruct_pandas  # noqa: F401

--- a/python/perspective/perspective/core/data/np.py
+++ b/python/perspective/perspective/core/data/np.py
@@ -35,19 +35,18 @@ def deconstruct_numpy(array):
         # bool => byte
         data = data.astype("b", copy=False)
     elif np.issubdtype(data.dtype, np.datetime64):
-        # cast datetimes to timestamps
+        # cast datetimes to millisecond timestamps
+        # because datetime64("nat") is a double, cast to float64 here - C++ handles the rest
         if data.dtype == np.dtype("datetime64[us]"):
-            data = data.astype("int64", copy=False) / 1000000
+            data = data.astype(np.float64, copy=False) / 1000
         elif data.dtype == np.dtype("datetime64[ns]"):
-            data = data.astype("int64", copy=False) / 1000000000
+            data = data.astype(np.float64, copy=False) / 1000000
         elif data.dtype == np.dtype("datetime64[ms]"):
-            data = data.astype("int64", copy=False)
+            data = data.astype(np.float64, copy=False)
         elif data.dtype == np.dtype("datetime64[s]"):
-            data = data.astype("int64", copy=False) * 1000
+            data = data.astype(np.float64, copy=False) * 1000
     elif np.issubdtype(data.dtype, np.timedelta64):
-        data = data.astype("int64", copy=False)
-
-    print(data.dtype)
+        data = data.astype(np.float64, copy=False)
 
     return {
             "array": data,

--- a/python/perspective/perspective/core/data/np.py
+++ b/python/perspective/perspective/core/data/np.py
@@ -1,0 +1,41 @@
+# *****************************************************************************
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+
+def deconstruct_numpy(array):
+    '''Given a numpy array, parse it and return the data as well as a numpy array of null indices.
+
+    Args:
+        array (numpy.array)
+
+    Returns:
+        dict : `array` is the original array, and `mask` is an array of booleans where `True` represents a nan/None value.
+    '''
+    import numpy as np
+
+    # use `isnull` or `isnan` depending on dtype
+    if array.dtype == object or array.dtype == str:
+        import pandas as pd
+        data = array
+        mask = np.argwhere(pd.isnull(array)).flatten()
+    else:
+        masked = np.ma.masked_invalid(array)
+        data = masked.data
+        mask = np.argwhere(masked.mask).flatten()
+
+    if array.dtype == bool or array.dtype == "?":
+        # convert booleans to int
+        data = data.view(dtype="int64")
+    elif np.issubdtype(array.dtype, np.datetime64):
+        # convert datetimes to milliseconds from nanoseconds
+        data = data.view(dtype="datetime64[ns]").view("int64") / 1000000000
+
+    return {
+            "array": data,
+            "mask": mask
+        }

--- a/python/perspective/perspective/core/data/np.py
+++ b/python/perspective/perspective/core/data/np.py
@@ -17,10 +17,10 @@ def deconstruct_numpy(array):
         dict : `array` is the original array, and `mask` is an array of booleans where `True` represents a nan/None value.
     '''
     import numpy as np
+    import pandas as pd
 
     # use `isnull` or `isnan` depending on dtype
-    if array.dtype == object or array.dtype == str:
-        import pandas as pd
+    if pd.api.types.is_object_dtype(array.dtype):
         data = array
         mask = np.argwhere(pd.isnull(array)).flatten()
     else:
@@ -29,10 +29,10 @@ def deconstruct_numpy(array):
         mask = np.argwhere(masked.mask).flatten()
 
     if array.dtype == bool or array.dtype == "?":
-        # convert booleans to int
-        data = data.view(dtype="int64")
+        # bool => byte
+        data = data.view("b")
     elif np.issubdtype(array.dtype, np.datetime64):
-        # convert datetimes to milliseconds from nanoseconds
+        # datetime64[ns] => int timestamp in milliseconds
         data = data.view(dtype="datetime64[ns]").view("int64") / 1000000000
 
     return {

--- a/python/perspective/perspective/core/data/np.py
+++ b/python/perspective/perspective/core/data/np.py
@@ -5,6 +5,13 @@
 # This file is part of the Perspective library, distributed under the terms of
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
+import numpy as np
+import pandas as pd
+from datetime import datetime
+from perspective.table.libbinding import t_dtype
+from perspective.table._date_validator import _PerspectiveDateValidator
+
+date_validator = _PerspectiveDateValidator()
 
 
 def deconstruct_numpy(array):
@@ -16,11 +23,9 @@ def deconstruct_numpy(array):
     Returns:
         dict : `array` is the original array, and `mask` is an array of booleans where `True` represents a nan/None value.
     '''
-    import numpy as np
-    import pandas as pd
-
+    is_object_or_string = pd.api.types.is_object_dtype(array.dtype) or pd.api.types.is_string_dtype(array.dtype)
     # use `isnull` or `isnan` depending on dtype
-    if pd.api.types.is_object_dtype(array.dtype):
+    if is_object_or_string:
         data = array
         mask = np.argwhere(pd.isnull(array)).flatten()
     else:
@@ -28,12 +33,31 @@ def deconstruct_numpy(array):
         data = masked.data
         mask = np.argwhere(masked.mask).flatten()
 
-    if array.dtype == bool or array.dtype == "?":
+    if is_object_or_string:
+        # do our best to clean object arrays
+        # if data[0] is a nan, then it'll either end up being a float or promoted to string
+        # so work with the assumption that data[0] is a non-null value
+        if isinstance(data[0], datetime) or isinstance(data[0], np.datetime64):
+            data = data.astype("datetime64[us]", copy=False).view("int64") / 1000000
+        elif isinstance(data[0], str) and date_validator.format(data[0]) == t_dtype.DTYPE_TIME:
+            data = np.array([date_validator.parse(d) for d in data]).astype("datetime64[us]", copy=False).view("int64") / 1000000
+    elif data.dtype == bool or data.dtype == "?":
         # bool => byte
-        data = data.view("b")
-    elif np.issubdtype(array.dtype, np.datetime64):
-        # datetime64[ns] => int timestamp in milliseconds
-        data = data.view(dtype="datetime64[ns]").view("int64") / 1000000000
+        data = data.astype("b", copy=False)
+    elif np.issubdtype(data.dtype, np.datetime64):
+        # cast datetimes to timestamps
+        if data.dtype == np.dtype("datetime64[us]"):
+            data = data.astype("int64", copy=False) / 1000000
+        elif data.dtype == np.dtype("datetime64[ns]"):
+            data = data.astype("int64", copy=False) / 1000000000
+        elif data.dtype == np.dtype("datetime64[ms]"):
+            data = data.astype("int64", copy=False)
+            print("MS", data, data.dtype)
+        elif data.dtype == np.dtype("datetime64[s]"):
+            data = data.astype("int64", copy=False) * 1000
+            print("S", data, data.dtype)
+    elif np.issubdtype(data.dtype, np.timedelta64):
+        data = data.astype("int64", copy=False)
 
     return {
             "array": data,

--- a/python/perspective/perspective/core/data/np.py
+++ b/python/perspective/perspective/core/data/np.py
@@ -8,6 +8,9 @@
 import six
 import numpy as np
 import pandas as pd
+from datetime import datetime
+
+DATE_DTYPES = [np.dtype("datetime64[D]"), np.dtype("datetime64[W]"), np.dtype("datetime64[M]"), np.dtype("datetime64[Y]")]
 
 
 def deconstruct_numpy(array):
@@ -35,6 +38,11 @@ def deconstruct_numpy(array):
         # bool => byte
         data = data.astype("b", copy=False)
     elif np.issubdtype(data.dtype, np.datetime64):
+
+        # treat days/weeks/months/years as datetime objects - avoid idiosyncracy with days of month, etc.
+        if data.dtype in DATE_DTYPES:
+            data = data.astype(datetime)
+
         # cast datetimes to millisecond timestamps
         # because datetime64("nat") is a double, cast to float64 here - C++ handles the rest
         if data.dtype == np.dtype("datetime64[us]"):
@@ -45,6 +53,10 @@ def deconstruct_numpy(array):
             data = data.astype(np.float64, copy=False)
         elif data.dtype == np.dtype("datetime64[s]"):
             data = data.astype(np.float64, copy=False) * 1000
+        elif data.dtype == np.dtype("datetime64[m]"):
+            data = data.astype(np.float64, copy=False) * 60000
+        elif data.dtype == np.dtype("datetime64[h]"):
+            data = data.astype(np.float64, copy=False) * 3600000
     elif np.issubdtype(data.dtype, np.timedelta64):
         data = data.astype(np.float64, copy=False)
 

--- a/python/perspective/perspective/core/data/pd.py
+++ b/python/perspective/perspective/core/data/pd.py
@@ -38,6 +38,10 @@ def deconstruct_pandas(data):
         # use these columns
         kwargs['columns'] = orig_columns
 
+    # Decompose Period index to timestamps
+    if isinstance(data.index, pd.PeriodIndex):
+        data.index = data.index.to_timestamp()
+
     if isinstance(data.index, pd.MultiIndex):
         kwargs['row_pivots'] = list(data.index.names)
         kwargs['columns'] = data.columns.tolist()

--- a/python/perspective/perspective/include/perspective/python.h
+++ b/python/perspective/perspective/include/perspective/python.h
@@ -310,7 +310,8 @@ PYBIND11_MODULE(libbinding, m)
         .value("DTYPE_STR", DTYPE_STR)
         .value("DTYPE_USER_VLEN", DTYPE_USER_VLEN)
         .value("DTYPE_LAST_VLEN", DTYPE_LAST_VLEN)
-        .value("DTYPE_LAST", DTYPE_LAST);
+        .value("DTYPE_LAST", DTYPE_LAST)
+        .value("DTYPE_OBJECT", DTYPE_OBJECT);
 
      /******************************************************************************
      *

--- a/python/perspective/perspective/include/perspective/python/fill.h
+++ b/python/perspective/perspective/include/perspective/python/fill.h
@@ -22,23 +22,15 @@ namespace binding {
  * Fill columns with data
  */
 
-void _fill_col_time(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
-void _fill_col_date(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
-void _fill_col_bool(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
-void _fill_col_string(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
-void _fill_col_int64(t_data_accessor accessor, t_data_table& tbl, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
-void _fill_col_numeric(t_data_accessor accessor, t_data_table& tbl, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
-void _fill_data_helper(t_data_accessor accessor, t_data_table& tbl, std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update);
-
-
 template <>
 void set_column_nth(std::shared_ptr<t_column> col, t_uindex idx, t_val value);
+
 /******************************************************************************
  *
  * Fill tables with data
  */
 
-void _fill_data(t_data_table& tbl, t_data_accessor accessor, const t_schema& input_schema, const std::string& index, std::uint32_t offset, std::uint32_t limit, bool is_arrow, bool is_update);
+void _fill_data(t_data_table& tbl, t_data_accessor accessor, const t_schema& input_schema, const std::string& index, std::uint32_t offset, std::uint32_t limit, bool is_update);
 
 /******************************************************************************
  *

--- a/python/perspective/perspective/include/perspective/python/numpy.h
+++ b/python/perspective/perspective/include/perspective/python/numpy.h
@@ -1,0 +1,75 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+#ifdef PSP_ENABLE_PYTHON
+#pragma once
+#include <perspective/first.h>
+#include <perspective/base.h>
+#include <perspective/column.h>
+
+namespace perspective {
+namespace numpy {
+
+    /**
+     * NumpyLoader fast-tracks the loading of Numpy arrays into Perspective, utilizing memcpy whenever possible.
+     */
+    class PERSPECTIVE_EXPORT NumpyLoader {
+        public:
+            NumpyLoader();
+            ~NumpyLoader();
+
+            /**
+             * Fill a `t_data_table` with numpy array-backed data.
+             */
+            void fill_table(t_data_table& tbl, const std::string& index, std::uint32_t offset,
+                std::uint32_t limit, bool is_update)
+
+            /**
+             * Fill a column with a Numpy array by copying it wholesale into the column without iteration.
+             * 
+             * @param array
+             * @param col
+             * @param length
+             * @param type
+             * @param is_update
+             */
+            template <typename T>
+            void fill_column(T* array, std::shared_ptr<t_column> col, std::uint64_t length, t_dtype type, bool is_update);
+
+        private:
+            /**
+             * Given a py::array_t, use instanceof to convert it into a valid Perspective dtype.
+             */
+            t_dtype convert_type(t_val array);
+    };
+
+    /**
+     * Given a source and destination column pointer, copy the data from source to destination at `offset`.
+     * 
+     * @param source
+     * @param dest
+     * @param length - the length of the source array
+     * @param offset
+     */
+    template <typename T>
+    void copy_array(T* source, std::shared_ptr<t_column> dest, const std::uint64_t length, const std::uint64_t offset) {
+        std::uint64_t size;
+        // TODO: only works for doubles
+        std::memcpy((void*) dest->get_nth<T>(offset), (void*) source, length * 8);
+        dest->valid_raw_fill();
+    }
+
+    template <typename T>
+    void NumpyLoader::fill_column(T* source, std::shared_ptr<t_column> col, std::uint64_t length, t_dtype type, bool is_update) {
+        copy_array(source, col, length, 0);
+    }
+   
+} // namespace numpy
+} // numpy perspective
+#endif

--- a/python/perspective/perspective/include/perspective/python/numpy.h
+++ b/python/perspective/perspective/include/perspective/python/numpy.h
@@ -65,14 +65,14 @@ namespace numpy {
             /**
              * When memory cannot be copied (for dtype=object arrays, for example), fill the column through iteration.
              */
-            void fill_column_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_column_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
 
             // Fill helpers
-            void fill_numeric_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);       
-            void fill_date_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
-            void fill_datetime_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
-            void fill_string_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
-            void fill_bool_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_numeric_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);       
+            void fill_date_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_datetime_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_string_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_bool_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
 
             /**
              * Extract a numpy array from src and copy it into dest.

--- a/python/perspective/perspective/include/perspective/python/numpy.h
+++ b/python/perspective/perspective/include/perspective/python/numpy.h
@@ -16,6 +16,7 @@
 #include <perspective/exception.h>
 #include <perspective/column.h>
 #include <perspective/data_table.h>
+#include <perspective/python/utils.h>
 
 namespace perspective {
 namespace numpy {
@@ -27,6 +28,11 @@ namespace numpy {
         public:
             NumpyLoader(py::object accessor);
             ~NumpyLoader();
+
+            /**
+             * Initialize the Numpy loader by constructing the column names and data types arrays.
+             */
+            void init();
 
             /**
              * Fill a `t_data_table` with numpy array-backed data.
@@ -43,13 +49,19 @@ namespace numpy {
              * @param type
              * @param is_update
              */
-            void fill_column(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_column(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
 
             std::vector<std::string> names() const;
             std::vector<t_dtype> types() const;
-            std::uint32_t num_rows() const;
+            std::uint32_t row_count() const;
         private:
-            void fill_column_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+            /**
+             * When memory cannot be copied (for dtype=object arrays, for example), fill the column through iteration.
+             */
+            void fill_column_iter(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+
+            // Fill helpers
+            void fill_numeric_iter(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);       
             void fill_date_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
             void fill_datetime_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
             void fill_string_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
@@ -58,15 +70,22 @@ namespace numpy {
             /**
              * Extract a numpy array from src and copy it into dest.
              */
-            void copy_array(py::object src, std::shared_ptr<t_column> dest, const std::uint64_t offset);
+            void copy_array(py::object src, std::shared_ptr<t_column> dest, t_dtype np_dtype, const std::uint64_t offset);
 
+            // Return the column names from the Python data accessor
+            std::vector<std::string> make_names();
+
+            // Map the dtype of each numpy array into Perspective `t_dtype`s.
+            std::vector<t_dtype> make_types();
+
+            bool m_init;
             py::object m_accessor;
             std::vector<std::string> m_names;
             std::vector<t_dtype> m_types;
     };
 
     template <typename T>
-    void copy_array_helper(void* src, std::shared_ptr<t_column> dest, const std::uint64_t offset);
+    void copy_array_helper(const void* src, std::shared_ptr<t_column> dest, const std::uint64_t offset);
 
 } // namespace numpy
 } // numpy perspective

--- a/python/perspective/perspective/include/perspective/python/numpy.h
+++ b/python/perspective/perspective/include/perspective/python/numpy.h
@@ -39,6 +39,20 @@ namespace numpy {
              */
             void init();
 
+            bool has_numeric_dtype() const;
+
+            /**
+             * Given `inferred_types` from Perspective, use the `m_types` array of numpy array dtypes and 
+             * reconcile differences between numeric dtypes by *preferring the dtype of the numpy array* and 
+             * returning a vector of the correct, reconciled types.
+             * 
+             * This prevents the situation where Perspective infers an int column to `DTYPE_INT32` but the
+             * numpy array dtype is actually "int64".
+             * 
+             * Marked const as this method does not mutate the internal `m_types` property. 
+             */
+            std::vector<t_dtype> reconcile_dtypes(const std::vector<t_dtype>& inferred_types) const;
+
             /**
              * Fill a `t_data_table` with numpy array-backed data.
              */
@@ -63,26 +77,53 @@ namespace numpy {
             std::uint32_t row_count() const;
         private:
             /**
-             * When memory cannot be copied (for dtype=object arrays, for example), fill the column through iteration.
+             * When memory cannot be copied for dtype=object arrays, for example), fill the column through iteration.
              */
             void fill_column_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
 
-            // Fill object arrays using accessor and cast<T>
+            /**
+             * Fill arrays with dtype=object using the data accessor's marshal method.
+             * 
+             * Because we don't iterate through the array directly, don't pass the array into this method/any others that call `marshal`.
+             * 
+             * If filling a column of `DTYPE_TIME`, <T> is always `std::int64_t`.
+             */
             template <typename T>
-            void fill_object_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_object_iter(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
 
-            // Fill arrays with defined numpy dtypes that are not `object`
-            void fill_numeric_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);       
-            void fill_date_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
-            void fill_datetime_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
-            void fill_bool_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
+            // Fill dates that might be `datetime.date` or strings
+            void fill_date_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
+
+            // Fill using numpy arrays with defined numpy dtypes that are not `object`
+
+            /**
+             * Given a numpy array containing a numeric type, and a determination that `type` is numeric (int/float), fill it iteratively.
+             * 
+             * Iterating through the array and filling the underlying column allows us to cast the array's values to the `t_dtype` of the table,
+             * which may be of a higher or a lower bit width (i.e. filling a table that was inferred as `DTYPE_INT32` with `DTYPE_INT64`, 
+             * which is more commonly used in numpy arrays.)
+             */
+            void fill_numeric_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
+
+            void fill_datetime_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, 
+                t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
+            
+            void fill_bool_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
 
             /**
              * Extract a numpy array from src and copy it into dest.
              * 
+             * If `np_dtype` and `type` mismatch in the following cases, then fill iteratively:
+             * 
+             * - when `np_dtype` is int64 and `t_dtype` is `DTYPE_INT32` or `DTYPE_FLOAT64`
+             * - when `np_dtype` is float64 and `t_dtype` is `DTYPE_INT32` or `DTYPE_INT64`
+             * 
+             * These errors occur frqeuently when a Table is created from non-numpy data, then updated with a numpy array.
+             * The `t_dtype` of the Table always supercedes the array dtype, as the table is immutable after creation.
+             * 
              * Returns a `t_fill_status` enum indicating success or failure of the copy operation.
              */
-            t_fill_status try_copy_array(const py::array& src, std::shared_ptr<t_column> dest, t_dtype np_dtype, const std::uint64_t offset);
+            t_fill_status try_copy_array(const py::array& src, std::shared_ptr<t_column> dest, t_dtype np_dtype, t_dtype type, const std::uint64_t offset);
 
             // Return the column names from the Python data accessor
             std::vector<std::string> make_names();
@@ -91,6 +132,13 @@ namespace numpy {
             std::vector<t_dtype> make_types();
 
             bool m_init;
+
+            /**
+             * A flag to determine whether to reconcile numpy array dtype with perspective inferred types.
+             *
+             * Defaults to false - is true when any array dtype is of int/float/bool.
+             */
+            bool m_has_numeric_dtype;
             py::object m_accessor;
             std::vector<std::string> m_names;
             std::vector<t_dtype> m_types;

--- a/python/perspective/perspective/include/perspective/python/numpy.h
+++ b/python/perspective/perspective/include/perspective/python/numpy.h
@@ -125,6 +125,8 @@ namespace numpy {
              */
             t_fill_status try_copy_array(const py::array& src, std::shared_ptr<t_column> dest, t_dtype np_dtype, t_dtype type, const std::uint64_t offset);
 
+            void fill_validity_map(std::shared_ptr<t_column> col, std::uint64_t* mask_ptr, std::size_t mask_size, bool is_update);
+
             // Return the column names from the Python data accessor
             std::vector<std::string> make_names();
 
@@ -144,6 +146,9 @@ namespace numpy {
             std::vector<t_dtype> m_types;
     };
 
+    /**
+     * Copy the data of a numpy array into a `t_column`.
+     */
     template <typename T>
     void copy_array_helper(const void* src, std::shared_ptr<t_column> dest, const std::uint64_t offset);
 

--- a/python/perspective/perspective/include/perspective/python/numpy.h
+++ b/python/perspective/perspective/include/perspective/python/numpy.h
@@ -21,6 +21,11 @@
 namespace perspective {
 namespace numpy {
 
+    enum t_fill_status {
+        FILL_SUCCESS,
+        FILL_FAIL
+    };
+
     /**
      * NumpyLoader fast-tracks the loading of Numpy arrays into Perspective, utilizing memcpy whenever possible.
      */
@@ -43,7 +48,9 @@ namespace numpy {
             /**
              * Fill a column with a Numpy array by copying it wholesale into the column without iteration.
              * 
-             * @param array
+             * If the copy operation fails, fill the column iteratively.
+             * 
+             * @param tbl
              * @param col
              * @param length
              * @param type
@@ -58,19 +65,21 @@ namespace numpy {
             /**
              * When memory cannot be copied (for dtype=object arrays, for example), fill the column through iteration.
              */
-            void fill_column_iter(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_column_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
 
             // Fill helpers
-            void fill_numeric_iter(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);       
-            void fill_date_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
-            void fill_datetime_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
-            void fill_string_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
-            void fill_bool_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_numeric_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);       
+            void fill_date_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_datetime_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_string_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
+            void fill_bool_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update);
 
             /**
              * Extract a numpy array from src and copy it into dest.
+             * 
+             * Returns a `t_fill_status` enum indicating success or failure of the copy operation.
              */
-            void copy_array(py::object src, std::shared_ptr<t_column> dest, t_dtype np_dtype, const std::uint64_t offset);
+            t_fill_status try_copy_array(const py::array& src, std::shared_ptr<t_column> dest, t_dtype np_dtype, const std::uint64_t offset);
 
             // Return the column names from the Python data accessor
             std::vector<std::string> make_names();

--- a/python/perspective/perspective/include/perspective/python/numpy.h
+++ b/python/perspective/perspective/include/perspective/python/numpy.h
@@ -67,11 +67,14 @@ namespace numpy {
              */
             void fill_column_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
 
-            // Fill helpers
+            // Fill object arrays using accessor and cast<T>
+            template <typename T>
+            void fill_object_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
+
+            // Fill arrays with defined numpy dtypes that are not `object`
             void fill_numeric_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);       
             void fill_date_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
             void fill_datetime_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
-            void fill_string_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
             void fill_bool_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update);
 
             /**

--- a/python/perspective/perspective/src/fill.cpp
+++ b/python/perspective/perspective/src/fill.cpp
@@ -12,6 +12,7 @@
 #include <perspective/binding.h>
 #include <perspective/python/base.h>
 #include <perspective/python/fill.h>
+#include <perspective/python/numpy.h>
 #include <perspective/python/utils.h>
 
 namespace perspective {
@@ -24,258 +25,144 @@ namespace binding {
 
 void
 _fill_col_time(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name,
-    std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update) {
+    std::int32_t cidx, t_dtype type, bool is_update) {
     t_uindex nrows = col->size();
 
-    if (is_arrow) {
-        // t_val data = accessor["values"];
-        // arrow packs 64 bit into two 32 bit ints
-        // arrow::vecFromTypedArray(data, col->get_nth<t_time>(0), nrows * 2);
-
-        // std::int8_t unit = accessor["type"]["unit"].as<std::int8_t>();
-        // if (unit != /* Arrow.enum_.TimeUnit.MILLISECOND */ 1) {
-            // Slow path - need to convert each value
-            // std::int64_t factor = 1;
-            // if (unit == /* Arrow.enum_.TimeUnit.NANOSECOND */ 3) {
-                // factor = 1e6;
-            // } else if (unit == /* Arrow.enum_.TimeUnit.MICROSECOND */ 2) {
-                // factor = 1e3;
-            // }
-            // for (auto i = 0; i < nrows; ++i) {
-                // col->set_nth<std::int64_t>(i, *(col->get_nth<std::int64_t>(i)) / factor);
-            // }
-        // }
-    } else {
-        for (auto i = 0; i < nrows; ++i) {
-            if (!accessor.attr("has_column")(i, name).cast<bool>()) {
-                continue;
-            }
-
-            t_val item = accessor.attr("marshal")(cidx, i, type);
-
-            if (item.is_none()) {
-                if (is_update) {
-                    col->unset(i);
-                } else {
-                    col->clear(i);
-                }
-                continue;
-            }
-
-            col->set_nth(i, item.cast<std::int64_t>());
+    for (auto i = 0; i < nrows; ++i) {
+        if (!accessor.attr("_has_column")(i, name).cast<bool>()) {
+            continue;
         }
+
+        t_val item = accessor.attr("marshal")(cidx, i, type);
+
+        if (item.is_none()) {
+            if (is_update) {
+                col->unset(i);
+            } else {
+                col->clear(i);
+            }
+            continue;
+        }
+
+        col->set_nth(i, item.cast<std::int64_t>());
     }
 }
 
 void
 _fill_col_date(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name,
-    std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update) {
+    std::int32_t cidx, t_dtype type, bool is_update) {
     t_uindex nrows = col->size();
 
-    if (is_arrow) {
-        // t_val data = dcol["values"];
-        // // arrow packs 64 bit into two 32 bit ints
-        // arrow::vecFromTypedArray(data, col->get_nth<t_time>(0), nrows * 2);
-
-        // std::int8_t unit = dcol["type"]["unit"].as<std::int8_t>();
-        // if (unit != /* Arrow.enum_.TimeUnit.MILLISECOND */ 1) {
-        //     // Slow path - need to convert each value
-        //     std::int64_t factor = 1;
-        //     if (unit == /* Arrow.enum_.TimeUnit.NANOSECOND */ 3) {
-        //         factor = 1e6;
-        //     } else if (unit == /* Arrow.enum_.TimeUnit.MICROSECOND */ 2) {
-        //         factor = 1e3;
-        //     }
-        //     for (auto i = 0; i < nrows; ++i) {
-        //         col->set_nth<std::int32_t>(i, *(col->get_nth<std::int32_t>(i)) / factor);
-        //     }
-        // }
-    } else {
-        for (auto i = 0; i < nrows; ++i) {
-            if (!accessor.attr("has_column")(i, name).cast<bool>()) {
-                continue;
-            }
-
-            t_val item = accessor.attr("marshal")(cidx, i, type);
-
-            if (item.is_none()) {
-                if (is_update) {
-                    col->unset(i);
-                } else {
-                    col->clear(i);
-                }
-                continue;
-            }
-
-
-            auto date_components = item.cast<std::map<std::string, std::int32_t>>();
-            t_date dt = t_date(date_components["year"], date_components["month"], date_components["day"]);
-            col->set_nth(i, dt);
+    for (auto i = 0; i < nrows; ++i) {
+        if (!accessor.attr("_has_column")(i, name).cast<bool>()) {
+            continue;
         }
+
+        t_val item = accessor.attr("marshal")(cidx, i, type);
+
+        if (item.is_none()) {
+            if (is_update) {
+                col->unset(i);
+            } else {
+                col->clear(i);
+            }
+            continue;
+        }
+
+
+        auto date_components = item.cast<std::map<std::string, std::int32_t>>();
+        t_date dt = t_date(date_components["year"], date_components["month"], date_components["day"]);
+        col->set_nth(i, dt);
     }
 }
 
 void
 _fill_col_bool(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name,
-    std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update) {
+    std::int32_t cidx, t_dtype type, bool is_update) {
     t_uindex nrows = col->size();
 
-    if (is_arrow) {
-        // TODO
-        // bools are stored using a bit mask
-        // t_val data = accessor["values"];
-        // for (auto i = 0; i < nrows; ++i) {
-        //     t_val item = data[i / 8];
-
-        //     if (item.isUndefined()) {
-        //         continue;
-        //     }
-
-        //     if (item.isNull()) {
-        //         if (is_update) {
-        //             col->unset(i);
-        //         } else {
-        //             col->clear(i);
-        //         }
-        //         continue;
-        //     }
-
-        //     std::uint8_t elem = item.as<std::uint8_t>();
-        //     bool v = elem & (1 << (i % 8));
-        //     col->set_nth(i, v);
-        // }
-    } else {
-        for (auto i = 0; i < nrows; ++i) {
-            if (!accessor.attr("has_column")(i, name).cast<bool>()) {
-                continue;
-            }
-
-            t_val item = accessor.attr("marshal")(cidx, i, type);
-
-            if (item.is_none()) {
-                if (is_update) {
-                    col->unset(i);
-                } else {
-                    col->clear(i);
-                }
-                continue;
-            }
-
-            auto elem = item.cast<bool>();
-            col->set_nth(i, elem);
+    for (auto i = 0; i < nrows; ++i) {
+        if (!accessor.attr("_has_column")(i, name).cast<bool>()) {
+            continue;
         }
+
+        t_val item = accessor.attr("marshal")(cidx, i, type);
+
+        if (item.is_none()) {
+            if (is_update) {
+                col->unset(i);
+            } else {
+                col->clear(i);
+            }
+            continue;
+        }
+
+        auto elem = item.cast<bool>();
+        col->set_nth(i, elem);
     }
 }
 
 void
 _fill_col_string(t_data_accessor accessor, std::shared_ptr<t_column> col, std::string name,
-    std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update) {
+    std::int32_t cidx, t_dtype type, bool is_update) {
 
     t_uindex nrows = col->size();
 
-    if (is_arrow) {
-        // TODO
-        // if (accessor["constructor"]["name"].as<std::string>() == "DictionaryVector") {
-
-        //     t_val dictvec = accessor["dictionary"];
-        //     arrow::fill_col_dict(dictvec, col);
-
-        //     // Now process index into dictionary
-
-        //     // Perspective stores string indices in a 32bit unsigned array
-        //     // Javascript's typed arrays handle copying from various bitwidth arrays
-        //     // properly
-        //     t_val vkeys = accessor["indices"]["values"];
-        //     arrow::vecFromTypedArray(
-        //         vkeys, col->get_nth<t_uindex>(0), nrows, "Uint32Array");
-
-        // } else if (accessor["constructor"]["name"].as<std::string>() == "Utf8Vector"
-        //     || accessor["constructor"]["name"].as<std::string>() == "BinaryVector") {
-
-        //     t_val vdata = accessor["values"];
-        //     std::int32_t vsize = vdata["length"].as<std::int32_t>();
-        //     std::vector<std::uint8_t> data;
-        //     data.reserve(vsize);
-        //     data.resize(vsize);
-        //     arrow::vecFromTypedArray(vdata, data.data(), vsize);
-
-        //     t_val voffsets = accessor["valueOffsets"];
-        //     std::int32_t osize = voffsets["length"].as<std::int32_t>();
-        //     std::vector<std::int32_t> offsets;
-        //     offsets.reserve(osize);
-        //     offsets.resize(osize);
-        //     arrow::vecFromTypedArray(voffsets, offsets.data(), osize);
-
-        //     std::string elem;
-
-        //     for (std::int32_t i = 0; i < nrows; ++i) {
-        //         std::int32_t bidx = offsets[i];
-        //         std::size_t es = offsets[i + 1] - bidx;
-        //         elem.assign(reinterpret_cast<char*>(data.data()) + bidx, es);
-        //         col->set_nth(i, elem);
-        //     }
-        // }
-    } else {
-        for (auto i = 0; i < nrows; ++i) {
-            if (!accessor.attr("has_column")(i, name).cast<bool>()) {
-                continue;
-            }
-
-            t_val item = accessor.attr("marshal")(cidx, i, type);
-
-            if (item.is_none()) {
-                if (is_update) {
-                    col->unset(i);
-                } else {
-                    col->clear(i);
-                }
-                continue;
-            }
-
-            col->set_nth(i, item.cast<std::string>());
+    for (auto i = 0; i < nrows; ++i) {
+        if (!accessor.attr("_has_column")(i, name).cast<bool>()) {
+            continue;
         }
+
+        t_val item = accessor.attr("marshal")(cidx, i, type);
+
+        if (item.is_none()) {
+            if (is_update) {
+                col->unset(i);
+            } else {
+                col->clear(i);
+            }
+            continue;
+        }
+
+        // convert to a python string first
+        std::wstring welem = item.cast<std::wstring>();
+        std::wstring_convert<utf16convert_type, wchar_t> converter;
+        std::string elem = converter.to_bytes(welem);
+        col->set_nth(i, elem);
     }
 }
 
 void
 _fill_col_int64(t_data_accessor accessor, t_data_table& tbl, std::shared_ptr<t_column> col, std::string name,
-    std::int32_t cidx, t_dtype type, bool is_arrow, bool is_update) {
+    std::int32_t cidx, t_dtype type, bool is_update) {
     t_uindex nrows = col->size();
 
-    if (is_arrow) {
-        // TODO
-        // t_val data = accessor["values"];
-        // // arrow packs 64 bit into two 32 bit ints
-        // arrow::vecFromTypedArray(data, col->get_nth<std::int64_t>(0), nrows * 2);
-    } else {
-        t_uindex nrows = col->size();
-        for (auto i = 0; i < nrows; ++i) {
-            if (!accessor.attr("has_column")(i, name).cast<bool>()) {
-                continue;
-            }
+    for (auto i = 0; i < nrows; ++i) {
+        if (!accessor.attr("_has_column")(i, name).cast<bool>()) {
+            continue;
+        }
 
-            t_val item = accessor.attr("marshal")(cidx, i, type);
+        t_val item = accessor.attr("marshal")(cidx, i, type);
 
-            if (item.is_none()) {
-                if (is_update) {
-                    col->unset(i);
-                } else {
-                    col->clear(i);
-                }
-                continue;
-            }
-
-            double fval = item.cast<double>();
-            if (isnan(fval)) {
-                WARN("Promoting %s to string from int64", name);
-                tbl.promote_column(name, DTYPE_STR, i, false);
-                col = tbl.get_column(name);
-                _fill_col_string(
-                    accessor, col, name, cidx, DTYPE_STR, is_arrow, is_update);
-                return;
+        if (item.is_none()) {
+            if (is_update) {
+                col->unset(i);
             } else {
-                col->set_nth(i, static_cast<std::int64_t>(fval));
+                col->clear(i);
             }
+            continue;
+        }
+
+        double fval = item.cast<double>();
+        if (isnan(fval)) {
+            WARN("Promoting %s to string from int64", name);
+            tbl.promote_column(name, DTYPE_STR, i, false);
+            col = tbl.get_column(name);
+            _fill_col_string(
+                accessor, col, name, cidx, DTYPE_STR, is_update);
+            return;
+        } else {
+            col->set_nth(i, static_cast<std::int64_t>(fval));
         }
     }
 }
@@ -346,99 +233,98 @@ set_column_nth(std::shared_ptr<t_column> col, t_uindex idx, t_val value) {
 
 void
 _fill_col_numeric(t_data_accessor accessor, t_data_table& tbl,
-    std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type,
-    bool is_arrow, bool is_update) {
+    std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_update) {
     t_uindex nrows = col->size();
 
-    if (is_arrow) {
-        // TODO
-        // t_val data = accessor["values"];
-
-        // switch (type) {
-        //     case DTYPE_INT8: {
-        //         arrow::vecFromTypedArray(data, col->get_nth<std::int8_t>(0), nrows);
-        //     } break;
-        //     case DTYPE_INT16: {
-        //         arrow::vecFromTypedArray(data, col->get_nth<std::int16_t>(0), nrows);
-        //     } break;
-        //     case DTYPE_INT32: {
-        //         arrow::vecFromTypedArray(data, col->get_nth<std::int32_t>(0), nrows);
-        //     } break;
-        //     case DTYPE_FLOAT32: {
-        //         arrow::vecFromTypedArray(data, col->get_nth<float>(0), nrows);
-        //     } break;
-        //     case DTYPE_FLOAT64: {
-        //         arrow::vecFromTypedArray(data, col->get_nth<double>(0), nrows);
-        //     } break;
-        //     default:
-        //         break;
-        // }
-    } else {
-        for (auto i = 0; i < nrows; ++i) {
-            if (!accessor.attr("has_column")(i, name).cast<bool>()) {
-                continue;
-            }
-
-            t_val item = accessor.attr("marshal")(cidx, i, type);
-
-            if (item.is_none()) {
-                if (is_update) {
-                    col->unset(i);
-                } else {
-                    col->clear(i);
-                }
-                continue;
-            }
-
-            switch (type) {
-                case DTYPE_INT8: {
-                    col->set_nth(i, item.cast<std::int8_t>());
-                } break;
-                case DTYPE_INT16: {
-                    col->set_nth(i, item.cast<std::int16_t>());
-                } break;
-                case DTYPE_INT32: {
-                    // This handles cases where a long sequence of e.g. 0 precedes a clearly
-                    // float value in an inferred column. Would not be needed if the type
-                    // inference checked the entire column/we could reset parsing.
-                    double fval = item.cast<double>();
-                    if (fval > 2147483647 || fval < -2147483648) {
-                        WARN("Promoting %s to float from int32", name);
-                        tbl.promote_column(name, DTYPE_FLOAT64, i, true);
-                        col = tbl.get_column(name);
-                        type = DTYPE_FLOAT64;
-                        col->set_nth(i, fval);
-                    } else if (isnan(fval)) {
-                        WARN("Promoting column %s to string from int32", name);
-                        tbl.promote_column(name, DTYPE_STR, i, false);
-                        col = tbl.get_column(name);
-                        _fill_col_string(
-                            accessor, col, name, cidx, DTYPE_STR, is_arrow, is_update);
-                        return;
-                    } else {
-                        col->set_nth(i, static_cast<std::int32_t>(fval));
-                    }
-                } break;
-                case DTYPE_FLOAT32: {
-                    col->set_nth(i, item.cast<float>());
-                } break;
-                case DTYPE_FLOAT64: {
-                    bool is_float = py::isinstance<py::float_>(item);
-                    bool is_numpy_nan = is_float && npy_isnan(item.cast<double>());
-                    if (!is_float || is_numpy_nan) {
-                        WARN("Promoting column %s to string from float64", name);
-                        tbl.promote_column(name, DTYPE_STR, i, false);
-                        col = tbl.get_column(name);
-                        _fill_col_string(
-                            accessor, col, name, cidx, DTYPE_STR, is_arrow, is_update);
-                        return;
-                    }
-                    col->set_nth(i, item.cast<double>());
-                } break;
-                default:
-                    break;
-            }
+    for (auto i = 0; i < nrows; ++i) {
+        if (!accessor.attr("_has_column")(i, name).cast<bool>()) {
+            continue;
         }
+
+        t_val item = accessor.attr("marshal")(cidx, i, type);
+
+        if (item.is_none()) {
+            if (is_update) {
+                col->unset(i);
+            } else {
+                col->clear(i);
+            }
+            continue;
+        }
+
+        switch (type) {
+            case DTYPE_INT8: {
+                col->set_nth(i, item.cast<std::int8_t>());
+            } break;
+            case DTYPE_INT16: {
+                col->set_nth(i, item.cast<std::int16_t>());
+            } break;
+            case DTYPE_INT32: {
+                // This handles cases where a long sequence of e.g. 0 precedes a clearly
+                // float value in an inferred column. Would not be needed if the type
+                // inference checked the entire column/we could reset parsing.
+                double fval = item.cast<double>();
+                if (fval > 2147483647 || fval < -2147483648) {
+                    WARN("Promoting %s to float from int32", name);
+                    tbl.promote_column(name, DTYPE_FLOAT64, i, true);
+                    col = tbl.get_column(name);
+                    type = DTYPE_FLOAT64;
+                    col->set_nth(i, fval);
+                } else if (isnan(fval)) {
+                    WARN("Promoting column %s to string from int32", name);
+                    tbl.promote_column(name, DTYPE_STR, i, false);
+                    col = tbl.get_column(name);
+                    _fill_col_string(
+                        accessor, col, name, cidx, DTYPE_STR, is_update);
+                    return;
+                } else {
+                    col->set_nth(i, static_cast<std::int32_t>(fval));
+                }
+            } break;
+            case DTYPE_FLOAT32: {
+                col->set_nth(i, item.cast<float>());
+            } break;
+            case DTYPE_FLOAT64: {
+                bool is_float = py::isinstance<py::float_>(item);
+                bool is_numpy_nan = is_float && npy_isnan(item.cast<double>());
+                if (!is_float || is_numpy_nan) {
+                    WARN("Promoting column %s to string from float64", name);
+                    tbl.promote_column(name, DTYPE_STR, i, false);
+                    col = tbl.get_column(name);
+                    _fill_col_string(
+                        accessor, col, name, cidx, DTYPE_STR, is_update);
+                    return;
+                }
+                col->set_nth(i, item.cast<double>());
+            } break;
+            default:
+                break;
+        }
+    }
+}
+
+/**
+ * Fill float64 columns with a numpy array.
+ */
+void _fill_col_numpy(t_data_accessor accessor, t_data_table& tbl,
+    std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_update) {
+    t_val dcol = accessor.attr("_get_column")(name);
+    double *array = (double *)dcol.cast<py::array_t<double>>().request().ptr;
+
+    t_uindex nrows = col->size();
+
+    std::cout << "using numpy loader" << std::endl;
+    for (auto i = 0; i < nrows; ++i) {
+        double item = array[i];
+        if(npy_isnan(item)){
+            if (is_update) {
+                col->unset(i);
+            } else {
+                col->clear(i);
+            }
+            continue;
+        }
+        col->set_nth(i, item);
     }
 }
 
@@ -456,30 +342,40 @@ make_computed_lambdas(std::vector<t_val> computed) {
 
 void
 _fill_data_helper(t_data_accessor accessor, t_data_table& tbl,
-    std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type,
-    bool is_arrow, bool is_update) {
+    std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_update) {
+    numpy::NumpyLoader numpy_loader;
     switch (type) {
         case DTYPE_INT64: {
-            _fill_col_int64(accessor, tbl, col, name, cidx, type, is_arrow, is_update);
+            _fill_col_int64(accessor, tbl, col, name, cidx, type, is_update);
         } break;
         case DTYPE_BOOL: {
-            _fill_col_bool(accessor, col, name, cidx, type, is_arrow, is_update);
+            _fill_col_bool(accessor, col, name, cidx, type, is_update);
         } break;
         case DTYPE_DATE: {
-            _fill_col_date(accessor, col, name, cidx, type, is_arrow, is_update);
+            _fill_col_date(accessor, col, name, cidx, type, is_update);
         } break;
         case DTYPE_TIME: {
-            _fill_col_time(accessor, col, name, cidx, type, is_arrow, is_update);
+            _fill_col_time(accessor, col, name, cidx, type, is_update);
         } break;
         case DTYPE_STR: {
-            _fill_col_string(accessor, col, name, cidx, type, is_arrow, is_update);
+            _fill_col_string(accessor, col, name, cidx, type, is_update);
+        } break;
+        case DTYPE_FLOAT64: {
+            if (accessor.attr("_is_numpy")(name).cast<bool>() == true) {
+                py::array_t<double> dcol = accessor.attr("_get_column")(name);
+                std::int64_t length = py::len(dcol);
+                double* array = (double *)dcol.request().ptr;
+                numpy_loader.fill_column(array, col, length, type, is_update);
+            } else {
+                _fill_col_numeric(accessor, tbl, col, name, cidx, type, is_update);
+            }
         } break;
         case DTYPE_NONE: {
             break;
         }
         default:
             _fill_col_numeric(
-                accessor, tbl, col, name, cidx, type, is_arrow, is_update);
+                accessor, tbl, col, name, cidx, type, is_update);
     }
 }
 
@@ -490,8 +386,7 @@ _fill_data_helper(t_data_accessor accessor, t_data_table& tbl,
 
 void
 _fill_data(t_data_table& tbl, t_data_accessor accessor, const t_schema& input_schema,
-           const std::string& index, std::uint32_t offset, std::uint32_t limit,
-           bool is_arrow, bool is_update) {
+           const std::string& index, std::uint32_t offset, std::uint32_t limit, bool is_update) {
     bool implicit_index = false;
     std::vector<std::string> col_names(input_schema.columns());
     std::vector<t_dtype> data_types(input_schema.types());
@@ -500,37 +395,16 @@ _fill_data(t_data_table& tbl, t_data_accessor accessor, const t_schema& input_sc
         auto name = col_names[cidx];
         auto type = data_types[cidx];
 
-        t_val dcol = py::none();
-
-        if (is_arrow) {
-            //TODO
-            // dcol = accessor["cdata"][cidx];
-        } else {
-            dcol = accessor;
-        }
         if (name == "__INDEX__") {
             implicit_index = true;
             std::shared_ptr<t_column> pkey_col_sptr = tbl.add_column_sptr("psp_pkey", type, true);
-            _fill_data_helper(dcol, tbl, pkey_col_sptr, "psp_pkey", cidx, type, is_arrow, is_update);
+            _fill_data_helper(accessor, tbl, pkey_col_sptr, "psp_pkey", cidx, type, is_update);
             tbl.clone_column("psp_pkey", "psp_okey");
             continue;
          }
 
         auto col = tbl.get_column(name);
-        _fill_data_helper(dcol, tbl, col, name, cidx, type, is_arrow, is_update);
-
-        if (is_arrow) {
-            // TODO
-            // // Fill validity bitmap
-            // std::uint32_t null_count = dcol["nullCount"].cast<std::uint32_t>();
-
-            // if (null_count == 0) {
-            //     col->valid_raw_fill();
-            // } else {
-            //     t_val validity = dcol["nullBitmap"];
-            //     arrow::fill_col_valid(validity, col);
-            // }
-        }
+        _fill_data_helper(accessor, tbl, col, name, cidx, type, is_update);
     }
     // Fill index column - recreated every time a `t_data_table` is created.
     if (!implicit_index) {

--- a/python/perspective/perspective/src/fill.cpp
+++ b/python/perspective/perspective/src/fill.cpp
@@ -12,7 +12,6 @@
 #include <perspective/binding.h>
 #include <perspective/python/base.h>
 #include <perspective/python/fill.h>
-#include <perspective/python/numpy.h>
 #include <perspective/python/utils.h>
 
 namespace perspective {
@@ -303,31 +302,6 @@ _fill_col_numeric(t_data_accessor accessor, t_data_table& tbl,
     }
 }
 
-/**
- * Fill float64 columns with a numpy array.
- */
-void _fill_col_numpy(t_data_accessor accessor, t_data_table& tbl,
-    std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_update) {
-    t_val dcol = accessor.attr("_get_column")(name);
-    double *array = (double *)dcol.cast<py::array_t<double>>().request().ptr;
-
-    t_uindex nrows = col->size();
-
-    std::cout << "using numpy loader" << std::endl;
-    for (auto i = 0; i < nrows; ++i) {
-        double item = array[i];
-        if(npy_isnan(item)){
-            if (is_update) {
-                col->unset(i);
-            } else {
-                col->clear(i);
-            }
-            continue;
-        }
-        col->set_nth(i, item);
-    }
-}
-
 /*
 void
 add_computed_column(std::shared_ptr<t_data_table> table, const std::vector<t_uindex>& row_indices, t_val computed_def) {
@@ -343,7 +317,6 @@ make_computed_lambdas(std::vector<t_val> computed) {
 void
 _fill_data_helper(t_data_accessor accessor, t_data_table& tbl,
     std::shared_ptr<t_column> col, std::string name, std::int32_t cidx, t_dtype type, bool is_update) {
-    numpy::NumpyLoader numpy_loader;
     switch (type) {
         case DTYPE_INT64: {
             _fill_col_int64(accessor, tbl, col, name, cidx, type, is_update);
@@ -359,16 +332,6 @@ _fill_data_helper(t_data_accessor accessor, t_data_table& tbl,
         } break;
         case DTYPE_STR: {
             _fill_col_string(accessor, col, name, cidx, type, is_update);
-        } break;
-        case DTYPE_FLOAT64: {
-            if (accessor.attr("_is_numpy")(name).cast<bool>() == true) {
-                py::array_t<double> dcol = accessor.attr("_get_column")(name);
-                std::int64_t length = py::len(dcol);
-                double* array = (double *)dcol.request().ptr;
-                numpy_loader.fill_column(array, col, length, type, is_update);
-            } else {
-                _fill_col_numeric(accessor, tbl, col, name, cidx, type, is_update);
-            }
         } break;
         case DTYPE_NONE: {
             break;

--- a/python/perspective/perspective/src/numpy.cpp
+++ b/python/perspective/perspective/src/numpy.cpp
@@ -1,0 +1,22 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+#ifdef PSP_ENABLE_PYTHON
+#include <perspective/python/numpy.h>
+
+using namespace perspective;
+
+namespace perspective {
+namespace numpy {
+
+    NumpyLoader::NumpyLoader() {}
+    NumpyLoader::~NumpyLoader() {}
+    
+} // namespace numpy
+} // namespace perspective
+#endif

--- a/python/perspective/perspective/src/numpy.cpp
+++ b/python/perspective/perspective/src/numpy.cpp
@@ -17,6 +17,7 @@ namespace numpy {
 
     NumpyLoader::NumpyLoader(py::object accessor)
         : m_init(false)
+        , m_has_numeric_dtype(false)
         , m_accessor(accessor) {}
 
     NumpyLoader::~NumpyLoader() {}
@@ -27,6 +28,35 @@ namespace numpy {
         m_types = make_types();
         m_init = true;
     }
+
+    bool
+    NumpyLoader::has_numeric_dtype() const {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+        return m_has_numeric_dtype;
+    }
+
+    std::vector<t_dtype> 
+    NumpyLoader::reconcile_dtypes(const std::vector<t_dtype>& inferred_types) const {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+        std::vector<t_dtype> reconciled_types;
+        std::uint32_t num_columns = m_names.size();
+
+        for (auto i = 0; i < num_columns; ++i) {
+            t_dtype numpy_type = m_types[i];
+            t_dtype inferred_type = inferred_types[i];
+            switch (numpy_type) {
+                case DTYPE_OBJECT: {
+                    // inferred type has the correct underlying type for the array
+                    reconciled_types.push_back(inferred_type);
+                } break;
+                default: {
+                    reconciled_types.push_back(numpy_type);
+                }
+            }
+        }
+
+        return reconciled_types;
+    };
 
     std::vector<std::string>
     NumpyLoader::names() const {
@@ -92,45 +122,45 @@ namespace numpy {
     void 
     NumpyLoader::fill_column(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
         PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-        std::cout << "filling " << name << std::endl;
+
         // Use name index instead of column index - prevents off-by-one errors with the "index" column.
         auto name_it = std::find(m_names.begin(), m_names.end(), name); 
         
-        // If the column name is not in the dataset, break
+        // If the column name is not in the dataset, return and move on.
         if (name_it == m_names.end()) {
             return;
         }
 
         auto nidx = std::distance(m_names.begin(), name_it);
 
-        /**
-         * np_dtype is used to attempt `memcpy` of the numpy array into perspective.
-         * if memcpy fails, it is most likely a numpy array with `dtype=object`, so use the inferred type from perspective.
-         */
+        // np_dtype is one of the integer/float/bool dtypes, or `DTYPE_OBJECT`.
         t_dtype np_dtype = m_types[nidx];
        
         py::dict source = m_accessor.attr("_get_numpy_column")(name);
         py::array array = source["array"].cast<py::array>();
         py::array_t<std::uint64_t> mask = source["mask"].cast<py::array_t<std::uint64_t>>();
 
-        std::cout << name << ", npt: " << dtype_to_str(np_dtype) << ", t: " << dtype_to_str(type) << std::endl;
+        std::cout << name << ", npd: " << dtype_to_str(np_dtype) << ", d: " << dtype_to_str(type) << std::endl;
 
          /**
          * Catch common type mismatches and fill iteratively when a numpy dtype is of greater bit width than the Perspective t_dtype:
          * - when `np_dtype` is int64 and `t_dtype` is `DTYPE_INT32` or `DTYPE_FLOAT64`
          * - when `np_dtype` is float64 and `t_dtype` is `DTYPE_INT32` or `DTYPE_INT64`
-         * These errors occur frqeuently when a Table is created from non-numpy data, then updated with a numpy array.
+         * - when `type` is float64 and `np_dtype` is `DTYPE_FLOAT32` or `DTYPE_FLOAT64`
+         * 
+         * These errors occur frqeuently when a Table is created from non-numpy data or schema, then updated with a numpy array.
          * In these cases, the `t_dtype` of the Table supercedes the array dtype.
          */
         bool should_iter = (np_dtype == DTYPE_INT64 && (type == DTYPE_INT32 || type == DTYPE_FLOAT64)) || \
-            (np_dtype == DTYPE_FLOAT64 && (type == DTYPE_INT32 || type == DTYPE_INT64));
+            (np_dtype == DTYPE_FLOAT64 && (type == DTYPE_INT32 || type == DTYPE_INT64)) || \
+            (type == DTYPE_INT64 && (np_dtype == DTYPE_FLOAT32 || np_dtype == DTYPE_FLOAT64));
         if (should_iter) {
             // Skip straight to numeric fill
             fill_numeric_iter(array, tbl, col, name, np_dtype, type, cidx, is_update);
             return;
         }
 
-        bool copy_status = try_copy_array(array, col, np_dtype, 0);
+        bool copy_status = try_copy_array(array, col, np_dtype, type, 0);
 
         if (copy_status == t_fill_status::FILL_FAIL) {
             fill_column_iter(array, tbl, col, name, np_dtype, type, cidx, is_update);
@@ -151,37 +181,11 @@ namespace numpy {
                 }
             }
         }
-
-        col->pprint();
-    }
-
-    void
-    NumpyLoader::fill_column_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
-        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-        std::cout << name << " iterating" << std::endl;
-        switch (type) {
-            case DTYPE_TIME: {
-                fill_datetime_iter(array, col, name, np_dtype, type, cidx, is_update);
-            } break;
-            case DTYPE_DATE: {
-                fill_date_iter(array, col, name, np_dtype, type, cidx, is_update);
-            } break;
-            case DTYPE_BOOL: {
-                fill_bool_iter(array, col, name, np_dtype, type, cidx, is_update);
-            } break;
-            case DTYPE_STR: {
-                fill_object_iter<std::string>(col, name, np_dtype, type, cidx, is_update);
-            } break;
-            default: {
-                fill_numeric_iter(array, tbl, col, name, np_dtype, type, cidx, is_update);
-                break;
-            }
-        }
     }
 
     template <typename T>
     void
-    NumpyLoader::fill_object_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
+    NumpyLoader::fill_object_iter(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
         t_uindex nrows = col->size();
 
         for (auto i = 0; i < nrows; ++i) {
@@ -200,14 +204,155 @@ namespace numpy {
         }
     }
 
+    // Add explicit instantiations for int32, int64, and float64 as they have promotion logic
+    template <>
     void
-    NumpyLoader::fill_datetime_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
+    NumpyLoader::fill_object_iter<std::int32_t>(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
+        t_uindex nrows = col->size();
+
+        for (auto i = 0; i < nrows; ++i) {
+            t_val item = m_accessor.attr("marshal")(cidx, i, type);
+
+            if (item.is_none()) {
+                if (is_update) {
+                    col->unset(i);
+                } else {
+                    col->clear(i);
+                }
+                continue;
+            }
+
+            double fval = item.cast<double>();
+            if (fval > 2147483647 || fval < -2147483648) {
+                binding::WARN("Promoting %s to float from int32", name);
+                tbl.promote_column(name, DTYPE_FLOAT64, i, true);
+                col = tbl.get_column(name);
+                type = DTYPE_FLOAT64;
+                col->set_nth(i, fval);
+            } else if (isnan(fval)) {
+                binding::WARN("Promoting column %s to string from int32", name);
+                tbl.promote_column(name, DTYPE_STR, i, false);
+                col = tbl.get_column(name);
+                fill_object_iter<std::string>(
+                    tbl, col, name, np_dtype, DTYPE_STR, cidx, is_update);
+                return;
+            } else {
+                col->set_nth(i, static_cast<std::int32_t>(fval));
+            }
+        }
+    }
+
+    template <>
+    void
+    NumpyLoader::fill_object_iter<std::int64_t>(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
+        t_uindex nrows = col->size();
+
+        for (auto i = 0; i < nrows; ++i) {
+            t_val item = m_accessor.attr("marshal")(cidx, i, type);
+
+            if (item.is_none()) {
+                if (is_update) {
+                    col->unset(i);
+                } else {
+                    col->clear(i);
+                }
+                continue;
+            }
+
+            double fval = item.cast<double>();
+            if (isnan(fval)) {
+                binding::WARN("Promoting %s to string from int64", name);
+                tbl.promote_column(name, DTYPE_STR, i, false);
+                col = tbl.get_column(name);
+                fill_object_iter<std::string>(
+                    tbl, col, name, np_dtype, DTYPE_STR, cidx, is_update);
+                return;
+            } else {
+                col->set_nth(i, static_cast<std::int64_t>(fval));
+            }
+        }
+    }
+
+    template <>
+    void
+    NumpyLoader::fill_object_iter<double>(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
+        t_uindex nrows = col->size();
+
+        for (auto i = 0; i < nrows; ++i) {
+            t_val item = m_accessor.attr("marshal")(cidx, i, type);
+
+            if (item.is_none()) {
+                if (is_update) {
+                    col->unset(i);
+                } else {
+                    col->clear(i);
+                }
+                continue;
+            }
+
+            bool is_float = py::isinstance<py::float_>(item);
+            bool is_numpy_nan = is_float && npy_isnan(item.cast<double>());
+            if (!is_float || is_numpy_nan) {
+                binding::WARN("Promoting column %s to string from float64", name);
+                tbl.promote_column(name, DTYPE_STR, i, false);
+                col = tbl.get_column(name);
+                fill_object_iter<std::string>(
+                    tbl, col, name, np_dtype, DTYPE_STR, cidx, is_update);
+                return;
+            }
+            col->set_nth(i, item.cast<double>());
+        }
+    }
+
+    // Must be below `fill_object_iter` explicit instantiations.
+    void
+    NumpyLoader::fill_column_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+        // Numpy arrays are guaranteed to be continous and valid by the time they enter this block,
+        // but if they're of dtype object, then we need to pass it through `m_accessor.marshal`.
+        switch (type) {
+            case DTYPE_TIME: {
+                // covers dtype `datetime64[us/ns/ms/s]`
+                if (np_dtype == DTYPE_OBJECT) {
+                    fill_object_iter<std::int64_t>(tbl, col, name, np_dtype, type, cidx, is_update);
+                } else {
+                    fill_datetime_iter(array, tbl, col, name, np_dtype, type, cidx, is_update);
+                }
+            } break;
+            case DTYPE_DATE: {
+                // `datetime.date` objects or `datetime64[D/W/M/Y]`, always fill by using `marshal`.
+                fill_date_iter(col, name, np_dtype, type, cidx, is_update);
+            } break;
+            case DTYPE_BOOL: {
+                if (np_dtype == DTYPE_OBJECT) {
+                    fill_object_iter<bool>(tbl, col, name, np_dtype, type, cidx, is_update);
+                } else {
+                    fill_bool_iter(array, tbl, col, name, np_dtype, type, cidx, is_update);
+                }
+            } break;
+            case DTYPE_STR: {
+                // dtype `U`
+                fill_object_iter<std::string>(tbl, col, name, np_dtype, type, cidx, is_update);
+            } break;
+            default: {
+                // TODO: do we need to check for object fill again here
+                // dtype `i/u/f`
+                fill_numeric_iter(array, tbl, col, name, np_dtype, type, cidx, is_update);
+                break;
+            }
+        }
+    }
+
+    // `array.dtype=datetime64[ns/us/ms/s]`
+    void
+    NumpyLoader::fill_datetime_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, 
+        const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
         PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         t_uindex nrows = col->size();
 
         if (np_dtype == DTYPE_OBJECT) {
             // handle object arrays
-            fill_object_iter<std::int64_t>(col, name, np_dtype, type, cidx, is_update); 
+            fill_object_iter<std::int64_t>(tbl, col, name, np_dtype, type, cidx, is_update); 
         } else {
             double* ptr = (double*) array.data(); // read as double to handle nan
 
@@ -219,7 +364,7 @@ namespace numpy {
     }
 
     void
-    NumpyLoader::fill_date_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
+    NumpyLoader::fill_date_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
         PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         t_uindex nrows = col->size();
 
@@ -243,14 +388,14 @@ namespace numpy {
     }
 
     void
-    NumpyLoader::fill_bool_iter(const py::array& array, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
+    NumpyLoader::fill_bool_iter(const py::array& array, t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype np_dtype, t_dtype type, std::uint32_t cidx, bool is_update) {
         PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         t_uindex nrows = col->size();
 
         // handle Nan/None in boolean array with dtype=object
         if (np_dtype == DTYPE_OBJECT) {
             // handle object arrays
-            fill_object_iter<bool>(col, name, np_dtype, type, cidx, is_update); 
+            fill_object_iter<bool>(tbl, col, name, np_dtype, type, cidx, is_update); 
         } else {
             bool* ptr = (bool*) array.data(); 
 
@@ -267,7 +412,59 @@ namespace numpy {
         t_uindex nrows = col->size();
         const void* ptr = array.data();
 
-        // we can always fill numeric columns with C++ iteration
+        // We fill by object when `np_dtype`=object, or if there are type mismatches between `np_dtype` and `type`.
+        bool types_mismatched = (np_dtype == DTYPE_INT64 && (type == DTYPE_INT32 || type == DTYPE_FLOAT64)) || \
+            (np_dtype == DTYPE_FLOAT64 && (type == DTYPE_INT32 || type == DTYPE_INT64)) || \
+            (type == DTYPE_INT64 && (np_dtype == DTYPE_FLOAT32 || np_dtype == DTYPE_FLOAT64));
+
+        if (types_mismatched || np_dtype == DTYPE_OBJECT) {
+            switch (type) {
+                case DTYPE_UINT8: {
+                    fill_object_iter<std::uint8_t>(tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                case DTYPE_UINT16: {
+                    fill_object_iter<std::uint16_t> (tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                case DTYPE_UINT32: {
+                    fill_object_iter<std::uint32_t>(tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                case DTYPE_UINT64: {
+                    fill_object_iter<std::uint64_t>(tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                case DTYPE_INT8: {
+                    fill_object_iter<std::int8_t>(tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                case DTYPE_INT16: {
+                    fill_object_iter<std::int16_t>(tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                case DTYPE_INT32: {
+                    fill_object_iter<std::int32_t>(tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                case DTYPE_INT64: {
+                    fill_object_iter<std::int64_t>(tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                case DTYPE_FLOAT32: {
+                    fill_object_iter<float>(tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                case DTYPE_FLOAT64: {
+                    fill_object_iter<double>(tbl, col, name, np_dtype, type, cidx, is_update);
+                    return;
+                } break;
+                default:
+                    PSP_COMPLAIN_AND_ABORT("Unable to fill non-numeric column in `fill_numeric_iter`.")
+            }
+        }
+
+        // Iterate through the C++ array and try to cast. Array is guaranteed to be of the correct dtype and consistent in its values.
         for (auto i = 0; i < nrows; ++i) {
             if (isnan(((double*) ptr)[i]) || npy_isnan(((double*) ptr)[i])) {
                 if (is_update) {
@@ -298,69 +495,17 @@ namespace numpy {
                     col->set_nth(i, ((std::int16_t*)ptr)[i]);
                 } break;
                 case DTYPE_INT32: {
-                    std::int32_t item = ((std::int32_t*) ptr)[i];
-
-                    if (np_dtype == DTYPE_INT64) {
-                        item = ((std::int64_t*) ptr)[i]; // c++ automatically handles conversion
-                    } else if (np_dtype == DTYPE_FLOAT64) {
-                        item = ((double*) ptr)[i]; // truncate decimal
-                    } 
-
-                    // This handles cases where a long sequence of e.g. 0 precedes a clearly
-                    // float value in an inferred column. Would not be needed if the type
-                    // inference checked the entire column/we could reset parsing.
-                    double fval = ((double*) ptr)[i];
-                    if (fval > 2147483647 || fval < -2147483648) {
-                        binding::WARN("Promoting %s to float from int32", name);
-                        tbl.promote_column(name, DTYPE_FLOAT64, i, true);
-                        col = tbl.get_column(name);
-                        type = DTYPE_FLOAT64;
-                        col->set_nth(i, fval);
-                    } else if (isnan(fval) || npy_isnan(fval)) {
-                        binding::WARN("Promoting %s to string from int32", name);
-                        tbl.promote_column(name, DTYPE_STR, i, false);
-                        col = tbl.get_column(name);
-                        fill_object_iter<std::string>(col, name, np_dtype, DTYPE_STR, cidx, is_update);
-                        return;
-                    } else {
-                        col->set_nth(i, item);
-                    }
+                    // No need for promotion logic if array is consistent
+                    col->set_nth<std::int32_t>(i, ((std::int32_t*) ptr)[i]);
                 } break;
                 case DTYPE_INT64: {
-                    std::int64_t item = ((std::int64_t*) ptr)[i];
-                    if (np_dtype == DTYPE_FLOAT64) {
-                        item = ((double*) ptr)[i];
-                    }
-                    
-                    double fval = ((double*) ptr)[i];
-                    if (isnan(fval) || npy_isnan(fval)) {
-                        binding::WARN("Promoting %s to string from int64", name);
-                        tbl.promote_column(name, DTYPE_STR, i, false);
-                        col = tbl.get_column(name);
-                        fill_object_iter<std::string>(col, name, np_dtype, DTYPE_STR, cidx, is_update);
-                        return;
-                    } 
-                    
-                    col->set_nth<std::int64_t>(i, item);
+                    col->set_nth<std::int64_t>(i, ((std::int64_t*) ptr)[i]);
                 } break;
                 case DTYPE_FLOAT32: {
                     col->set_nth(i, ((float*) ptr)[i]);
                 } break;
                 case DTYPE_FLOAT64: {
-                    double item = ((double*)ptr)[i];
-                    if (np_dtype == DTYPE_INT64) {
-                        item = ((std::int64_t*) ptr)[i];
-                    }
-                    // if the value is a nan, or if the numpy dtype is string (i.e. not a copyable type), promote
-                    bool is_numeric_type = np_dtype == DTYPE_INT64 || np_dtype == DTYPE_FLOAT64;
-                    if (!is_numeric_type || isnan(item) || npy_isnan(item)) {
-                        binding::WARN("Promoting %s to string from float64", name);
-                        tbl.promote_column(name, DTYPE_STR, i, false);
-                        col = tbl.get_column(name);
-                        fill_object_iter<std::string>(col, name, np_dtype, DTYPE_STR, cidx, is_update);
-                        return;
-                    }
-                    col->set_nth<double>(i, item);
+                    col->set_nth<double>(i, ((double*)ptr)[i]);
                 } break;
                 default:
                     break;
@@ -373,7 +518,7 @@ namespace numpy {
      * Copy numpy arrays into columns
      */
     t_fill_status 
-    NumpyLoader::try_copy_array(const py::array& src, std::shared_ptr<t_column> dest, t_dtype np_dtype, const std::uint64_t offset) {
+    NumpyLoader::try_copy_array(const py::array& src, std::shared_ptr<t_column> dest, t_dtype np_dtype, t_dtype type, const std::uint64_t offset) {
         PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         std::int64_t length = src.size();
 
@@ -402,6 +547,7 @@ namespace numpy {
             } break;
             case DTYPE_INT64:
             case DTYPE_TIME: {
+                std::cout << "copying int64/time" << std::endl;
                 copy_array_helper<std::int64_t>(src.data(), dest, offset);
             } break;
             case DTYPE_FLOAT32: {

--- a/python/perspective/perspective/src/numpy.cpp
+++ b/python/perspective/perspective/src/numpy.cpp
@@ -7,6 +7,7 @@
  *
  */
 #ifdef PSP_ENABLE_PYTHON
+#include <perspective/python/fill.h>
 #include <perspective/python/numpy.h>
 
 using namespace perspective;
@@ -14,8 +15,250 @@ using namespace perspective;
 namespace perspective {
 namespace numpy {
 
-    NumpyLoader::NumpyLoader() {}
+    NumpyLoader::NumpyLoader(py::object accessor)
+        : m_accessor(accessor) {}
+
     NumpyLoader::~NumpyLoader() {}
+
+    void
+    NumpyLoader::fill_table(t_data_table& tbl, const t_schema& input_schema,
+        const std::string& index, std::uint32_t offset, std::uint32_t limit, bool is_update) {
+        bool implicit_index = false;
+        std::vector<std::string> col_names(input_schema.columns());
+        std::vector<t_dtype> data_types(input_schema.types());
+
+        for (auto cidx = 0; cidx < col_names.size(); ++cidx) {
+            auto name = col_names[cidx];
+            auto type = data_types[cidx];
+
+            if (name == "__INDEX__") {
+                implicit_index = true;
+                std::shared_ptr<t_column> pkey_col_sptr = tbl.add_column_sptr("psp_pkey", type, true);
+                fill_column(pkey_col_sptr, "psp_pkey", type, cidx, is_update);
+                tbl.clone_column("psp_pkey", "psp_okey");
+                continue;
+            }
+
+            auto col = tbl.get_column(name);
+            fill_column(col, name, type, cidx, is_update);
+        }
+
+        // Fill index column - recreated every time a `t_data_table` is created.
+        if (!implicit_index) {
+            if (index == "") {
+                // Use row number as index if not explicitly provided or provided with `__INDEX__`
+                auto key_col = tbl.add_column("psp_pkey", DTYPE_INT32, true);
+                auto okey_col = tbl.add_column("psp_okey", DTYPE_INT32, true);
+
+                for (std::uint32_t ridx = 0; ridx < tbl.size(); ++ridx) {
+                    key_col->set_nth<std::int32_t>(ridx, (ridx + offset) % limit);
+                    okey_col->set_nth<std::int32_t>(ridx, (ridx + offset) % limit);
+                }
+            } else {
+                tbl.clone_column(index, "psp_pkey");
+                tbl.clone_column(index, "psp_okey");
+            }
+        }
+    }
+
+    
+    void 
+    NumpyLoader::fill_column(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        // Force path for datetimes
+        if (type == DTYPE_TIME) {
+            fill_datetime_iter(col, name, type, cidx, is_update);
+            return;
+        }
+        
+        try {
+            // TODO: updates are not applying
+            py::dict source = m_accessor.attr("_get_numpy_column")(name);
+            py::object array = source["array"];
+            py::object mask = source["mask"];
+            copy_array(array, col, 0);
+
+            // Fill validity map
+            col->valid_raw_fill();
+            col->pprint();
+            auto num_invalid = len(mask);
+
+            if (num_invalid > 0) {
+                py::array_t<std::uint64_t> null_array = mask;
+                std::uint64_t* ptr = (std::uint64_t*) null_array.request().ptr;
+                for (auto i = 0; i < num_invalid; ++i) {
+                    std::uint64_t idx = ptr[i];
+                    if (is_update) {
+                        col->unset(idx);
+                    } else {
+                        col->clear(idx);
+                    }
+                }
+            }
+
+            col->pprint();
+        } catch (const PerspectiveException& ex) {
+            fill_column_iter(col, name, type, cidx, is_update);
+        }
+    }
+
+    void
+    NumpyLoader::fill_column_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        switch (type) {
+            case DTYPE_TIME: {
+                fill_datetime_iter(col, name, type, cidx, is_update);
+            } break;
+            case DTYPE_DATE: {
+                fill_date_iter(col, name, type, cidx, is_update);
+            } break;
+            case DTYPE_STR: {
+                fill_string_iter(col, name, type, cidx, is_update);
+            } break;
+            case DTYPE_BOOL: {
+                fill_bool_iter(col, name, type, cidx, is_update);
+            } break;
+            default: {
+                break;
+            }
+        }
+    }
+
+    void
+    NumpyLoader::fill_datetime_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        // memcpy doesn't work at the moment - simulate that path but iterate through
+        t_uindex nrows = col->size();
+        py::dict source = m_accessor.attr("_get_numpy_column")(name);
+        py::array_t<std::int64_t> array = source["array"].cast<py::array_t<std::int64_t>>();
+        std::int64_t* ptr = (std::int64_t*) array.request().ptr;
+
+        for (auto i = 0; i < nrows; ++i) {
+            col->set_nth(i, ptr[i] * 1000); // convert to milliseconds         
+        }
+
+        py::array_t<std::int64_t> mask = source["mask"].cast<py::array_t<std::int64_t>>();
+        auto num_nulls = mask.request().size;
+        std::int64_t* mask_ptr = (std::int64_t*) mask.request().ptr;
+        for (auto i = 0; i < num_nulls; ++i) {
+            col->set_valid(mask_ptr[i], false);
+        }
+    }
+
+    void
+    NumpyLoader::fill_date_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        t_uindex nrows = col->size();
+
+        for (auto i = 0; i < nrows; ++i) {
+            t_val item = m_accessor.attr("marshal")(cidx, i, type);
+
+            if (item.is_none()) {
+                if (is_update) {
+                    col->unset(i);
+                } else {
+                    col->clear(i);
+                }
+                continue;
+            }
+
+
+            auto date_components = item.cast<std::map<std::string, std::int32_t>>();
+            t_date dt = t_date(date_components["year"], date_components["month"], date_components["day"]);
+            col->set_nth(i, dt);
+        }
+    }
+
+    void
+    NumpyLoader::fill_string_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        t_uindex nrows = col->size();
+
+        for (auto i = 0; i < nrows; ++i) {
+            t_val item = m_accessor.attr("marshal")(cidx, i, type);
+
+            if (item.is_none()) {
+                if (is_update) {
+                    col->unset(i);
+                } else {
+                    col->clear(i);
+                }
+                continue;
+            }
+
+            // convert to a python string first
+            std::wstring welem = item.cast<std::wstring>();
+            std::wstring_convert<utf16convert_type, wchar_t> converter;
+            std::string elem = converter.to_bytes(welem);
+            col->set_nth(i, elem);
+        }
+    }
+
+    void
+    NumpyLoader::fill_bool_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        t_uindex nrows = col->size();
+        py::dict source = m_accessor.attr("_get_numpy_column")(name);
+        py::array array = source["array"].cast<py::object>();
+        std::int32_t* ptr = (std::int32_t*) array.request().ptr;
+
+        for (auto i = 0; i < nrows; ++i) {
+            t_val item = m_accessor.attr("marshal")(cidx, i, type);
+
+            if (item.is_none()) {
+                if (is_update) {
+                    col->unset(i);
+                } else {
+                    col->clear(i);
+                }
+                continue;
+            }
+
+            col->set_nth(i, item.cast<bool>());
+        }
+    }
+
+    void
+    NumpyLoader::copy_array(py::object src, std::shared_ptr<t_column> dest, const std::uint64_t offset) {
+        std::int64_t length = py::len(src);
+
+        // Cannot be templated without templating out the class
+        if (py::isinstance<py::array_t<std::uint8_t>>(src)) {
+            py::array_t<std::uint8_t> array = src; 
+            copy_array_helper<std::uint8_t>(array.request().ptr, dest, offset);
+        } else if (py::isinstance<py::array_t<std::uint16_t>>(src)) {
+            py::array_t<std::uint16_t> array = src;
+            copy_array_helper<std::uint16_t>(array.request().ptr, dest, offset);
+        } else if (py::isinstance<py::array_t<std::uint32_t>>(src)) {
+            py::array_t<std::uint32_t> array = src;
+            copy_array_helper<std::uint32_t>(array.request().ptr, dest, offset);
+        } else if (py::isinstance<py::array_t<std::uint64_t>>(src)) {
+            py::array_t<std::uint64_t> array = src;
+            copy_array_helper<std::uint64_t>(array.request().ptr, dest, offset);
+        } else if (py::isinstance<py::array_t<std::int8_t>>(src)) {
+            py::array_t<std::int8_t> array = src;
+            copy_array_helper<std::int8_t>(array.request().ptr, dest, offset);
+        } else if (py::isinstance<py::array_t<std::int16_t>>(src)) {
+            py::array_t<std::int16_t> array = src;
+            copy_array_helper<std::int16_t>(array.request().ptr, dest, offset);
+        } else if (py::isinstance<py::array_t<std::int32_t>>(src)) {
+            py::array_t<std::int32_t> array = src;
+            copy_array_helper<std::int32_t>(array.request().ptr, dest, offset);
+        } else if (py::isinstance<py::array_t<std::int64_t>>(src)) {
+            py::array_t<std::int64_t> array = src;
+            copy_array_helper<std::int64_t>(array.request().ptr, dest, offset);
+        } else if (py::isinstance<py::array_t<float>>(src)) {
+            py::array_t<float> array = src;
+            copy_array_helper<float>(array.request().ptr, dest, offset);
+        } else if (py::isinstance<py::array_t<double>>(src)) {
+            py::array_t<double> array = src;
+            copy_array_helper<double>(array.request().ptr, dest, offset);
+        } else {
+            std::string type_string = src.get_type().attr("__name__").cast<std::string>();
+            std::stringstream ss;
+            ss << "Could not copy numpy array of type " << type_string << std::endl;
+            PSP_COMPLAIN_AND_ABORT(ss.str());
+        }
+    }
+
+    template <typename T>
+    void copy_array_helper(void* src, std::shared_ptr<t_column> dest, const std::uint64_t offset) {
+        std::memcpy(dest->get_nth<T>(offset), src, dest->size() * sizeof(T));
+    }
     
 } // namespace numpy
 } // namespace perspective

--- a/python/perspective/perspective/src/numpy.cpp
+++ b/python/perspective/perspective/src/numpy.cpp
@@ -55,10 +55,6 @@ namespace numpy {
             }
         }
 
-        for (auto d : reconciled_types) {
-            std::cout << get_dtype_descr(d) << std::endl;
-        }
-
         return reconciled_types;
     };
 
@@ -318,8 +314,8 @@ namespace numpy {
         // but if they're of dtype object, then we need to pass it through `m_accessor.marshal`.
         switch (type) {
             case DTYPE_TIME: {
-                // covers dtype `datetime64[us/ns/ms/s]` and parses date strings
-                if (np_dtype == DTYPE_OBJECT || np_dtype == DTYPE_STR) {
+                // covers dtype `datetime64[us/ns/ms/s]`, date strings, and integer timestamps in ms or s since epoch
+                if (np_dtype != DTYPE_TIME) {
                     fill_object_iter<std::int64_t>(tbl, col, name, np_dtype, type, cidx, is_update);
                 } else {
                     fill_datetime_iter(array, tbl, col, name, np_dtype, type, cidx, is_update);

--- a/python/perspective/perspective/src/numpy.cpp
+++ b/python/perspective/perspective/src/numpy.cpp
@@ -16,13 +16,40 @@ namespace perspective {
 namespace numpy {
 
     NumpyLoader::NumpyLoader(py::object accessor)
-        : m_accessor(accessor) {}
+        : m_init(false)
+        , m_accessor(accessor) {}
 
     NumpyLoader::~NumpyLoader() {}
 
     void
+    NumpyLoader::init() {
+        m_names = make_names();
+        m_types = make_types();
+        m_init = true;
+    }
+
+    std::vector<std::string>
+    NumpyLoader::names() const {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+        return m_names;
+    }
+
+    std::vector<t_dtype>
+    NumpyLoader::types() const {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+        return m_types;
+    }
+
+    std::uint32_t
+    NumpyLoader::row_count() const {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+        return m_accessor.attr("row_count")().cast<std::uint32_t>();
+    }
+
+    void
     NumpyLoader::fill_table(t_data_table& tbl, const t_schema& input_schema,
         const std::string& index, std::uint32_t offset, std::uint32_t limit, bool is_update) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         bool implicit_index = false;
         std::vector<std::string> col_names(input_schema.columns());
         std::vector<t_dtype> data_types(input_schema.types());
@@ -31,16 +58,18 @@ namespace numpy {
             auto name = col_names[cidx];
             auto type = data_types[cidx];
 
+            std::cout << "Column " << name << " has infer type " << dtype_to_str(type) << std::endl;
+
             if (name == "__INDEX__") {
                 implicit_index = true;
                 std::shared_ptr<t_column> pkey_col_sptr = tbl.add_column_sptr("psp_pkey", type, true);
-                fill_column(pkey_col_sptr, "psp_pkey", type, cidx, is_update);
+                fill_column(tbl, pkey_col_sptr, "__INDEX__", type, cidx, is_update);
                 tbl.clone_column("psp_pkey", "psp_okey");
                 continue;
             }
 
             auto col = tbl.get_column(name);
-            fill_column(col, name, type, cidx, is_update);
+            fill_column(tbl, col, name, type, cidx, is_update);
         }
 
         // Fill index column - recreated every time a `t_data_table` is created.
@@ -63,19 +92,40 @@ namespace numpy {
 
     
     void 
-    NumpyLoader::fill_column(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
-        // Force path for datetimes
+    NumpyLoader::fill_column(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+
+        // TODO: can be removed
         if (type == DTYPE_TIME) {
             fill_datetime_iter(col, name, type, cidx, is_update);
             return;
         }
+
+        std::cout << m_names << std::endl;
+        // Use name index instead of column index - prevents off-by-one errors with the "index" column.
+        auto name_it = std::find(m_names.begin(), m_names.end(), name); 
+        
+        if (name_it == m_names.end()) {
+            std::stringstream ss;
+            ss << "Cannot fill column '" << name << "' as it is not in the table schema.";
+            PSP_COMPLAIN_AND_ABORT(ss.str());
+        }
+
+        auto nidx = std::distance(m_names.begin(), name_it);
+
+        /**
+         * np_dtype is used to attempt `memcpy` of the numpy array into perspective.
+         * if memcpy fails, it is most likely a numpy array with `dtype=object`, so use the inferred type from perspective.
+         */
+        t_dtype np_dtype = m_types[nidx];
+
+        std::cout << "COL " << name << " with dtype " << dtype_to_str(np_dtype) << std::endl;
         
         try {
-            // TODO: updates are not applying
-            py::dict source = m_accessor.attr("_get_numpy_column")(name);
+            py::dict source = m_accessor.attr("_get_numpy_column")(name, type);
             py::object array = source["array"];
             py::object mask = source["mask"];
-            copy_array(array, col, 0);
+            copy_array(array, col, np_dtype, 0);
 
             // Fill validity map
             col->valid_raw_fill();
@@ -84,7 +134,7 @@ namespace numpy {
 
             if (num_invalid > 0) {
                 py::array_t<std::uint64_t> null_array = mask;
-                std::uint64_t* ptr = (std::uint64_t*) null_array.request().ptr;
+                std::uint64_t* ptr = (std::uint64_t*) null_array.data();
                 for (auto i = 0; i < num_invalid; ++i) {
                     std::uint64_t idx = ptr[i];
                     if (is_update) {
@@ -97,12 +147,13 @@ namespace numpy {
 
             col->pprint();
         } catch (const PerspectiveException& ex) {
-            fill_column_iter(col, name, type, cidx, is_update);
+            fill_column_iter(tbl, col, name, type, cidx, is_update);
         }
     }
 
     void
-    NumpyLoader::fill_column_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+    NumpyLoader::fill_column_iter(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         switch (type) {
             case DTYPE_TIME: {
                 fill_datetime_iter(col, name, type, cidx, is_update);
@@ -110,32 +161,124 @@ namespace numpy {
             case DTYPE_DATE: {
                 fill_date_iter(col, name, type, cidx, is_update);
             } break;
-            case DTYPE_STR: {
-                fill_string_iter(col, name, type, cidx, is_update);
-            } break;
             case DTYPE_BOOL: {
                 fill_bool_iter(col, name, type, cidx, is_update);
             } break;
+            case DTYPE_STR: {
+                fill_string_iter(col, name, type, cidx, is_update);
+            } break;
             default: {
+                fill_numeric_iter(tbl, col, name, type, cidx, is_update);
                 break;
+            }
+        }
+    }
+
+    void 
+    NumpyLoader::fill_numeric_iter(t_data_table& tbl, std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+        t_uindex nrows = col->size();
+
+        for (auto i = 0; i < nrows; ++i) {
+            t_val item = m_accessor.attr("marshal")(cidx, i, type);
+
+            if (item.is_none()) {
+                if (is_update) {
+                    col->unset(i);
+                } else {
+                    col->clear(i);
+                }
+                continue;
+            }
+
+            switch (type) {
+                case DTYPE_UINT8: {
+                    col->set_nth(i, item.cast<std::uint8_t>());
+                } break;
+                case DTYPE_UINT16: {
+                    col->set_nth(i, item.cast<std::uint16_t>());
+                } break;
+                case DTYPE_UINT32: {
+                    col->set_nth(i, item.cast<std::uint32_t>());
+                } break;
+                case DTYPE_UINT64: {
+                    col->set_nth(i, item.cast<std::uint64_t>());
+                } break;
+                case DTYPE_INT8: {
+                    col->set_nth(i, item.cast<std::int8_t>());
+                } break;
+                case DTYPE_INT16: {
+                    col->set_nth(i, item.cast<std::int16_t>());
+                } break;
+                case DTYPE_INT32: {
+                    // This handles cases where a long sequence of e.g. 0 precedes a clearly
+                    // float value in an inferred column. Would not be needed if the type
+                    // inference checked the entire column/we could reset parsing.
+                    double fval = item.cast<double>();
+                    if (fval > 2147483647 || fval < -2147483648) {
+                        binding::WARN("Promoting %s to float from int32", name);
+                        tbl.promote_column(name, DTYPE_FLOAT64, i, true);
+                        col = tbl.get_column(name);
+                        type = DTYPE_FLOAT64;
+                        col->set_nth(i, fval);
+                    } else if (isnan(fval)) {
+                        binding::WARN("Promoting %s to string from int32", name);
+                        tbl.promote_column(name, DTYPE_STR, i, false);
+                        col = tbl.get_column(name);
+                        fill_string_iter(col, name, DTYPE_STR, cidx, is_update);
+                        return;
+                    } else {
+                        col->set_nth(i, static_cast<std::int32_t>(fval));
+                    }
+                } break;
+                case DTYPE_INT64: {
+                    double fval = item.cast<double>();
+                    if (isnan(fval)) {
+                        binding::WARN("Promoting %s to string from int64", name);
+                        tbl.promote_column(name, DTYPE_STR, i, false);
+                        col = tbl.get_column(name);
+                        fill_string_iter(col, name, DTYPE_STR, cidx, is_update);
+                        return;
+                    } else {
+                        col->set_nth(i, static_cast<std::int64_t>(fval));
+                    }
+                } break;
+                case DTYPE_FLOAT32: {
+                    col->set_nth(i, item.cast<float>());
+                } break;
+                case DTYPE_FLOAT64: {
+                    bool is_float = py::isinstance<py::float_>(item);
+                    bool is_numpy_nan = is_float && npy_isnan(item.cast<double>());
+                    if (!is_float || is_numpy_nan) {
+                        binding::WARN("Promoting %s to string from int64", name);
+                        tbl.promote_column(name, DTYPE_STR, i, false);
+                        col = tbl.get_column(name);
+                        fill_string_iter(col, name, DTYPE_STR, cidx, is_update);
+                        return;
+                    }
+                    col->set_nth(i, item.cast<double>());
+                } break;
+                default:
+                    break;
             }
         }
     }
 
     void
     NumpyLoader::fill_datetime_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         // memcpy doesn't work at the moment - simulate that path but iterate through
         t_uindex nrows = col->size();
-        py::dict source = m_accessor.attr("_get_numpy_column")(name);
+        py::dict source = m_accessor.attr("_get_numpy_column")(name, type);
         py::array_t<std::int64_t> array = source["array"].cast<py::array_t<std::int64_t>>();
-        std::int64_t* ptr = (std::int64_t*) array.request().ptr;
+        std::int64_t* ptr = (std::int64_t*) array.data();
 
         for (auto i = 0; i < nrows; ++i) {
             col->set_nth(i, ptr[i] * 1000); // convert to milliseconds         
         }
 
         py::array_t<std::int64_t> mask = source["mask"].cast<py::array_t<std::int64_t>>();
-        auto num_nulls = mask.request().size;
+        auto num_nulls = mask.size();
         std::int64_t* mask_ptr = (std::int64_t*) mask.request().ptr;
         for (auto i = 0; i < num_nulls; ++i) {
             col->set_valid(mask_ptr[i], false);
@@ -144,6 +287,7 @@ namespace numpy {
 
     void
     NumpyLoader::fill_date_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         t_uindex nrows = col->size();
 
         for (auto i = 0; i < nrows; ++i) {
@@ -167,6 +311,7 @@ namespace numpy {
 
     void
     NumpyLoader::fill_string_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         t_uindex nrows = col->size();
 
         for (auto i = 0; i < nrows; ++i) {
@@ -181,20 +326,14 @@ namespace numpy {
                 continue;
             }
 
-            // convert to a python string first
-            std::wstring welem = item.cast<std::wstring>();
-            std::wstring_convert<utf16convert_type, wchar_t> converter;
-            std::string elem = converter.to_bytes(welem);
-            col->set_nth(i, elem);
+            col->set_nth(i, item.cast<std::string>());
         }
     }
 
     void
     NumpyLoader::fill_bool_iter(std::shared_ptr<t_column> col, const std::string& name, t_dtype type, std::uint32_t cidx, bool is_update) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         t_uindex nrows = col->size();
-        py::dict source = m_accessor.attr("_get_numpy_column")(name);
-        py::array array = source["array"].cast<py::object>();
-        std::int32_t* ptr = (std::int32_t*) array.request().ptr;
 
         for (auto i = 0; i < nrows; ++i) {
             t_val item = m_accessor.attr("marshal")(cidx, i, type);
@@ -213,51 +352,109 @@ namespace numpy {
     }
 
     void
-    NumpyLoader::copy_array(py::object src, std::shared_ptr<t_column> dest, const std::uint64_t offset) {
+    NumpyLoader::copy_array(py::object src, std::shared_ptr<t_column> dest, t_dtype np_dtype, const std::uint64_t offset) {
+        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
         std::int64_t length = py::len(src);
 
-        // Cannot be templated without templating out the class
-        if (py::isinstance<py::array_t<std::uint8_t>>(src)) {
-            py::array_t<std::uint8_t> array = src; 
-            copy_array_helper<std::uint8_t>(array.request().ptr, dest, offset);
-        } else if (py::isinstance<py::array_t<std::uint16_t>>(src)) {
-            py::array_t<std::uint16_t> array = src;
-            copy_array_helper<std::uint16_t>(array.request().ptr, dest, offset);
-        } else if (py::isinstance<py::array_t<std::uint32_t>>(src)) {
-            py::array_t<std::uint32_t> array = src;
-            copy_array_helper<std::uint32_t>(array.request().ptr, dest, offset);
-        } else if (py::isinstance<py::array_t<std::uint64_t>>(src)) {
-            py::array_t<std::uint64_t> array = src;
-            copy_array_helper<std::uint64_t>(array.request().ptr, dest, offset);
-        } else if (py::isinstance<py::array_t<std::int8_t>>(src)) {
-            py::array_t<std::int8_t> array = src;
-            copy_array_helper<std::int8_t>(array.request().ptr, dest, offset);
-        } else if (py::isinstance<py::array_t<std::int16_t>>(src)) {
-            py::array_t<std::int16_t> array = src;
-            copy_array_helper<std::int16_t>(array.request().ptr, dest, offset);
-        } else if (py::isinstance<py::array_t<std::int32_t>>(src)) {
-            py::array_t<std::int32_t> array = src;
-            copy_array_helper<std::int32_t>(array.request().ptr, dest, offset);
-        } else if (py::isinstance<py::array_t<std::int64_t>>(src)) {
-            py::array_t<std::int64_t> array = src;
-            copy_array_helper<std::int64_t>(array.request().ptr, dest, offset);
-        } else if (py::isinstance<py::array_t<float>>(src)) {
-            py::array_t<float> array = src;
-            copy_array_helper<float>(array.request().ptr, dest, offset);
-        } else if (py::isinstance<py::array_t<double>>(src)) {
-            py::array_t<double> array = src;
-            copy_array_helper<double>(array.request().ptr, dest, offset);
-        } else {
-            std::string type_string = src.get_type().attr("__name__").cast<std::string>();
-            std::stringstream ss;
-            ss << "Could not copy numpy array of type " << type_string << std::endl;
-            PSP_COMPLAIN_AND_ABORT(ss.str());
+        // Ensure input is a a numpy array
+        py::array array = py::array::ensure(src);
+
+        if (!array) {
+            PSP_COMPLAIN_AND_ABORT("Cannot copy a non-numpy array into Perspective.");
+        }
+
+        switch (np_dtype) {
+            case DTYPE_UINT8: {
+                copy_array_helper<std::uint8_t>(array.data(), dest, offset);
+            } break;
+            case DTYPE_UINT16: {
+                copy_array_helper<std::uint16_t>(array.data(), dest, offset);
+            } break;
+            case DTYPE_UINT32: {
+                copy_array_helper<std::uint32_t>(array.data(), dest, offset);
+            } break;
+            case DTYPE_UINT64: {
+                copy_array_helper<std::uint64_t>(array.data(), dest, offset);
+            } break;
+            case DTYPE_INT8: {
+                copy_array_helper<std::int8_t>(array.data(), dest, offset);
+            } break;
+            case DTYPE_INT16: {
+                copy_array_helper<std::int16_t>(array.data(), dest, offset);
+            } break;
+            case DTYPE_INT32: {
+                copy_array_helper<std::int32_t>(array.data(), dest, offset);
+            } break;
+            case DTYPE_INT64: {
+                copy_array_helper<std::int64_t>(array.data(), dest, offset);
+            } break;
+            case DTYPE_FLOAT32: {
+                copy_array_helper<float>(array.data(), dest, offset);
+            } break;
+            case DTYPE_FLOAT64: {
+                copy_array_helper<double>(array.data(), dest, offset);
+            } break;
+            default: {
+                std::stringstream ss;
+                ss << "Could not copy numpy array of Perspective `t_dtype` '" << dtype_to_str(np_dtype) << "'" << std::endl;
+                PSP_COMPLAIN_AND_ABORT(ss.str());
+                break;
+            }
         }
     }
 
     template <typename T>
-    void copy_array_helper(void* src, std::shared_ptr<t_column> dest, const std::uint64_t offset) {
+    void copy_array_helper(const void* src, std::shared_ptr<t_column> dest, const std::uint64_t offset) {
         std::memcpy(dest->get_nth<T>(offset), src, dest->size() * sizeof(T));
+    }
+
+    std::vector<std::string>
+    NumpyLoader::make_names() {
+        auto names = py::list(m_accessor.attr("data")().attr("keys")());
+        return names.cast<std::vector<std::string>>();
+    }
+
+    std::vector<t_dtype>
+    NumpyLoader::make_types() {
+        std::vector<t_dtype> rval;
+        
+        py::list arrays = m_accessor.attr("data")().attr("values")();
+        for (const auto& a : arrays) {
+            py::array array = py::array::ensure(a);
+
+            if (!array || array.dtype().kind() == 'O' || array.dtype().kind() == 'M') {
+                rval.push_back(DTYPE_STR);
+                continue;
+            }
+
+            if (py::isinstance<py::array_t<std::uint8_t>>(array)) {
+                rval.push_back(DTYPE_UINT8);
+            } else if (py::isinstance<py::array_t<std::uint16_t>>(array)) {
+                rval.push_back(DTYPE_UINT16);
+            } else if (py::isinstance<py::array_t<std::uint32_t>>(array)) {
+                rval.push_back(DTYPE_UINT32);
+            } else if (py::isinstance<py::array_t<std::uint64_t>>(array)) {
+                rval.push_back(DTYPE_UINT64);
+            } else if (py::isinstance<py::array_t<std::int8_t>>(array)) {
+                rval.push_back(DTYPE_INT8);
+            } else if (py::isinstance<py::array_t<std::int16_t>>(array)) {
+                rval.push_back(DTYPE_INT16);
+            } else if (py::isinstance<py::array_t<std::int32_t>>(array)) {
+                rval.push_back(DTYPE_INT32);
+            } else if (py::isinstance<py::array_t<std::int64_t>>(array)) {
+                rval.push_back(DTYPE_INT64);
+            } else if (py::isinstance<py::array_t<float>>(array)) {
+                rval.push_back(DTYPE_FLOAT32);
+            } else if (py::isinstance<py::array_t<double>>(array)) {
+                rval.push_back(DTYPE_FLOAT64);
+            } else if (py::isinstance<py::array_t<bool>>(array)) {
+                rval.push_back(DTYPE_BOOL);
+            } else {
+                PSP_COMPLAIN_AND_ABORT("Cannot infer type of non-numpy array.");
+            }
+        }
+
+        return rval;
     }
     
 } // namespace numpy

--- a/python/perspective/perspective/src/table.cpp
+++ b/python/perspective/perspective/src/table.cpp
@@ -14,6 +14,7 @@
 #include <perspective/python/accessor.h>
 #include <perspective/python/base.h>
 #include <perspective/python/fill.h>
+#include <perspective/python/numpy.h>
 #include <perspective/python/table.h>
 #include <perspective/python/utils.h>
 
@@ -30,6 +31,7 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor, t_va
     std::vector<std::string> column_names;
     std::vector<t_dtype> data_types;
     arrow::ArrowLoader arrow_loader;
+    numpy::NumpyLoader numpy_loader(accessor);
 
     // Determine metadata
     bool is_delete = op == OP_DELETE;
@@ -112,6 +114,10 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor, t_va
         row_count = arrow_loader.num_rows();
         data_table.extend(arrow_loader.num_rows());
         arrow_loader.fill_table(data_table, index, offset, limit, is_update);
+    } else if(accessor.attr("_is_numpy").cast<bool>() == true) {
+        row_count = accessor.attr("row_count")().cast<std::int32_t>();
+        data_table.extend(row_count);
+        numpy_loader.fill_table(data_table, input_schema, index, offset, limit, is_update);
     } else {
         row_count = accessor.attr("row_count")().cast<std::int32_t>();
         data_table.extend(row_count);

--- a/python/perspective/perspective/src/table.cpp
+++ b/python/perspective/perspective/src/table.cpp
@@ -67,7 +67,10 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor, t_va
          */
         numpy_loader.init();
         column_names = numpy_loader.names();
-        data_types = get_data_types(accessor.attr("data")(), 1, column_names, accessor.attr("date_validator")().cast<t_val>());
+
+        // composite array and inferred `data_types` for the Table
+        std::vector<t_dtype> inferred_types = get_data_types(accessor.attr("data")(), 1, column_names, accessor.attr("date_validator")().cast<t_val>());
+        data_types = numpy_loader.reconcile_dtypes(inferred_types);
     }  else {
         // Infer names and types
         t_val data = accessor.attr("data")();

--- a/python/perspective/perspective/src/table.cpp
+++ b/python/perspective/perspective/src/table.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor, t_va
         std::uint32_t limit, py::str index, t_op op, bool is_update, bool is_arrow) {
     std::vector<std::string> column_names;
     std::vector<t_dtype> data_types;
-    arrow::ArrowLoader loader;
+    arrow::ArrowLoader arrow_loader;
 
     // Determine metadata
     bool is_delete = op == OP_DELETE;
@@ -38,9 +38,9 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor, t_va
         std::int32_t size = bytes.attr("__len__")().cast<std::int32_t>();
         void * ptr = malloc(size);
         std::memcpy(ptr, bytes.cast<std::string>().c_str(), size);
-        loader.initialize((uintptr_t)ptr, size);
-        column_names = loader.names();
-        data_types = loader.types();
+        arrow_loader.initialize((uintptr_t)ptr, size);
+        column_names = arrow_loader.names();
+        data_types = arrow_loader.types();
     } else if (is_update || is_delete) {
         column_names = accessor.attr("names")().cast<std::vector<std::string>>();
         data_types = accessor.attr("types")().cast<std::vector<t_dtype>>();
@@ -109,13 +109,13 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor, t_va
     std::uint32_t row_count;
 
     if (is_arrow) {
-        row_count = loader.num_rows();
-        data_table.extend(loader.num_rows());
-        loader.fill_table(data_table, index, offset, limit, is_update);
+        row_count = arrow_loader.num_rows();
+        data_table.extend(arrow_loader.num_rows());
+        arrow_loader.fill_table(data_table, index, offset, limit, is_update);
     } else {
         row_count = accessor.attr("row_count")().cast<std::int32_t>();
         data_table.extend(row_count);
-        _fill_data(data_table, accessor, input_schema, index, offset, limit, is_arrow, is_update);
+        _fill_data(data_table, accessor, input_schema, index, offset, limit, is_update);
     }
 
      if (!computed.is_none()) {

--- a/python/perspective/perspective/src/utils.cpp
+++ b/python/perspective/perspective/src/utils.cpp
@@ -75,6 +75,9 @@ t_dtype type_string_to_t_dtype(std::string value, std::string name){
     } else if (value == "Timestamp") {
         // Pandas timestamp
         type = t_dtype::DTYPE_TIME;
+    } else if (value == "Period") {
+        // Pandas period
+        type = t_dtype::DTYPE_TIME;
     } else if (value == "date") {
         // Python date
         // TODO inheritance

--- a/python/perspective/perspective/src/utils.cpp
+++ b/python/perspective/perspective/src/utils.cpp
@@ -111,6 +111,7 @@ scalar_to_py(const t_tscalar& scalar, bool cast_double, bool cast_string) {
             } else if (cast_string) {
                 return py::cast(scalar.to_string(false)); // should reimplement
             } else {
+                // Stored timestamp should always be milliseconds
                 auto ms = std::chrono::milliseconds(scalar.to_int64());
                 auto time_point = std::chrono::time_point<std::chrono::system_clock>(ms);
                 return py::cast(time_point);

--- a/python/perspective/perspective/src/utils.cpp
+++ b/python/perspective/perspective/src/utils.cpp
@@ -120,8 +120,10 @@ scalar_to_py(const t_tscalar& scalar, bool cast_double, bool cast_string) {
                 return py::cast(time_point);
             }
         }
-        case DTYPE_FLOAT64:
         case DTYPE_FLOAT32: {
+            return py::cast(scalar.get<float>());
+        }
+        case DTYPE_FLOAT64: {
             if (cast_double) {
                 auto x = scalar.to_uint64();
                 double y = *reinterpret_cast<double*>(&x);
@@ -142,12 +144,9 @@ scalar_to_py(const t_tscalar& scalar, bool cast_double, bool cast_string) {
         case DTYPE_UINT32:
         case DTYPE_INT8:
         case DTYPE_INT16:
-        case DTYPE_INT32: {
-            return py::cast(scalar.to_int64());
-        }
+        case DTYPE_INT32:
         case DTYPE_UINT64:
         case DTYPE_INT64: {
-            // This could potentially lose precision
             return py::cast(scalar.to_int64());
         }
         case DTYPE_NONE: {

--- a/python/perspective/perspective/src/utils.cpp
+++ b/python/perspective/perspective/src/utils.cpp
@@ -82,6 +82,9 @@ t_dtype type_string_to_t_dtype(std::string value, std::string name){
         // Python date
         // TODO inheritance
         type = t_dtype::DTYPE_DATE;
+    } else if (value == "timedelta64") {
+        // cast timedelta to string to preserve units
+        type = t_dtype::DTYPE_STR;
     } else {
         CRITICAL("Unknown type '%s' for key '%s'", value, name);
     }

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -204,7 +204,7 @@ class _PerspectiveAccessor(object):
             return isinstance(data, numpy.ndarray)
         return False
 
-    def _get_numpy_column(self, name, type):
+    def _get_numpy_column(self, name):
         '''For columnar datasets, return the list/Numpy array that contains the data for a single column.
 
         Args:
@@ -214,22 +214,7 @@ class _PerspectiveAccessor(object):
             list/numpy.array/None : returns the column's data, or None if it cannot be found.
         '''
         if self._is_numpy_column(name):
-            column = deconstruct_numpy(self._data_or_schema.get(name, None))
-            dtype = column["array"].dtype
-
-            # TODO: don't actually do this in production
-            # Coerce int64 into int32, coerce float into int64
-            if type == t_dtype.DTYPE_INT32:
-                if numpy.issubdtype(dtype, numpy.integer):
-                    column["array"] = column["array"].astype(numpy.int32)
-            elif type == t_dtype.DTYPE_INT64:
-                if numpy.issubdtype(dtype, numpy.float):
-                    column["array"] = column["array"].astype(numpy.int64)
-
-            return column
-
-        else:
-            return None
+            return deconstruct_numpy(self._data_or_schema.get(name, None))
 
     def _has_column(self, ridx, name):
         '''Given a column name, validate that it is in the row.

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -10,6 +10,7 @@ import pandas
 import numpy
 from math import isnan
 from ._date_validator import _PerspectiveDateValidator
+from ..core.data import deconstruct_numpy
 
 try:
     from .libbinding import t_dtype
@@ -38,16 +39,17 @@ def _type_to_format(data_or_schema):
     '''
     if isinstance(data_or_schema, list):
         # records
-        return 0, data_or_schema
+        return False, 0, data_or_schema
     elif isinstance(data_or_schema, dict):
         # schema or columns
         for v in data_or_schema.values():
             if isinstance(v, type) or isinstance(v, str):
                 # schema maps name -> type
-                return 2, data_or_schema
+                return False, 2, data_or_schema
             elif isinstance(v, list) or iter(v):
                 # if columns entries are iterable, type 1
-                return 1, data_or_schema
+                # TODO: parse dict of numpy arrays as numpy
+                return False, 1, data_or_schema
             else:
                 # Can't process
                 raise NotImplementedError("Dict values must be list or type!")
@@ -55,7 +57,7 @@ def _type_to_format(data_or_schema):
         raise NotImplementedError("Dict values must be list or type!")
     elif isinstance(data_or_schema, numpy.recarray):
         columns = [data_or_schema[col] for col in data_or_schema.dtype.names]
-        return 1, dict(zip(data_or_schema.dtype.names, columns))
+        return True, 1, dict(zip(data_or_schema.dtype.names, columns))
     else:
         if not (isinstance(data_or_schema, pandas.DataFrame) or isinstance(data_or_schema, pandas.Series)):
             # if pandas not installed or is not a dataframe or series
@@ -66,14 +68,14 @@ def _type_to_format(data_or_schema):
             # flatten column/index multiindex
             df, _ = deconstruct_pandas(data_or_schema)
 
-            return 1, {c: df[c].values for c in df.columns}
+            return True, 1, {c: df[c].values for c in df.columns}
 
 
 class _PerspectiveAccessor(object):
     '''A uniform accessor that wraps data/schemas of varying formats with a common `marshal` function.'''
 
     def __init__(self, data_or_schema):
-        self._format, self._data_or_schema = _type_to_format(data_or_schema)
+        self._is_numpy, self._format, self._data_or_schema = _type_to_format(data_or_schema)
         self._date_validator = _PerspectiveDateValidator()
         self._row_count = \
             len(self._data_or_schema) if self._format == 0 else \
@@ -186,14 +188,14 @@ class _PerspectiveAccessor(object):
 
         return val
 
-    def _is_numpy(self, name):
+    def _is_numpy_column(self, name):
         '''For columnar datasets, return whether the underlying data is a Numpy array.'''
         if self._format == 1:
             data = self._data_or_schema.get(name, None)
             return isinstance(data, numpy.ndarray)
         return False
 
-    def _get_column(self, name):
+    def _get_numpy_column(self, name):
         '''For columnar datasets, return the list/Numpy array that contains the data for a single column.
 
         Args:
@@ -202,8 +204,8 @@ class _PerspectiveAccessor(object):
         Returns:
             list/numpy.array/None : returns the column's data, or None if it cannot be found.
         '''
-        if self._format == 1:
-            return self._data_or_schema.get(name, None)
+        if self._is_numpy_column(name):
+            return deconstruct_numpy(self._data_or_schema.get(name, None))
         else:
             return None
 

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -42,60 +42,58 @@ class _PerspectiveDateValidator(object):
         except (ValueError, OverflowError):
             return None
 
-    def to_date_components(self, d):
+    def to_date_components(self, obj):
         '''Return a dictionary of string keys and integer values for `year`, `month`, and `day`.
 
         This method converts both datetime.date and numpy.datetime64 objects that contain datetime.date.
         '''
-        if d is None:
-            return d
+        if obj is None:
+            return obj
 
-        if isinstance(d, numpy.datetime64):
-            if str(d) == "NaT":
+        if isinstance(obj, numpy.datetime64):
+            if str(obj) == "NaT":
                 return None
-            dt = d.astype(datetime)
-            return {
-                "year": dt.year,
-                "month": dt.month,
-                "day": dt.day
-            }
+            obj = obj.astype(datetime)
+
+            if (six.PY2 and isinstance(obj, long)) or isinstance(obj, int):
+                obj = datetime.fromtimestamp(obj / 1000000000)
 
         return {
-            "year": d.year,
-            "month": d.month,
-            "day": d.day
+            "year": obj.year,
+            "month": obj.month,
+            "day": obj.day
         }
 
-    def to_timestamp(self, d):
+    def to_timestamp(self, obj):
         '''Return an integer that corresponds to the Unix timestamp, i.e. number of milliseconds since epoch.
 
         This method converts both datetime.datetime and numpy.datetime64 objects.
         '''
-        if d is None:
-            return d
+        if obj is None:
+            return obj
 
         if six.PY2:
-            if isinstance(d, long):
+            if isinstance(obj, long):
                 # compat with python2 long from datetime.datetime
-                d = d / 1000000000
-                return long(d)
+                obj = obj / 1000000000
+                return long(obj)
 
-        if isinstance(d, numpy.datetime64):
-            if str(d) == "NaT":
+        if isinstance(obj, numpy.datetime64):
+            if str(obj) == "NaT":
                 return None
 
-            d = d.astype(datetime)
+            obj = obj.astype(datetime)
 
             if six.PY2:
-                if isinstance(d, long):
-                    return long(round(d / 1000000))
+                if isinstance(obj, long):
+                    return long(round(obj / 1000000))
 
-            if isinstance(d, int):
+            if isinstance(obj, int):
                 # sometimes `astype(datetime)` returns an int timestamp in nanoseconds - parse this.
-                return round(d / 1000000)
+                return round(obj / 1000000)
 
         # Convert `datetime.datetime` and `pandas.Timestamp` to millisecond timestamps
-        return int((time.mktime(d.timetuple()) + d.microsecond / 1000000.0) * 1000)
+        return int((time.mktime(obj.timetuple()) + obj.microsecond / 1000000.0) * 1000)
 
     def format(self, s):
         '''Return either t_dtype.DTYPE_DATE or t_dtype.DTYPE_TIME depending on the format of the parsed date.

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -24,6 +24,8 @@ if six.PY2:
 class _PerspectiveDateValidator(object):
     '''Validate and parse dates using the `dateutil` package.'''
 
+    EPOCH = datetime(1970, 1, 1)
+
     def parse(self, str):
         '''Return a datetime.datetime object containing the parsed date, or None if the date is invalid.
 
@@ -91,6 +93,18 @@ class _PerspectiveDateValidator(object):
             if isinstance(obj, int):
                 # sometimes `astype(datetime)` returns an int timestamp in nanoseconds - parse this.
                 return round(obj / 1000000)
+
+        # TODO: full support for unix/second timestamps
+        if isinstance(obj, (int, float)):
+            # figure out whether the timestamp is in seconds or milliseconds
+            try:
+                # TODO: this sucks, but milliseconds will overflow, seconds will fit
+                datetime(obj)
+                # convert to milliseconds
+                return obj * 1000
+            except (ValueError, OverflowError):
+                # milliseconds
+                return obj
 
         # Convert `datetime.datetime` and `pandas.Timestamp` to millisecond timestamps
         return int((time.mktime(obj.timetuple()) + obj.microsecond / 1000000.0) * 1000)

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -84,6 +84,7 @@ class _PerspectiveDateValidator(object):
             if str(obj) == "NaT":
                 return None
 
+            # astype(datetime) returns an int or a long (in python 2)
             obj = obj.astype(datetime)
 
             if six.PY2:
@@ -91,7 +92,6 @@ class _PerspectiveDateValidator(object):
                     return long(round(obj / 1000000))
 
             if isinstance(obj, int):
-                # sometimes `astype(datetime)` returns an int timestamp in nanoseconds - parse this.
                 return round(obj / 1000000)
 
         # TODO: full support for unix/second timestamps

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -8,7 +8,7 @@
 import six
 import time
 import numpy
-from datetime import datetime
+from datetime import date, datetime
 from re import search
 from dateutil.parser import parse
 
@@ -86,6 +86,10 @@ class _PerspectiveDateValidator(object):
 
             # astype(datetime) returns an int or a long (in python 2)
             obj = obj.astype(datetime)
+
+            if isinstance(obj, date) and not isinstance(obj, datetime):
+                # handle numpy "datetime64[D/W/M/Y]" - mktime output in seconds
+                return int((time.mktime(obj.timetuple())) * 1000)
 
             if six.PY2:
                 if isinstance(obj, long):

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -164,7 +164,6 @@ class Table(object):
                 self._accessor._types.append(index_dtype)
             else:
                 self._accessor._types.append(t_dtype.DTYPE_INT32)
-            print(self._accessor.names(), self._accessor.types())
 
         self._table = make_table(self._table, self._accessor, None, self._limit, self._index, t_op.OP_INSERT, True, False)
 

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -164,7 +164,6 @@ class Table(object):
                 self._accessor._types.append(index_dtype)
             else:
                 self._accessor._types.append(t_dtype.DTYPE_INT32)
-            print(self._accessor._names, self._accessor._types)
 
         self._table = make_table(self._table, self._accessor, None, self._limit, self._index, t_op.OP_INSERT, True, False)
 

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -164,6 +164,7 @@ class Table(object):
                 self._accessor._types.append(index_dtype)
             else:
                 self._accessor._types.append(t_dtype.DTYPE_INT32)
+            print(self._accessor._names, self._accessor._types)
 
         self._table = make_table(self._table, self._accessor, None, self._limit, self._index, t_op.OP_INSERT, True, False)
 

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -164,6 +164,7 @@ class Table(object):
                 self._accessor._types.append(index_dtype)
             else:
                 self._accessor._types.append(t_dtype.DTYPE_INT32)
+            print(self._accessor.names(), self._accessor.types())
 
         self._table = make_table(self._table, self._accessor, None, self._limit, self._index, t_op.OP_INSERT, True, False)
 

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -252,8 +252,6 @@ class Table(object):
         '''Delete this table and clean up associated resources in the core engine.
 
         Tables with associated views cannot be deleted.
-
-        Called when `__del__` is called by GC.
         '''
         if len(self._views) > 0:
             raise PerspectiveError("Cannot delete a Table with active views still linked to it - call delete() on each view, and try again.")

--- a/python/perspective/perspective/tests/table/test_table.py
+++ b/python/perspective/perspective/tests/table/test_table.py
@@ -295,67 +295,67 @@ class TestTable(object):
         filter = ["a", "<", 1]
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
-        assert tbl.is_valid_filter(filter) == True
+        assert tbl.is_valid_filter(filter) is True
 
     def test_table_not_is_valid_filter_str(self):
         filter = ["a", "<", None]
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
-        assert tbl.is_valid_filter(filter) == False
+        assert tbl.is_valid_filter(filter) is False
 
     def test_table_is_valid_filter_filter_op(self):
         filter = ["a", t_filter_op.FILTER_OP_IS_NULL]
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
-        assert tbl.is_valid_filter(filter) == True
+        assert tbl.is_valid_filter(filter) is True
 
     def test_table_not_is_valid_filter_filter_op(self):
         filter = ["a", t_filter_op.FILTER_OP_GT, None]
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
-        assert tbl.is_valid_filter(filter) == False
+        assert tbl.is_valid_filter(filter) is False
 
     def test_table_is_valid_filter_date(self):
         filter = ["a", t_filter_op.FILTER_OP_GT, date.today()]
         tbl = Table({
             "a": date
         })
-        assert tbl.is_valid_filter(filter) == True
+        assert tbl.is_valid_filter(filter) is True
 
     def test_table_not_is_valid_filter_date(self):
         filter = ["a", t_filter_op.FILTER_OP_GT, None]
         tbl = Table({
             "a": date
         })
-        assert tbl.is_valid_filter(filter) == False
+        assert tbl.is_valid_filter(filter) is False
 
     def test_table_is_valid_filter_datetime(self):
         filter = ["a", t_filter_op.FILTER_OP_GT, datetime.now()]
         tbl = Table({
             "a": datetime
         })
-        assert tbl.is_valid_filter(filter) == True
+        assert tbl.is_valid_filter(filter) is True
 
     def test_table_not_is_valid_filter_datetime(self):
         filter = ["a", t_filter_op.FILTER_OP_GT, None]
         tbl = Table({
             "a": datetime
         })
-        assert tbl.is_valid_filter(filter) == False
+        assert tbl.is_valid_filter(filter) is False
 
     def test_table_is_valid_filter_datetime_str(self):
         filter = ["a", t_filter_op.FILTER_OP_GT, "7/11/2019 5:30PM"]
         tbl = Table({
             "a": datetime
         })
-        assert tbl.is_valid_filter(filter) == True
+        assert tbl.is_valid_filter(filter) is True
 
     def test_table_not_is_valid_filter_datetime_str(self):
         filter = ["a", t_filter_op.FILTER_OP_GT, None]
         tbl = Table({
             "a": datetime
         })
-        assert tbl.is_valid_filter(filter) == False
+        assert tbl.is_valid_filter(filter) is False
 
     # index
 

--- a/python/perspective/perspective/tests/table/test_table_numpy.py
+++ b/python/perspective/perspective/tests/table/test_table_numpy.py
@@ -297,27 +297,19 @@ class TestTableNumpy(object):
 
     def test_table_np_promote_to_string(self):
         data = {
-            "a": np.arange(5),
-            "b": np.array([1, 2, 3, "abc", 5]),
-            "c": np.array([1, 2, 3, 2147483648, "abcdef"])
+            "a": np.arange(4),
+            "b": np.array([1, 2, "abc", "abc"]),
         }
-        tbl = Table({
-            "a": int,
-            "b": float,
-            "c": int
-        })
-        tbl.update(data)
-        assert tbl.size() == 5
+        tbl = Table(data)
+        assert tbl.size() == 4
         assert tbl.schema() == {
             "a": int,
             "b": str,
-            "c": str
         }
 
         assert tbl.view().to_dict() == {
-            "a": [0, 1, 2, 3, 4],
-            "b": ["1", "2", "3", "4", "5"],
-            "c": ["1.0", "2.0", "3.0", "2147483648.0", "?"]
+            "a": [0, 1, 2, 3],
+            "b": ["1", "2", "abc", "abc"],
         }
 
     def test_table_np_implicit_index(self):
@@ -342,7 +334,8 @@ class TestTableNumpy(object):
         }
 
     def test_table_recarray(self):
-        table = Table(np.array([(1.0, 2), (3.0, 4)], dtype=[('x', '<f8'), ('y', '<i8')]).view(np.recarray))
+        d = np.array([(1.0, 2), (3.0, 4)], dtype=[('x', '<f8'), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
         assert table.schema() == {
             "x": float,
             "y": int

--- a/python/perspective/perspective/tests/table/test_table_numpy.py
+++ b/python/perspective/perspective/tests/table/test_table_numpy.py
@@ -6,6 +6,7 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
+import six
 import numpy as np
 from pytest import raises
 from perspective import PerspectiveError
@@ -22,41 +23,85 @@ class TestTableNumpy(object):
         data = {"a": np.array([1, 2, 3]), "b": np.array([4, 5, 6])}
         tbl = Table(data)
         assert tbl.size() == 3
+        assert tbl.view().to_dict() == {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6]
+        }
+
+    def test_table_int_with_None(self):
+        data = {"a": np.array([1, 2, 3, None, None]), "b": np.array([4, 5, 6, None, None])}
+        tbl = Table(data)
+        assert tbl.size() == 5
+        assert tbl.view().to_dict() == {
+            "a": [1, 2, 3, None, None],
+            "b": [4, 5, 6, None, None]
+        }
 
     def test_table_int8(self):
         data = {"a": np.array([1, 2, 3]).astype(np.int8), "b": np.array([4, 5, 6]).astype(np.int8)}
         tbl = Table(data)
         assert tbl.size() == 3
+        assert tbl.view().to_dict() == {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6]
+        }
 
     def test_table_int16(self):
         data = {"a": np.array([1, 2, 3]).astype(np.int16), "b": np.array([4, 5, 6]).astype(np.int16)}
         tbl = Table(data)
         assert tbl.size() == 3
+        assert tbl.view().to_dict() == {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6]
+        }
 
     def test_table_int32(self):
         data = {"a": np.array([1, 2, 3]).astype(np.int32), "b": np.array([4, 5, 6]).astype(np.int32)}
         tbl = Table(data)
         assert tbl.size() == 3
+        assert tbl.view().to_dict() == {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6]
+        }
 
     def test_table_int64(self):
         data = {"a": np.array([1, 2, 3]).astype(np.int64), "b": np.array([4, 5, 6]).astype(np.int64)}
         tbl = Table(data)
         assert tbl.size() == 3
+        assert tbl.view().to_dict() == {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6]
+        }
 
     def test_table_float(self):
         data = {"a": np.array([1.1, 2.2]), "b": np.array([3.3, 4.4])}
         tbl = Table(data)
         assert tbl.size() == 2
+        assert tbl.view().to_dict() == {
+            "a": [1.1, 2.2],
+            "b": [3.3, 4.4]
+        }
 
     def test_table_float32(self):
         data = {"a": np.array([1.1, 2.2]).astype(np.float32), "b": np.array([3.3, 4.4]).astype(np.float32)}
         tbl = Table(data)
         assert tbl.size() == 2
+        assert tbl.view().to_dict() == {
+            # py::cast automatically upcasts to 64-bit float
+            "a": [1.100000023841858, 2.200000047683716],
+            "b": [3.299999952316284, 4.400000095367432]
+        }
 
     def test_table_float64(self):
         data = {"a": np.array([1.1, 2.2]).astype(np.float64), "b": np.array([3.3, 4.4]).astype(np.float64)}
         tbl = Table(data)
         assert tbl.size() == 2
+        assert tbl.view().to_dict() == {
+            "a": [1.1, 2.2],
+            "b": [3.3, 4.4]
+        }
+
+    # booleans
 
     def test_table_bool(self):
         data = {"a": np.array([True, False]), "b": np.array([False, True])}
@@ -71,14 +116,77 @@ class TestTableNumpy(object):
         data = {"a": np.array([True, False]).astype(np.bool8), "b": np.array([False, True]).astype(np.bool8)}
         tbl = Table(data)
         assert tbl.size() == 2
+        assert tbl.view().to_dict() == {
+            "a": [True, False],
+            "b": [False, True]
+        }
+
+    def test_table_bool_with_none(self):
+        data = {"a": np.array([True, False, None, False]), "b": np.array([False, True, None, False])}
+        tbl = Table(data)
+        assert tbl.size() == 4
+        assert tbl.view().to_dict() == {
+            "a": [True, False, None, False],
+            "b": [False, True, None, False]
+        }
+
+    def test_table_bool_with_dtype(self):
+        data = {"a": np.array([True, False, False], dtype="?"), "b": np.array([False, True, False], dtype="?")}
+        tbl = Table(data)
+        assert tbl.size() == 3
+        assert tbl.view().to_dict() == {
+            "a": [True, False, False],
+            "b": [False, True, False]
+        }
+
+    # strings
+    def test_table_str_object(self):
+        data = {"a": np.array(["abc", "def"], dtype=object), "b": np.array(["hij", "klm"], dtype=object)}
+        tbl = Table(data)
+        assert tbl.size() == 2
+        assert tbl.view().to_dict() == {
+            "a": ["abc", "def"],
+            "b": ["hij", "klm"]
+        }
+
+    def test_table_str_dtype(self):
+        dtype = "U3"
+        if six.PY2:
+            dtype = "|S3"
+        data = {"a": np.array(["abc", "def"], dtype=dtype), "b": np.array(["hij", "klm"], dtype=dtype)}
+        tbl = Table(data)
+        assert tbl.size() == 2
+        assert tbl.view().to_dict() == {
+            "a": ["abc", "def"],
+            "b": ["hij", "klm"]
+        }
+
+    def test_table_unicode_py2(self):
+        if six.PY2:
+            data = {
+                "a": np.array([unicode("abc"), unicode("def")]),  # noqa: F821
+                "b": np.array([unicode("hij"), unicode("klm")])  # noqa: F821
+            }
+            tbl = Table(data)
+            assert tbl.size() == 2
+            assert tbl.view().to_dict() == {
+                "a": ["abc", "def"],
+                "b": ["hij", "klm"]
+            }
+
+    # date and datetime
 
     def test_table_date(self):
-        data = {"a": np.array([date.today()]), "b": np.array([date.today()])}
+        data = {"a": np.array([date(2019, 7, 11)]), "b": np.array([date(2019, 7, 12)])}
         tbl = Table(data)
         assert tbl.size() == 1
         assert tbl.schema() == {
             "a": date,
             "b": date
+        }
+        assert tbl.view().to_dict() == {
+            "a": [datetime(2019, 7, 11, 0, 0)],
+            "b": [datetime(2019, 7, 12, 0, 0)]
         }
 
     def test_table_np_datetime(self):
@@ -117,7 +225,7 @@ class TestTableNumpy(object):
         })
 
         assert tbl.view().to_dict() == {
-            "a": data
+            "a": [datetime(2019, 7, 11, 15, 30, 5), datetime(2019, 7, 11, 15, 30, 5)]
         }
 
     def test_table_np_datetime_string_on_schema(self):
@@ -166,6 +274,76 @@ class TestTableNumpy(object):
 
         assert tbl.view().to_dict() == {
             "a": [datetime(2019, 7, 12, 11, 0)]
+        }
+
+    def test_table_np_datetime_m(self):
+        tbl = Table({
+            "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[m]")
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [datetime(2019, 7, 12, 11, 0)]
+        }
+
+    def test_table_np_datetime_h(self):
+        tbl = Table({
+            "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[h]")
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [datetime(2019, 7, 12, 11, 0)]
+        }
+
+    def test_table_np_datetime_D(self):
+        tbl = Table({
+            "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[D]")
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [datetime(2019, 7, 12, 0, 0)]
+        }
+
+    def test_table_np_datetime_W(self):
+        tbl = Table({
+            "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[W]")
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [datetime(2019, 7, 11, 0, 0)]
+        }
+
+    def test_table_np_datetime_M(self):
+        tbl = Table({
+            "a": np.array([
+                datetime(2019, 5, 12, 11, 0),
+                datetime(2019, 6, 12, 11, 0),
+                datetime(2019, 7, 12, 11, 0)],
+                dtype="datetime64[M]")
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [
+                datetime(2019, 5, 1, 0, 0),
+                datetime(2019, 6, 1, 0, 0),
+                datetime(2019, 7, 1, 0, 0)
+            ]
+        }
+
+    def test_table_np_datetime_Y(self):
+        tbl = Table({
+            "a": np.array([
+                datetime(2017, 5, 12, 11, 0),
+                datetime(2018, 6, 12, 11, 0),
+                datetime(2019, 7, 12, 11, 0)],
+                dtype="datetime64[Y]")
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [
+                datetime(2017, 1, 1, 0, 0),
+                datetime(2018, 1, 1, 0, 0),
+                datetime(2019, 1, 1, 0, 0)
+            ]
         }
 
     def test_table_np_datetime_ms_nat(self):
@@ -364,6 +542,22 @@ class TestTableNumpy(object):
             "b": [1, 2, 3, 4, 5]
         }
 
+    # structured array
+
+    def test_table_structured_array(self):
+        d = np.array([(1.0, 2), (3.0, 4)], dtype=[('x', '<f8'), ('y', '<i8')])
+        table = Table(d)
+        assert table.schema() == {
+            "x": float,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [1.0, 3.0],
+            "y": [2, 4]
+        }
+
+    # recarray
+
     def test_table_recarray(self):
         d = np.array([(1.0, 2), (3.0, 4)], dtype=[('x', '<f8'), ('y', '<i8')]).view(np.recarray)
         table = Table(d)
@@ -376,8 +570,143 @@ class TestTableNumpy(object):
             "y": [2, 4]
         }
 
+    def test_table_recarray_datetime_ns(self):
+        d = np.array([(datetime(2019, 7, 11, 8, 30, 29), 2), (datetime(2019, 7, 11, 8, 30, 29), 4)], dtype=[('x', "datetime64[ns]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [datetime(2019, 7, 11, 8, 30, 29), datetime(2019, 7, 11, 8, 30, 29)],
+            "y": [2, 4]
+        }
+
+    def test_table_recarray_datetime_us(self):
+        d = np.array([(datetime(2019, 7, 11, 8, 30, 29), 2), (datetime(2019, 7, 11, 8, 30, 29), 4)], dtype=[('x', "datetime64[us]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [datetime(2019, 7, 11, 8, 30, 29), datetime(2019, 7, 11, 8, 30, 29)],
+            "y": [2, 4]
+        }
+
+    def test_table_recarray_datetime_ms(self):
+        d = np.array([(datetime(2019, 7, 11, 8, 30, 29), 2), (datetime(2019, 7, 11, 8, 30, 29), 4)], dtype=[('x', "datetime64[ms]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [datetime(2019, 7, 11, 8, 30, 29), datetime(2019, 7, 11, 8, 30, 29)],
+            "y": [2, 4]
+        }
+
+    def test_table_recarray_datetime_s(self):
+        d = np.array([(datetime(2019, 7, 11, 8, 30, 29), 2), (datetime(2019, 7, 11, 8, 30, 29), 4)], dtype=[('x', "datetime64[s]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [datetime(2019, 7, 11, 8, 30, 29), datetime(2019, 7, 11, 8, 30, 29)],
+            "y": [2, 4]
+        }
+
+    def test_table_recarray_datetime_m(self):
+        d = np.array([(datetime(2019, 7, 11, 8, 30, 29), 2), (datetime(2019, 7, 11, 8, 31, 29), 4)], dtype=[('x', "datetime64[m]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [datetime(2019, 7, 11, 8, 30, 0), datetime(2019, 7, 11, 8, 31, 0)],
+            "y": [2, 4]
+        }
+
+    def test_table_recarray_datetime_h(self):
+        d = np.array([(datetime(2019, 7, 11, 8, 30, 29), 2), (datetime(2019, 7, 11, 9, 30, 29), 4)], dtype=[('x', "datetime64[h]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [datetime(2019, 7, 11, 8, 0, 0), datetime(2019, 7, 11, 9, 0, 0)],
+            "y": [2, 4]
+        }
+
+    def test_table_recarray_datetime_D(self):
+        d = np.array([(datetime(2019, 7, 11, 8, 30, 29), 2), (datetime(2019, 7, 12, 8, 30, 29), 4)], dtype=[('x', "datetime64[D]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [datetime(2019, 7, 11, 0, 0, 0), datetime(2019, 7, 12, 0, 0, 0)],
+            "y": [2, 4]
+        }
+
+    def test_table_recarray_datetime_W(self):
+        d = np.array([(datetime(2019, 6, 30, 0, 0, 0), 2), (datetime(2019, 7, 7, 0, 0, 0), 4)], dtype=[('x', "datetime64[W]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            # one week apart
+            "x": [datetime(2019, 6, 27, 0, 0, 0), datetime(2019, 7, 4, 0, 0, 0)],
+            "y": [2, 4]
+        }
+
+    def test_table_recarray_datetime_M(self):
+        d = np.array([(datetime(2019, 6, 11, 8, 30, 29), 2), (datetime(2019, 7, 11, 8, 30, 29), 4)], dtype=[('x', "datetime64[M]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [datetime(2019, 6, 1, 0, 0, 0), datetime(2019, 7, 1, 0, 0, 0)],
+            "y": [2, 4]
+        }
+
+    def test_table_recarray_datetime_Y(self):
+        d = np.array([(datetime(2018, 7, 11, 8, 30, 29), 2), (datetime(2019, 7, 11, 8, 30, 29), 4)], dtype=[('x', "datetime64[Y]"), ('y', '<i8')]).view(np.recarray)
+        table = Table(d)
+        assert table.schema() == {
+            "x": datetime,
+            "y": int
+        }
+        assert table.view().to_dict() == {
+            "x": [datetime(2018, 1, 1, 0, 0, 0), datetime(2019, 1, 1, 0, 0, 0)],
+            "y": [2, 4]
+        }
+
     def test_table_recarray_str(self):
         table = Table(np.array([("string1", "string2"), ("string3", "string4")], dtype=[('x', 'O'), ('y', 'O')]).view(np.recarray))
+        assert table.schema() == {
+            "x": str,
+            "y": str
+        }
+        assert table.view().to_dict() == {
+            "x": ["string1", "string3"],
+            "y": ["string2", "string4"]
+        }
+
+    def test_table_recarray_str_dtype(self):
+        dtype = "U7"
+        if six.PY2:
+            dtype = "|S7"
+        table = Table(np.array([("string1", "string2"), ("string3", "string4")], dtype=[('x', dtype), ('y', dtype)]).view(np.recarray))
         assert table.schema() == {
             "x": str,
             "y": str

--- a/python/perspective/perspective/tests/table/test_table_numpy.py
+++ b/python/perspective/perspective/tests/table/test_table_numpy.py
@@ -111,9 +111,22 @@ class TestTableNumpy(object):
         }
 
     def test_table_np_datetime_string_dtype(self):
+        data = ["2019/07/11 15:30:05", "2019/07/11 15:30:05"]
         tbl = Table({
-            "a": np.array(["2019/07/11 15:30:05", "2019/07/11 15:30:05"])
+            "a": np.array(data)
         })
+
+        assert tbl.view().to_dict() == {
+            "a": data
+        }
+
+    def test_table_np_datetime_string_on_schema(self):
+        data = ["2019/07/11 15:30:05", "2019/07/11 15:30:05"]
+        tbl = Table({
+            "a": datetime
+        })
+
+        tbl.update({"a": data})
 
         assert tbl.view().to_dict() == {
             "a": [datetime(2019, 7, 11, 15, 30, 5), datetime(2019, 7, 11, 15, 30, 5)]
@@ -153,6 +166,24 @@ class TestTableNumpy(object):
 
         assert tbl.view().to_dict() == {
             "a": [datetime(2019, 7, 12, 11, 0)]
+        }
+
+    def test_table_np_datetime_ms_nat(self):
+        tbl = Table({
+            "a": np.array([datetime(2019, 7, 12, 11, 0), np.datetime64("nat")], dtype="datetime64[ms]")
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [datetime(2019, 7, 12, 11, 0), None]
+        }
+
+    def test_table_np_datetime_s_nat(self):
+        tbl = Table({
+            "a": np.array([datetime(2019, 7, 12, 11, 0), np.datetime64("nat")], dtype="datetime64[s]")
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [datetime(2019, 7, 12, 11, 0), None]
         }
 
     def test_table_np_timedelta(self):

--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -102,6 +102,40 @@ class TestTablePandas(object):
         table.update(df)
         assert table.view().to_dict()["a"] == data
 
+    def test_table_pandas_from_schema_float_all_nan(self):
+        data = [np.nan, np.nan, np.nan, np.nan]
+        df = pd.DataFrame({
+            "a": data
+        })
+        table = Table({
+            "a": float
+        })
+        table.update(df)
+        assert table.view().to_dict()["a"] == [None, None, None, None]
+
+    def test_table_pandas_from_schema_float_to_int(self):
+        data = [None, 1.5, None, 2.5, None, 3.5, 4.5]
+        df = pd.DataFrame({
+            "a": data
+        })
+        table = Table({
+            "a": int
+        })
+        table.update(df)
+        # truncates decimal
+        assert table.view().to_dict()["a"] == [None, 1, None, 2, None, 3, 4]
+
+    def test_table_pandas_from_schema_int_to_float(self):
+        data = [None, 1, None, 2, None, 3, 4]
+        df = pd.DataFrame({
+            "a": data
+        })
+        table = Table({
+            "a": float
+        })
+        table.update(df)
+        assert table.view().to_dict()["a"] == [None, 1.0, None, 2.0, None, 3.0, 4.0]
+
     def test_table_pandas_from_schema_date(self):
         data = [date(2019, 8, 15), None, date(2019, 8, 16)]
         df = pd.DataFrame({

--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -260,3 +260,35 @@ class TestTablePandas(object):
         df_both = pd.DataFrame(np.random.randn(3, 16), index=['A', 'B', 'C'], columns=index)
         table = Table(df_both)
         assert table.size() == 48
+
+    # Make sure numpy arrays within dataframes work in any configuration
+
+    def test_table_pandas_symmetric(self):
+        data = [None, 1, None, 2, None, 3, 4]
+        df = pd.DataFrame({
+            "a": data
+        })
+        table = Table(df)
+        assert table.view().to_dict()["a"] == data
+
+    def test_tables_pandas_from_schema_int(self):
+        data = [None, 1, None, 2, None, 3, 4]
+        df = pd.DataFrame({
+            "a": data
+        })
+        table = Table({
+            "a": int
+        })
+        table.update(df)
+        assert table.view().to_dict()["a"] == data
+
+    def test_tables_pandas_from_schema_bool(self):
+        data = [True, False, True, False]
+        df = pd.DataFrame({
+            "a": data
+        })
+        table = Table({
+            "a": bool
+        })
+        table.update(df)
+        assert table.view().to_dict()["a"] == data

--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -423,6 +423,14 @@ class TestTablePandas(object):
         table = Table(df)
         assert table.view().to_dict()["a"] == [datetime(2019, 7, 11, 12, 30, 5), None, datetime(2019, 7, 11, 13, 30, 5), None]
 
+    def test_table_pandas_timestamp_explicit_dtype(self):
+        data = [pd.Timestamp(2019, 7, 11, 12, 30, 5), None, pd.Timestamp(2019, 7, 11, 13, 30, 5), None]
+        df = pd.DataFrame({
+            "a": np.array(data, dtype="datetime64[ns]")
+        })
+        table = Table(df)
+        assert table.view().to_dict()["a"] == [datetime(2019, 7, 11, 12, 30, 5), None, datetime(2019, 7, 11, 13, 30, 5), None]
+
     def test_table_pandas_update_datetime_with_timestamp(self):
         data = [datetime(2019, 7, 11, 12, 30, 5), None, datetime(2019, 7, 11, 13, 30, 5), None]
         df = pd.DataFrame({
@@ -435,6 +443,18 @@ class TestTablePandas(object):
         table.update(df2)
         assert table.view().to_dict()["a"] == [datetime(2019, 7, 11, 12, 30, 5), None, datetime(2019, 7, 11, 13, 30, 5), None,
                                                datetime(2019, 7, 11, 12, 30, 5), None, datetime(2019, 7, 11, 13, 30, 5), None]
+
+    def test_tables_pandas_timedf(self):
+        data = pd.util.testing.makeTimeDataFrame(5)
+        table = Table(data)
+        assert table.size() == 5
+        assert table.view().to_dict()["index"] == [
+            datetime(2000, 1, 3, 0, 0),
+            datetime(2000, 1, 4, 0, 0),
+            datetime(2000, 1, 5, 0, 0),
+            datetime(2000, 1, 6, 0, 0),
+            datetime(2000, 1, 7, 0, 0)
+        ]
     # Timeseries/Period index
 
     def test_table_pandas_timeseries(self):

--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -555,7 +555,6 @@ class TestTablePandas(object):
 
     def test_table_read_nan_bool_col(self):
         data = pd.DataFrame({"bool": [np.nan, True, np.nan], "bool2": [False, np.nan, True]})
-        print(data.dtypes)
         tbl = Table(data)
         # if np.nan begins a column, it is inferred as float and then can be promoted. if np.nan is in the values (but not at start), the column type is whatever is inferred.
         assert tbl.schema() == {

--- a/python/perspective/perspective/tests/table/test_update.py
+++ b/python/perspective/perspective/tests/table/test_update.py
@@ -194,6 +194,45 @@ class TestUpdate(object):
             "a": [1, 2, 3, 4, 5, 6, 7, 8]
         }
 
+    def test_update_df_i32_vs_i64(self):
+        tbl = Table({"a": int})
+
+        update_data = pd.DataFrame({
+            "a": np.array([5, 6, 7, 8], dtype="int64")
+        })
+
+        tbl.update(update_data)
+
+        assert tbl.view().to_dict() == {
+            "a": [5, 6, 7, 8]
+        }
+
+    def test_update_df_bool(self):
+        tbl = Table({"a": [True, False, True, False]})
+
+        update_data = pd.DataFrame({
+            "a": [True, False, True, False]
+        })
+
+        tbl.update(update_data)
+
+        assert tbl.view().to_dict() == {
+            "a": [True, False, True, False, True, False, True, False]
+        }
+
+    def test_update_df_str(self):
+        tbl = Table({"a": ["a", "b", "c", "d"]})
+
+        update_data = pd.DataFrame({
+            "a": ["a", "b", "c", "d"]
+        })
+
+        tbl.update(update_data)
+
+        assert tbl.view().to_dict() == {
+            "a": ["a", "b", "c", "d", "a", "b", "c", "d"]
+        }
+
     def test_update_df_datetime(self):
         tbl = Table({"a": [np.datetime64(datetime(2019, 7, 11, 11, 0))]})
 

--- a/python/perspective/perspective/tests/table/test_update.py
+++ b/python/perspective/perspective/tests/table/test_update.py
@@ -58,6 +58,17 @@ class TestUpdate(object):
             "a": [1, 2, 3, 4, 5, 6, 7, 8]
         }
 
+    def test_update_np_one_col(self):
+        tbl = Table({
+            "a": np.array([1, 2, 3, 4]),
+            "b": np.array([2, 3, 4, 5])
+        })
+        tbl.update({"a": np.array([5, 6, 7, 8])})
+        assert tbl.view().to_dict() == {
+            "a": [1, 2, 3, 4, 5, 6, 7, 8],
+            "b": [2, 3, 4, 5, None, None, None, None]
+        }
+
     def test_update_np_datetime(self):
         tbl = Table({
             "a": [np.datetime64(datetime(2019, 7, 11, 11, 0))]
@@ -65,6 +76,19 @@ class TestUpdate(object):
 
         tbl.update({
             "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype=datetime)
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [datetime(2019, 7, 11, 11, 0), datetime(2019, 7, 12, 11, 0)]
+        }
+
+    def test_update_np_datetime_str(self):
+        tbl = Table({
+            "a": [np.datetime64(datetime(2019, 7, 11, 11, 0))]
+        })
+
+        tbl.update({
+            "a": np.array(["2019/7/12 11:00:00"])
         })
 
         assert tbl.view().to_dict() == {
@@ -293,6 +317,23 @@ class TestUpdate(object):
         assert tbl.view().to_dict() == {
             "a": [datetime(2019, 7, 12, 11, 0)],
             "b": [1]
+        }
+
+    def test_update_df_one_col(self):
+        tbl = Table({
+            "a": [1, 2, 3, 4],
+            "b": ["a", "b", "c", "d"]
+        })
+
+        update_data = pd.DataFrame({
+            "a": [5, 6, 7]
+        })
+
+        tbl.update(update_data)
+
+        assert tbl.view().to_dict() == {
+            "a": [1, 2, 3, 4, 5, 6, 7],
+            "b": ["a", "b", "c", "d", None, None, None]
         }
 
     def test_update_df_nonseq_partial(self):


### PR DESCRIPTION
This PR adds a separate load path for Pandas dataframe and numpy arrays (dictionaries of numpy arrays, numpy structured arrays, and numpy record arrays. 

- It will try to copy all arrays of integral/float/bool type, and fill other types through iteration.
- Arrays of `dtype=object` will always be iteratively filled using the `marshal` method, which coerces data into the correct format. 
- Support for mixed dictionaries of numpy arrays and lists has been deprecated: datasets should be fully composed of `numpy.ndarray` or `list`, but not both.
- Adds support for numpy structured arrays.
- Adds and fully tests support for all numpy datetime types from nanosecond (`datetime64[ns]`) to year (`datetime64[Y]`).
- Adds support for loading timestamps (in seconds or milliseconds since epoch) into columns already typed as `datetime`. To load timestamps as datetimes, either construct the table with a schema of {"name": datetime}, or with a valid datetime/Timestamp/datetime64 object.
- Adds and tests support for timedelta64 arrays, which are cast into string to preserve their units.
- Adds and tests support for `pandas.DateTimeIndex` and `pandas.PeriodIndex`.