### PR TITLE
Add benchmark suite for Python, Refactor module loading for environments where C++ cannot be built

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
         "build": "node scripts/build.js",
         "build_python": "node scripts/build_python.js",
         "bench": "node scripts/bench.js",
+        "bench_python": "python3 python/perspective/bench/perspective_benchmark.py",
         "setup": "node scripts/setup.js",
         "docs": "node scripts/docs.js",
         "test": "node scripts/test.js",

--- a/python/perspective/bench/__init__.py
+++ b/python/perspective/bench/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+from bench import Benchmark, Suite, Runner
+
+__all__ = ["Benchmark", "Suite", "Runner"]

--- a/python/perspective/bench/bench.py
+++ b/python/perspective/bench/bench.py
@@ -1,0 +1,162 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+import logging
+import os
+import sys
+import signal
+from time import perf_counter
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
+from perspective import Table  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+
+
+class Benchmark(object):
+    """A single Benchmark function. Use as a decorator for stateless lambdas
+    with no parameters.
+
+    Example:
+        >>> func = Benchmark(lambda: self._view.to_records(), meta={
+                "name": "to_records",
+                "group": "view"
+            })
+    """
+
+    def __init__(self, func, meta={}):
+        """A decorator for a benchmark function, which will attach each attribute
+        of the `meta` dictionary to the decorated function as well as provide
+        it with the `benchmark` attribute.
+
+        Args:
+            meta (dict) : a metadata dictionary, whose keys and values will
+                become attributes on the benchmark function. The metadata dictionary
+                should be consistent within each suite, i.e. there should be no
+                additional values in between different methods decorated with
+                `@benchmark`.
+        """
+        self._func = func
+        self._meta = meta
+        self.benchmark = True
+
+        for k, v in self._meta.items():
+            marked_key = "__BENCH__{0}".format(k)
+            setattr(self, marked_key, v)
+
+    def __call__(self):
+        """Call the lambda bound to the decorator. This call asserts that the
+        lambda has no parameters and no reference to a `self` object.
+        """
+        self._func()
+
+
+class Suite(object):
+    """A benchmark suite stub that contains `register_benchmarks` and generic
+    before/after methods.
+
+    Inherit from this class and implement `register_benchmarks`, which should
+    set all benchmark methods as attributes on the class.
+    """
+
+    def register_benchmarks(self):
+        """Registers all callbacks with `Runner`.
+
+        This function must be implemented in all child classes of `Suite.`
+        """
+        raise NotImplementedError(
+                "Must implement `register_benchmarks` to run benchmark suite.")
+
+    def before_all(self):
+        pass
+
+    def after_all(self):
+        pass
+
+    def before_each(self):
+        pass
+
+    def after_each(self):
+        pass
+
+
+class Runner(object):
+
+    ITERATIONS = 10
+
+    def __init__(self, suite):
+        """Initializes a benchmark runner for the `Suite`.
+
+        Args:
+            suite (Suite) : A class that inherits from `Suite`, with any number
+                of instance methods decorated with `@benchmark`.
+        """
+        self._suite = suite
+        self._benchmarks = []
+        self._table = None
+
+        self._suite.register_benchmarks()
+
+        class_attrs = self._suite.__class__.__dict__.items()
+        instance_attrs = self._suite.__dict__.items()
+
+        for (k, v) in class_attrs:
+            if hasattr(v, "benchmark") and getattr(v, "benchmark") is True:
+                logging.info("Registering {0}".format(k))
+                self._benchmarks.append(v)
+
+        for (k, v) in instance_attrs:
+            if hasattr(v, "benchmark") and getattr(v, "benchmark") is True:
+                logging.info("Registering {0}".format(k))
+                self._benchmarks.append(v)
+
+        # Write results on SIGINT
+        signal.signal(signal.SIGINT, self.sigint_handler)
+
+    def sigint_handler(self, signum, frame):
+        """On SIGINT, write benchmark results to Arrow and exit gracefully."""
+        self.write_results()
+        sys.exit(0)
+
+    def write_results(self):
+        """Writes the results to an arrow file."""
+        if not self._table:
+            logging.info("No results to write, exiting.")
+            return
+        logging.info("Writing results to Arrow...")
+
+    def run_method(self, func, *args, **kwargs):
+        """Wrap the benchmark `func` with timing code and run for n
+        `ITERATIONS`, returning a result row that can be fed into Perspective.
+        """
+        overall_result = {
+            k.replace("__BENCH__", ""):
+                v for (k, v) in func.__dict__.items() if "__BENCH__" in k
+        }
+
+        iter_results = []
+        for i in range(Runner.ITERATIONS):
+            start = perf_counter()
+            func(*args, **kwargs)
+            end = perf_counter()
+            iter_results.append(end - start)
+
+        overall_result["__TIME__"] = sum(iter_results) / len(iter_results)
+        return overall_result
+
+    def run(self):
+        """Runs each benchmark function from the suite for n `ITERATIONS`,
+        timing each function and writing the results to a `perspective.Table`.
+        """
+        logging.info("Running benchmark suite...")
+        for benchmark in self._benchmarks:
+            result = self.run_method(benchmark)
+            print(result)
+            if self._table is None:
+                self._table = Table([result])
+            else:
+                self._table.update([result])
+        self.write_results()

--- a/python/perspective/bench/bench.py
+++ b/python/perspective/bench/bench.py
@@ -30,7 +30,7 @@ class BenchmarkTornadoHandler(tornado.web.RequestHandler):
 
 
 class Benchmark(object):
-    """A single Benchmark function. Use as a decorator for stateless lambdas
+    """A single Benchmark function. Use as a wrapper for stateless lambdas
     with no parameters.
 
     Example:

--- a/python/perspective/bench/benchmark.html
+++ b/python/perspective/bench/benchmark.html
@@ -1,0 +1,54 @@
+<!--
+   
+   Copyright (c) 2019, the Perspective Authors.
+   
+   This file is part of the Perspective library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+
+    <script src="http://localhost:8080/perspective-viewer"></script>
+    <script src="http://localhost:8080/perspective-viewer-hypergrid"></script>
+    <script src="http://localhost:8080/perspective-viewer-d3fc"></script>
+    <script src="http://localhost:8080/perspective"></script>
+
+    <link rel='stylesheet' href="http://localhost:8080/material.dark.css">
+
+    <style>
+        perspective-viewer{position:absolute;top:0;left:0;right:0;bottom:0;}
+    </style>
+
+</head>
+
+<body>
+
+    <perspective-viewer 
+        id="viewer" 
+        editable
+        plugin="d3_y_bar"
+        columns='["__TIME__"]'
+        row-pivots='["group", "name"]'
+        column-pivots='["group", "name"]'
+        aggregates="{'__TIME__':'avg'}">
+    </perspective-viewer>
+
+    <script>
+
+        window.addEventListener('WebComponentsReady', async function() {
+            const websocket = perspective.websocket("ws://localhost:8888/websocket");
+            const table = websocket.open_table('benchmark_results');
+            document.getElementById('viewer').load(table);
+        });
+
+    </script>
+
+</body>
+
+</html>

--- a/python/perspective/bench/perspective_benchmark.py
+++ b/python/perspective/bench/perspective_benchmark.py
@@ -1,0 +1,125 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+import os
+import sys
+from functools import partial
+from bench import Benchmark, Suite, Runner
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
+from perspective import Table  # noqa: E402
+
+SUPERSTORE_ARROW = os.path.join(
+    os.path.dirname(__file__),
+    "..", "..", "..",
+    "examples",
+    "simple",
+    "superstore.arrow")
+
+
+def make_meta(group, name):
+    return {
+        "group": group,
+        "name": name,
+        "version": "master"
+    }
+
+
+class PerspectiveBenchmark(Suite):
+
+    AGG_OPTIONS = [
+        [{"column": "Sales", "op": "sum"}],
+        [{"column": "State", "op": "dominant"}],
+        [{"column": "Order Date", "op": "dominant"}]
+    ]
+    COLUMN_PIVOT_OPTIONS = [[], ["Sub-Category"], ["Category", "Sub-Category"]]
+    ROW_PIVOT_OPTIONS = [[], ["State"], ["State", "City"]]
+
+    VERSION = "master"
+
+    def __init__(self):
+        """Create a benchmark suite for `perspective-python`."""
+        with open(SUPERSTORE_ARROW, "rb") as arrow:
+            tbl = Table(arrow.read())
+            self._view = tbl.view()
+            self.dict = self._view.to_dict()
+            self.records = self._view.to_records()
+            self.numpy = self._view.to_numpy()
+            self.csv = self._view.to_csv()
+            self.arrow = self._view.to_arrow()
+            self._table = tbl
+
+    def register_benchmarks(self):
+        """Register all the benchmark methods - each method creates a number of
+        lambdas, and then calls `setattr` on the Suite itself so that the
+        `Runner` can find the tests at runtime."""
+        self.benchmark_table()
+        self.benchmark_view_zero()
+        self.benchmark_view_one()
+        self.benchmark_view_two()
+        self.benchmark_view_two_column_only()
+        self.benchmark_to_format()
+
+    def benchmark_table(self):
+        """Benchmark table creation from different formats."""
+        for name in ("dict", "records", "numpy"):
+            data = getattr(self, name)
+            test_meta = make_meta("table", name)
+            func = Benchmark(lambda: Table(data), meta=test_meta)
+            setattr(self, "table_{0}".format(name), func)
+
+    def benchmark_view_zero(self):
+        """Benchmark view creation with zero pivots."""
+        func = Benchmark(self._table.view, meta=make_meta("view", "zero"))
+        setattr(self, "view_zero", func)
+
+    def benchmark_view_one(self):
+        """Benchmark view creation with different pivots."""
+        for pivot in PerspectiveBenchmark.ROW_PIVOT_OPTIONS:
+            if len(pivot) == 0:
+                continue
+            test_meta = make_meta("view", "one_{0}_pivot".format(len(pivot)))
+            view_constructor = partial(self._table.view, row_pivots=pivot)
+            func = Benchmark(view_constructor, meta=test_meta)
+            setattr(self, "view_{0}".format(test_meta["name"]), func)
+
+    def benchmark_view_two(self):
+        """Benchmark view creation with row and column pivots."""
+        for i in range(len(PerspectiveBenchmark.ROW_PIVOT_OPTIONS)):
+            RP = PerspectiveBenchmark.ROW_PIVOT_OPTIONS[i]
+            CP = PerspectiveBenchmark.COLUMN_PIVOT_OPTIONS[i]
+            if len(RP) == 0 and len(CP) == 0:
+                continue
+            test_meta = make_meta("view", "two_{0}x{1}_pivot".format(len(RP), len(CP)))
+            view_constructor = partial(
+                self._table.view, row_pivots=RP, column_pivots=CP)
+            func = Benchmark(view_constructor, meta=test_meta)
+            setattr(self, "view_{0}".format(test_meta["name"]), func)
+
+    def benchmark_view_two_column_only(self):
+        """Benchmark column-only view creation."""
+        for pivot in PerspectiveBenchmark.COLUMN_PIVOT_OPTIONS:
+            test_meta = make_meta(
+                "view", "two_column_only_{0}_pivot".format(len(pivot)))
+            view_constructor = partial(self._table.view, column_pivots=pivot)
+            func = Benchmark(view_constructor, meta=test_meta)
+            setattr(self, "view_{0}".format(test_meta["name"]), func)
+
+    def benchmark_to_format(self):
+        """Benchmark each `to_format` method."""
+        for name in ("numpy", "dict", "records", "df"):
+            test_meta = make_meta("to_format", name)
+            func = Benchmark(
+                getattr(self._view, "to_{0}".format(name)), meta=test_meta)
+            setattr(self, "to_format_{0}".format(name), func)
+
+
+if __name__ == "__main__":
+    # Initialize a suite and runner, then call `.run()`
+    suite = PerspectiveBenchmark()
+    runner = Runner(suite)
+    runner.run()

--- a/python/perspective/bench/perspective_benchmark.py
+++ b/python/perspective/bench/perspective_benchmark.py
@@ -12,6 +12,9 @@ from functools import partial
 from bench import Benchmark, Suite, Runner
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
 from perspective import Table  # noqa: E402
+from perspective.tests.common import superstore  # noqa: E402
+
+SUPERSTORE = superstore(9994)
 
 SUPERSTORE_ARROW = os.path.join(
     os.path.dirname(__file__),
@@ -43,16 +46,14 @@ class PerspectiveBenchmark(Suite):
 
     def __init__(self):
         """Create a benchmark suite for `perspective-python`."""
-        with open(SUPERSTORE_ARROW, "rb") as arrow:
-            tbl = Table(arrow.read())
-            self._view = tbl.view()
-            self.dict = self._view.to_dict()
-            self.records = self._view.to_records()
-            self.df = self._view.to_df()
-            self.numpy = self._view.to_numpy()
-            self.csv = self._view.to_csv()
-            self.arrow = self._view.to_arrow()
-            self._table = tbl
+        tbl = Table(SUPERSTORE)
+        self._view = tbl.view()
+        self.dict = self._view.to_dict()
+        self.records = self._view.to_records()
+        self.df = SUPERSTORE
+        self.csv = self._view.to_csv()
+        self.arrow = self._view.to_arrow()
+        self._table = tbl
 
     def register_benchmarks(self):
         """Register all the benchmark methods - each method creates a number of
@@ -71,7 +72,7 @@ class PerspectiveBenchmark(Suite):
 
     def benchmark_table(self):
         """Benchmark table creation from different formats."""
-        for name in ("df", "dict", "records", "numpy"):
+        for name in ("df", "dict", "records"):
             data = getattr(self, name)
             test_meta = make_meta("table", name)
             func = Benchmark(lambda: Table(data), meta=test_meta)
@@ -128,7 +129,7 @@ class PerspectiveBenchmark(Suite):
 
     def benchmark_to_format_zero(self):
         """Benchmark each `to_format` method."""
-        for name in ("numpy", "dict", "records", "df"):
+        for name in ("numpy", "dict", "records", "df", "arrow"):
             test_meta = make_meta("to_format", name)
             func = Benchmark(
                 getattr(self._view, "to_{0}".format(name)), meta=test_meta)
@@ -136,7 +137,7 @@ class PerspectiveBenchmark(Suite):
 
     def benchmark_to_format_one(self):
         """Benchmark each `to_format` method for one-sided contexts."""
-        for name in ("numpy", "dict", "records", "df"):
+        for name in ("numpy", "dict", "records", "df", "arrow"):
             for pivot in PerspectiveBenchmark.ROW_PIVOT_OPTIONS:
                 if len(pivot) == 0:
                     continue
@@ -149,7 +150,7 @@ class PerspectiveBenchmark(Suite):
 
     def benchmark_to_format_two(self):
         """Benchmark each `to_format` method for two-sided contexts."""
-        for name in ("numpy", "dict", "records", "df"):
+        for name in ("numpy", "dict", "records", "df", "arrow"):
             for i in range(len(PerspectiveBenchmark.ROW_PIVOT_OPTIONS)):
                 RP = PerspectiveBenchmark.ROW_PIVOT_OPTIONS[i]
                 CP = PerspectiveBenchmark.COLUMN_PIVOT_OPTIONS[i]
@@ -165,7 +166,7 @@ class PerspectiveBenchmark(Suite):
     def benchmark_to_format_two_column_only(self):
         """Benchmark each `to_format` method for two-sided column-only
         contexts."""
-        for name in ("dict", "records", "df"):
+        for name in ("dict", "records", "df", "arrow"):
             for pivot in PerspectiveBenchmark.COLUMN_PIVOT_OPTIONS:
                 if len(pivot) == 0:
                     continue

--- a/python/perspective/bench/perspective_benchmark.py
+++ b/python/perspective/bench/perspective_benchmark.py
@@ -68,7 +68,7 @@ class PerspectiveBenchmark(Suite):
         self.benchmark_to_format_zero()
         self.benchmark_to_format_one()
         self.benchmark_to_format_two()
-        # self.benchmark_to_format_two_column_only()
+        self.benchmark_to_format_two_column_only()
 
     def benchmark_table(self):
         """Benchmark table creation from different formats."""

--- a/python/perspective/bench/perspective_benchmark.py
+++ b/python/perspective/bench/perspective_benchmark.py
@@ -89,7 +89,7 @@ class PerspectiveBenchmark(Suite):
 
     def benchmark_view_zero(self):
         """Benchmark view creation with zero pivots."""
-        func = Benchmark(self._table.view, meta=make_meta("view", "zero"))
+        func = Benchmark(lambda: self._table.view(), meta=make_meta("view", "zero"))
         setattr(self, "view_zero", func)
 
     def benchmark_view_one(self):
@@ -99,7 +99,7 @@ class PerspectiveBenchmark(Suite):
                 continue
             test_meta = make_meta("view", "one_{0}_pivot".format(len(pivot)))
             view_constructor = partial(self._table.view, row_pivots=pivot)
-            func = Benchmark(view_constructor, meta=test_meta)
+            func = Benchmark(lambda: view_constructor(), meta=test_meta)
             setattr(self, "view_{0}".format(test_meta["name"]), func)
 
     def benchmark_view_two(self):
@@ -113,7 +113,7 @@ class PerspectiveBenchmark(Suite):
                 "view", "two_{0}x{1}_pivot".format(len(RP), len(CP)))
             view_constructor = partial(
                 self._table.view, row_pivots=RP, column_pivots=CP)
-            func = Benchmark(view_constructor, meta=test_meta)
+            func = Benchmark(lambda: view_constructor(), meta=test_meta)
             setattr(self, "view_{0}".format(test_meta["name"]), func)
 
     def benchmark_view_two_column_only(self):
@@ -124,7 +124,7 @@ class PerspectiveBenchmark(Suite):
             test_meta = make_meta(
                 "view", "two_column_only_{0}_pivot".format(len(pivot)))
             view_constructor = partial(self._table.view, column_pivots=pivot)
-            func = Benchmark(view_constructor, meta=test_meta)
+            func = Benchmark(lambda: view_constructor(), meta=test_meta)
             setattr(self, "view_{0}".format(test_meta["name"]), func)
 
     def benchmark_to_format_zero(self):
@@ -132,7 +132,7 @@ class PerspectiveBenchmark(Suite):
         for name in ("numpy", "dict", "records", "df", "arrow"):
             test_meta = make_meta("to_format", name)
             func = Benchmark(
-                getattr(self._view, "to_{0}".format(name)), meta=test_meta)
+                lambda: getattr(self._view, "to_{0}".format(name))(), meta=test_meta)
             setattr(self, "to_format_{0}".format(name), func)
 
     def benchmark_to_format_one(self):
@@ -145,7 +145,7 @@ class PerspectiveBenchmark(Suite):
                     "to_format", "{0}_{1}".format(name, len(pivot)))
                 view = self._table.view(row_pivots=pivot)
                 func = Benchmark(
-                    getattr(view, "to_{0}".format(name)), meta=test_meta)
+                    lambda: getattr(view, "to_{0}".format(name))(), meta=test_meta)
                 setattr(self, "to_format_{0}".format(test_meta["name"]), func)
 
     def benchmark_to_format_two(self):
@@ -160,7 +160,7 @@ class PerspectiveBenchmark(Suite):
                     "to_format", "{0}_{1}x{2}".format(name, len(RP), len(CP)))
                 view = self._table.view(row_pivots=RP, column_pivots=CP)
                 func = Benchmark(
-                    getattr(view, "to_{0}".format(name)), meta=test_meta)
+                    lambda: getattr(view, "to_{0}".format(name))(), meta=test_meta)
                 setattr(self, "to_format_{0}".format(test_meta["name"]), func)
 
     def benchmark_to_format_two_column_only(self):
@@ -174,7 +174,7 @@ class PerspectiveBenchmark(Suite):
                     "to_format", "{0}_{1}_column".format(name, len(pivot)))
                 view = self._table.view(column_pivots=pivot)
                 func = Benchmark(
-                    getattr(view, "to_{0}".format(name)), meta=test_meta)
+                    lambda: getattr(view, "to_{0}".format(name))(), meta=test_meta)
                 setattr(self, "to_format_{0}".format(test_meta["name"]), func)
 
 

--- a/python/perspective/package.json
+++ b/python/perspective/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "webpack": "webpack --color --config ./webpack.config.js ./js/* && cpx \"node_modules/@finos/perspective/build/*.wasm\" \"perspective/node/assets\"&& cpx \"node_modules/zeromq/build/Release/zmq.node\" \"perspective/node/assets\"",
     "clean": "rimraf build",
+    "bench": "python3 bench/perspective_benchmark.py",
     "docs": "python3 docs/generate.py"
   },
   "files": [

--- a/python/perspective/perspective/__init__.py
+++ b/python/perspective/perspective/__init__.py
@@ -6,17 +6,10 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
+from .libpsp import *  # noqa: F401, F403
 from .core import *  # noqa: F401, F403
 from .core._version import __version__  # noqa: F401
-from .manager import *  # noqa: F401, F403
-from .tornado_handler import *  # noqa: F401, F403
-from .viewer import *  # noqa: F401, F403
 from .widget import *  # noqa: F401, F403
-
-try:
-    from .table import *  # noqa: F401, F403
-except ImportError:
-    pass
 
 try:
     from .node import *  # noqa: F401, F403

--- a/python/perspective/perspective/libpsp.py
+++ b/python/perspective/perspective/libpsp.py
@@ -1,0 +1,30 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+from logging import critical
+
+
+def is_libpsp():
+    """Was libbinding successfully loaded in this module?"""
+    return __is_libpsp__
+
+
+__is_libpsp__ = True
+
+try:
+    # Load all `libbinding` depending modules in one go, otherwise nothing
+    # dependent on `libbinding` is exposed.
+    from .table import *  # noqa: F401, F403
+    from .manager import *  # noqa: F401, F403
+    from .tornado_handler import *  # noqa: F401, F403
+    from .viewer import *  # noqa: F401, F403
+except ImportError:
+    __is_libpsp__ = False
+    critical("Failed to import C++ bindings for Perspective "
+             "probably as it could not be built for your architecture "
+             "(check install logs for more details).\n"
+             "You can still use `PerspectiveWidget` in client mode using JupyterLab.")

--- a/python/perspective/perspective/manager/manager.py
+++ b/python/perspective/perspective/manager/manager.py
@@ -15,14 +15,9 @@ from functools import partial
 from ..core.exception import PerspectiveError
 from ..table._callback_cache import _PerspectiveCallBackCache
 from ..table._date_validator import _PerspectiveDateValidator
-from ..table import Table
+from ..table import Table, PerspectiveCppError
 from ..table.view import View
 from .session import PerspectiveSession
-
-try:
-    from ..table import PerspectiveCppError
-except ImportError:
-    pass
 
 
 def gen_name(size=10, chars=string.ascii_uppercase + string.digits):

--- a/python/perspective/perspective/table/__init__.py
+++ b/python/perspective/perspective/table/__init__.py
@@ -7,20 +7,6 @@
 #
 
 from .table import Table
+from .libbinding import PerspectiveCppError
 
-
-def is_libpsp():
-    """Was libbinding successfully loaded in this module?"""
-    return __is_libpsp__
-
-
-__all__ = ["Table", "is_libpsp"]
-
-__is_libpsp__ = True
-
-try:
-    from .libbinding import PerspectiveCppError  # noqa: F401
-    __all__.append("PerspectiveCppError")
-except ImportError:
-    __is_libpsp__ = False
-    pass
+__all__ = ["Table", "PerspectiveCppError"]

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -190,48 +190,46 @@ class _PerspectiveAccessor(object):
         # first, check for numpy nans without using numpy.isnan as it tries to
         # cast values
         if isinstance(val, float) and isnan(val):
-            val = None
+            return None
         elif isinstance(val, list) and len(val) == 1:
             # strip out values encased lists
             val = val[0]
-        elif dtype == t_dtype.DTYPE_BOOL:
-            # True values are y, yes, t, true, on and 1; false values are n, no,
-            # f, false, off and 0.
-            val = bool(strtobool(str(val)))
-        elif dtype == t_dtype.DTYPE_INT32 or dtype == t_dtype.DTYPE_INT64:
-            if not isinstance(val, bool) and isinstance(val, (float, numpy.floating)):
-                # should be able to update int columns with either ints or
-                # floats
-                val = int(val)
-        elif dtype == t_dtype.DTYPE_FLOAT32 or dtype == t_dtype.DTYPE_FLOAT64:
-            if not isinstance(val, bool) and isinstance(val, _PerspectiveAccessor.INTEGER_TYPES):
-                # should be able to update float columns with either ints or
-                # floats
-                val = float(val)
-        elif dtype == t_dtype.DTYPE_DATE:
-            # return datetime.date
-            if isinstance(val, str):
-                parsed = self._date_validator.parse(val)
-                val = self._date_validator.to_date_components(parsed)
-            else:
-                val = self._date_validator.to_date_components(val)
-        elif dtype == t_dtype.DTYPE_TIME:
-            # return unix timestamps for time
-            if isinstance(val, str):
-                parsed = self._date_validator.parse(val)
-                val = self._date_validator.to_timestamp(parsed)
-            else:
-                val = self._date_validator.to_timestamp(val)
         elif dtype == t_dtype.DTYPE_STR:
             if isinstance(val, (bytes, bytearray)):
-                val = val.decode("utf-8")
+                return val.decode("utf-8")
             else:
                 if six.PY2:
                     # six.u mangles quotes with escape sequences - use native
                     # unicode()
-                    val = unicode(val)  # noqa: F821
+                    return unicode(val)  # noqa: F821
                 else:
-                    val = str(val)
+                    return str(val)
+        elif dtype == t_dtype.DTYPE_DATE:
+            # return datetime.date
+            if isinstance(val, str):
+                parsed = self._date_validator.parse(val)
+                return self._date_validator.to_date_components(parsed)
+            else:
+                return self._date_validator.to_date_components(val)
+        elif dtype == t_dtype.DTYPE_TIME:
+            # return unix timestamps for time
+            if isinstance(val, str):
+                parsed = self._date_validator.parse(val)
+                return self._date_validator.to_timestamp(parsed)
+            else:
+                return self._date_validator.to_timestamp(val)
+        elif dtype == t_dtype.DTYPE_BOOL:
+            # True values are y, yes, t, true, on and 1; false values are n, no,
+            # f, false, off and 0.
+            return bool(strtobool(str(val)))
+        elif dtype == t_dtype.DTYPE_INT32 or dtype == t_dtype.DTYPE_INT64:
+            if not isinstance(val, bool) and isinstance(val, (float, numpy.floating)):
+                # update int columns with either ints or floats
+                return int(val)
+        elif dtype == t_dtype.DTYPE_FLOAT32 or dtype == t_dtype.DTYPE_FLOAT64:
+            if not isinstance(val, bool) and isinstance(val, _PerspectiveAccessor.INTEGER_TYPES):
+                # update float columns with either ints or floats
+                return float(val)
 
         return val
 
@@ -265,10 +263,8 @@ class _PerspectiveAccessor(object):
             bool: True if column is in row, or if column belongs to pkey/op
                 columns required by the engine. False otherwise.
         '''
-        if name in ("psp_pkey", "psp_okey", "psp_op"):
+        if self._format != 0 or name in ("psp_pkey", "psp_okey", "psp_op"):
+            # no partial updates available on meta column, schema, dict updates
             return True
-        if self._format == 0:
-            return name in self._data_or_schema[ridx]
         else:
-            # no partial updates available on schema or dict updates
-            return True
+            return name in self._data_or_schema[ridx]

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -16,11 +16,7 @@ from ._date_validator import _PerspectiveDateValidator
 from ..core.data import deconstruct_numpy, deconstruct_pandas
 from ..core.data.pd import _parse_datetime_index
 from ..core.exception import PerspectiveError
-
-try:
-    from .libbinding import t_dtype
-except ImportError:
-    pass
+from .libbinding import t_dtype
 
 
 def _flatten_structure(array):

--- a/python/perspective/perspective/table/_data_formatter.py
+++ b/python/perspective/perspective/table/_data_formatter.py
@@ -9,13 +9,9 @@
 import numpy as np
 from math import trunc
 from ._constants import COLUMN_SEPARATOR_STRING
-
-try:
-    from .libbinding import get_data_slice_zero, get_data_slice_one, get_data_slice_two, \
-        get_from_data_slice_zero, get_from_data_slice_one, get_from_data_slice_two, \
-        get_pkeys_from_data_slice_zero, get_pkeys_from_data_slice_one, get_pkeys_from_data_slice_two
-except ImportError:
-    pass
+from .libbinding import get_data_slice_zero, get_data_slice_one, get_data_slice_two, \
+    get_from_data_slice_zero, get_from_data_slice_one, get_from_data_slice_two, \
+    get_pkeys_from_data_slice_zero, get_pkeys_from_data_slice_one, get_pkeys_from_data_slice_two
 
 
 def _mod(a, b):

--- a/python/perspective/perspective/table/_data_formatter.py
+++ b/python/perspective/perspective/table/_data_formatter.py
@@ -51,9 +51,9 @@ def to_format(options, view, output_format):
             data.append({})
 
         for cidx in range(options["start_col"], options["end_col"]):
-            name = COLUMN_SEPARATOR_STRING.join([n.to_string(False) for n in column_names[cidx]])
+            name = column_names[cidx]
 
-            if _mod((cidx - (1 if view._sides > 0 else 0)), (num_columns + num_hidden)) >= len(view._config.get_columns()):
+            if _mod((cidx - (1 if view._sides > 0 else 0)), (num_columns + num_hidden)) >= num_columns:
                 # don't emit columns used for hidden sort
                 continue
             elif cidx == options["start_col"] and view._sides > 0:
@@ -127,7 +127,12 @@ def _to_format_helper(view, options=None):
     else:
         data_slice = get_data_slice_two(view._view, opts["start_row"], opts["end_row"], opts["start_col"], opts["end_col"])
 
-    column_names = data_slice.get_column_names()
+    raw_names = data_slice.get_column_names()
+    column_names = []
+
+    for n in raw_names:
+        column_names.append(COLUMN_SEPARATOR_STRING.join(
+            [path.to_string(False) for path in n]))
 
     return opts, column_names, data_slice
 

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -13,11 +13,7 @@ from pandas import Period
 from datetime import date, datetime
 from re import search
 from dateutil.parser import parse
-
-try:
-    from .libbinding import t_dtype
-except ImportError:
-    pass
+from .libbinding import t_dtype
 
 if six.PY2:
     from past.builtins import long

--- a/python/perspective/perspective/table/_utils.py
+++ b/python/perspective/perspective/table/_utils.py
@@ -7,11 +7,7 @@
 #
 
 from datetime import date, datetime
-
-try:
-    from .libbinding import t_dtype
-except ImportError:
-    pass
+from .libbinding import t_dtype
 
 
 def _extract_type(type, typemap):

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -13,12 +13,8 @@ from ._callback_cache import _PerspectiveCallBackCache
 from ..core.exception import PerspectiveError
 from ._state import _PerspectiveStateManager
 from ._utils import _dtype_to_pythontype, _dtype_to_str
-
-try:
-    from .libbinding import make_table, str_to_filter_op, t_filter_op, \
-                            t_op, t_dtype
-except ImportError:
-    pass
+from .libbinding import make_table, str_to_filter_op, t_filter_op, \
+                        t_op, t_dtype
 
 
 class Table(object):

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -16,13 +16,9 @@ from ._constants import COLUMN_SEPARATOR_STRING
 from ._utils import _str_to_pythontype
 from ._callback_cache import _PerspectiveCallBackCache
 from ._date_validator import _PerspectiveDateValidator
-
-try:
-    from .libbinding import make_view_zero, make_view_one, make_view_two,\
-        to_arrow_zero, to_arrow_one, to_arrow_two, get_row_delta_zero,\
-        get_row_delta_one, get_row_delta_two
-except ImportError:
-    pass
+from .libbinding import make_view_zero, make_view_one, make_view_two,\
+    to_arrow_zero, to_arrow_one, to_arrow_two, get_row_delta_zero,\
+    get_row_delta_one, get_row_delta_two
 
 
 class View(object):

--- a/python/perspective/perspective/tests/client/test_client.py
+++ b/python/perspective/perspective/tests/client/test_client.py
@@ -1,0 +1,222 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+import six
+import os
+import numpy as np
+import pandas as pd
+from datetime import date, datetime
+from functools import partial
+from types import MethodType
+
+# rename libbinding.so and libpsp.so temporarily to ensure that client mode
+# works automatically when the C++ build fails.
+lib_path = os.path.join(os.path.dirname(__file__), "..", "..", "table")
+binding = os.path.join(lib_path, "libbinding.so")
+psp = os.path.join(lib_path, "libpsp.so")
+new_binding = os.path.join(lib_path, "notlibbinding.so")
+new_psp = os.path.join(lib_path, "notlibpsp.so")
+
+
+def mock_post(self, msg, msg_id=None, assert_msg=None):
+    '''Mock the widget's `post()` method so we can introspect the contents.'''
+    assert msg == assert_msg
+
+
+def setup_module():
+    os.rename(binding, new_binding)
+    os.rename(psp, new_psp)
+    assert os.path.exists(new_binding)
+    assert os.path.exists(new_psp)
+    assert not os.path.exists(binding)
+    assert not os.path.exists(psp)
+
+
+def teardown_module():
+    os.rename(new_binding, binding)
+    os.rename(new_psp, psp)
+    assert os.path.exists(binding)
+    assert os.path.exists(psp)
+    assert not os.path.exists(new_binding)
+    assert not os.path.exists(new_psp)
+
+
+class TestClient(object):
+
+    def test_widget_client(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": [i for i in range(50)]}
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == data
+
+    def test_widget_client_np(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": np.arange(0, 50)}
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": [i for i in range(50)]
+        }
+
+    def test_widget_client_df(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = pd.DataFrame({
+            "a": np.arange(10),
+            "b": [True for i in range(10)],
+            "c": [str(i) for i in range(10)]
+        })
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "index": [i for i in range(10)],
+            "a": [i for i in range(10)],
+            "b": [True for i in range(10)],
+            "c": [str(i) for i in range(10)]
+        }
+
+    def test_widget_client_np_structured_array(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = np.array([(1, 2), (3, 4)], dtype=[("a", "int64"), ("b", "int64")])
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": [1, 3],
+            "b": [2, 4]
+        }
+
+    def test_widget_client_np_recarray(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = np.array([(1, 2), (3, 4)], dtype=[("a", "int64"), ("b", "int64")]).view(np.recarray)
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": [1, 3],
+            "b": [2, 4]
+        }
+
+    def test_widget_client_schema(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        widget = perspective.PerspectiveWidget({
+            "a": int,
+            "b": float,
+            "c": bool,
+            "d": date,
+            "e": datetime,
+            "f": str
+        })
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": "integer",
+            "b": "float",
+            "c": "boolean",
+            "d": "date",
+            "e": "datetime",
+            "f": "string"
+        }
+
+    def test_widget_client_schema_py2_types(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        if six.PY2:
+            widget = perspective.PerspectiveWidget({
+                "a": long,  # noqa: F821
+                "b": float,
+                "c": bool,
+                "d": date,
+                "e": datetime,
+                "f": unicode  # noqa: F821
+            })
+            assert hasattr(widget, "table") is False
+            assert widget._data == {
+                "a": "integer",
+                "b": "float",
+                "c": "boolean",
+                "d": "date",
+                "e": "datetime",
+                "f": "string"
+            }
+
+    def test_widget_client_update(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": np.arange(0, 50)}
+        comparison_data = {
+            "a": [i for i in range(50)]
+        }
+        widget = perspective.PerspectiveWidget(data)
+        mocked_post = partial(mock_post, assert_msg={
+            "cmd": "update",
+            "data": comparison_data
+        })
+        widget.post = MethodType(mocked_post, widget)
+        widget.update(data)
+        assert hasattr(widget, "table") is False
+
+    def test_widget_client_update_cached(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": [1, 2]}
+        widget = perspective.PerspectiveWidget(data)
+        mocked_post = partial(mock_post, assert_msg={
+            "cmd": "update",
+            "data": data
+        })
+        widget.post = MethodType(mocked_post, widget)
+        widget.update(data)
+        assert widget._predisplay_update_cache == [data]
+        widget._displayed = True
+        widget.update(data)
+        assert widget._predisplay_update_cache == [data]
+
+    def test_widget_client_replace(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": np.arange(0, 50)}
+        new_data = {"a": [1]}
+        widget = perspective.PerspectiveWidget(data)
+        mocked_post = partial(mock_post, assert_msg={
+            "cmd": "replace",
+            "data": new_data
+        })
+        widget.post = MethodType(mocked_post, widget)
+        widget.replace(new_data)
+        assert widget._data is new_data
+
+    def test_widget_delete_client(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": np.arange(0, 50)}
+        widget = perspective.PerspectiveWidget(data)
+        mocked_post = partial(mock_post, assert_msg={
+            "cmd": "delete"
+        })
+        widget.delete()
+        widget.post = MethodType(mocked_post, widget)
+
+    def test_widget_load_column_pivots_client(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        # behavior should not change for client mode
+        arrays = [np.array(['bar', 'bar', 'bar', 'bar', 'baz', 'baz', 'baz', 'baz', 'foo', 'foo', 'foo', 'foo', 'qux', 'qux', 'qux', 'qux']),
+                  np.array(['one', 'one', 'two', 'two', 'one', 'one', 'two', 'two', 'one', 'one', 'two', 'two', 'one', 'one', 'two', 'two']),
+                  np.array(['X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y'])]
+        tuples = list(zip(*arrays))
+        index = pd.MultiIndex.from_tuples(tuples, names=['first', 'second', 'third'])
+        df_both = pd.DataFrame(np.random.randn(3, 16), index=['A', 'B', 'C'], columns=index)
+        widget = perspective.PerspectiveWidget(df_both)
+        assert hasattr(widget, "table") is False
+        assert widget.columns == [' ']
+        assert widget.column_pivots == ['first', 'second', 'third']
+        assert widget.row_pivots == ['index']

--- a/python/perspective/perspective/tests/conftest.py
+++ b/python/perspective/perspective/tests/conftest.py
@@ -13,7 +13,6 @@ import pandas as pd
 import pyarrow as pa
 from datetime import datetime
 from pytest import fixture
-from perspective import Table
 
 
 def _make_date_time_index(size, time_unit):
@@ -140,12 +139,6 @@ class Util:
     def make_series(size=10, freq="D"):
         index = _make_date_time_index(size, freq)
         return pd.Series(data=np.random.rand(size), index=index)
-
-    @staticmethod
-    def compare_delta(received, expected):
-        """Compare an arrow-serialized row delta by constructing a Table."""
-        tbl = Table(received)
-        assert tbl.view().to_dict() == expected
 
 
 class Sentinel(object):

--- a/python/perspective/perspective/tests/table/test_table.py
+++ b/python/perspective/perspective/tests/table/test_table.py
@@ -8,16 +8,12 @@
 #
 import six
 import sys
+from datetime import date, datetime
 from pytest import raises
 from perspective.table import Table
 from perspective.core.exception import PerspectiveError
 from perspective.table._state import _PerspectiveStateManager
-from datetime import date, datetime
-
-try:
-    from perspective.table.libbinding import t_filter_op, PerspectiveCppError
-except ImportError:
-    pass
+from perspective.table.libbinding import t_filter_op, PerspectiveCppError
 
 
 class TestTable(object):

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -12,6 +12,12 @@ from perspective.table import Table
 from datetime import date, datetime
 
 
+
+def compare_delta(received, expected):
+    """Compare an arrow-serialized row delta by constructing a Table."""
+    tbl = Table(received)
+    assert tbl.view().to_dict() == expected
+
 class TestView(object):
     def test_view_zero(self):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
@@ -748,7 +754,7 @@ class TestView(object):
         }
 
         def cb1(delta):
-            util.compare_delta(delta, update_data)
+            compare_delta(delta, update_data)
 
         tbl = Table(data)
         view = tbl.view()
@@ -763,7 +769,7 @@ class TestView(object):
         }
 
         def cb1(delta):
-            util.compare_delta(delta, {
+            compare_delta(delta, {
                 "a": [9, 5],
                 "b": [12, 6]
             })
@@ -786,7 +792,7 @@ class TestView(object):
         }
 
         def cb1(delta):
-            util.compare_delta(delta, {
+            compare_delta(delta, {
                 "2|a": [1, None],
                 "2|b": [2, None],
                 "4|a": [3, None],
@@ -815,7 +821,7 @@ class TestView(object):
         }
 
         def cb1(delta):
-            util.compare_delta(delta, {
+            compare_delta(delta, {
                 "2|a": [1, None],
                 "2|b": [2, None],
                 "4|a": [3, None],

--- a/python/perspective/perspective/tests/widget/test_widget.py
+++ b/python/perspective/perspective/tests/widget/test_widget.py
@@ -6,9 +6,7 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
-import six
 import numpy as np
-import pandas as pd
 from datetime import date, datetime
 from functools import partial
 from types import MethodType
@@ -32,6 +30,18 @@ class TestWidget:
         widget = PerspectiveWidget(None, plugin="x_bar", row_pivots=["a"])
         assert widget.plugin == "x_bar"
         assert widget.row_pivots == ["a"]
+
+    def test_widget_schema(self):
+        schema = {
+            "a": int,
+            "b": float,
+            "c": bool,
+            "d": date,
+            "e": datetime,
+            "f": str
+        }
+        widget = PerspectiveWidget(schema)
+        assert widget.table.schema() == schema
 
     def test_widget_schema_with_index(self):
         widget = PerspectiveWidget({"a": int}, index="a")
@@ -71,122 +81,6 @@ class TestWidget:
         with raises(PerspectiveError):
             PerspectiveWidget(data, index="index", limit=1)
 
-    # client-only mode
-
-    def test_widget_client(self):
-        data = {"a": [i for i in range(50)]}
-        widget = PerspectiveWidget(data, client=True)
-        assert widget.table is None
-        assert widget._data == data
-
-    def test_widget_client_np(self):
-        data = {"a": np.arange(0, 50)}
-        widget = PerspectiveWidget(data, client=True)
-        assert widget.table is None
-        assert widget._data == {
-            "a": [i for i in range(50)]
-        }
-
-    def test_widget_client_df(self):
-        data = pd.DataFrame({
-            "a": np.arange(10),
-            "b": [True for i in range(10)],
-            "c": [str(i) for i in range(10)]
-        })
-        widget = PerspectiveWidget(data, client=True)
-        assert widget.table is None
-        assert widget._data == {
-            "index": [i for i in range(10)],
-            "a": [i for i in range(10)],
-            "b": [True for i in range(10)],
-            "c": [str(i) for i in range(10)]
-        }
-
-    def test_widget_client_np_structured_array(self):
-        data = np.array([(1, 2), (3, 4)], dtype=[("a", "int64"), ("b", "int64")])
-        widget = PerspectiveWidget(data, client=True)
-        assert widget.table is None
-        assert widget._data == {
-            "a": [1, 3],
-            "b": [2, 4]
-        }
-
-    def test_widget_client_np_recarray(self):
-        data = np.array([(1, 2), (3, 4)], dtype=[("a", "int64"), ("b", "int64")]).view(np.recarray)
-        widget = PerspectiveWidget(data, client=True)
-        assert widget.table is None
-        assert widget._data == {
-            "a": [1, 3],
-            "b": [2, 4]
-        }
-
-    def test_widget_client_schema(self):
-        widget = PerspectiveWidget({
-            "a": int,
-            "b": float,
-            "c": bool,
-            "d": date,
-            "e": datetime,
-            "f": str
-        }, client=True)
-        assert widget.table is None
-        assert widget._data == {
-            "a": "integer",
-            "b": "float",
-            "c": "boolean",
-            "d": "date",
-            "e": "datetime",
-            "f": "string"
-        }
-
-    def test_widget_client_schema_py2_types(self):
-        if six.PY2:
-            widget = PerspectiveWidget({
-                "a": long,  # noqa: F821
-                "b": float,
-                "c": bool,
-                "d": date,
-                "e": datetime,
-                "f": unicode  # noqa: F821
-            }, client=True)
-            assert widget.table is None
-            assert widget._data == {
-                "a": "integer",
-                "b": "float",
-                "c": "boolean",
-                "d": "date",
-                "e": "datetime",
-                "f": "string"
-            }
-
-    def test_widget_client_update(self):
-        data = {"a": np.arange(0, 50)}
-        comparison_data = {
-            "a": [i for i in range(50)]
-        }
-        widget = PerspectiveWidget(data, client=True)
-        mocked_post = partial(mock_post, assert_msg={
-            "cmd": "update",
-            "data": comparison_data
-        })
-        widget.post = MethodType(mocked_post, widget)
-        widget.update(data)
-        assert widget.table is None
-
-    def test_widget_client_update_cached(self):
-        data = {"a": [1, 2]}
-        widget = PerspectiveWidget(data, client=True)
-        mocked_post = partial(mock_post, assert_msg={
-            "cmd": "update",
-            "data": data
-        })
-        widget.post = MethodType(mocked_post, widget)
-        widget.update(data)
-        assert widget._predisplay_update_cache == [data]
-        widget._displayed = True
-        widget.update(data)
-        assert widget._predisplay_update_cache == [data]
-
     # clear
 
     def test_widget_clear(self):
@@ -195,16 +89,6 @@ class TestWidget:
         widget.clear()
         assert widget.table.size() == 0
 
-    def test_widget_client_clear(self):
-        data = {"a": np.arange(0, 50)}
-        widget = PerspectiveWidget(data, client=True)
-        mocked_post = partial(mock_post, assert_msg={
-            "cmd": "clear"
-        })
-        widget.post = MethodType(mocked_post, widget)
-        widget.clear()
-        assert widget._data is None
-
     # replace
 
     def test_widget_replace(self):
@@ -212,18 +96,6 @@ class TestWidget:
         widget = PerspectiveWidget(data)
         widget.replace({"a": [1]})
         assert widget.table.size() == 1
-
-    def test_widget_client_replace(self):
-        data = {"a": np.arange(0, 50)}
-        new_data = {"a": [1]}
-        widget = PerspectiveWidget(data, client=True)
-        mocked_post = partial(mock_post, assert_msg={
-            "cmd": "replace",
-            "data": new_data
-        })
-        widget.post = MethodType(mocked_post, widget)
-        widget.replace(new_data)
-        assert widget._data is new_data
 
     # delete
 
@@ -236,12 +108,3 @@ class TestWidget:
         widget.post = MethodType(mocked_post, widget)
         widget.delete()
         assert widget.table is None
-
-    def test_widget_delete_client(self):
-        data = {"a": np.arange(0, 50)}
-        widget = PerspectiveWidget(data, client=True)
-        mocked_post = partial(mock_post, assert_msg={
-            "cmd": "delete"
-        })
-        widget.delete()
-        widget.post = MethodType(mocked_post, widget)

--- a/python/perspective/perspective/tests/widget/test_widget_pandas.py
+++ b/python/perspective/perspective/tests/widget/test_widget_pandas.py
@@ -110,20 +110,6 @@ class TestWidgetPandas:
         assert widget.column_pivots == ['first', 'second', 'third']
         assert widget.row_pivots == ['index']
 
-    def test_widget_load_column_pivots_client(self):
-        # behavior should not change for client mode
-        arrays = [np.array(['bar', 'bar', 'bar', 'bar', 'baz', 'baz', 'baz', 'baz', 'foo', 'foo', 'foo', 'foo', 'qux', 'qux', 'qux', 'qux']),
-                  np.array(['one', 'one', 'two', 'two', 'one', 'one', 'two', 'two', 'one', 'one', 'two', 'two', 'one', 'one', 'two', 'two']),
-                  np.array(['X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y'])]
-        tuples = list(zip(*arrays))
-        index = pd.MultiIndex.from_tuples(tuples, names=['first', 'second', 'third'])
-        df_both = pd.DataFrame(np.random.randn(3, 16), index=['A', 'B', 'C'], columns=index)
-        widget = PerspectiveWidget(df_both, client=True)
-        assert widget.table is None
-        assert widget.columns == [' ']
-        assert widget.column_pivots == ['first', 'second', 'third']
-        assert widget.row_pivots == ['index']
-
     def test_widget_load_column_pivots_preserve_user_settings(self):
         arrays = [np.array(['bar', 'bar', 'bar', 'bar', 'baz', 'baz', 'baz', 'baz', 'foo', 'foo', 'foo', 'foo', 'qux', 'qux', 'qux', 'qux']),
                   np.array(['one', 'one', 'two', 'two', 'one', 'one', 'two', 'two', 'one', 'one', 'two', 'two', 'one', 'one', 'two', 'two']),

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -10,8 +10,10 @@ from random import random
 from .validate import validate_plugin, validate_columns, validate_row_pivots, validate_column_pivots, \
     validate_aggregates, validate_sort, validate_filters, validate_plugin_config
 from .viewer_traitlets import PerspectiveTraitlets
-from ..manager import PerspectiveManager
-from ..table import Table
+from ..libpsp import is_libpsp
+
+if is_libpsp():
+    from ..libpsp import Table, PerspectiveManager
 
 
 class PerspectiveViewer(PerspectiveTraitlets, object):
@@ -75,7 +77,8 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
 
         # Create an instance of `PerspectiveManager`, which receives messages
         # from the `PerspectiveJupyterClient` on the front-end.
-        self.manager = PerspectiveManager()
+        if is_libpsp():
+            self.manager = PerspectiveManager()
         self.table_name = None  # not a traitlet - only used in python
         self.view_name = None
 

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -16,7 +16,7 @@ from ipywidgets import Widget
 from traitlets import observe, Unicode
 from ..core.data import deconstruct_pandas
 from ..core.exception import PerspectiveError
-from ..table import Table, is_libpsp
+from ..libpsp import is_libpsp
 from ..viewer import PerspectiveViewer
 
 
@@ -225,8 +225,10 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
         self.on_msg(self.handle_message)
 
         if self.client:
-            if isinstance(table_or_data, Table):
-                raise PerspectiveError("Client mode PerspectiveWidget expects data or schema, not a `perspective.Table`!")
+            if is_libpsp():
+                from ..libpsp import Table
+                if isinstance(table_or_data, Table):
+                    raise PerspectiveError("Client mode PerspectiveWidget expects data or schema, not a `perspective.Table`!")
 
             if index is not None:
                 self._client_options["index"] = index

--- a/scripts/build_python.js
+++ b/scripts/build_python.js
@@ -44,7 +44,11 @@ try {
 
         cmd = cmd + `${PYTHON} -m pip install -e .[dev] && \
             ${PYTHON} -m flake8 perspective && echo OK && \
-            ${PYTHON} -m pytest -vvv perspective --cov=perspective`;
+            ${PYTHON} -m pytest -vvv perspective
+            --noconftest perspective/tests/client && \
+            ${PYTHON} -m pytest -vvv perspective
+            --ignore=perspective/tests/client
+            --cov=perspective`;
         if (IMAGE == "python") {
             cmd = cmd + `&& \
                 ${PYTHON} setup.py sdist && \

--- a/scripts/build_python.js
+++ b/scripts/build_python.js
@@ -12,15 +12,11 @@ const fs = require("fs-extra");
 
 const IS_DOCKER = process.env.PSP_DOCKER;
 const IS_PY2 = getarg("--python2");
-const PYTHON = IS_PY2 ? "python2" : (getarg("--python38") ? "python3.8": "python3.7");
-const IMAGE = IS_DOCKER ?
-                python_image(getarg("--manylinux2010") ? "manylinux2010":
-                             getarg("--manylinux2014") ? "manylinux2014":
-                             "", PYTHON) :"";
+const PYTHON = IS_PY2 ? "python2" : getarg("--python38") ? "python3.8" : "python3.7";
+const IMAGE = IS_DOCKER ? python_image(getarg("--manylinux2010") ? "manylinux2010" : getarg("--manylinux2014") ? "manylinux2014" : "", PYTHON) : "";
 
 const IS_CI = getarg("--ci");
 const IS_INSTALL = getarg("--install");
-
 
 try {
     const dist = resolve`${__dirname}/../python/perspective/dist`;
@@ -36,21 +32,23 @@ try {
 
     let cmd;
     if (IS_CI) {
-        if(IS_PY2)
+        if (IS_PY2)
             // shutil_which is required in setup.py
             cmd = bash`${PYTHON} -m pip install backports.shutil_which &&`;
-        else
-            cmd = bash``;
+        else cmd = bash``;
 
-        cmd = cmd + `${PYTHON} -m pip install -e .[dev] && \
+        cmd =
+            cmd +
+            `${PYTHON} -m pip install -e .[dev] && \
             ${PYTHON} -m flake8 perspective && echo OK && \
-            ${PYTHON} -m pytest -vvv perspective
-            --noconftest perspective/tests/client && \
+            ${PYTHON} -m pytest -vvv --noconftest perspective/tests/client && \
             ${PYTHON} -m pytest -vvv perspective
             --ignore=perspective/tests/client
             --cov=perspective`;
         if (IMAGE == "python") {
-            cmd = cmd + `&& \
+            cmd =
+                cmd +
+                `&& \
                 ${PYTHON} setup.py sdist && \
                 ${PYTHON} -m pip install -U dist/*.tar.gz`;
         }

--- a/scripts/test_python.js
+++ b/scripts/test_python.js
@@ -23,11 +23,26 @@ try {
     if (process.env.PSP_DOCKER) {
         execute`${docker(IMAGE)} bash -c "cd \
             python/perspective && TZ=UTC ${PYTHON} -m pytest \
-            ${VERBOSE ? "-vv" : "-v"} perspective --cov=perspective"`;
+            ${VERBOSE ? "-vv" : "-v"} --noconftest 
+            perspective/tests/client"`;
+
+        execute`${docker(IMAGE)} bash -c "cd \
+            python/perspective && TZ=UTC ${PYTHON} -m pytest \
+            ${VERBOSE ? "-vv" : "-v"} perspective
+            --ignore=perspective/tests/client 
+            --cov=perspective"`;
     } else {
         const python_path = resolve`${__dirname}/../python/perspective`;
+        // Tests for client mode (when C++ assets are not present) require
+        // a new runtime.
         execute`cd ${python_path} && TZ=UTC ${PYTHON} -m pytest \
-            ${VERBOSE ? "-vv" : "-v"} perspective --cov=perspective`;
+            ${VERBOSE ? "-vv" : "-v"} --noconftest 
+            perspective/tests/client`;
+
+        execute`cd ${python_path} && TZ=UTC ${PYTHON} -m pytest \
+            ${VERBOSE ? "-vv" : "-v"} perspective
+            --ignore=perspective/tests/client
+            --cov=perspective`;
     }
 } catch (e) {
     console.log(e.message);

--- a/scripts/test_python.js
+++ b/scripts/test_python.js
@@ -6,16 +6,12 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
-const {execute, docker, clean, resolve, getarg, bash, python_image} = require("./script_utils.js");
+const {execute, docker, resolve, getarg, python_image} = require("./script_utils.js");
 
 const VERBOSE = getarg("--verbose");
-const IS_DOCKER = process.env.PSP_DOCKER;
-const IS_PY2 = getarg("--python2"); 
-const PYTHON = IS_PY2 ? "python2" : (getarg("--python38") ? "python3.8": "python3.7");
-const IMAGE = python_image(getarg("--manylinux2010") ? "manylinux2010": 
-                           getarg("--manylinux2014") ? "manylinux2014":
-                           "", PYTHON);
-const IS_FIX = getarg("--fix");
+const IS_PY2 = getarg("--python2");
+const PYTHON = IS_PY2 ? "python2" : getarg("--python38") ? "python3.8" : "python3.7";
+const IMAGE = python_image(getarg("--manylinux2010") ? "manylinux2010" : getarg("--manylinux2014") ? "manylinux2014" : "", PYTHON);
 
 try {
     // dependencies need to be installed for test_python:table and


### PR DESCRIPTION
This PR adds a primitive benchmark suite for `perspective-python`, which follows the convention set by the Javascript benchmark suite - it runs operations for Table construction from different datasets, view construction with different pivot settings, and serializing data in all formats from each of those views. Benchmark results are written to a `perspective.Table` which is hosted via Tornado when the suite finishes (or when Ctrl-C is used to exit the script).

Additionally, this PR refactors the module loading semantic for `perspective-python`: when the C++ runtime is not present, a reasonable error message is logged, and symbols dependent on the C++ binding will not be exported in the module. `PerspectiveWidget` in client mode becomes the only usable symbol, and `Table`, `PerspectiveManager`, `PerspectiveTornadoHandler`, and `PerspectiveViewer` are not exported at all. A new test module has been added to assert correct behavior in this case.

The error message in question:

![Screen Shot 2020-01-06 at 2 59 40 PM](https://user-images.githubusercontent.com/13220267/71845755-04fb6280-3097-11ea-9424-7c6b2f34ac8b.png)

Finally, minor refactors were made in `to_format` for performance enhancements.