### PR TITLE
Node.js `table` unpin

### DIFF
--- a/packages/perspective/src/js/perspective.node.js
+++ b/packages/perspective/src/js/perspective.node.js
@@ -263,27 +263,58 @@ class WebSocketServer extends Server {
         }
     }
 
-    /**
-     * Expose a Perspective table through the WebSocket, allowing it to be
-     * accessed by a unique name.
-     *
-     * @param {String} name
-     * @param {Perspective.table} table
-     */
-    host_table(name, table) {
-        this._tables[name] = table;
-        table.view({columns: []});
+    _host(cache, name, input) {
+        if (cache[name] !== undefined) {
+            throw new Error(`"${name}" already exists`);
+        }
+        input.on_delete(() => {
+            delete cache[name];
+        });
+        cache[name] = input;
     }
 
     /**
-     * Expose a Perspective view through the WebSocket, allowing it to be
-     * accessed by a unique name.
+     * Expose a Perspective `table` through the WebSocket, allowing
+     * it to be accessed by a unique name from a client.  Hosted objects
+     * are automatically `eject`ed when their `delete()` method is called.
      *
      * @param {String} name
-     * @param {Perspective.view} view
+     * @param {perspective.table} table `table` to host.
+     */
+    host_table(name, table) {
+        this._host(this._tables, name, table);
+    }
+
+    /**
+     * Expose a Perspective `view` through the WebSocket, allowing
+     * it to be accessed by a unique name from a client.  Hosted objects
+     * are automatically `eject`ed when their `delete()` method is called.
+     *
+     * @param {String} name
+     * @param {perspective.view} view `view` to host.
      */
     host_view(name, view) {
-        this._views[name] = view;
+        this._host(this._views, name, view);
+    }
+
+    /**
+     * Cease hosting a `table` on this server.  Hosted objects
+     * are automatically `eject`ed when their `delete()` method is called.
+     *
+     * @param {String} name
+     */
+    eject_table(name) {
+        delete this._tables[name];
+    }
+
+    /**
+     * Cease hosting a `view` on this server.  Hosted objects
+     * are automatically `eject`ed when their `delete()` method is called.
+     *
+     * @param {String} name
+     */
+    eject_view(name) {
+        delete this._views[name];
     }
 
     close() {


### PR DESCRIPTION
Fixes #841 

* Removes the empty `view()` which kept hosted `table` alive.  `<perspective-viewer>` no longer deletes it's `table` when it is [itself deleted](https://github.com/finos/perspective/blob/eaabd8b39349fc39cb23f4891b56430fa8fec993/packages/perspective-viewer/src/js/viewer/perspective_element.js#L458), so this is not default deleted (though it can still be explicitly deleted remotely - probably something to change later).
* Adds `on_delete` callbacks for both, unhosting objects when they are deleted.
* Adds `eject_table()` and `eject_view()` methods.
