### PR TITLE
Widget fixes for resizing, TS typings, boolean columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ simple to build real-time & user configurable analytics entirely in the browser.
 
 - Integration with [Jupyterlab](https://github.com/finos/perspective/tree/master/packages/perspective-jupyterlab).
 
-- Runtimes for the Browser and Node.js.
+- Runtimes for the Browser, Python, and Node.js.
 
 ## Examples
 |||
@@ -48,7 +48,9 @@ simple to build real-time & user configurable analytics entirely in the browser.
 
 * [Project Site](https://perspective.finos.org/)
 * [Installation](https://perspective.finos.org/docs/md/installation.html)
-* [User's Guide](https://perspective.finos.org/docs/md/usage.html)
+* [Javascript User's Guide](https://perspective.finos.org/docs/md/js.html)
+* [Python User's Guide](https://perspective.finos.org/docs/md/python.html)
 * [Developer's Guide](https://perspective.finos.org/docs/md/development.html)
 * [Perspective API](https://github.com/finos/perspective/blob/master/packages/perspective/README.md)
 * [Perspective Viewer API](https://github.com/finos/perspective/blob/master/packages/perspective-viewer/README.md)
+* [Perspective Python API](https://perspective.finos.org/docs/obj/perspective-python.html)

--- a/cpp/perspective/src/cpp/scalar.cpp
+++ b/cpp/perspective/src/cpp/scalar.cpp
@@ -661,7 +661,7 @@ t_tscalar::to_string(bool for_expr) const {
             return ss.str();
         } break;
         case DTYPE_BOOL: {
-            ss << get<bool>();
+            ss << std::boolalpha << get<bool>();
             return ss.str();
         } break;
         case DTYPE_INT8: {

--- a/packages/perspective-phosphor/src/ts/widget.ts
+++ b/packages/perspective-phosphor/src/ts/widget.ts
@@ -374,7 +374,8 @@ export class PerspectiveWidget extends Widget {
         if (!viewer.notifyResize) {
             console.warn("Warning: not bound to real element");
         } else {
-            viewer.notifyResize = viewer.notifyResize.bind(viewer);
+            const resize_observer = new MutationObserver(viewer.notifyResize.bind(viewer));
+            resize_observer.observe(node, { attributes: true });
         }
         return viewer;
     }

--- a/packages/perspective-viewer/index.d.ts
+++ b/packages/perspective-viewer/index.d.ts
@@ -2,8 +2,8 @@ import {Table, TableData, TableOptions, Schema, View, ViewConfig} from '@finos/p
 
 declare module '@finos/perspective-viewer' {
     export interface PerspectiveViewer extends PerspectiveViewerOptions, HTMLElement {
-        load(data: TableData | Table, options: TableOptions): void;
-        load(schema: Schema, options: TableOptions): void;
+        load(data: TableData | Table, options?: TableOptions): void;
+        load(schema: Schema, options?: TableOptions): void;
         update(data: TableData): void;
         notifyResize(): void;
         delete(delete_table: boolean): Promise<void>;

--- a/python/perspective/perspective/manager/manager.py
+++ b/python/perspective/perspective/manager/manager.py
@@ -212,7 +212,7 @@ class PerspectiveManager(object):
         for name in names:
             self._views.pop(name)
 
-        print("GC {} views in memory".format(count))
+        logging.warn("GC {} views in memory".format(count))
 
     def _make_message(self, id, result):
         '''Return a serializable message for a successful result.'''

--- a/python/perspective/perspective/manager/manager.py
+++ b/python/perspective/perspective/manager/manager.py
@@ -212,7 +212,7 @@ class PerspectiveManager(object):
         for name in names:
             self._views.pop(name)
 
-        logging.warn("GC {} views in memory".format(count))
+        logging.warning("GC {} views in memory".format(count))
 
     def _make_message(self, id, result):
         '''Return a serializable message for a successful result.'''

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -8,6 +8,7 @@
 import six
 import pandas
 import numpy
+from distutils.util import strtobool
 from math import isnan
 from ._date_validator import _PerspectiveDateValidator
 from ..core.data import deconstruct_numpy, deconstruct_pandas
@@ -78,6 +79,7 @@ def _type_to_format(data_or_schema):
         else:
             # flatten column/index multiindex
             df, _ = deconstruct_pandas(data_or_schema)
+            print(df, _)
             return True, 1, {c: df[c].values for c in df.columns}
 
 
@@ -187,6 +189,9 @@ class _PerspectiveAccessor(object):
         elif isinstance(val, list) and len(val) == 1:
             # strip out values encased lists
             val = val[0]
+        elif dtype == t_dtype.DTYPE_BOOL:
+            # True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0.
+            val = bool(strtobool(str(val)))
         elif dtype == t_dtype.DTYPE_INT32 or dtype == t_dtype.DTYPE_INT64:
             if not isinstance(val, bool) and isinstance(val, (float, numpy.floating)):
                 # should be able to update int columns with either ints or floats

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -79,7 +79,6 @@ def _type_to_format(data_or_schema):
         else:
             # flatten column/index multiindex
             df, _ = deconstruct_pandas(data_or_schema)
-            print(df, _)
             return True, 1, {c: df[c].values for c in df.columns}
 
 

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -116,7 +116,8 @@ class Table(object):
         Returns:
             :obj:`list`: a list of string column names
         '''
-        return list(self.schema().keys())
+        return [name for name in self._table.get_schema().columns()
+                if name != "psp_okey"]
 
     def computed_schema(self):
         '''Returns a schema of computed columns added by the user.
@@ -179,7 +180,7 @@ class Table(object):
             >>> tbl.view().to_dict()
             {"a": [1, 2, 3], "b": ["a", "a", "a"]}
         '''
-        columns = [name for name in self._table.get_schema().columns() if name != "psp_okey"]
+        columns = self.columns()
         types = self._table.get_schema().types()
         self._accessor = _PerspectiveAccessor(data)
         self._accessor._names = columns + [name for name in self._accessor._names if name == "__INDEX__"]

--- a/python/perspective/perspective/tests/table/test_table.py
+++ b/python/perspective/perspective/tests/table/test_table.py
@@ -134,6 +134,19 @@ class TestTable(object):
             "b": bool
         }
 
+    def test_table_bool_str(self):
+        bool_data = [{"a": "True", "b": "False"}, {"a": "True", "b": "True"}]
+        tbl = Table(bool_data)
+        assert tbl.size() == 2
+        assert tbl.schema() == {
+            "a": bool,
+            "b": bool
+        }
+        assert tbl.view().to_dict() == {
+            "a": [True, True],
+            "b": [False, True]
+        }
+
     def test_table_float(self):
         float_data = [{"a": 1.5, "b": 2.5}, {"a": 3.2, "b": 3.1}]
         tbl = Table(float_data)

--- a/python/perspective/perspective/tests/table/test_table_infer.py
+++ b/python/perspective/perspective/tests/table/test_table_infer.py
@@ -40,6 +40,25 @@ class TestTableInfer(object):
             "b": bool
         }
 
+    def test_table_bool_infer_str_all_formats_from_schema(self):
+        bool_data = [
+            {"a": "True", "b": "False"},
+            {"a": "t", "b": "f"},
+            {"a": "true", "b": "false"},
+            {"a": 1, "b": 0},
+            {"a": "on", "b": "off"}
+        ]
+        tbl = Table(bool_data)
+        assert tbl.schema() == {
+            "a": bool,
+            "b": bool
+        }
+        assert tbl.size() == 5
+        assert tbl.view().to_dict() == {
+            "a": [True, True, True, True, True],
+            "b": [False, False, False, False, False]
+        }
+
     def test_table_promote_float(self):
         if six.PY2:
             data = {"a": [1.5, 2.5, 3.5, 4.5, "abc"]}

--- a/python/perspective/perspective/tests/table/test_table_infer.py
+++ b/python/perspective/perspective/tests/table/test_table_infer.py
@@ -22,6 +22,24 @@ class TestTableInfer(object):
         tbl = Table(data)
         assert tbl.schema() == {"a": float}
 
+    def test_table_infer_bool(self):
+        bool_data = [{"a": True, "b": False}, {"a": True, "b": True}]
+        tbl = Table(bool_data)
+        assert tbl.size() == 2
+        assert tbl.schema() == {
+            "a": bool,
+            "b": bool
+        }
+
+    def test_table_infer_bool_str(self):
+        bool_data = [{"a": "True", "b": "False"}, {"a": "True", "b": "True"}]
+        tbl = Table(bool_data)
+        assert tbl.size() == 2
+        assert tbl.schema() == {
+            "a": bool,
+            "b": bool
+        }
+
     def test_table_promote_float(self):
         if six.PY2:
             data = {"a": [1.5, 2.5, 3.5, 4.5, "abc"]}

--- a/python/perspective/perspective/tests/table/test_table_numpy.py
+++ b/python/perspective/perspective/tests/table/test_table_numpy.py
@@ -152,6 +152,19 @@ class TestTableNumpy(object):
             "b": [False, True, False]
         }
 
+    def test_table_bool_str(self):
+        data = {"a": np.array(["True", "False"]), "b": np.array(["False", "True"])}
+        tbl = Table(data)
+        assert tbl.size() == 2
+        assert tbl.schema() == {
+            "a": bool,
+            "b": bool
+        }
+        assert tbl.view().to_dict() == {
+            "a": [True, False],
+            "b": [False, True]
+        }    
+
     # strings
 
     def test_table_str_object(self):

--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -320,6 +320,19 @@ class TestTablePandas(object):
         table.update(df)
         assert table.view().to_dict()["a"] == data
 
+    def test_table_pandas_from_schema_bool_str(self):
+        data = ["True", "False", "True", "False"]
+        df = pd.DataFrame({
+            "a": data
+        })
+        table = Table({
+            "a": bool
+        })
+        table.update(df)
+        assert table.view().to_dict()["a"] == [
+            True, False, True, False
+        ]
+
     def test_table_pandas_from_schema_float(self):
         data = [None, 1.5, None, 2.5, None, 3.5, 4.5]
         df = pd.DataFrame({

--- a/python/perspective/perspective/tests/table/test_update.py
+++ b/python/perspective/perspective/tests/table/test_update.py
@@ -51,6 +51,62 @@ class TestUpdate(object):
         tbl.update({"a": ["abc"], "b": [456]})
         assert tbl.view().to_records() == [{"a": "abc", "b": 456}]
 
+    # bool
+
+    def test_table_bool_from_schema(self):
+        bool_data = [{"a": True, "b": False}, {"a": True, "b": True}]
+        tbl = Table({
+            "a": bool,
+            "b": bool
+        })
+        tbl.update(bool_data)
+        assert tbl.size() == 2
+        assert tbl.view().to_records() == bool_data
+
+    def test_table_bool_str_from_schema(self):
+        bool_data = [{"a": "True", "b": "False"}, {"a": "True", "b": "True"}]
+        tbl = Table({
+            "a": bool,
+            "b": bool
+        })
+        tbl.update(bool_data)
+        assert tbl.size() == 2
+        assert tbl.view().to_records() == [
+            {"a": True, "b": False},
+            {"a": True, "b": True}]
+
+    def test_table_bool_str_all_formats_from_schema(self):
+        bool_data = [
+            {"a": "True", "b": "False"},
+            {"a": "t", "b": "f"},
+            {"a": "true", "b": "false"},
+            {"a": 1, "b": 0},
+            {"a": "on", "b": "off"}
+        ]
+        tbl = Table({
+            "a": bool,
+            "b": bool
+        })
+        tbl.update(bool_data)
+        assert tbl.size() == 5
+        assert tbl.view().to_dict() == {
+            "a": [True, True, True, True, True],
+            "b": [False, False, False, False, False]
+        }
+
+    def test_table_bool_int_from_schema(self):
+        bool_data = [{"a": 1, "b": 0}, {"a": 1, "b": 0}]
+        tbl = Table({
+            "a": bool,
+            "b": bool
+        })
+        tbl.update(bool_data)
+        assert tbl.size() == 2
+        assert tbl.view().to_dict() == {
+            "a": [True, True],
+            "b": [False, False]
+        }
+
     # dates and datetimes
     def test_update_date(self):
         tbl = Table({"a": [date(2019, 7, 11)]})

--- a/python/perspective/perspective/tests/table/test_update.py
+++ b/python/perspective/perspective/tests/table/test_update.py
@@ -53,7 +53,7 @@ class TestUpdate(object):
 
     # bool
 
-    def test_table_bool_from_schema(self):
+    def test_update_bool_from_schema(self):
         bool_data = [{"a": True, "b": False}, {"a": True, "b": True}]
         tbl = Table({
             "a": bool,
@@ -63,7 +63,7 @@ class TestUpdate(object):
         assert tbl.size() == 2
         assert tbl.view().to_records() == bool_data
 
-    def test_table_bool_str_from_schema(self):
+    def test_update_bool_str_from_schema(self):
         bool_data = [{"a": "True", "b": "False"}, {"a": "True", "b": "True"}]
         tbl = Table({
             "a": bool,
@@ -75,7 +75,7 @@ class TestUpdate(object):
             {"a": True, "b": False},
             {"a": True, "b": True}]
 
-    def test_table_bool_str_all_formats_from_schema(self):
+    def test_update_bool_str_all_formats_from_schema(self):
         bool_data = [
             {"a": "True", "b": "False"},
             {"a": "t", "b": "f"},
@@ -94,7 +94,7 @@ class TestUpdate(object):
             "b": [False, False, False, False, False]
         }
 
-    def test_table_bool_int_from_schema(self):
+    def test_update_bool_int_from_schema(self):
         bool_data = [{"a": 1, "b": 0}, {"a": 1, "b": 0}]
         tbl = Table({
             "a": bool,

--- a/python/perspective/perspective/tests/table/test_update_numpy.py
+++ b/python/perspective/perspective/tests/table/test_update_numpy.py
@@ -30,6 +30,23 @@ class TestUpdateNumpy(object):
             "b": [2, 3, 4, 5, None, None, None, None]
         }
 
+    def test_update_np_bool_str(self):
+        tbl = Table({
+            "a": [True]
+        })
+
+        assert tbl.schema() == {
+            "a": bool
+        }
+
+        tbl.update({
+            "a": np.array(["False"])
+        })
+
+        assert tbl.view().to_dict() == {
+            "a": [True, False]
+        }
+
     def test_update_np_date(self):
         tbl = Table({
             "a": [date(2019, 7, 11)]

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -165,6 +165,17 @@ class TestView(object):
         paths = view.column_paths()
         assert paths == ["1|a", "1|b", "2|a", "2|b", "3|a", "3|b"]
 
+    def test_view_column_path_pivot_by_bool(self):
+        data = {
+            "a": [1, 2, 3],
+            "b": [True, False, True],
+            "c": [3, 2, 1]
+        }
+        tbl = Table(data)
+        view = tbl.view(column_pivots=["b"])
+        paths = view.column_paths()
+        assert paths == ["false|a", "false|b", "false|c", "true|a", "true|b", "true|c"]
+
     # schema correctness
 
     def test_string_view_schema(self):

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -172,7 +172,7 @@ class TestView(object):
             "c": [3, 2, 1]
         }
         tbl = Table(data)
-        view = tbl.view(column_pivots=["b"])
+        view = tbl.view(column_pivots=["b"], columns=["a", "b", "c"])
         paths = view.column_paths()
         assert paths == ["false|a", "false|b", "false|c", "true|a", "true|b", "true|c"]
 

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -186,7 +186,6 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
         # Parse the dataset we pass in - if it's Pandas, preserve pivots
         if isinstance(table_or_data, pandas.DataFrame) or isinstance(table_or_data, pandas.Series):
             data, pivots = deconstruct_pandas(table_or_data)
-            print(data, pivots)
             table_or_data = data
 
             if pivots.get("row_pivots", None):

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -186,6 +186,7 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
         # Parse the dataset we pass in - if it's Pandas, preserve pivots
         if isinstance(table_or_data, pandas.DataFrame) or isinstance(table_or_data, pandas.Series):
             data, pivots = deconstruct_pandas(table_or_data)
+            print(data, pivots)
             table_or_data = data
 
             if pivots.get("row_pivots", None):


### PR DESCRIPTION
- Fix widget resize by calling `notifyResize` properly
- Fix typing for Perspective Viewer by making table options optional
- Fix exception thrown when string booleans ("True", "False") were passed into Perspective
  - use [`distutils.util.strtobool`](https://docs.python.org/2/distutils/apiref.html#distutils.util.strtobool) to parse truthy/falsy values
- Make sure column pivots on booleans return `true` or `false` as their column name, not 0/1