### PR TITLE
Python versioning fix

### DIFF
--- a/python/perspective/.bumpversion.cfg
+++ b/python/perspective/.bumpversion.cfg
@@ -10,7 +10,7 @@ serialize =
 optional_value = final
 values = 
 	alpha
-	candidate
+	rc
 	final
 
 [bumpversion:part:build]


### PR DESCRIPTION
This PR changes 'candidate' to 'rc' in bumpversion.cfg, ensuring that the values used for versioning Python are finally correct.