### PR TITLE
Allow client mode widget to be constructed with schema

### DIFF
--- a/python/perspective/perspective/core/widget.py
+++ b/python/perspective/perspective/core/widget.py
@@ -34,11 +34,11 @@ def _type_to_string(t):
         return "date"
     elif t is datetime:
         return "datetime"
-    elif t in six.string_types:
+    elif t is six.binary_type or t is six.text_type:
         return "string"
     else:
         raise PerspectiveError(
-            "Unsupported type `{0}` in schema - Perspective supports `int`, `float`, `bool`, `date`, `datetime`, and `str`.".format(str(t)))
+            "Unsupported type `{0}` in schema - Perspective supports `int`, `float`, `bool`, `date`, `datetime`, and `str` (or `unicode`).".format(str(t)))
 
 
 def _serialize(data):

--- a/python/perspective/perspective/tests/core/test_widget.py
+++ b/python/perspective/perspective/tests/core/test_widget.py
@@ -5,7 +5,9 @@
 # This file is part of the Perspective library, distributed under the terms of
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
+import six
 import numpy as np
+from datetime import date, datetime
 from pytest import raises
 from perspective import PerspectiveError, PerspectiveWidget, Table
 
@@ -67,6 +69,45 @@ class TestWidget:
         widget = PerspectiveWidget(data, client=True)
         assert widget.table is None
         assert widget._data == data
+
+    def test_widget_client_schema(self):
+        widget = PerspectiveWidget({
+            "a": int,
+            "b": float,
+            "c": bool,
+            "d": date,
+            "e": datetime,
+            "f": str
+        }, client=True)
+        assert widget.table is None
+        assert widget._data == {
+            "a": "integer",
+            "b": "float",
+            "c": "boolean",
+            "d": "date",
+            "e": "datetime",
+            "f": "string"
+        }
+
+    def test_widget_client_schema_py2_types(self):
+        if six.PY2:
+            widget = PerspectiveWidget({
+                "a": long,  # noqa: F821
+                "b": float,
+                "c": bool,
+                "d": date,
+                "e": datetime,
+                "f": unicode  # noqa: F821
+            }, client=True)
+            assert widget.table is None
+            assert widget._data == {
+                "a": "integer",
+                "b": "float",
+                "c": "boolean",
+                "d": "date",
+                "e": "datetime",
+                "f": "string"
+            }
 
     def test_widget_client_update(self):
         data = {"a": np.arange(0, 50)}


### PR DESCRIPTION
This PR allows widgets to be constructed with schemas when using the client-only flag. Previously, type objects were not serialized properly, and schema construction failed.