### PR TITLE
Workspace fixes

### DIFF
--- a/packages/perspective-bench/bench/versions.js
+++ b/packages/perspective-bench/bench/versions.js
@@ -37,7 +37,10 @@ const FINOS_VERSIONS = ["0.3.1", "0.3.0", "0.3.0-rc.3", "0.3.0-rc.2", "0.3.0-rc.
 const UMD_VERSIONS = ["0.3.9", "0.3.8", "0.3.7", "0.3.6"];
 
 async function run() {
-    await PerspectiveBench.run("master", "bench/perspective.benchmark.js", `http://host.docker.internal:8080/perspective.js`, {output: "dist/benchmark", puppeteer: true});
+    await PerspectiveBench.run("master", "bench/perspective.benchmark.js", `http://${process.env.PSP_DOCKER_PUPPETEER ? `localhost` : `host.docker.internal`}:8080/perspective.js`, {
+        output: "dist/benchmark",
+        puppeteer: true
+    });
 
     for (const version of UMD_VERSIONS) {
         const url = `https://unpkg.com/@finos/perspective@${version}/dist/umd/perspective.js`;

--- a/packages/perspective-bench/src/js/bench.js
+++ b/packages/perspective-bench/src/js/bench.js
@@ -13,6 +13,8 @@ const perspective = require("@finos/perspective");
 const chalk = require("chalk");
 const program = require("commander");
 
+const execSync = require("child_process").execSync;
+
 chalk.enabled = true;
 chalk.level = 1;
 
@@ -98,6 +100,8 @@ exports.run = async function run(version, benchmark, ...cmdArgs) {
             headless: true,
             args: ["--no-sandbox"]
         });
+
+        execSync(`renice -n -20 ${browser.process().pid}`, {stdio: "inherit"});
 
         bins = await run_version(browser, cmdArgs, RUN_TEST);
 

--- a/packages/perspective-bench/src/js/browser_runtime.js
+++ b/packages/perspective-bench/src/js/browser_runtime.js
@@ -11,6 +11,8 @@ const ITERATIONS = 100;
 const ITERATION_TIME = 500;
 const TOSS_ITERATIONS = 0;
 const INDENT_LEVEL = 2;
+const MIN_TIMEOUT = 0;
+const OUTPUT_MODE = "flat";
 
 async function* filterOutliers(someArray) {
     const values = [],
@@ -38,59 +40,135 @@ function quotechalk(x) {
     return x.replace(/\{/g, "\\{").replace(/\}/g, "\\}");
 }
 
+function to_table(col_lengths, padding = 0) {
+    return function(...row) {
+        try {
+            let result = "".padStart(padding - 2, " ");
+            for (let c = 0; c < row.length; ++c) {
+                let method = "padEnd";
+                let col_length = col_lengths[c];
+                if (Array.isArray(col_length)) {
+                    [method, col_length] = col_length;
+                }
+                col_length = col_length || 0;
+                const cell = row[c];
+                let real_cell = cell.replace(/{[a-zA-Z]+? ([^{]+?)}/g, "$1");
+                let real_cell_length = cell.length;
+                while (real_cell.length < real_cell_length) {
+                    real_cell_length = real_cell.length;
+                    real_cell = cell.replace(/{[a-zA-Z]+? ([^{]+?)}/g, "$1");
+                }
+
+                if (col_length < real_cell.length) {
+                    col_length = real_cell.length;
+                    col_lengths[c] = [method, col_length];
+                }
+                const cell_length = cell.length + Math.max(0, col_length - real_cell.length);
+                result += "  " + cell[method].call(cell, cell_length, " ");
+            }
+            console.log(result);
+        } catch (e) {
+            console.error(e.message);
+        }
+    };
+}
+
+let PRINTER, LAST_PATH;
+
 class Benchmark {
-    constructor(desc, body, indent, categories, after_each, iterations, timeout, toss) {
+    constructor(desc, path, body, indent, categories, after_each, iterations, timeout, toss) {
         this._desc = quotechalk(desc);
         this._body = body;
+        this._path = path.slice(0, path.length - 2);
         this._indent = indent;
         this._after_each = after_each;
         this._categories = categories;
         this._iterations = iterations;
         this._timeout = timeout;
         this._toss = toss;
+
+        const iter_length = Math.log10(ITERATIONS) * 2 + 3;
+        const per_length = 9;
+        this._table_printer = PRINTER =
+            PRINTER ||
+            to_table(
+                [
+                    ...(OUTPUT_MODE === "tree" ? [...path.map(() => undefined), undefined] : []),
+                    ["padStart", iter_length],
+                    ["padStart", per_length],
+                    ["padStart", undefined],
+                    ["padStart", undefined],
+                    ["padStart", undefined]
+                ],
+                OUTPUT_MODE === "grouped" ? (indent - 1) * INDENT_LEVEL : "  "
+            );
     }
 
-    log(reps, t) {
-        const completed = reps - this._toss();
-        const total = this._iterations() - this._toss();
+    log(reps, totals) {
+        const t = totals.reduce((x, y) => x + y);
+        const mean = t / reps;
+        const stddev = Math.sqrt(totals.map(x => Math.pow(x - mean, 2)).reduce((x, y) => x + y) / reps) / mean;
+        const completed = reps;
+        const total = this._iterations();
         const time = t / 1000;
         const completed_per = completed / total;
         const time_per = time / completed;
-        const color = completed_per < 0.33 ? "redBright" : completed_per < 0.66 ? "yellowBright" : "greenBright";
-        let log = " ".repeat(this._indent + INDENT_LEVEL);
-        log += `{${color} ${completed}}{whiteBright /${total} `;
-        log += `({${color} ${(100 * completed_per).toFixed(2)}}%)}`;
-        log += `    {whiteBright ${time.toFixed(3)}}s {whiteBright ${time_per.toFixed(2)}} secs/op`;
-        log += `    {whiteBright ${this._desc}}`;
-
-        console.log(log);
+        const color = completed_per >= 1 ? "white" : completed_per < 0.33 ? "redBright" : completed_per < 0.66 ? "yellowBright" : "greenBright";
+        const stddev_color = stddev < 0.25 ? "greenBright" : stddev < 0.5 ? "yellowBright" : "redBright";
+        const path = [...this._path.reverse(), this._desc];
+        const last_path = path.slice();
+        if (LAST_PATH) {
+            for (let x = 0; x < path.length; ++x) {
+                if (path[x] === LAST_PATH[x]) {
+                    path[x] = "-";
+                    if (x > 0) {
+                        path[x - 1] = "";
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+        LAST_PATH = last_path;
+        this._table_printer(
+            ...(OUTPUT_MODE === "tree" ? path : []),
+            `{${color} ${completed}}{whiteBright /${total}}`,
+            `({${color} ${(100 * completed_per).toFixed(2)}}{whiteBright %)}`,
+            `{whiteBright ${time.toFixed(3)}}s`,
+            `{whiteBright ${time_per.toFixed(2)}}secs/op`,
+            `{${stddev_color} ${(100 * stddev).toFixed(2)}}{whiteBright %} σ/mean`,
+            ...(OUTPUT_MODE === "flat" ? this._path : []),
+            ...(OUTPUT_MODE === "tree" ? [] : [`{whiteBright ${this._desc}}`])
+        );
     }
 
     *case_iter() {
         let x, start, now;
-        for (x = 0; x < this._iterations() + this._toss(); x++) {
+        for (x = 0; !start || performance.now() - start < MIN_TIMEOUT || x < this._iterations() + this._toss(); x++) {
             if (x >= this._toss() && start == undefined) {
-                start = Date.now();
+                start = performance.now();
             }
-            now = Date.now();
+            now = performance.now();
             if (now - start > this._timeout()) {
-                this.log(x, now - start);
                 return;
             }
 
             yield x >= this._toss();
         }
-        this.log(x, now - start);
     }
 
     async *run() {
         try {
             const categories = this._categories();
+            let count = 0,
+                totals = [];
             for (const not_warmup of this.case_iter(this._desc)) {
                 const start = performance.now();
                 await this._body();
                 const stop = performance.now() - start;
                 if (not_warmup) {
+                    totals.push(stop);
+                    count += 1;
                     yield {
                         test: this._desc,
                         time: stop,
@@ -101,6 +179,7 @@ class Benchmark {
                     await this._after_each();
                 }
             }
+            this.log(count, totals);
         } catch (e) {
             console.error(`Benchmark ${this._desc} failed`, e);
         }
@@ -136,6 +215,7 @@ class Suite {
         context._benchmarks.push(
             new Benchmark(
                 desc,
+                this._context.map(x => x._name),
                 body,
                 context._indent,
                 () => unwind(stack),
@@ -188,7 +268,7 @@ class Suite {
 
     async *run_all_cases() {
         this._context.unshift(this);
-        if (this._name) {
+        if (this._name && OUTPUT_MODE === "grouped") {
             console.log(`${" ".repeat(this._indent)}{whiteBright ${this._name}}`);
         }
         if (this._body) {

--- a/packages/perspective-phosphor/config/tsconfig.json
+++ b/packages/perspective-phosphor/config/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true,
+        "esModuleInterop": true,
         "noImplicitAny": true,
         "noEmitOnError": true,
         "noUnusedLocals": true,

--- a/packages/perspective-phosphor/config/webpack.config.js
+++ b/packages/perspective-phosphor/config/webpack.config.js
@@ -8,35 +8,16 @@
  */
 
 const path = require("path");
-const webpack = require("webpack");
+const common = require("@finos/perspective/src/config/common.config.js");
 
-module.exports = {
-    mode: process.env.PSP_NO_MINIFY || process.env.PSP_DEBUG ? "development" : process.env.NODE_ENV || "production",
-    entry: path.join(__dirname, "../dist/esm/index.js"),
-    devtool: "source-map",
-    resolve: {
-        extensions: [".ts", ".js", ".json"]
-    },
-    externals: [/^[a-z0-9@]/],
-    plugins: [new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /(en|es|fr)$/)],
-    performance: {
-        hints: false,
-        maxEntrypointSize: 512000,
-        maxAssetSize: 512000
-    },
-    stats: {modules: false, hash: false, version: false, builtAt: false, entrypoints: false},
-    module: {
-        rules: [
-            {
-                test: /\.less$/,
-                use: [{loader: "css-loader"}, {loader: "less-loader"}]
-            },
-            {test: /\.ts?$/, loader: "ts-loader", options: {configFile: "config/tsconfig.json"}}
-        ]
-    },
-    output: {
-        filename: "index.js",
-        libraryTarget: "commonjs",
-        path: path.resolve(__dirname, "../dist/cjs")
-    }
-};
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: path.join(__dirname, "../dist/esm/index.js"),
+        externals: [/^[a-z0-9@]/],
+        output: {
+            filename: "index.js",
+            libraryTarget: "commonjs",
+            path: path.resolve(__dirname, "../dist/cjs")
+        }
+    })
+);

--- a/packages/perspective-phosphor/config/webpack.umd.config.js
+++ b/packages/perspective-phosphor/config/webpack.umd.config.js
@@ -1,10 +1,8 @@
 const cjsConfig = require("./webpack.config");
 const path = require("path");
-const PerspectiveWebpackPlugin = require("@finos/perspective-webpack-plugin");
 
 module.exports = Object.assign({}, cjsConfig, {
     externals: [],
-    plugins: [new PerspectiveWebpackPlugin()],
     output: {
         filename: "perspective-phosphor.js",
         library: "PerspectivePhosphor",

--- a/packages/perspective-phosphor/package.json
+++ b/packages/perspective-phosphor/package.json
@@ -34,7 +34,7 @@
         "@phosphor/application": "^1.7.3",
         "@phosphor/default-theme": "0.1.8",
         "@phosphor/widgets": "^1.9.3",
-        "lodash.uniqby": "^4.7.0"
+        "lodash": "^4.17.4"
     },
     "devDependencies": {
         "@finos/perspective-webpack-plugin": "^0.4.0-rc.6",

--- a/packages/perspective-phosphor/src/less/widget.less
+++ b/packages/perspective-phosphor/src/less/widget.less
@@ -6,6 +6,7 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+ 
  @import "~@finos/perspective-viewer/src/less/fonts.less";
  @import (reference) "~@finos/perspective-viewer/src/themes/material-dense.less";
  @import (reference) "~@finos/perspective-viewer/src/themes/material-dense.dark.less";

--- a/packages/perspective-phosphor/src/theme/default/index.less
+++ b/packages/perspective-phosphor/src/theme/default/index.less
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+ 
 @import '~@phosphor/default-theme/style/index.css';
 @import "./tabbar.less";
 

--- a/packages/perspective-phosphor/src/theme/default/tabbar.less
+++ b/packages/perspective-phosphor/src/theme/default/tabbar.less
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 .p-TabBar-tab.p-mod-maximize > .p-TabBar-tabMaximizeIcon {
     display: none;
 }

--- a/packages/perspective-phosphor/src/theme/material/dockpanel.less
+++ b/packages/perspective-phosphor/src/theme/material/dockpanel.less
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 .p-DockPanel {
     overflow: visible !important;
 }

--- a/packages/perspective-phosphor/src/theme/material/dockpanel.less
+++ b/packages/perspective-phosphor/src/theme/material/dockpanel.less
@@ -9,6 +9,63 @@
 
 .p-DockPanel {
     overflow: visible !important;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+.p-PerspectiveScrollPanel::-webkit-scrollbar {
+    width: 1em;
+    height: 1em;
+}
+
+.p-PerspectiveScrollPanel::-webkit-scrollbar-track {
+    background-color: #eee;
+}
+
+.p-PerspectiveScrollPanel::-webkit-scrollbar-corner  {
+    background-color: #eee;
+}
+
+.p-PerspectiveScrollPanel::-webkit-scrollbar-thumb {
+  background-color: #aaa;
+  //outline: 1px solid #666;
+  height: 0.8em;
+  width: 0.8em;
+  border: 8px solid #eee;
+  border-left-width: 0px;
+  border-top-width: 0px;
+}
+
+.p-DockPanel.ew, .p-DockPanel.ew .p-Widget,.p-SplitPanel.ew, .p-SplitPanel.ew .p-Widget {
+    cursor: ew-resize !important;
+}
+
+.p-DockPanel.ns, .p-DockPanel.ns .p-Widget, .p-SplitPanel.ns, .p-SplitPanel.ns .p-Widget {
+    cursor: ns-resize !important;
+}
+
+.p-Master {
+    min-width: 300px;
+}
+
+.p-DockPanel.resizing perspective-viewer, .p-SplitPanel.resizing perspective-viewer {
+    pointer-events: none;
+}
+
+.p-DockPanel-handle.resizing {
+    background-color: rgba(0,0,0,0.05);
+}
+
+.p-PerspectiveScrollPanel {
+    overflow: auto !important;
+}
+
+.p-Panel {
+    min-height: 100%;
+
 }
 
 

--- a/packages/perspective-phosphor/src/theme/material/index.less
+++ b/packages/perspective-phosphor/src/theme/material/index.less
@@ -1,2 +1,11 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 @import "./material-phosphor.less";
 @import "~@finos/perspective-viewer/dist/themes/material-dense.less";

--- a/packages/perspective-phosphor/src/theme/material/material-phosphor.less
+++ b/packages/perspective-phosphor/src/theme/material/material-phosphor.less
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 @import "~@phosphor/widgets/style/index.css";
 @import "./tabbar.less";
 @import "./dockpanel.less";

--- a/packages/perspective-phosphor/src/theme/material/menu.less
+++ b/packages/perspective-phosphor/src/theme/material/menu.less
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 @import "~@phosphor/widgets/style/menu.css";
 
 .p-Menu {

--- a/packages/perspective-phosphor/src/theme/material/tabbar.less
+++ b/packages/perspective-phosphor/src/theme/material/tabbar.less
@@ -59,8 +59,7 @@
 }
 
 .p-BoxPanel {
-    margin: 24px 20px 16px 20px;
-    overflow: visible !important;
+    overflow: scroll !important;
 }
 
 
@@ -136,7 +135,7 @@
 .p-TabBar-content {
     padding: 0px;
     overflow: hidden;
-    margin: 0px 0px -1px 0px;
+    margin: 0px -4px -1px -4px;
     border-bottom: 0px solid #fff !important;
     border-left: 1px solid #eaeaea;
     border-right: 1px solid #eaeaea;
@@ -158,6 +157,7 @@
 }
 
 .p-TabBar-tab {
+    margin: 0px 4px;
     border-color: #eaeaea;
 }
 

--- a/packages/perspective-phosphor/src/theme/material/tabbar.less
+++ b/packages/perspective-phosphor/src/theme/material/tabbar.less
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 @import "~@finos/perspective-viewer/src/less/variables.less";
 
 .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:before {

--- a/packages/perspective-phosphor/src/theme/material/widget.less
+++ b/packages/perspective-phosphor/src/theme/material/widget.less
@@ -25,6 +25,8 @@
 .p-Widget.PSPContainer {
     border: @border-color;
     border-width: 0px !important;
+    min-width: 300px;
+    min-height: 200px;
 }
 
 .night .p-Widget.PSPContainer {

--- a/packages/perspective-phosphor/src/theme/material/widget.less
+++ b/packages/perspective-phosphor/src/theme/material/widget.less
@@ -1,3 +1,11 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
 
 .p-Widget.PSPContainer {
   background-color: none;

--- a/packages/perspective-phosphor/src/theme/material/workspace.less
+++ b/packages/perspective-phosphor/src/theme/material/workspace.less
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 .p-SplitPanel{
     height: 100%;
     width: 100%;

--- a/packages/perspective-phosphor/src/theme/vaporwave/index.less
+++ b/packages/perspective-phosphor/src/theme/vaporwave/index.less
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 @import "../material/material-phosphor.less";
 @import (reference) "~@finos/perspective-viewer/dist/themes/vaporwave.less";
 

--- a/packages/perspective-phosphor/src/ts/dockpanel/discrete.ts
+++ b/packages/perspective-phosphor/src/ts/dockpanel/discrete.ts
@@ -1,0 +1,134 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import {DockPanel, SplitPanel, Widget} from "@phosphor/widgets";
+import {toArray} from "@phosphor/algorithm";
+
+const DISCRETE_STEP_SIZE = 1;
+
+function cloneMouseEvent(x: number, y: number, e: MouseEvent): MouseEvent {
+    const evt = document.createEvent("MouseEvent");
+    evt.initMouseEvent(e.type, true, e.cancelable, e.view, e.detail, e.screenX, e.screenY, x, y, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey, e.button, e.relatedTarget);
+    return evt;
+}
+
+class DiscreteContext {
+    _offset_drag_start: {[key: string]: number};
+    _offset_drag_current: {[key: string]: number};
+    _rect: ClientRect;
+
+    _clamp(orient: "width" | "height", client: number): number | undefined {
+        const margin = {width: 300, height: 200}[orient];
+        const [min, max] = [margin, this._rect[orient] - margin];
+        return client < min ? min : client > max ? max : undefined;
+    }
+
+    _block_move(key: "x" | "y", client: number): number {
+        const val = this._offset_drag_start[key];
+        const old = this._offset_drag_current[key];
+        const method = client < old ? "ceil" : "floor";
+        const diff = client - val;
+        return Math[method](diff / DISCRETE_STEP_SIZE) * DISCRETE_STEP_SIZE + val;
+    }
+
+    _check_prev(clientX: number, clientY: number): boolean {
+        const {x: old_clientX, y: old_clientY} = this._offset_drag_current;
+        if (clientX !== old_clientX || clientY !== old_clientY) {
+            this._offset_drag_current = {x: clientX, y: clientY};
+            return true;
+        }
+        return false;
+    }
+
+    calculate_move({clientX, clientY}: MouseEvent): {x: number; y: number} | void {
+        clientX -= this._rect.left;
+        clientY -= this._rect.top;
+        const blockX = this._block_move("x", clientX);
+        const blockY = this._block_move("y", clientY);
+        clientX = this._clamp("width", clientX) || this._clamp("width", blockX) || blockX;
+        clientY = this._clamp("height", clientY) || this._clamp("height", blockY) || blockY;
+        if (this._check_prev(clientX, clientY)) {
+            return {x: clientX + this._rect.left, y: clientY + this._rect.top};
+        }
+    }
+
+    constructor(x: number, y: number, rect: ClientRect) {
+        this._rect = rect;
+        this._offset_drag_start = this._offset_drag_current = {
+            x: x - rect.left,
+            y: y - rect.top
+        };
+    }
+}
+
+function extend(base: any, handle: string): any {
+    return class extends base {
+        private context: DiscreteContext;
+
+        handleEvent(event: MouseEvent): void {
+            switch (event.type) {
+                case "mousedown":
+                    {
+                        const elem = event.target as HTMLElement;
+                        if (!elem.classList.contains(handle)) {
+                            break;
+                        }
+                        if ([elem, elem.parentElement].some(x => x.getAttribute("data-orientation") === "horizontal")) {
+                            this.addClass("ew");
+                        } else {
+                            this.addClass("ns");
+                        }
+                        this.addClass("resizing");
+                        const {clientX, clientY} = event;
+                        this._offset_target = elem as HTMLElement;
+                        this._offset_target.classList.add("resizing");
+                        this.context = new DiscreteContext(clientX, clientY, this.node.getBoundingClientRect());
+                    }
+                    break;
+                case "mousemove":
+                    if (!DISCRETE_STEP_SIZE) {
+                        super.handleEvent(event);
+                    } else if (this.context && !event.shiftKey) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        const update = this.context.calculate_move(event);
+                        if (update) {
+                            const new_event = cloneMouseEvent(update.x, update.y, event as MouseEvent);
+                            super.handleEvent(new_event);
+                        }
+                        return;
+                    }
+                    break;
+                case "mouseup":
+                    {
+                        this.removeClass("resizing");
+                        this.removeClass("ew");
+                        this.removeClass("ns");
+                        this._offset_target.classList.remove("resizing");
+                        delete this.context;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            super.handleEvent(event);
+        }
+    };
+}
+
+export class DiscreteDockPanel extends (extend(DockPanel, "p-DockPanel-handle") as typeof DockPanel) {}
+export class DiscreteSplitPanel extends (extend(SplitPanel, "p-SplitPanel-handle") as typeof SplitPanel) {
+    onResize(msg: Widget.ResizeMessage): void {
+        for (const widget of toArray(this.widgets)) {
+            widget.node.style.minWidth = `300px`;
+            widget.node.style.minHeight = `200px`;
+        }
+        super.onResize(msg);
+    }
+}

--- a/packages/perspective-phosphor/src/ts/dockpanel/dockpanel.ts
+++ b/packages/perspective-phosphor/src/ts/dockpanel/dockpanel.ts
@@ -16,6 +16,7 @@ import {PerspectiveTabBarRenderer} from "./tabbarrenderer";
 import {PerspectiveWidget, PerspectiveWidgetOptions} from "../widget";
 import {Signal} from "@phosphor/signaling";
 import {CommandRegistry} from "@phosphor/commands";
+import {DiscreteDockPanel} from "./discrete";
 
 export interface SerializableITabAreaConfig extends Omit<DockLayout.ITabAreaConfig, "widgets"> {
     widgets: PerspectiveWidgetOptions[];
@@ -53,7 +54,7 @@ export interface ContextMenuArgs {
     event: MouseEvent;
 }
 // tslint:disable-next-line: max-classes-per-file
-export class PerspectiveDockPanel extends DockPanel {
+export class PerspectiveDockPanel extends DiscreteDockPanel {
     public id = "main";
 
     public maximized: boolean;

--- a/packages/perspective-phosphor/src/ts/dockpanel/index.ts
+++ b/packages/perspective-phosphor/src/ts/dockpanel/index.ts
@@ -1,1 +1,10 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 export * from "./dockpanel";

--- a/packages/perspective-phosphor/src/ts/index.ts
+++ b/packages/perspective-phosphor/src/ts/index.ts
@@ -6,6 +6,7 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+
 export * from "./widget";
 export * from "./utils";
 export * from "./dockpanel";

--- a/packages/perspective-phosphor/src/ts/widget.ts
+++ b/packages/perspective-phosphor/src/ts/widget.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 /******************************************************************************
  *
  * Copyright (c) 2018, the Perspective Authors.
@@ -7,6 +6,8 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+
+/* eslint-disable @typescript-eslint/camelcase */
 
 import "@finos/perspective-viewer";
 

--- a/packages/perspective-phosphor/src/ts/widget.ts
+++ b/packages/perspective-phosphor/src/ts/widget.ts
@@ -380,12 +380,6 @@ export class PerspectiveWidget extends Widget {
         div.style.setProperty("flex-direction", "row");
         node.appendChild(div);
 
-        if (!viewer.notifyResize) {
-            console.warn("Warning: not bound to real element");
-        } else {
-            const resize_observer = new MutationObserver(() => viewer.notifyResize.call(viewer));
-            resize_observer.observe(node, {attributes: true});
-        }
         return viewer;
     }
 

--- a/packages/perspective-phosphor/src/ts/workspace/index.ts
+++ b/packages/perspective-phosphor/src/ts/workspace/index.ts
@@ -1,1 +1,10 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 export * from "./workspace";

--- a/packages/perspective-phosphor/src/ts/workspace/workspace.ts
+++ b/packages/perspective-phosphor/src/ts/workspace/workspace.ts
@@ -1,8 +1,18 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 import {SplitPanel, DockLayout, Widget, DockPanel} from "@phosphor/widgets";
 import {PerspectiveDockPanel, ContextMenuArgs} from "../dockpanel/dockpanel";
 import {Menu} from "@phosphor/widgets";
 import {createCommands} from "../dockpanel/contextmenu";
 import {CommandRegistry} from "@phosphor/commands";
+
 import PerspectiveViewer from "@finos/perspective-viewer";
 import {PerspectiveWidget} from "../widget";
 import {toArray} from "@phosphor/algorithm";

--- a/packages/perspective-phosphor/src/ts/workspace/workspace.ts
+++ b/packages/perspective-phosphor/src/ts/workspace/workspace.ts
@@ -1,12 +1,12 @@
 import {SplitPanel, DockLayout, Widget, DockPanel} from "@phosphor/widgets";
 import {PerspectiveDockPanel, ContextMenuArgs} from "../dockpanel/dockpanel";
-import {uniqBy} from "lodash";
 import {Menu} from "@phosphor/widgets";
 import {createCommands} from "../dockpanel/contextmenu";
 import {CommandRegistry} from "@phosphor/commands";
 import PerspectiveViewer from "@finos/perspective-viewer";
 import {PerspectiveWidget} from "../widget";
 import {toArray} from "@phosphor/algorithm";
+import uniqBy from "lodash/uniqBy";
 
 export interface PerspectiveWorkspaceOptions {
     node?: HTMLElement;

--- a/packages/perspective-phosphor/test/results/results.json
+++ b/packages/perspective-phosphor/test/results/results.json
@@ -1,6 +1,6 @@
 {
-    "__GIT_COMMIT__": "69f226c12c8f1325277c0be34a1aeeaec0da43f1",
+    "__GIT_COMMIT__": "87c584bb668ec75e982194118056185f56382580",
     "index.html/perspective workspace and master view": "8c6165a59ac1e0e02e619021751df3c3",
-    "index.html/simple perspective workspace": "bf77f9ccdb8e6a05a03993f500a0ef15",
-    "index.html/perspective workspace and duplicate view": "58b9cdf69828c87cf1e1ae48aa684e4d"
+    "index.html/simple perspective workspace": "d974ae5d13c533be2ad7345558599a48",
+    "index.html/perspective workspace and duplicate view": "f4c4444d8781b64a01dd112b503c834a"
 }

--- a/packages/perspective-phosphor/test/unit/__mocks__/@finos/perspective-viewer.js
+++ b/packages/perspective-phosphor/test/unit/__mocks__/@finos/perspective-viewer.js
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 const originalCreateElement = document.createElement;
 
 document.createElement = name => {

--- a/packages/perspective-phosphor/test/unit/js/dockpanel.spec.js
+++ b/packages/perspective-phosphor/test/unit/js/dockpanel.spec.js
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 import {PerspectiveDockPanel} from "../../../dist/esm/dockpanel";
 import {PerspectiveWidget} from "../../../dist/esm/widget";
 import {Widget} from "@phosphor/widgets";

--- a/packages/perspective-phosphor/test/unit/js/workspace.spec.js
+++ b/packages/perspective-phosphor/test/unit/js/workspace.spec.js
@@ -1,3 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 /* eslint-disable @typescript-eslint/camelcase */
 import {PerspectiveWorkspace} from "../../../dist/esm/workspace";
 import {toArray} from "@phosphor/algorithm";

--- a/packages/perspective-viewer-d3fc/src/config/cjs.config.js
+++ b/packages/perspective-viewer-d3fc/src/config/cjs.config.js
@@ -1,13 +1,15 @@
 const path = require("path");
 const common = require("@finos/perspective/src/config/common.config.js");
 
-module.exports = Object.assign({}, common(), {
-    entry: "./dist/esm/index.js",
-    externals: [/^[a-z0-9@]/],
-    output: {
-        filename: "perspective-viewer-d3fc.js",
-        library: "perspective-view-d3fc",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../dist/cjs")
-    }
-});
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: "./dist/esm/index.js",
+        externals: [/^[a-z0-9@]/],
+        output: {
+            filename: "perspective-viewer-d3fc.js",
+            library: "perspective-view-d3fc",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist/cjs")
+        }
+    })
+);

--- a/packages/perspective-viewer-d3fc/src/config/umd.config.js
+++ b/packages/perspective-viewer-d3fc/src/config/umd.config.js
@@ -1,12 +1,14 @@
 const path = require("path");
 const common = require("@finos/perspective/src/config/common.config.js");
 
-module.exports = Object.assign({}, common(), {
-    entry: "./dist/cjs/perspective-viewer-d3fc.js",
-    output: {
-        filename: "perspective-viewer-d3fc.js",
-        library: "perspective-view-d3fc",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../dist/umd")
-    }
-});
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: "./dist/cjs/perspective-viewer-d3fc.js",
+        output: {
+            filename: "perspective-viewer-d3fc.js",
+            library: "perspective-view-d3fc",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist/umd")
+        }
+    })
+);

--- a/packages/perspective-viewer-d3fc/src/js/axis/chartFactory.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/chartFactory.js
@@ -61,6 +61,13 @@ const chartFactory = (xAxis, yAxis, cartesian, canvas) => {
 
     const oldDecorate = chart.decorate();
     chart.decorate((container, data) => {
+        const plotArea = container.select("d3fc-svg.plot-area");
+
+        plotArea
+            .select("svg")
+            .node()
+            .setAttribute("viewBox", `0 0 ${plotArea.node().clientWidth} ${plotArea.node().clientHeight}`);
+
         oldDecorate(container, data);
         if (!axisSplitter) return;
 

--- a/packages/perspective-viewer-highcharts/src/config/cjs.config.js
+++ b/packages/perspective-viewer-highcharts/src/config/cjs.config.js
@@ -1,13 +1,15 @@
 const path = require("path");
 const common = require("@finos/perspective/src/config/common.config.js");
 
-module.exports = Object.assign({}, common(), {
-    entry: "./dist/esm/index.js",
-    externals: [/^[a-z0-9@]/],
-    output: {
-        filename: "perspective-viewer-highcharts.js",
-        library: "perspective-viewer-highcharts",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../dist/cjs")
-    }
-});
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: "./dist/esm/index.js",
+        externals: [/^[a-z0-9@]/],
+        output: {
+            filename: "perspective-viewer-highcharts.js",
+            library: "perspective-viewer-highcharts",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist/cjs")
+        }
+    })
+);

--- a/packages/perspective-viewer-highcharts/src/config/umd.config.js
+++ b/packages/perspective-viewer-highcharts/src/config/umd.config.js
@@ -1,12 +1,14 @@
 const path = require("path");
 const common = require("@finos/perspective/src/config/common.config.js");
 
-module.exports = Object.assign({}, common(), {
-    entry: "./dist/cjs/perspective-viewer-highcharts.js",
-    output: {
-        filename: "perspective-viewer-highcharts.js",
-        library: "perspective-view-highcharts",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../dist/umd")
-    }
-});
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: "./dist/cjs/perspective-viewer-highcharts.js",
+        output: {
+            filename: "perspective-viewer-highcharts.js",
+            library: "perspective-view-highcharts",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist/umd")
+        }
+    })
+);

--- a/packages/perspective-viewer-hypergrid/src/config/cjs.config.js
+++ b/packages/perspective-viewer-hypergrid/src/config/cjs.config.js
@@ -1,13 +1,15 @@
 const path = require("path");
 const common = require("@finos/perspective/src/config/common.config.js");
 
-module.exports = Object.assign({}, common(), {
-    entry: "./dist/esm/hypergrid.js",
-    externals: [/^[a-z0-9@]/],
-    output: {
-        filename: "perspective-viewer-hypergrid.js",
-        library: "perspective-viewer-hypergrid",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../dist/cjs")
-    }
-});
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: "./dist/esm/hypergrid.js",
+        externals: [/^[a-z0-9@]/],
+        output: {
+            filename: "perspective-viewer-hypergrid.js",
+            library: "perspective-viewer-hypergrid",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist/cjs")
+        }
+    })
+);

--- a/packages/perspective-viewer-hypergrid/src/config/umd.config.js
+++ b/packages/perspective-viewer-hypergrid/src/config/umd.config.js
@@ -1,12 +1,14 @@
 const path = require("path");
 const common = require("@finos/perspective/src/config/common.config.js");
 
-module.exports = Object.assign({}, common(), {
-    entry: "./dist/cjs/perspective-viewer-hypergrid.js",
-    output: {
-        filename: "perspective-viewer-hypergrid.js",
-        library: "perspective-viewer-hypergrid",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../dist/umd")
-    }
-});
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: "./dist/cjs/perspective-viewer-hypergrid.js",
+        output: {
+            filename: "perspective-viewer-hypergrid.js",
+            library: "perspective-viewer-hypergrid",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist/umd")
+        }
+    })
+);

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -9,7 +9,7 @@
 
 import rectangular from "rectangular";
 import superscript from "superscript-number";
-import lodash from "lodash";
+import isEqual from "lodash/isEqual";
 
 import cellRenderersRegistry from "faux-hypergrid/src/cellRenderers";
 
@@ -113,8 +113,8 @@ function setPSP(payload, force = false) {
     if (
         !force &&
         this._memoized_schema &&
-        lodash.isEqual(this._memoized_schema.slice(0, this._memoized_schema.length), new_schema.slice(0, new_schema.length)) &&
-        lodash.isEqual(payload.rowPivots, this._memoized_pivots)
+        isEqual(this._memoized_schema.slice(0, this._memoized_schema.length), new_schema.slice(0, new_schema.length)) &&
+        isEqual(payload.rowPivots, this._memoized_pivots)
     ) {
         this.grid.sbVScroller.index = 0;
         this.grid.behavior.dataModel.data = payload.rows;

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -350,6 +350,12 @@ export const install = function(grid) {
         this.renderLastSelection(gc);
     };
 
+    grid.canvas.canvas.addEventListener("mousewheel", e => {
+        if (e.shiftKey) {
+            e.stopPropagation();
+        }
+    });
+
     // Corrects for deselection behavior on keyiup due to shadow-dom
     grid.canvas.hasFocus = function() {
         if (!grid.div.isConnected) {

--- a/packages/perspective-viewer-hypergrid/src/js/styles.js
+++ b/packages/perspective-viewer-hypergrid/src/js/styles.js
@@ -8,7 +8,7 @@
  */
 
 import {PropsBuilder, get_style} from "@finos/perspective-viewer/dist/esm/custom_styles";
-import {cloneDeep} from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 
 const properties = new PropsBuilder();
 const title = `--hypergrid`;

--- a/packages/perspective-viewer/src/config/cjs.config.js
+++ b/packages/perspective-viewer/src/config/cjs.config.js
@@ -1,12 +1,14 @@
 const path = require("path");
 const common = require("@finos/perspective/src/config/common.config.js");
 
-module.exports = Object.assign({}, common(), {
-    entry: "./dist/esm/viewer.js",
-    externals: [/^[a-z0-9@]/],
-    output: {
-        filename: "perspective-viewer.js",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../dist/cjs")
-    }
-});
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: "./dist/esm/viewer.js",
+        externals: [/^[a-z0-9@]/],
+        output: {
+            filename: "perspective-viewer.js",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist/cjs")
+        }
+    })
+);

--- a/packages/perspective-viewer/src/config/umd.config.js
+++ b/packages/perspective-viewer/src/config/umd.config.js
@@ -2,18 +2,8 @@ const path = require("path");
 const fs = require("fs");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const common = require("@finos/perspective/src/config/common.config.js");
-
+const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 const THEMES = fs.readdirSync(path.resolve(__dirname, "..", "themes"));
-const CONFIG = common();
-
-CONFIG.plugins.push(
-    new MiniCssExtractPlugin({
-        splitChunks: {
-            chunks: "all"
-        },
-        filename: "[name].css"
-    })
-);
 
 function try_delete(name) {
     const filePath = path.resolve(__dirname, "..", "..", "dist", "umd", name);
@@ -22,38 +12,50 @@ function try_delete(name) {
     }
 }
 
-CONFIG.plugins.push({
-    apply: compiler => {
-        compiler.hooks.afterEmit.tap("AfterEmitPlugin", () => {
-            for (const theme of THEMES) {
-                try_delete(theme.replace("less", "js"));
-                try_delete(theme.replace("less", "js.map"));
-                try_delete(theme.replace("less", "css.map"));
-            }
-        });
-    }
-});
-
-CONFIG.module.rules.push({
-    test: /\.(woff|ttf|eot|svg|woff2)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-    loader: "base64-font-loader"
-});
-
-CONFIG.module.rules.push({
-    test: /themes[\\/].+?\.less$/,
-    use: [{loader: MiniCssExtractPlugin.loader}, "css-loader", "less-loader"]
-});
-
 function reducer(obj, key, val) {
     obj[key] = val;
     return obj;
 }
 
-module.exports = Object.assign({}, CONFIG, {
-    entry: THEMES.reduce((obj, theme) => reducer(obj, theme.replace(".less", ""), path.resolve(__dirname, "..", "themes", theme)), {"perspective-viewer": "./dist/cjs/perspective-viewer.js"}),
-    output: {
-        filename: "[name].js",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../dist/umd")
-    }
+module.exports = common({}, config => {
+    config.plugins.push(
+        new MiniCssExtractPlugin({
+            splitChunks: {
+                chunks: "all"
+            },
+            filename: "[name].css"
+        })
+    );
+
+    config.plugins.push({
+        apply: compiler => {
+            compiler.hooks.afterEmit.tap("AfterEmitPlugin", () => {
+                for (const theme of THEMES) {
+                    try_delete(theme.replace("less", "js"));
+                    try_delete(theme.replace("less", "js.map"));
+                    try_delete(theme.replace("less", "css.map"));
+                }
+            });
+        }
+    });
+
+    config.plugins.push(new FixStyleOnlyEntriesPlugin());
+    config.module.rules.push({
+        test: /\.(woff|ttf|eot|svg|woff2)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        loader: "base64-font-loader"
+    });
+
+    config.module.rules.push({
+        test: /themes[\\/].+?\.less$/,
+        use: [{loader: MiniCssExtractPlugin.loader}, "css-loader", "less-loader"]
+    });
+
+    return Object.assign(config, {
+        entry: THEMES.reduce((obj, theme) => reducer(obj, theme.replace(".less", ""), path.resolve(__dirname, "..", "themes", theme)), {"perspective-viewer": "./dist/cjs/perspective-viewer.js"}),
+        output: {
+            filename: "[name].js",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist/umd")
+        }
+    });
 });

--- a/packages/perspective-viewer/src/js/computed_column/state.js
+++ b/packages/perspective-viewer/src/js/computed_column/state.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {values} from "lodash";
+import values from "lodash/values";
 
 export default class State {
     constructor() {

--- a/packages/perspective-viewer/src/js/row.js
+++ b/packages/perspective-viewer/src/js/row.js
@@ -7,7 +7,7 @@
  *
  */
 
-import _ from "lodash";
+import debounce from "lodash/debounce";
 
 import Awesomplete from "awesomplete";
 import awesomplete_style from "!!css-loader!awesomplete/awesomplete.css";
@@ -268,7 +268,7 @@ class Row extends HTMLElement {
             this.dispatchEvent(new CustomEvent("sort-order", {detail: event}));
         });
 
-        const debounced_filter = _.debounce(event => this._update_filter(event), 50);
+        const debounced_filter = debounce(event => this._update_filter(event), 50);
         this._filter_operator.addEventListener("change", () => {
             this._filter_operand.focus();
             this._filter_operator.style.width = get_text_width(this._filter_operator.value);

--- a/packages/perspective-viewer/src/js/viewer/perspective_element.js
+++ b/packages/perspective-viewer/src/js/viewer/perspective_element.js
@@ -7,7 +7,8 @@
  *
  */
 
-import _ from "lodash";
+import debounce from "lodash/debounce";
+import isEqual from "lodash/isEqual";
 import {html, render} from "lit-html";
 
 import perspective from "@finos/perspective";
@@ -345,7 +346,7 @@ export class PerspectiveElement extends StateElement {
 
     _is_config_changed(config) {
         const plugin_name = this.getAttribute("plugin");
-        if (_.isEqual(config, this._previous_config) && plugin_name === this._previous_plugin_name) {
+        if (isEqual(config, this._previous_config) && plugin_name === this._previous_plugin_name) {
             return false;
         } else {
             this._previous_config = config;
@@ -491,7 +492,7 @@ export class PerspectiveElement extends StateElement {
     }
 
     _register_debounce_instance() {
-        const _update = _.debounce((resolve, ignore_size_check, force_update, limit_points) => {
+        const _update = debounce((resolve, ignore_size_check, force_update, limit_points) => {
             this._new_view({ignore_size_check, force_update, limit_points}).then(resolve);
         }, 0);
 

--- a/packages/perspective-viewer/src/themes/material-dense.less
+++ b/packages/perspective-viewer/src/themes/material-dense.less
@@ -20,6 +20,7 @@
    --hypergrid-row--height: 20px;
    --side_panel--padding: 12px 12px 12px 10px;
    --top_panel--padding: 0px 0px 12px 0px;
+   --column-drop-label--margin: -10px 0px 0px 0px;
    --column-drop-container--margin: 12px 12px 0px 0px;
    --column-container--margin: 12px 0px 0px 0px;
    --row_draggable--animation: none;

--- a/packages/perspective/src/config/perspective.config.js
+++ b/packages/perspective/src/config/perspective.config.js
@@ -2,59 +2,61 @@ const path = require("path");
 const common = require("./common.config.js");
 const TerserPlugin = require("terser-webpack-plugin");
 
-module.exports = Object.assign({}, common({build_worker: true}), {
-    entry: "./dist/esm/perspective.parallel.js",
-    output: {
-        filename: "perspective.js",
-        library: "perspective",
-        libraryTarget: "umd",
-        libraryExport: "default",
-        path: path.resolve(__dirname, "../../dist/umd")
-    },
-    optimization: {
-        minimizer: [
-            new TerserPlugin({
-                cache: true,
-                parallel: true,
-                test: /\.js(\?.*)?$/i,
-                exclude: /(wasm|asmjs)/,
-                sourceMap: true,
-                terserOptions: {
-                    keep_infinity: true
-                }
-            }),
-            new TerserPlugin({
-                cache: true,
-                parallel: true,
-                test: /wasm/,
-                sourceMap: true,
-                terserOptions: {
-                    mangle: false,
-                    keep_infinity: true
-                }
-            }),
-            new TerserPlugin({
-                cache: true,
-                parallel: true,
-                test: /asmjs/,
-                exclude: /psp/,
-                sourceMap: false,
-                terserOptions: {
-                    ecma: undefined,
-                    warnings: false,
-                    parse: undefined,
-                    compress: false,
-                    mangle: false,
-                    module: false,
-                    output: null,
-                    toplevel: false,
-                    nameCache: null,
-                    ie8: true,
-                    keep_classnames: true,
-                    keep_fnames: true,
-                    safari10: true
-                }
-            })
-        ]
-    }
-});
+module.exports = common({build_worker: true}, config =>
+    Object.assign(config, {
+        entry: "./dist/esm/perspective.parallel.js",
+        output: {
+            filename: "perspective.js",
+            library: "perspective",
+            libraryTarget: "umd",
+            libraryExport: "default",
+            path: path.resolve(__dirname, "../../dist/umd")
+        },
+        optimization: {
+            minimizer: [
+                new TerserPlugin({
+                    cache: true,
+                    parallel: true,
+                    test: /\.js(\?.*)?$/i,
+                    exclude: /(wasm|asmjs)/,
+                    sourceMap: true,
+                    terserOptions: {
+                        keep_infinity: true
+                    }
+                }),
+                new TerserPlugin({
+                    cache: true,
+                    parallel: true,
+                    test: /wasm/,
+                    sourceMap: true,
+                    terserOptions: {
+                        mangle: false,
+                        keep_infinity: true
+                    }
+                }),
+                new TerserPlugin({
+                    cache: true,
+                    parallel: true,
+                    test: /asmjs/,
+                    exclude: /psp/,
+                    sourceMap: false,
+                    terserOptions: {
+                        ecma: undefined,
+                        warnings: false,
+                        parse: undefined,
+                        compress: false,
+                        mangle: false,
+                        module: false,
+                        output: null,
+                        toplevel: false,
+                        nameCache: null,
+                        ie8: true,
+                        keep_classnames: true,
+                        keep_fnames: true,
+                        safari10: true
+                    }
+                })
+            ]
+        }
+    })
+);

--- a/packages/perspective/src/config/perspective.node.config.js
+++ b/packages/perspective/src/config/perspective.node.config.js
@@ -2,38 +2,40 @@ const path = require("path");
 const common = require("./common.config.js");
 const TerserPlugin = require("terser-webpack-plugin");
 
-module.exports = Object.assign({}, common(), {
-    entry: "./dist/esm/perspective.node.js",
-    target: "node",
-    externals: [/^[a-z0-9].*?$/g],
-    node: {
-        __dirname: false,
-        __filename: false
-    },
-    output: {
-        filename: "perspective.node.js",
-        path: path.resolve(__dirname, "../../dist/umd"),
-        libraryTarget: "umd"
-    },
-    optimization: {
-        minimizer: [
-            new TerserPlugin({
-                cache: true,
-                parallel: true,
-                test: /\.js(\?.*)?$/i,
-                exclude: /node/,
-                sourceMap: true
-            }),
-            new TerserPlugin({
-                cache: true,
-                parallel: true,
-                test: /node/,
-                sourceMap: true,
-                terserOptions: {
-                    mangle: false,
-                    keep_infinity: true
-                }
-            })
-        ]
-    }
-});
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: "./dist/esm/perspective.node.js",
+        target: "node",
+        externals: [/^[a-z0-9].*?$/g],
+        node: {
+            __dirname: false,
+            __filename: false
+        },
+        output: {
+            filename: "perspective.node.js",
+            path: path.resolve(__dirname, "../../dist/umd"),
+            libraryTarget: "umd"
+        },
+        optimization: {
+            minimizer: [
+                new TerserPlugin({
+                    cache: true,
+                    parallel: true,
+                    test: /\.js(\?.*)?$/i,
+                    exclude: /node/,
+                    sourceMap: true
+                }),
+                new TerserPlugin({
+                    cache: true,
+                    parallel: true,
+                    test: /node/,
+                    sourceMap: true,
+                    terserOptions: {
+                        mangle: false,
+                        keep_infinity: true
+                    }
+                })
+            ]
+        }
+    })
+);

--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -7,6 +7,8 @@
  *
  */
 
+require("./script_utils.js");
+
 const execSync = require("child_process").execSync;
 
 const execute = cmd => execSync(cmd, {stdio: "inherit"});
@@ -36,7 +38,7 @@ function docker() {
 }
 
 try {
-    if (!process.env.PSP_LOCAL_PUPPETEER) {
+    if (!process.env.PSP_DOCKER_PUPPETEER) {
         execute(docker());
     } else {
         execute(`nice -n -20 node_modules/.bin/lerna exec --scope=@finos/perspective-bench -- yarn bench`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9256,11 +9256,6 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash.uniqby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
-  integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
-
 lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"


### PR DESCRIPTION
New resize/minimum-size behavior for `perspective-workspace`, as well as support for discrete resize.  Also a culmination of fixes resulting from review of recent commits:
* Updates to the `perspective-bench` suite which allow more granular seleciton of Arrow related benchmarks (for testing the `to-arrow` branch).
* Improvements to all asset build sizes due to `lodash`.
* Added missing license headers.
* Fixed jumpy resize behavior in `perspective-viewer-d3fc`

