### PR TITLE
Update versioning script for Python

### DIFF
--- a/python/perspective/perspective/core/_version.py
+++ b/python/perspective/perspective/core/_version.py
@@ -17,7 +17,7 @@ VersionInfo = namedtuple('VersionInfo', [
 ])
 
 # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
-version_info = VersionInfo(0, 4, 0, 'candidate', 6)
+version_info = VersionInfo(0, 4, 0, 'rc', 6)
 
 _specifier_ = {'alpha': 'alpha', 'beta': 'beta', 'rc': 'rc', 'final': ''}
 

--- a/scripts/version_python.js
+++ b/scripts/version_python.js
@@ -41,9 +41,6 @@ const parse_version = function(version) {
         let optional_versions = split[split.length - 2].split("-");
         patch = optional_versions[0];
         release_level = optional_versions[1];
-        if (release_level === "rc") {
-            release_level = "candidate"; // 'candidate' maps into bumpversion, 'rc' does not
-        }
         serial = split[split.length - 1];
     }
 
@@ -54,4 +51,6 @@ console.log(`Bumping \`perspective-python\` version to ${VERSION}`);
 
 const python_path = resolve`${__dirname}/../python/perspective`;
 const version_path = resolve`${__dirname}/../python/perspective/perspective/core/_version.py`;
+const bumpversion_path = resolve`${__dirname}/../python/perspective/.bumpversion.cfg`;
 execute`cd ${python_path} && bumpversion --allow-dirty --new-version "${parse_version(VERSION)}" ${version_path}`;
+execute`git add ${version_path} ${bumpversion_path}`;


### PR DESCRIPTION
This PR changes the versioning script to use the correct value for `rc`, as well as adding the changed Python version files to Git so that `lerna publish` can pick them up.