### PR TITLE
Preserve user columns and pivots in widget

### DIFF
--- a/python/perspective/perspective/tests/core/test_widget_pandas.py
+++ b/python/perspective/perspective/tests/core/test_widget_pandas.py
@@ -98,7 +98,7 @@ class TestWidgetPandas:
     def test_widget_load_pivot_table_with_user_pivots(self):
         pivot_table = pd.pivot_table(DF, values='Discount', index=['Country', 'Region'], columns='Category')
         widget = PerspectiveWidget(pivot_table, row_pivots=["Category", "Segment"])
-        assert widget.row_pivots == ['Country', 'Region']
+        assert widget.row_pivots == ['Category', 'Segment']
         assert widget.column_pivots == []
         assert widget.columns == ['Financials', 'Industrials', 'Technology']
         # table should host flattened data
@@ -122,7 +122,7 @@ class TestWidgetPandas:
     def test_widget_load_row_pivots_with_user_pivots(self):
         df_pivoted = DF.set_index(['Country', 'Region'])
         widget = PerspectiveWidget(df_pivoted, row_pivots=["Category", "Segment"])
-        assert widget.row_pivots == ['Country', 'Region']  # dataframe pivots should overwrite user pivots
+        assert widget.row_pivots == ['Category', 'Segment']
         assert widget.column_pivots == []
         assert sorted(widget.columns) == sorted(['Category', 'City', 'Customer ID', 'Discount', 'Order Date', 'Order ID', 'Postal Code',
                                                  'Product ID', 'Profit', 'Quantity', 'Row ID', 'Sales', 'Segment', 'Ship Date',
@@ -155,5 +155,17 @@ class TestWidgetPandas:
         widget = PerspectiveWidget(df_both, client=True)
         assert widget.table is None
         assert widget.columns == [' ']
+        assert widget.column_pivots == ['first', 'second', 'third']
+        assert widget.row_pivots == ['index']
+
+    def test_widget_load_column_pivots_preserve_user_settings(self):
+        arrays = [np.array(['bar', 'bar', 'bar', 'bar', 'baz', 'baz', 'baz', 'baz', 'foo', 'foo', 'foo', 'foo', 'qux', 'qux', 'qux', 'qux']),
+                  np.array(['one', 'one', 'two', 'two', 'one', 'one', 'two', 'two', 'one', 'one', 'two', 'two', 'one', 'one', 'two', 'two']),
+                  np.array(['X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y'])]
+        tuples = list(zip(*arrays))
+        index = pd.MultiIndex.from_tuples(tuples, names=['first', 'second', 'third'])
+        df_both = pd.DataFrame(np.random.randn(3, 16), index=['A', 'B', 'C'], columns=index)
+        widget = PerspectiveWidget(df_both, columns=["first", "third"])
+        assert widget.columns == ['first', "third"]
         assert widget.column_pivots == ['first', 'second', 'third']
         assert widget.row_pivots == ['index']

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -202,17 +202,17 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
 
         # Parse the dataset we pass in - if it's Pandas, preserve pivots
         if isinstance(table_or_data, pandas.DataFrame) or isinstance(table_or_data, pandas.Series):
-            data, pivots = deconstruct_pandas(table_or_data)
+            data, config = deconstruct_pandas(table_or_data)
             table_or_data = data
 
-            if pivots.get("row_pivots", None):
-                kwargs.update({"row_pivots": pivots["row_pivots"]})
+            if config.get("row_pivots", None) and "row_pivots" not in kwargs:
+                kwargs.update({"row_pivots": config["row_pivots"]})
 
-            if pivots.get("column_pivots", None):
-                kwargs.update({"column_pivots": pivots["column_pivots"]})
+            if config.get("column_pivots", None) and "column_pivots" not in kwargs:
+                kwargs.update({"column_pivots": config["column_pivots"]})
 
-            if pivots.get("columns", None):
-                kwargs.update({"columns": pivots["columns"]})
+            if config.get("columns", None) and "columns" not in kwargs:
+                kwargs.update({"columns": config["columns"]})
 
         # Initialize the viewer
         super(PerspectiveWidget, self).__init__(**kwargs)


### PR DESCRIPTION
When passing in `pandas.MultiIndex` to `PerspectiveWidget`, the parsed columns and pivots take precedence over all `kwargs` passed in by the user. This PR prefers user input for widgets created from dataframe for `columns`, `row_pivots`, and `column_pivots`.