### PR TITLE
Fix misordered columns in update

### DIFF
--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -151,7 +151,7 @@ class Table(object):
         Args:
             data (dict|list|dataframe) : the data with which to update the Table
         '''
-        columns = self.columns()
+        columns = [name for name in self._table.get_schema().columns() if name != "psp_okey"]
         types = self._table.get_schema().types()
         self._accessor = _PerspectiveAccessor(data)
         self._accessor._names = columns + [name for name in self._accessor._names if name == "__INDEX__"]


### PR DESCRIPTION
Updates previously used the `names` property of the table, which may be of a different order than the schema of the `t_gnode`. Remove the use of `names` and replace with `get_columns()` from the gnode schema.