### PR TITLE
Fixed Python Arrow loading bug

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -241,7 +241,7 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 	#####################
 	if(CMAKE_BUILD_TYPE_LOWER STREQUAL debug)
 		set(OPT_FLAGS " \
-			-O1 \
+			-O0 \
 			-g3 \
 			")
 	else()

--- a/cpp/perspective/src/cpp/arrow.cpp
+++ b/cpp/perspective/src/cpp/arrow.cpp
@@ -180,15 +180,16 @@ namespace arrow {
                 auto indices = scol->indices();
                 switch (indices->type()->id()) {
                     case ::arrow::Int8Type::type_id: {
-                        iter_col_copy<::arrow::Int8Array, uint32_t>(dest, indices, offset, len);
+                        iter_col_copy<::arrow::Int8Array, t_uindex>(dest, indices, offset, len);
                     } break;
                     case ::arrow::Int16Type::type_id: {
-                        iter_col_copy<::arrow::Int16Array, uint32_t>(dest, indices, offset, len);
+                        iter_col_copy<::arrow::Int16Array, t_uindex>(dest, indices, offset, len);
                     } break;
                     case ::arrow::Int32Type::type_id: {
-                        auto sindices = std::static_pointer_cast<::arrow::Int32Array>(indices);
-                        std::memcpy(dest->get_nth<std::int32_t>(offset),
-                            (void*)sindices->raw_values(), len * 4);
+                        iter_col_copy<::arrow::Int32Array, t_uindex>(dest, indices, offset, len);
+                    } break;
+                    case ::arrow::Int64Type::type_id: {
+                         iter_col_copy<::arrow::Int64Array, t_uindex>(dest, indices, offset, len);
                     } break;
                     default:
                         std::stringstream ss;

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -13,6 +13,7 @@ from ._data_formatter import to_format
 from ._constants import COLUMN_SEPARATOR_STRING
 from ._utils import _str_to_pythontype
 from ._callback_cache import _PerspectiveCallBackCache
+from ._date_validator import _PerspectiveDateValidator
 
 try:
     from .libbinding import make_view_zero, make_view_one, make_view_two
@@ -37,7 +38,12 @@ class View(object):
         self._config = ViewConfig(**config)
         self._sides = self.sides()
 
-        date_validator = self._table._accessor._date_validator
+        date_validator = None
+        if hasattr(self._table._accessor, "_data_validator"):
+            date_validator = self._table._accessor._date_validator
+        else:
+            date_validator = _PerspectiveDateValidator()
+
         if self._sides == 0:
             self._view = make_view_zero(self._table._table, self._name, COLUMN_SEPARATOR_STRING, self._config, date_validator)
         elif self._sides == 1:

--- a/python/perspective/perspective/tests/table/test_table_arrow.py
+++ b/python/perspective/perspective/tests/table/test_table_arrow.py
@@ -5,7 +5,10 @@ FILE_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."
 
 class TestTableArrow(object):
    
-    def test_table_arrow(self):
+    def test_table_arrow_loads(self):
         with open(FILE_PATH, mode='rb') as file: # b is important -> binary
             tbl = Table(file.read())
             assert tbl.size() == 9994
+            v = tbl.view()
+            df = v.to_df()
+            assert df.shape == (9994, 21)


### PR DESCRIPTION
Fix for correct integer index type, resulting in working dictionary columns when read in Python, as reported by @sc1f 