### PR TITLE
Add `update` for widget in client mode, fix `on_update` in Python 2

### DIFF
--- a/packages/perspective-jupyterlab/src/ts/client.ts
+++ b/packages/perspective-jupyterlab/src/ts/client.ts
@@ -16,7 +16,7 @@ import {Client} from "@finos/perspective/dist/esm/api/client";
 export interface PerspectiveJupyterMessage {
     id: number;
     type: string;
-    data: string;
+    data: any;
 }
 
 /**

--- a/packages/perspective-jupyterlab/src/ts/view.ts
+++ b/packages/perspective-jupyterlab/src/ts/view.ts
@@ -123,12 +123,12 @@ export class PerspectiveView extends DOMWidgetView {
      * @param msg {PerspectiveJupyterMessage}
      */
     _handle_message(msg: PerspectiveJupyterMessage) {
-        // If in client-only mode (no Table on the python widget), message data is a JSON-serialized dataset
-        if (this.pWidget.client === true && msg.data) {
-            if (msg.data["cmd"] === "update" && msg.data["data"]) {
+        // If in client-only mode (no Table on the python widget), message.data is an object containing "data" and "options". 
+        if (this.pWidget.client === true && msg.data["data"]) {
+            if (msg.data["cmd"] === "update") {
                 this.pWidget._update(msg.data["data"]);
             } else {
-                this.pWidget.load(msg.data);
+                this.pWidget.load(msg.data["data"], msg.data["options"]);
             }
         } else {
             // Make a deep copy of each message - widget views share the same comm, so mutations on `msg` affect subsequent message handlers.

--- a/packages/perspective-jupyterlab/src/ts/view.ts
+++ b/packages/perspective-jupyterlab/src/ts/view.ts
@@ -125,7 +125,11 @@ export class PerspectiveView extends DOMWidgetView {
     _handle_message(msg: PerspectiveJupyterMessage) {
         // If in client-only mode (no Table on the python widget), message data is a JSON-serialized dataset
         if (this.pWidget.client === true && msg.data) {
-            this.pWidget.load(msg.data);
+            if (msg.data["cmd"] === "update" && msg.data["data"]) {
+                this.pWidget._update(msg.data["data"]);
+            } else {
+                this.pWidget.load(msg.data);
+            }
         } else {
             // Make a deep copy of each message - widget views share the same comm, so mutations on `msg` affect subsequent message handlers.
             const message = JSON.parse(JSON.stringify(msg));

--- a/packages/perspective-phosphor/src/ts/widget.ts
+++ b/packages/perspective-phosphor/src/ts/widget.ts
@@ -10,7 +10,7 @@
 
 import "@finos/perspective-viewer";
 
-import {Table, TableData} from "@finos/perspective";
+import {Table, TableData, TableOptions} from "@finos/perspective";
 import {Message} from "@phosphor/messaging";
 import {Widget} from "@phosphor/widgets";
 import {MIME_TYPE, PSP_CLASS, PSP_CONTAINER_CLASS, PSP_CONTAINER_CLASS_DARK} from "./utils";
@@ -140,8 +140,8 @@ export class PerspectiveWidget extends Widget {
      *
      * @param table a `perspective.table` object.
      */
-    load(table: TableData | Table): void {
-        this.viewer.load(table);
+    load(table: (TableData | Table), options?: TableOptions): void {
+        this.viewer.load(table, options);
     }
 
     /**

--- a/packages/perspective-phosphor/src/ts/widget.ts
+++ b/packages/perspective-phosphor/src/ts/widget.ts
@@ -144,6 +144,15 @@ export class PerspectiveWidget extends Widget {
         this.viewer.load(table);
     }
 
+    /**
+     * Update the viewer with new data.
+     * 
+     * @param data 
+     */
+    _update(data: TableData): void {
+        this.viewer.update(data);
+    }
+
     get table(): Table {
         return this.viewer.table;
     }

--- a/packages/perspective-viewer/index.d.ts
+++ b/packages/perspective-viewer/index.d.ts
@@ -2,7 +2,7 @@ import {Table, TableData, TableOptions, Schema, View, ViewConfig} from '@finos/p
 
 declare module '@finos/perspective-viewer' {
     export interface PerspectiveViewer extends PerspectiveViewerOptions, HTMLElement {
-        load(data: TableData | Table): void;
+        load(data: TableData | Table, options: TableOptions): void;
         load(schema: Schema, options: TableOptions): void;
         update(data: TableData): void;
         notifyResize(): void;

--- a/python/perspective/perspective/core/manager.py
+++ b/python/perspective/perspective/core/manager.py
@@ -174,7 +174,7 @@ class PerspectiveManager(object):
             method = msg.get("method", None)
             if method and method[:2] == "on":
                 # wrap the callback
-                callback = partial(PerspectiveManager.callback, msg=msg, post_callback=post_callback, self=self)
+                callback = partial(self.callback, msg=msg, post_callback=post_callback)
                 if callback_id:
                     self._callback_cache[callback_id] = callback
             elif callback_id is not None:

--- a/python/perspective/perspective/tests/core/test_widget.py
+++ b/python/perspective/perspective/tests/core/test_widget.py
@@ -62,3 +62,10 @@ class TestWidget:
         widget = PerspectiveWidget(data, client=True)
         assert widget.table is None
         assert widget._data == data
+
+    def test_widget_client_update(self):
+        data = {"a": np.arange(0, 50)}
+        widget = PerspectiveWidget(data, client=True)
+        widget.update(data)
+        assert widget.table is None
+        assert widget._data == data

--- a/python/perspective/perspective/tests/core/test_widget.py
+++ b/python/perspective/perspective/tests/core/test_widget.py
@@ -55,6 +55,11 @@ class TestWidget:
         widget = PerspectiveWidget(data, limit=1)
         assert widget.table.size() == 1
 
+    def test_widget_pass_options_invalid(self):
+        data = {"a": np.arange(0, 50)}
+        with raises(PerspectiveError):
+            PerspectiveWidget(data, index="index", limit=1)
+
     # client-only mode
 
     def test_widget_client(self):

--- a/scripts/build_python.js
+++ b/scripts/build_python.js
@@ -33,6 +33,8 @@ try {
     rimraf.sync(resolve(__dirname, "..", "python", "perspective", "obj")); // unused obj folder
     fs.copySync(resolve(__dirname, "..", "cpp", "perspective"), resolve(__dirname, "..", "python", "perspective"), {overwrite: true});
 
+    // travis sometimes caches this folder between py3 and py2 builds
+    rimraf.sync(resolve(__dirname, "..", "python", "perspective", "cmake"));
     mkdir(resolve(__dirname, "..", "python", "perspective", "cmake"));
     fs.copySync(resolve(__dirname, "..", "cmake"), resolve(__dirname, "..", "python", "perspective", "cmake"), {overwrite: true});
 

--- a/scripts/install_python.js
+++ b/scripts/install_python.js
@@ -7,16 +7,12 @@
  *
  */
 
-const args = process.argv.slice(2);
+const rimraf = require("rimraf");
 const resolve = require("path").resolve;
 const mkdir = require("mkdirp");
 const fs = require("fs-extra");
 const execSync = require("child_process").execSync;
 const execute = cmd => execSync(cmd, {stdio: "inherit"});
-
-const VALID_TARGETS = ["node", "table"];
-const HAS_TARGET = args.indexOf("--target") != -1;
-const VERBOSE = args.indexOf("--verbose") != -1;
 
 function docker(target = "perspective", image = "emsdk") {
     console.log(`-- Creating ${image} docker image`);
@@ -30,12 +26,11 @@ function docker(target = "perspective", image = "emsdk") {
 
 try {
     // copy C++ assets
+    rimraf.sync(resolve(__dirname, "..", "python", "perspective", "cmake"));
     mkdir(resolve(__dirname, "..", "python", "perspective", "cmake"));
-    fs.copySync(resolve(__dirname, "..", "cpp", "perspective"),
-        resolve(__dirname, "..", "python", "perspective"));
+    fs.copySync(resolve(__dirname, "..", "cpp", "perspective"), resolve(__dirname, "..", "python", "perspective"));
 
-    fs.copySync(resolve(__dirname, "..", "cmake"),
-        resolve(__dirname, "..", "python", "perspective", "cmake"));
+    fs.copySync(resolve(__dirname, "..", "cmake"), resolve(__dirname, "..", "python", "perspective", "cmake"));
 
     let cmd;
 


### PR DESCRIPTION
This PR fixes some remaining issues with the Python plugin:

- `on_update` now works in Python 2 after fixing a bug due to different implementations of `functools.partial` between Python 3 and Python 2
- `update` has been implemented for widgets running in client-only mode
- remove all build artifacts for python on each run of `yarn build`