### PR TITLE
Time zone awareness in perspective-python

### DIFF
--- a/python/perspective/perspective/src/utils.cpp
+++ b/python/perspective/perspective/src/utils.cpp
@@ -115,10 +115,11 @@ scalar_to_py(const t_tscalar& scalar, bool cast_double, bool cast_string) {
                 return py::cast(scalar.to_string(false)); // should reimplement
             } else {
                 /**
-                 * datetimes are stored as milliseconds since epoch in UTC.
-                 * Before datetimes are loaded into Perspective, they should be
-                 * converted into UTC for consistency.
+                 * datetimes are stored as milliseconds since epoch.
+                 * Before datetimes are loaded into Perspective, if they are
+                 * time zone aware, they must be converted into UTC.
                  */
+                std::cout << "cp: " <<  scalar.to_int64() << std::endl;
                 auto ms = std::chrono::milliseconds(scalar.to_int64());
                 auto time_point = std::chrono::time_point<std::chrono::system_clock>(ms);
                 /**

--- a/python/perspective/perspective/src/utils.cpp
+++ b/python/perspective/perspective/src/utils.cpp
@@ -114,9 +114,19 @@ scalar_to_py(const t_tscalar& scalar, bool cast_double, bool cast_string) {
             } else if (cast_string) {
                 return py::cast(scalar.to_string(false)); // should reimplement
             } else {
-                // Stored timestamp should always be milliseconds
+                /**
+                 * datetimes are stored as milliseconds since epoch in UTC.
+                 * Before datetimes are loaded into Perspective, they should be
+                 * converted into UTC for consistency.
+                 */
                 auto ms = std::chrono::milliseconds(scalar.to_int64());
                 auto time_point = std::chrono::time_point<std::chrono::system_clock>(ms);
+                /**
+                 * Pybind converts std::time_point to local time, and the
+                 * `datetime.datetime` object created by `py::cast` has NO
+                 * `timezone` property. It is created using `std::localtime`,
+                 * and cannot be made timezone-aware.
+                 */
                 return py::cast(time_point);
             }
         }

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -12,7 +12,7 @@ import numpy
 from datetime import date, datetime
 from dateutil.parser import parse
 from dateutil.tz import UTC
-from pandas import Period, Timestamp
+from pandas import Period
 from re import search
 from .libbinding import t_dtype
 
@@ -114,16 +114,12 @@ class _PerspectiveDateValidator(object):
             # and convert the datetime into UTC. If the datetime has no
             # `tzinfo` object, it is assumed to be in local time, and will
             # be converted and stored in Perspective as UTC.
-            is_timestamp = isinstance(obj, Timestamp)
-            if is_timestamp:
-                if obj.tzinfo is not None:
-                    # Convert aware Timestamp to aware Timestamp
-                    obj = obj.tz_convert("UTC")
-                else:
-                    # Convert non-aware Timestamp to aware Timestamp
-                    obj = obj.tz_localize("UTC")
-            else:
+            if obj.tzinfo is not None:
+                # Convert aware datetime to UTC
                 obj = obj.astimezone(UTC)
+            else:
+                # Make naive datetime aware
+                obj = obj.replace(tzinfo=UTC)
 
         if six.PY2:
             if isinstance(obj, long):

--- a/python/perspective/perspective/tests/table/test_table_datetime.py
+++ b/python/perspective/perspective/tests/table/test_table_datetime.py
@@ -1,0 +1,913 @@
+# *****************************************************************************
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+import os
+import time
+import pytz
+import numpy as np
+import pandas as pd
+from datetime import datetime
+from dateutil import tz
+from perspective.table import Table
+
+LOCAL_DATETIMES = [
+    datetime(2019, 1, 11, 0, 10, 20),
+    datetime(2019, 1, 11, 11, 10, 20),
+    datetime(2019, 1, 11, 19, 10, 20)
+]
+
+# Test the DST transition for Continental US
+LOCAL_DATETIMES_DST = [
+    datetime(2019, 3, 9, 12, 10, 20),
+    datetime(2019, 3, 19, 12, 10, 20),
+    datetime(2019, 11, 2, 12, 10, 20),
+    datetime(2019, 11, 3, 12, 10, 20)
+]
+
+LOCAL_TIMESTAMPS = [pd.Timestamp(d) for d in LOCAL_DATETIMES]
+LOCAL_TIMESTAMPS_DST = [pd.Timestamp(d) for d in LOCAL_DATETIMES_DST]
+
+# Set up testing data
+UTC = pytz.UTC
+
+UTC_DATETIMES = [UTC.localize(d) for d in LOCAL_DATETIMES]
+UTC_TIMESTAMPS = [UTC.localize(d) for d in LOCAL_TIMESTAMPS]
+
+UTC_DATETIMES_DST = [UTC.localize(d, is_dst=True) for d in LOCAL_DATETIMES_DST]
+UTC_TIMESTAMPS_DST = [UTC.localize(d, is_dst=True) for d in LOCAL_TIMESTAMPS_DST]
+
+PST = pytz.timezone("US/Pacific")
+CST = pytz.timezone("US/Central")
+EST = pytz.timezone("US/Eastern")
+GMT = pytz.timezone("GMT")
+HKT = pytz.timezone("Asia/Hong_Kong")
+JPT = pytz.timezone("Asia/Tokyo")
+ACT = pytz.timezone("Australia/ACT")
+
+TIMEZONES = [PST, CST, EST, GMT, HKT, JPT, ACT]
+
+TZ_DATETIMES = {}
+TZ_TIMESTAMPS = {}
+
+TZ_DATETIMES_DST = {}
+TZ_TIMESTAMPS_DST = {}
+
+for TZ in TIMEZONES:
+    TZ_DATETIMES[TZ.zone] = [d.astimezone(TZ) for d in LOCAL_DATETIMES]
+    TZ_TIMESTAMPS[TZ.zone] = [d.tz_localize(TZ) for d in LOCAL_TIMESTAMPS]
+    TZ_DATETIMES_DST[TZ.zone] = [d.astimezone(TZ) for d in LOCAL_DATETIMES_DST]
+    TZ_TIMESTAMPS_DST[TZ.zone] = [d.tz_localize(TZ) for d in LOCAL_TIMESTAMPS_DST]
+
+
+class TestTableDateTime(object):
+    """Test datetimes across configurations such as local time, timezone-aware,
+    timezone-naive, and UTC implementations.
+    """
+
+    def test_table_should_assume_local_time(self):
+        """If a datetime object has no `tzinfo`, it should be assumed to be in
+        local time.
+
+        It should be stored as UTC in Perspective, but serialized as local time.
+        Since the test harness runs in `TZ=UTC`, there should be no difference
+        between ingested and serialized time.
+        """
+        data = {
+            "a": LOCAL_DATETIMES
+        }
+        table = Table(data)
+        assert table.view().to_dict()["a"] == LOCAL_DATETIMES
+
+    def test_table_should_assume_local_time_numpy_datetime64(self):
+        data = {
+            "a": [np.datetime64(d) for d in LOCAL_DATETIMES]
+        }
+        table = Table(data)
+        assert table.view().to_dict()["a"] == LOCAL_DATETIMES
+
+    def test_table_should_assume_local_time_pandas_timestamp(self):
+        data = pd.DataFrame({
+            "a": LOCAL_TIMESTAMPS
+        })
+        table = Table(data)
+        assert table.view().to_dict()["a"] == LOCAL_DATETIMES
+
+    def test_table_should_assume_local_time_dst(self):
+        """If a datetime object has no `tzinfo`, it should be assumed to be in
+        local time.
+
+        It should be stored as UTC in Perspective, but serialized as local time.
+        Since the test harness runs in `TZ=UTC`, there should be no difference
+        between ingested and serialized time.
+        """
+        data = {
+            "a": LOCAL_DATETIMES_DST
+        }
+        table = Table(data)
+        assert table.view().to_dict()["a"] == LOCAL_DATETIMES_DST
+
+    def test_table_should_assume_local_time_numpy_datetime64_dst(self):
+        data = {
+            "a": [np.datetime64(d) for d in LOCAL_DATETIMES_DST]
+        }
+        table = Table(data)
+        assert table.view().to_dict()["a"] == LOCAL_DATETIMES_DST
+
+    def test_table_should_assume_local_time_pandas_timestamp_dst(self):
+        data = pd.DataFrame({
+            "a": LOCAL_TIMESTAMPS_DST
+        })
+        table = Table(data)
+        assert table.view().to_dict()["a"] == LOCAL_DATETIMES_DST
+
+
+class TestTableDateTimeUTCToLocal(object):
+
+    def teardown_method(self):
+        # Set timezone to UTC, always
+        os.environ["TZ"] = "UTC"
+        time.tzset()
+
+    def test_table_should_convert_UTC_to_local_time_pytz_pacific(self):
+        """If the datetime has `tzinfo` set, use it to convert the datetime to
+        UTC. Make sure this works with both `pytz` and `dateutil` for
+        `datetime` and `pandas.Timestamp`.
+        """
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Pacific"
+        time.tzset()
+
+        # Should be in PST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_central(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        # Should be in CST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_eastern(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_GMT(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        # Should be in GMT now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_HKT(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Hong_Kong"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_JPT(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Tokyo"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_ACT(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Australia/Sydney"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_pacific(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Pacific"
+        time.tzset()
+
+        # Should be in PST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_central(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        # Should be in CST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_eastern(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_GMT(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        # Should be in GMT now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_pacific_DST(self):
+        data = {
+            "a": UTC_DATETIMES_DST
+        }
+        table = Table(data)
+
+        print(TZ_DATETIMES_DST)
+
+        os.environ["TZ"] = "US/Pacific"
+        time.tzset()
+
+        # Should be in PST now
+        assert table.view().to_dict() == {
+            "a": [d.replace(tzinfo=None) for d in TZ_DATETIMES_DST["US/Pacific"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_central_DST(self):
+        data = {
+            "a": UTC_DATETIMES_DST
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        # Should be in CST now
+        assert table.view().to_dict() == {
+            "a": [d.replace(tzinfo=None) for d in TZ_DATETIMES_DST["US/Central"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_eastern_DST(self):
+        data = {
+            "a": UTC_DATETIMES_DST
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict() == {
+            "a": [d.replace(tzinfo=None) for d in TZ_DATETIMES_DST["US/Eastern"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_GMT_DST(self):
+        data = {
+            "a": UTC_DATETIMES_DST
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        # Should be in GMT now
+        assert table.view().to_dict() == {
+            "a": [d.replace(tzinfo=None) for d in TZ_DATETIMES_DST["GMT"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_HKT(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Hong_Kong"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_JPT(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Tokyo"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_ACT(self):
+        data = {
+            "a": UTC_DATETIMES
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Australia/Sydney"
+        time.tzset()
+
+        ACT = tz.gettz("Australia/Sydney")
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_pacific_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Pacific"
+        time.tzset()
+
+        # Should be in PST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_central_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        # Should be in CST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_eastern_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_GMT_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        # Should be in GMT now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_HKT_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Hong_Kong"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_JPT_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Tokyo"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_pytz_ACT_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Australia/Sydney"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_pacific_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Pacific"
+        time.tzset()
+
+        # Should be in PST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_central_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        CST = tz.gettz("US/Central")
+
+        # Should be in CST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_eastern_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_GMT_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        GMT = tz.gettz("GMT")
+
+        # Should be in GMT now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_HKT_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Hong_Kong"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_JPT_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Tokyo"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_ACT_timestamp(self):
+        data = {
+            "a": UTC_TIMESTAMPS
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Australia/Sydney"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+
+class TestTableDateTimeArbitaryToLocal(object):
+
+    def teardown_method(self):
+        # Set timezone to UTC, always
+        os.environ["TZ"] = "UTC"
+        time.tzset()
+
+    def test_table_should_convert_PST_to_local_time_pytz_central(self):
+        data = {
+            "a": TZ_DATETIMES["US/Pacific"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        # Should be in CST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_CST_to_local_time_pytz_eastern(self):
+        data = {
+            "a": TZ_DATETIMES["US/Central"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_EST_to_local_time_pytz_GMT(self):
+        data = {
+            "a": TZ_DATETIMES["US/Eastern"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        # Should be in GMT now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_GMT_to_local_time_pytz_HKT(self):
+        data = {
+            "a": TZ_DATETIMES["GMT"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Hong_Kong"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_HKT_to_local_time_pytz_JPT(self):
+        data = {
+            "a": TZ_DATETIMES["Asia/Hong_Kong"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Tokyo"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_JPT_to_local_time_pytz_ACT(self):
+        data = {
+            "a": TZ_DATETIMES["Asia/Tokyo"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Australia/Sydney"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_PST_to_local_time_dateutil_central(self):
+        data = {
+            "a": TZ_DATETIMES["US/Pacific"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        # Should be in CST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_CST_to_local_time_dateutil_eastern(self):
+        data = {
+            "a": TZ_DATETIMES["US/Central"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_EST_to_local_time_dateutil_GMT(self):
+        data = {
+            "a": TZ_DATETIMES["US/Eastern"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        # Should be in GMT now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_GMT_to_local_time_dateutil_HKT(self):
+        data = {
+            "a": TZ_DATETIMES["GMT"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Hong_Kong"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_HKT_to_local_time_dateutil_JPT(self):
+        data = {
+            "a": TZ_DATETIMES["Asia/Hong_Kong"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Tokyo"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_JPT_to_local_time_dateutil_ACT(self):
+        data = {
+            "a": TZ_DATETIMES["Asia/Tokyo"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Australia/Sydney"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_PST_to_local_time_pytz_central_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["US/Pacific"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        # Should be in CST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_CST_to_local_time_pytz_eastern_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["US/Central"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_EST_to_local_time_pytz_GMT_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["US/Eastern"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        # Should be in GMT now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_GMT_to_local_time_pytz_HKT_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["GMT"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Hong_Kong"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_HKT_to_local_time_pytz_JPT_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["Asia/Hong_Kong"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Tokyo"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_JPT_to_local_time_pytz_ACT_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["Asia/Tokyo"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Australia/Sydney"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_PST_to_local_time_dateutil_central_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["US/Pacific"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        # Should be in CST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_CST_to_local_time_dateutil_eastern_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["US/Central"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_EST_to_local_time_dateutil_GMT_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["US/Eastern"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        # Should be in GMT now
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_GMT_to_local_time_dateutil_HKT_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["GMT"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Hong_Kong"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_HKT_to_local_time_dateutil_JPT_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["Asia/Hong_Kong"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Asia/Tokyo"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
+        }
+
+    def test_table_should_convert_JPT_to_local_time_dateutil_ACT_timestamp(self):
+        data = {
+            "a": TZ_TIMESTAMPS["Asia/Tokyo"]
+        }
+        table = Table(data)
+
+        os.environ["TZ"] = "Australia/Sydney"
+        time.tzset()
+
+        assert table.view().to_dict() == {
+            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
+        }

--- a/python/perspective/perspective/tests/table/test_table_datetime.py
+++ b/python/perspective/perspective/tests/table/test_table_datetime.py
@@ -57,10 +57,10 @@ TZ_DATETIMES_DST = {}
 TZ_TIMESTAMPS_DST = {}
 
 for TZ in TIMEZONES:
-    TZ_DATETIMES[TZ.zone] = [d.astimezone(TZ) for d in LOCAL_DATETIMES]
+    TZ_DATETIMES[TZ.zone] = [TZ.localize(d) for d in LOCAL_DATETIMES]
     TZ_TIMESTAMPS[TZ.zone] = [d.tz_localize(TZ) for d in LOCAL_TIMESTAMPS]
-    TZ_DATETIMES_DST[TZ.zone] = [d.astimezone(TZ) for d in LOCAL_DATETIMES_DST]
-    TZ_TIMESTAMPS_DST[TZ.zone] = [d.tz_localize(TZ) for d in LOCAL_TIMESTAMPS_DST]
+    TZ_DATETIMES_DST[TZ.zone] = [d.astimezone(TZ) for d in UTC_DATETIMES_DST]
+    TZ_TIMESTAMPS_DST[TZ.zone] = [d.tz_convert(TZ) for d in UTC_TIMESTAMPS_DST]
 
 
 class TestTableDateTime(object):
@@ -293,8 +293,6 @@ class TestTableDateTimeUTCToLocal(object):
         }
         table = Table(data)
 
-        print(TZ_DATETIMES_DST)
-
         os.environ["TZ"] = "US/Pacific"
         time.tzset()
 
@@ -345,6 +343,54 @@ class TestTableDateTimeUTCToLocal(object):
             "a": [d.replace(tzinfo=None) for d in TZ_DATETIMES_DST["GMT"]]
         }
 
+    def test_table_should_convert_UTC_to_local_time_dateutil_pacific_DST_timestamp(self):
+        data = pd.DataFrame({
+            "a": UTC_TIMESTAMPS_DST
+        })
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Pacific"
+        time.tzset()
+
+        # Should be in PST now
+        assert table.view().to_dict()["a"] == [d.replace(tzinfo=None) for d in TZ_DATETIMES_DST["US/Pacific"]]
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_central_DST_timestamp(self):
+        data = pd.DataFrame({
+            "a": UTC_TIMESTAMPS_DST
+        })
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Central"
+        time.tzset()
+
+        # Should be in CST now
+        assert table.view().to_dict()["a"] == [d.replace(tzinfo=None) for d in TZ_DATETIMES_DST["US/Central"]]
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_eastern_DST_timestamp(self):
+        data = pd.DataFrame({
+            "a": UTC_TIMESTAMPS_DST
+        })
+        table = Table(data)
+
+        os.environ["TZ"] = "US/Eastern"
+        time.tzset()
+
+        # Should be in EST now
+        assert table.view().to_dict()["a"] == [d.replace(tzinfo=None) for d in TZ_DATETIMES_DST["US/Eastern"]]
+
+    def test_table_should_convert_UTC_to_local_time_dateutil_GMT_DST_timestamp(self):
+        data = pd.DataFrame({
+            "a": UTC_TIMESTAMPS_DST
+        })
+        table = Table(data)
+
+        os.environ["TZ"] = "GMT"
+        time.tzset()
+
+        # Should be in GMT now
+        assert table.view().to_dict()["a"] == [d.replace(tzinfo=None) for d in TZ_DATETIMES_DST["GMT"]]
+
     def test_table_should_convert_UTC_to_local_time_dateutil_HKT(self):
         data = {
             "a": UTC_DATETIMES
@@ -387,118 +433,102 @@ class TestTableDateTimeUTCToLocal(object):
         }
 
     def test_table_should_convert_UTC_to_local_time_pytz_pacific_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "US/Pacific"
         time.tzset()
 
         # Should be in PST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_pytz_central_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "US/Central"
         time.tzset()
 
         # Should be in CST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_pytz_eastern_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "US/Eastern"
         time.tzset()
 
         # Should be in EST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_pytz_GMT_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "GMT"
         time.tzset()
 
         # Should be in GMT now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_pytz_HKT_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "Asia/Hong_Kong"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_pytz_JPT_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "Asia/Tokyo"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_pytz_ACT_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "Australia/Sydney"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_dateutil_pacific_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "US/Pacific"
         time.tzset()
 
         # Should be in PST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_dateutil_central_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "US/Central"
@@ -507,28 +537,24 @@ class TestTableDateTimeUTCToLocal(object):
         CST = tz.gettz("US/Central")
 
         # Should be in CST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_dateutil_eastern_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "US/Eastern"
         time.tzset()
 
         # Should be in EST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_dateutil_GMT_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "GMT"
@@ -537,48 +563,40 @@ class TestTableDateTimeUTCToLocal(object):
         GMT = tz.gettz("GMT")
 
         # Should be in GMT now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_dateutil_HKT_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "Asia/Hong_Kong"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_dateutil_JPT_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "Asia/Tokyo"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_UTC_to_local_time_dateutil_ACT_timestamp(self):
-        data = {
+        data = pd.DataFrame({
             "a": UTC_TIMESTAMPS
-        }
+        })
         table = Table(data)
 
         os.environ["TZ"] = "Australia/Sydney"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
 
 
 class TestTableDateTimeArbitaryToLocal(object):
@@ -754,160 +772,136 @@ class TestTableDateTimeArbitaryToLocal(object):
         data = {
             "a": TZ_TIMESTAMPS["US/Pacific"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "US/Central"
         time.tzset()
 
         # Should be in CST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_CST_to_local_time_pytz_eastern_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["US/Central"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "US/Eastern"
         time.tzset()
 
         # Should be in EST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_EST_to_local_time_pytz_GMT_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["US/Eastern"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "GMT"
         time.tzset()
 
         # Should be in GMT now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_GMT_to_local_time_pytz_HKT_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["GMT"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "Asia/Hong_Kong"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_HKT_to_local_time_pytz_JPT_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["Asia/Hong_Kong"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "Asia/Tokyo"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_JPT_to_local_time_pytz_ACT_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["Asia/Tokyo"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "Australia/Sydney"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_PST_to_local_time_dateutil_central_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["US/Pacific"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "US/Central"
         time.tzset()
 
         # Should be in CST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(CST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_CST_to_local_time_dateutil_eastern_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["US/Central"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "US/Eastern"
         time.tzset()
 
         # Should be in EST now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(EST).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_EST_to_local_time_dateutil_GMT_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["US/Eastern"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "GMT"
         time.tzset()
 
         # Should be in GMT now
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(GMT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_GMT_to_local_time_dateutil_HKT_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["GMT"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "Asia/Hong_Kong"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(HKT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_HKT_to_local_time_dateutil_JPT_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["Asia/Hong_Kong"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "Asia/Tokyo"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(JPT).replace(tzinfo=None) for d in data["a"]]
 
     def test_table_should_convert_JPT_to_local_time_dateutil_ACT_timestamp(self):
         data = {
             "a": TZ_TIMESTAMPS["Asia/Tokyo"]
         }
-        table = Table(data)
+        table = Table(pd.DataFrame(data))
 
         os.environ["TZ"] = "Australia/Sydney"
         time.tzset()
 
-        assert table.view().to_dict() == {
-            "a": [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]
-        }
+        assert table.view().to_dict()["a"] == [d.astimezone(ACT).replace(tzinfo=None) for d in data["a"]]

--- a/python/perspective/perspective/tests/table/test_table_numpy.py
+++ b/python/perspective/perspective/tests/table/test_table_numpy.py
@@ -7,7 +7,6 @@
 #
 
 import six
-import time
 import numpy as np
 from pytest import raises
 from perspective import PerspectiveError

--- a/python/perspective/perspective/tests/table/test_update.py
+++ b/python/perspective/perspective/tests/table/test_update.py
@@ -5,10 +5,7 @@
 # This file is part of the Perspective library, distributed under the terms of
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
-import six
-import time
 import numpy as np
-import pandas as pd
 from datetime import date, datetime
 from perspective.table import Table
 

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -62,13 +62,16 @@ def _serialize(data):
         columns = [data[col].tolist() for col in data.dtype.names]
         return dict(zip(data.dtype.names, columns))
     elif isinstance(data, pandas.DataFrame) or isinstance(data, pandas.Series):
-        # take flattened dataframe and make it serializable
+        # Take flattened dataframe and make it serializable
         d = {}
         for name in data.columns:
             column = data[name]
             values = column.values
-            if numpy.issubdtype(column.dtype, numpy.datetime64):
-                # put it into a format parsable by perspective.js
+            # Timezone-aware datetime64 dtypes throw an exception when using
+            # `numpy.issubdtype` - match strings here instead.
+            str_dtype = str(column.dtype)
+            if "datetime64" in str_dtype:
+                # Convert all datetimes to string for serializing
                 values = numpy.datetime_as_string(column.values, unit="ms")
             d[name] = values.tolist()
         return d


### PR DESCRIPTION
This PR implements and tests `perspective-python`'s time zone semantics, and offers an explanation to how Perspective handles time zones.

### The Problem

In the browser use case, time zones do not pose a problem as all times are localized to the browser's time zone. When running `perspective-python` on the server, however, the server may not be in the same time zone as the client, and time zone handling must be defined. 

Currently, `perspective-python` makes the assumption that all `datetime` and `Timestamp` objects are defined in _local time_, and the `tzinfo` attribute is ignored. Internally, the C++ engine stores datetime values as Unix timestamps in milliseconds since epoch, and the [conversion](https://github.com/finos/perspective/blob/master/python/perspective/perspective/table/_date_validator.py#L91) from `datetime` to Unix timestamps is not time zone aware. 

When datetime values are serialized through the use of `to_dict`, `to_records`, etc., **PyBind** treats the Unix timestamp as _local time_, and the resulting `datetime` object that is created has no `tzinfo` attribute and is in _local time_. 

When the data from Python is consumed by a `perspective-viewer` in the browser, it is serialized *back to a Unix timestamp* before being sent over the network, and then the browser calls `new Date()` on the timestamp value to create the final representation inside the browser. 

Because `new Date()` treats the timestamp as _local time_ on the **browser**, which could be different than _local time_ on the **server**, there could exist a difference between the values passed into `perspective-python` and the values a user sees in `perspective-viewer`, made more difficult by the unclear and unspecified semantics around datetime and time zone handling. This PR attempts to codify time zone semantics and provide an explanation to the behavior.

### The Solution

This PR modifies the date validator in Python by converting all **time-zone aware** `datetime` and `Timestamp` objects (or any object passed in that has the `tzinfo` attribute set) to **UTC** before storing the timestamp into Perspective. **Naive datetimes** are assumed to be in _local time_, and will be processed as-is without conversion.

When the timestamp is serialized, it is converted (via Pybind) to **local time as determined by the Python runtime**. `perspective-viewer` will continue to treat `new Date()` in **local time as determined by the browser**. 

This implementation does not change the behavior of `perspective-python` for **naive** datetimes, but it allows us to use **aware** datetimes and view them in **local time**:

```
import pytz, datetime, perspective
pst = pytz.timezone("America/Los_Angeles")
# 8AM PST
data = {"time": [pst.localize(datetime.datetime(2020, 1, 10, 8, 30, 45))]}
table = perspective.Table(data)
print(table.view().to_dict())
# 11AM EST (my local time)
# {"time": [datetime.datetime(2020, 1, 10, 11, 30, 45)]}
```

The same datetime, but as a naive datetime:

```
import datetime, perspective
# 8AM local time
data = {"time": [datetime.datetime(2020, 1, 10, 8, 30, 45)]}
table = perspective.Table(data)
print(table.view().to_dict())
# 8AM EST (local time)
# {"time": [datetime.datetime(2020, 1, 10, 8, 30, 45)]}
```

#### Caveat: Pandas DataFrames

For Pandas DataFrames, any `datetime64` columns will **always be treated as UTC** and **always** serialized from Perspective in _local time_. For timestamps to be serialized _exactly_ as they were entered, use `tz_localize` or `tz_convert` from `Pandas` in order to localize the Timestamps into your local timezone:

```
from datetime import datetime
import pandas, pytz, perspective

EST = pytz.timezone("US/Eastern")

# Localized to EST, my local time
data = pandas.DataFrame({
  "time": [pandas.Timestamp(datetime(2019, 3, 9, 12, 30)).tz_localize(EST)]
})

table = perspective.Table(data)
print(table.view().to_records())
# {"time": [datetime(2019, 3, 9, 12, 30)]}
```

### Changelog

- Converts aware `datetime` and `pandas.Timestamp` objects to UTC
- Documents time zone semantics within Python and C++ code
- Comprehensive test suite asserting correctness for:
  * [pytz](http://pytz.sourceforge.net/) and [dateutil.tz](https://dateutil.readthedocs.io/en/stable/tz.html) timezones
  * Non-conversion of naive datetimes, and conversion of aware datetimes
  * Conversion of datetimes from one timezone to another, including DST correctness
  * Conversion of `pandas.Timestamps` for all of the above