### PR TITLE
Improve Perspective Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ simple to build real-time & user configurable analytics entirely in the browser.
 * [Javascript User's Guide](https://perspective.finos.org/docs/md/js.html)
 * [Python User's Guide](https://perspective.finos.org/docs/md/python.html)
 * [Developer's Guide](https://perspective.finos.org/docs/md/development.html)
+* [Conceptual Overview](https://perspective.finos.org/docs/md/concepts.html)
 * [Perspective API](https://github.com/finos/perspective/blob/master/packages/perspective/README.md)
 * [Perspective Viewer API](https://github.com/finos/perspective/blob/master/packages/perspective-viewer/README.md)
 * [Perspective Python API](https://perspective.finos.org/docs/obj/perspective-python.html)

--- a/docs/core/Footer.js
+++ b/docs/core/Footer.js
@@ -28,11 +28,12 @@ class Footer extends React.Component {
                     </a>
                     <div>
                         <h5>Docs</h5>
-                        <a href={this.docUrl("md/installation.html", this.props.language)}>Installation</a>
-                        <a href={this.docUrl("md/usage.html", this.props.language)}>Usage</a>
-                        <a href={this.docUrl("obj/perspective.html", this.props.language)}>Perspective API</a>
-                        <a href={this.docUrl("obj/perspective-viewer.html", this.props.language)}>Perspective Viewer API</a>
-                        <a href={this.docUrl("obj/perspective-python-table.html", this.props.language)}>Perspective Python API</a>
+                        <a href={"/docs/md/installation.html"}>Installation</a>
+                        <a href={"/docs/md/js.html"}>Javascript User Guide</a>
+                        <a href={"/docs/md/python.html"}>Python User Guide</a>
+                        <a href={"/docs/obj/perspective.html"}>Perspective API</a>
+                        <a href={"/docs/obj/perspective-viewer.html"}>Perspective Viewer API</a>
+                        <a href={"/docs/obj/perspective-python-table.html"}>Perspective Python API</a>
                     </div>
                     {/* <div>
             <h5>Community</h5>

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -35,6 +35,15 @@
       "md/styles": {
         "title": "CSS Styles"
       },
+      "obj/perspective-python": {
+        "title": "perspective-python API"
+      },
+      "obj/perspective-viewer": {
+        "title": "perspective-viewer API"
+      },
+      "obj/perspective": {
+        "title": "perspective API"
+      },
       "README": {
         "title": "README"
       }

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -17,6 +17,9 @@
       "blog/2020-01-06-v0.4.0-release": {
         "title": "0.4.0 Release"
       },
+      "md/concepts": {
+        "title": "Conceptual Overview"
+      },
       "md/development": {
         "title": "Developer Guide"
       },
@@ -31,21 +34,6 @@
       },
       "md/styles": {
         "title": "CSS Styles"
-      },
-      "obj/perspective-python-core": {
-        "title": "perspective.core Python API"
-      },
-      "obj/perspective-python-table": {
-        "title": "perspective.table Python API"
-      },
-      "obj/perspective-python": {
-        "title": "perspective-python API"
-      },
-      "obj/perspective-viewer": {
-        "title": "perspective-viewer API"
-      },
-      "obj/perspective": {
-        "title": "perspective API"
       },
       "README": {
         "title": "README"

--- a/docs/md/concepts.md
+++ b/docs/md/concepts.md
@@ -196,8 +196,8 @@ table.update(new_data);
 #### Partial Updates
 
 If `index` is not set, updates _append_ new data to the end of the `Table`.
-However, if `index` is set, Perspective allows _partial updates_ using the
-`index` to determine which rows to update:
+However, if `index` is set, Perspective allows _partial updates_ (in-place)
+using the `index` to determine which rows to update:
 
 ```javascript
 // Create an indexed table

--- a/docs/md/concepts.md
+++ b/docs/md/concepts.md
@@ -14,7 +14,8 @@ This document outlines the main concepts behind Perspective:
 - [`Table`](#table) Perspective's typed data interface
 - [`View`](#view) a query from a `Table` that calculates and returns data
 
-and explains the query options that can be used to create a `View`:
+and explains (with live examples) the query options that can be used to create
+a `View`:
 
 - [`row_pivots`](#row-pivots) splitting the dataset by unique row values
 - [`column_pivots`](#column-pivots) splitting the dataset by unique column
@@ -30,6 +31,11 @@ use the sidebar to find the documentation for the language of choice. Though
 the way these concepts operate in practice may vary slightly across different
 languages based on nuance, the concepts documented here hold true across all
 implementations of the Perspective library.
+
+<!--truncate-->
+
+<script src="../../../../js/concepts/index.js"></script>
+<link rel="stylesheet" href="../../../../css/concepts/index.css">
 
 ## Table
 
@@ -125,7 +131,7 @@ const table = perspective.table(data, {limit: 1000})
 ### Index
 
 Initializing a `Table` with an `index` allows Perspective to treat a column as
-the primary key, allowind in-place updates of rows. Only a
+the primary key, allowing in-place updates of rows. Only a
 single column can be used as an `index`, and like other `Table` parameters, 
 cannot be changed or removed after the `Table` creation. A column of any type
 may be used as an `index`.
@@ -138,7 +144,7 @@ const table = perspective.table(data, {index: "a"})
 ```
 
 An indexed `Table` allows for in-place _updates_ whenever a new rows shares an
-`index` values with an exisiting row, _partial updates_ when such a row leaves 
+`index` values with an existing row, _partial updates_ when such a row leaves 
 some column values `undefined`, and _removes_ to delete a row by `index`.
 
 ### `update()`
@@ -252,7 +258,7 @@ view.delete();
 
 `View` objects are immutable with respect to the arguments provided to the
 `view()` method;  to change these parameters, you must create a new `View` on
-the same `Table`.  `View`s are live with respect to the `Table`'s data however,
+the same `Table`. However, `View`s are live with respect to the `Table`'s data,
 and will (within a conflation window) update with the latest state as its
 parent's state updates, including incrementally recalculating all aggregates,
 pivots, filters, etc.
@@ -301,6 +307,10 @@ data query and transformation. All parameters can be applied in conjunction
 with each other, and there is no limit to the number of pivots, filters, etc.
 that can be applied.
 
+*All* examples in this section are live—feel free to play around with each
+`<perspective-viewer>` instance to see how different query parameters affect
+what you see.
+
 ### Row Pivots
 
 A row pivot _groups_ the dataset by the unique values of each column used as a
@@ -325,6 +335,17 @@ pivot of `["State", "City", "Neighborhood"]` shows the values for each
 neighborhood, which is grouped by city, which is in turn grouped by state. This
 allows for extremely fine-grained analysis applied over a large dataset.
 
+#### Example
+
+```html
+<perspective-viewer row-pivots='["State", "City"]' columns='["Sales", "Profit"]'>
+```
+
+<div>
+<perspective-viewer row-pivots='["State", "City"]' columns='["Sales", "Profit"]'>
+</perspective-viewer>
+</div>
+
 ### Column Pivots
 
 A column pivot _splits_ the dataset by the unique values of each column used as
@@ -344,6 +365,20 @@ const view = table.view({column_pivots: ["a", "c"]});
 Row pivots and column pivots can be used in conjunction to categorize and
 traverse over datasets, showing the insights a user is interested in. Row and
 column pivots are also easily transposable in `perspective-viewer`.
+
+#### Example
+
+```html
+<perspective-viewer
+    row-pivots='["Category"]'
+    column-pivots='["Region"]'
+    columns='["Sales", "Profit"]'>
+```
+
+<div>
+<perspective-viewer row-pivots='["Category"]' column-pivots='["Region"]' columns='["Sales", "Profit"]'>
+</perspective-viewer>
+</div>
 
 ### Aggregates
 
@@ -368,6 +403,20 @@ const view = table.view({
 });
 ```
 
+#### Example
+
+```html
+<perspective-viewer
+    aggregates='{"Sales": "avg", "Profit", "median"}'
+    row-pivots='["State", "City"]'
+    columns='["Sales", "Profit"]'>
+```
+
+<div>
+<perspective-viewer aggregates='{"Sales": "avg", "Profit": "median"}' row-pivots='["State", "City"]' columns='["Sales", "Profit"]'>
+</perspective-viewer>
+</div>
+
 ### Columns
 
 The `columns` property specifies which columns should be included in the
@@ -383,6 +432,17 @@ const view = table.view({
 });
 ```
 
+#### Example
+
+```html
+<perspective-viewer columns='["Sales", "Profit", "Segment"]'>
+```
+
+<div>
+<perspective-viewer columns='["Sales", "Profit", "Segment"]'>
+</perspective-viewer>
+</div>
+
 ### Sort
 
 The `sort` property specifies columns on which the query should be sorted,
@@ -397,6 +457,17 @@ const view = table.view({
     sort: [["a", "asc"]]
 });
 ```
+
+#### Example
+
+```html
+<perspective-viewer columns='["Sales", "Profit"]' sort='[["Sales", "desc"]]'>
+```
+
+<div>
+<perspective-viewer columns='["Sales", "Profit"]' sort='[["Sales", "desc"]]'>
+</perspective-viewer>
+</div>
 
 ### Filter
 
@@ -415,3 +486,17 @@ const view = table.view({
     filter: [["a", "<", 100]]
 });
 ```
+
+#### Example
+
+Note: Use the `filters` attribute on `<perspective-viewer>` instead of
+`filter`.
+
+```html
+<perspective-viewer columns='["Sales", "Profit"]' filters='[["State", "==", "Texas"]]'>
+```
+
+<div>
+<perspective-viewer columns='["Sales", "Profit"]' filters='[["State","==","Texas"]]'>
+</perspective-viewer>
+</div>

--- a/docs/md/concepts.md
+++ b/docs/md/concepts.md
@@ -1,0 +1,457 @@
+---
+id: concepts
+title: Conceptual Overview
+---
+
+Perspective is designed and built as an _interactive_ visualization
+component for _large, real-time_ datasets. It is designed to be fast, intuitive,
+and easily composable, making fine-grained analysis possible on any dataset.
+
+## Overview
+
+This document outlines the main concepts behind Perspective:
+
+- [`Table`](#table), Perspective's typed data interface
+- [`View`](#view), a query from a `Table` that calculates and returns data
+
+and explains the query options that can be used to create a `View`:
+
+- [`row_pivots`](#row-pivots), splitting the dataset by unique row values
+- [`column_pivots`](#column-pivots), splitting the dataset by unique column values
+- [`aggregates`](#aggregates), calculations over the dataset such as `sum`, `average`, or `distinct count`
+- [`columns`](#columns), specifying the columns the user is interested in seeing
+- [`sort`](#sort), ordering the dataset based on a column's values
+- [`filter`](#filter), filtering the dataset based on a column's values
+
+For language-specific guidance, API documentation, or quick-start user guides,
+use the sidebar to find the documentation for the language of choice. Though
+the way these concepts operate in practice may vary slightly across different
+languages based on nuance, the concepts documented here hold true across all
+implementations of the Perspective library.
+
+## Table
+
+The `Table` is Perspective's data interface, serving as the base on which all
+operations can be called.
+
+A `Table` contains columns, each of which have a unique name, are strongly and
+consistently typed, and contains rows of data conforming to the column's type.
+Each column in a `Table` must have the same number of rows, though not every
+row must contain data; null-values are used to indicate missing values in the
+dataset.
+
+The columns of a `Table` are _immutable after creation_, which means their names
+and data types cannot be changed after the `Table` has been created. Columns
+cannot be added or deleted after creation, but a `View` can be used to select
+an arbitary set of columns from the `Table`.
+
+The immutability of columns and data types after creation is important, as it
+allows Perspective to operate quickly over a large dataset and accumulate data
+without additional recalculation.
+
+### Schema and Data Types
+
+The mapping of a `Table`'s column names to data types is referred to as a
+`schema`. Each column has a unique name and a single data type:
+
+```javascript
+const schema = {
+    a: "integer",
+    b: "float",
+    c: "date",
+    d: "datetime",
+    e: "boolean",
+    f: "string"
+}
+```
+
+Because Perspective is built in multiple languages, data types must be
+expressible in the same way across different languages, both statically and
+dynamically typed.
+
+_Strings_ are used to represent the data types supported by Perspective:
+
+- `"integer"`: a 32-bit (or 64-bit depending on platform) integer
+- `"float"`: a 64-bit float
+- `"boolean"`: a boolean value of true or false
+- `"date"`: a date containing year, month, and day
+- `"datetime"`: a datetime containing year, month, day, hour, minute, second, and microsecond
+- `"string"`: a unicode string without any character limits
+
+Implementations of these data types will differ slightly based on language and
+platform. For example, "integer" in Perspective's Javascript library will always
+be 32-bit, whereas an "integer" in Perspective's Python library is 32-bit in
+Python 2, and 64-bit in Python 3.
+
+Additionally, if a defined type system is provided (that differentiates between
+integers and floats, as well as date and datetimes), Perspective allows the
+usage of type instances in the place of strings, such as in Python:
+
+```python
+from datetime import date, datetime
+
+schema = {
+    "a": int,
+    "b": float,
+    "c": date,
+    "d": datetime,
+    "e": bool,
+    "f": str
+}
+```
+
+### Constructing a `Table`
+
+`Table`s are constructed with either a dataset or a
+[`schema`](#schema-and-data-types). If a dataset is provided, Perspective reads
+the dataset and _infers_ a schema. When exact conformity to data types is
+necessary, always construct the `Table` using a schema.
+
+#### Data Formats
+
+`Table`s accept data in row or columnar orientation.
+
+A _row-oriented_ dataset is an array where each element is a dictionary with
+string column names as keys, and values that conform to the _data type_ of
+the column:
+
+```javascript
+data = [
+    {"a": 100, "b": 0.25, "c": new Date()},
+    {"a": 200, "b": 0.5, "c": new Date()}
+]
+```
+
+Rows should be consistent, with no additional or missing columns between each
+row.
+
+A _column oriented_ dataset is a dictionary where each key is a string column
+name, and each element is an array containing values that conform to the
+_data type_ of the column:
+
+```javascript
+data = {
+    "a": [100, 200, 300],
+    "b": [0.25, 0.5, 0.75],
+    "c": [new Date(), new Date(), new Date()]
+}
+```
+
+Each array in a column oriented dataset should be of equal length, and each
+element inside it should be of the same type.
+
+### Limit
+
+Initializing a `Table` with a `limit` sets a limitation on the total number of
+rows the `Table` can have. When the `Table` is updated, and the resulting size of
+the `Table` would exceed its `limit`, rows that exceed `limit` overwrite old
+rows starting at row 0.
+
+To create a `Table` with a `limit`, provide the `limit` property with an integer
+indicating the `limit`:
+
+```javascript
+const table = perspective.table(data, {limit: 1000})
+```
+
+`limit` cannot be used in conjunction with `index`.
+
+### Index
+
+Initializing a `Table` with an `index` allows Perspective to treat a column as
+the primary key, automatically sorting each row by ascending order of the
+primary key, and eliminating duplicate values in the primary key column. Only a
+single column can be used as an `index`, and it cannot be changed or removed
+after the creation of the `Table`. A column of any type may be used as an
+`index`.
+
+To create an indexed `Table`, provide the `index` property with a string column
+name to be used as an index:
+
+```javascript
+const table = perspective.table(data, {index: "a"})
+```
+
+An indexed `Table` allows for _partial update_ and _remove_ operations, as
+explained in the next section.
+
+### Update
+
+Once a `Table` has been created, it can be updated with new data conforming to
+the `Table`'s `schema`. The dataset used for `update` must conform with the
+formats supported by Perspective, and cannot be a `schema` (as the `schema`
+is immutable).
+
+If a `Table` was initialized with a `schema` instead of a dataset, use `update`
+to fill the `Table` with data.
+
+```javascript
+const table = perspective.table({
+    a: "integer",
+    b: "float"
+});
+table.update(new_data);
+```
+
+#### Partial Updates
+
+If `index` is not set, updates _append_ new data to the end of the `Table`.
+However, if `index` is set, Perspective allows _partial updates_ using the
+`index` to determine which rows to update:
+
+```javascript
+// Create an indexed table
+const table = perspective.table({
+    "id": [1, 2, 3, 4],
+    "name": ["a", "b", "c", "d"]
+}, {index: "id"});
+
+// Update rows with primary key `1` and `4`
+table.update({
+    "id": [1, 4],
+    "name": ["x", "y"]
+});
+```
+
+Provide a dataset with the rows to be updated as specified by primary key, and
+Perspective handles the lookup into those rows and applies the specified
+updates from the dataset. If `update` is called on an indexed `Table` and
+no primary keys are specified, or if the specified keys are not present in the
+`Table`, Perspective will append the dataset to the end of the `Table`.
+
+### Remove
+
+An indexed `Table` can also have rows removed by primary key:
+
+```javascript
+// Create an indexed table
+const table = perspective.table({
+    "id": [1, 2, 3, 4],
+    "name": ["a", "b", "c", "d"]
+}, {index: "id"});
+
+// Remove rows with primary key `1` and `4`
+table.remove([1, 4]);
+```
+
+To `remove` rows on an indexed `Table`, provide the `Table`'s `remove` method
+with an array of primary key values indicating which rows should be removed.
+
+### Delete
+
+Because Perspective's runtime is composed of different languages (due to the
+C++ engine), it is important to clean up resources that might have been created
+in C++ and cannot be reached by garbage collectors in the binding language
+(Javascript, Python etc.).
+
+The `Table`'s `delete` method guarantees the cleanup of all resources associated
+with a `Table`, which is _especially important_ in Javascript, as the JS garbage
+collector [cannot automatically clean up](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#memory-management)
+objects created in C++ through Emscripten.
+
+It is best practice to explicitly `delete` any `Table`s when they are no longer
+needed. Ensure that the `Table` has no `View`s created from it before deleting,
+as an exception will be thrown.
+
+### `on_delete`
+
+The `on_delete` callback allows users to execute an action immediately after the
+`Table` has been deleted. The callback runs after all resources have been
+cleaned up and removed. Multiple `on_delete` callbacks can be set, and they will
+run in the order in which they were set. If a callback is no longer needed, call
+the `remove_delete` method on the `Table` and provide the reference to a
+callback which should be removed and no longer called by Perspective.
+
+## View
+
+The `View` is Perspective's query and serialization interface. It represents a
+query on the dataset represented by the `Table`, and is always created on an
+existing `Table` instance:
+
+```javascript
+const table = perspective.table({
+    "id": [1, 2, 3, 4],
+    "name": ["a", "b", "c", "d"]
+});
+
+// Create a view showing just the `name` column
+const view = table.view({
+    columns: ["name"]
+});
+```
+
+A `View` is guaranteed to contain the latest state
+of the `Table`: a `View` created before its `Table` was updated with
+new data will always contain the updated dataset, and all aggregates, pivots,
+etc. will be recalculated to include the updated dataset.
+
+The `Table` does not offer any query, transformation, or
+serialization methods; all such operations are achieved by creating a `View`
+with the desired query, and then serializing the data from the `View`. This
+design decouples data loading with data querying, which means `View`s are
+extremely cheap to create.
+
+Like the `Table`, `View`s are immutable after creation, and a new `View` should
+be created for each new query on the `Table`.
+
+### Schema
+
+The `View` has its own `schema`, which is a mapping of column names to data
+types based on the `View`'s query.
+
+This differs from the `Table` schema as the `View`'s column names are dependent
+on whether the `View` has pivots applied, or whether it has selected certain
+columns from the `Table` for inclusion.
+
+The same holds for the `schema`'s data types, which can be altered depending on
+the type of aggregate applied. A `count` aggregate applied over a string column,
+for example, will return `"integer"` in the `View`'s `schema`.
+
+### `on_update`
+
+The `on_update` callback allows users to execute an action immediately after
+the `View`'s underlying `Table` has been updated. This is useful in situations
+where updating the `Table` leads to UI changes, recalculations, or any other
+actions that need to be triggered. Multiple `on_update` callbacks can be
+specified, and they will run in the order in which they were set. If a callback
+is no longer needed to run, use the `remove_update` method on the `View`
+instance.
+
+### `on_delete`
+
+The `on_delete` callback allows users to execute an action immediately after the
+`View` has been deleted. Multiple `on_delete` callbacks can be specified, and
+they will run in the order in which they were set. If a callback is no longer
+needed, call the `remove_delete` method on the `View` instance.
+
+### Delete
+
+Similar to the `Table`, the `View`'s `delete` method guarantees cleanup of the
+resources associated with the `View`. It is best practice to explicit delete
+`View`s when they are no longer needed. All `View`s created from a `Table`
+instance must be explicitly deleted before the `Table` can be deleted.
+
+## Query Options
+
+The `View`'s query options present a powerful and composable interface for data
+query and transformation. All query options can be applied in conjunction with
+each other, and there is no limit to the number of pivots, filters, etc. that
+can be applied.
+
+### Row Pivots
+
+A row pivot _groups_ the dataset by the unique values of each column used as a
+row pivot - a close analogue in SQL would be the `GROUP BY` statement.
+
+The underlying dataset is aggregated to show the values belonging to
+each group, and a total row is calculated for each column, showing the sum of
+all aggregated values inside the column. Row pivots are useful for hierarchies,
+categorizing data and attributing values, i.e. showing the number of units sold
+based on State and City.
+
+In Perspective, row pivots are represented as an array of string column names
+which will be applied as row pivots:
+
+```javascript
+const view = table.view({row_pivots: ["a", "c"]});
+```
+
+Pivots are applied in the order provided
+by the user, which allows for "drilling down" into data; for example, a row
+pivot of `["State", "City", "Neighborhood"]` shows the values for each
+neighborhood, which is grouped by city, which is in turn grouped by state. This
+allows for extremely fine-grained analysis applied over a large dataset.
+
+### Column Pivots
+
+A column pivot _splits_ the dataset by the unique values of each column used as
+a column pivot. The underlying dataset is not aggregated, and a new column is
+created for each unique value of the column pivot. Each newly created column
+contains the parts of the dataset that correspond to the column header, i.e.
+a `View` that has `["State"]` as its column pivot will have a new column for
+each state.
+
+In Perspective, column pivots are represented as an array of string column names
+which will be applied as column pivots:
+
+```javascript
+const view = table.view({column_pivots: ["a", "c"]});
+```
+
+Row pivots and column pivots can be used in conjunction to categorize and
+traverse over datasets, showing the insights a user is interested in. Row and
+column pivots are also easily transposable in `perspective-viewer`.
+
+### Aggregates
+
+Aggregates perform a calculation over an entire column, and are displayed when
+one or more [Row Pivots](#row-pivots) are applied to the `View`. Aggregates can
+be specified by the user, or Perspective will use the following sensible default
+aggregates based on column type:
+
+- "sum" for `integer` and `float` columns
+- "count" for all other columns
+
+Perspective provides a large selection of aggregate functions that can be
+applied to columns in the `View` constructor using a dictionary of column
+name to aggregate function name:
+
+```javascript
+const view = table.view({
+    aggregates: {
+        a: "avg",
+        b: "distinct count"
+    }
+});
+```
+
+The `aggregates` dictionary only needs to contain columns for which the default
+should be overridden.
+
+### Columns
+
+The `columns` property specifies which columns should be included in the
+`View`'s output. This allows users to show or hide a specific subset of columns,
+as well as control the order in which columns appear to the user.
+
+This is represented in Perspective as an array of string column names passed to
+the `View` constructor:
+
+```javascript
+const view = table.view({
+    columns: ["a"]
+});
+```
+
+### Sort
+
+The `sort` property specifies columns on which the query should be sorted,
+analogous to `ORDER BY` in SQL. A column can be sorted regardless of its
+data type, and sorts can be applied in ascending or descending order.
+
+Perspective represents `sort` as an array of arrays, with the values of each
+inner array being a string column name and a string sort direction:
+
+```javascript
+const view = table.view({
+    sort: [["a", "asc"]]
+});
+```
+
+### Filter
+
+The `filter` property specifies columns on which the query can be filtered,
+returning rows that pass the specified filter condition. This is analogous
+to the `WHERE` clause in SQL. There is no limit on the number of columns
+where `filter` is applied, but the resulting dataset is one that passes
+all the filter conditions, i.e. the filters are joined with an `AND` condition.
+
+Perspective represents `filter` as an array of arrays, with the values of each
+inner array being a string column name, a string filter operator, and a filter
+operand in the type of the column:
+
+```javascript
+const view = table.view({
+    filter: [["a", "<", 100]]
+});
+```

--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -3,21 +3,40 @@ id: installation
 title: Installation
 ---
 
-## Javascript / WebAssembly
+## Javascript
 
-### (!) An important note about Hosting
+Because Perspective uses both WebAssembly and Web Workers, each of which place
+constraints on how assets and scripts must be loaded, the installation process
+for Perspective in a Javascript environment is more complex than most "pure"
+Javascript libraries.
 
-Whether you use just the `perspective` engine itself, or the
-`perspective-viewer` web component, your browser will need to have access to the
-`.worker.*.js` and `.wasm` assets in addition to the bundled scripts themselves.
-These are downloaded asynchronously at runtime after detecting whether or not
-WebAssembly is supported by your browser. The assets can be found in the
-`build/` directory of the `@finos/perspective` and `@finos/perspective-viewer`
-packages.
+### From NPM
 
-When importing from NPM modules, you should use
-`@finos/perspective-webpack-plugin` to manage the `.worker.*.js` and `.wasm`
-assets for you. A sample config:
+For using Perspective from Node.js, or as a dependency in a `package.json` based
+`webpack` or other browser application build toolchain, Perspective is available
+via NPM:
+
+```bash
+$ yarn add @finos/perspective-viewer @finos/perspective-viewer-d3fc @finos/perspective-viewer-hypergrid
+```
+
+#### An important note about Hosting
+
+All uses of Perspective from NPM require the browser to have access to
+Perspective's `.worker.*.js` and `.wasm` assets _in addition_ to the bundled
+`.js` scripts. By default, Perspective [inlines](https://github.com/finos/perspective/pull/870)
+these assets into the `.js` scripts, and delivers them in one file. This has no
+performance impact, but does increase asset load time. Any non-trivial application
+should make use of `@finos/perspective-webpack-plugin`, which automatically
+splits the assets into separate files and downloads them when the bundling
+step runs.
+
+### Webpack Plugin
+
+When importing `perspective` from NPM modules for a browser application, you
+should use `@finos/perspective-webpack-plugin` to manage the `.worker.*.js` and
+`.wasm` assets for you. The plugin handles downloading and packaging
+Perspective's additional assets, and is easy to set up in your `webpack.config`:
 
 ```javascript
 const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
@@ -32,20 +51,16 @@ module.exports = {
 };
 ```
 
-Alternatively, you may use the built-in `WebSocketServer` Node.js server, host
-the contents of a package's `build/` in your application's build script, or
-otherwise making sure these directories are visible to your web server, e.g.:
-
-```javascript
-cp -r node_modules/@finos/perspective/build my_build/assets/
-```
-
 ### From CDN
 
-By far the easiest way to get started with Perspective in the browser, the full
-library can be used directly from
-[unpkg.com](https://unpkg.com/@finos/perspective-examples/build/perspective-viewer.js)
-CDN by simply adding these scripts to your `.html`'s `<head>` section:
+Perspective can be loaded directly from
+[unpkg.com](https://unpkg.com/@finos/perspective-viewer), which is the easiest
+way to get started with Perspective in the browser, and absolutely perfect
+for spinning up quick instances of `perspective-viewer`. An example is
+demonstrated in [`superstore-arrow.html`](https://github.com/finos/perspective/blob/master/examples/simple/superstore-arrow.html),
+which loads a dataset stored in the Apache Arrow format using the `Fetch` API.
+
+Add these scripts to your `.html`'s `<head>` section:
 
 ```html
 <script src="https://unpkg.com/@finos/perspective"></script>
@@ -66,8 +81,7 @@ const view = table.view({ sort: [["A", "desc"]] });
 Or create a `<perspective-viewer>` in HTML:
 
 ```html
-<perspective-viewer columns="['Sales', 'Profit']"
-  >`
+<perspective-viewer columns="['Sales', 'Profit']">`
   <script>
     const data = {
       Sales: [500, 1000, 1500],
@@ -76,24 +90,13 @@ Or create a `<perspective-viewer>` in HTML:
     // The `<perspective-viewer>` HTML element exposes the viewer API
     const el = document.getElementsByTagName("perspective-viewer")[0];
     el.load(data);
-  </script></perspective-viewer
->
+  </script>
+</perspective-viewer>
 ```
 
-Ultimately, for production you'll want Perspective incorporated directly into
-your application's build script for load performance, via another option below.
-
-### From NPM
-
-For using Perspective from Node.js, or as a depedency in a `package.json` based
-`webpack` or other browser application build toolchain, Perspective is available
-via NPM:
-
-```bash
-yarn add @finos/perspective-viewer
-yarn add @finos/perspective-viewer-d3fc
-yarn add @finos/perspective-viewer-hypergrid
-```
+This makes it extremely easy to spin up Perspective locally without depending
+on a build chain or other tooling. For production usage, you should incorporate
+Perspective into your application's bundled scripts using `NPM` and `Webpack`.
 
 ## Python
 
@@ -111,7 +114,7 @@ NumPy record arrays are all supported in `perspective-python`.
 pip install perspective-python
 ```
 
-#### Jupyterlab
+### Jupyterlab
 
 `PerspectiveWidget` is a JupyterLab widget that implements the same API as
 `<perspective-viewer>`, allowing for fast, intuitive

--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -83,16 +83,23 @@ Or create a `<perspective-viewer>` in HTML:
 ```html
 <perspective-viewer columns="['Sales', 'Profit']">`
   <script>
-    const data = {
-      Sales: [500, 1000, 1500],
-      Profit: [100.25, 200.5, 300.75]
-    };
-    // The `<perspective-viewer>` HTML element exposes the viewer API
-    const el = document.getElementsByTagName("perspective-viewer")[0];
-    el.load(data);
+    document.addEventListener("WebComponentsReady", function() {
+      const data = {
+        Sales: [500, 1000, 1500],
+        Profit: [100.25, 200.5, 300.75]
+      };
+      // The `<perspective-viewer>` HTML element exposes the viewer API
+      const el = document.getElementsByTagName("perspective-viewer")[0];
+      el.load(data);
+    });
   </script>
 </perspective-viewer>
 ```
+
+You must wait for the document `WebComponentsReady` event to fire,
+which indicates that the provided
+[webcomponents.js polyfill](https://github.com/webcomponents/webcomponentsjs)
+has loaded.
 
 This makes it extremely easy to spin up Perspective locally without depending
 on a build chain or other tooling. For production usage, you should incorporate

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -183,13 +183,16 @@ It exports Perspective's data interfaces:
 
 `@finos/perspective` also exports process management functions such as
 `worker()` and `websocket()` (in the browser) and `WebSocketServer()`
-(in node.js). See the [API documentation](/obj/perspective.html) for a complete reference on all exported methods.
+(in node.js). See the [API documentation](/obj/perspective.html) for a complete 
+reference on all exported methods.
 
-This module is a dependency of `@finos/perspective-viewer`, and is not needed if you only intend to use `<perspective-viewer>` to visualize simple data.
+This module is a dependency of `@finos/perspective-viewer`, and is not needed if 
+you only intend to use `<perspective-viewer>` to visualize simple data.
 
 ### Importing in the browser
 
-`perspective` can be imported as an ES6 module and/or `require` syntax if you're using a bundler such as Webpack (and the `@finos/perspective-webpack-plugin`):
+`perspective` can be imported as an ES6 module and/or `require` syntax if you're 
+using a bundler such as Webpack (and the `@finos/perspective-webpack-plugin`):
 
 ```javascript
 import perspective from "@finos/perspective";
@@ -213,7 +216,8 @@ const perspective = require("@finos/perspective");
 
 Once imported, you'll need to instantiate a `perspective` engine via the
 `worker()` method. This will create a new WebWorker (browser) or
-Process (Node.js), and load the WebAssembly binary; all calculation and data accumulation will occur in this separate process.
+Process (Node.js), and load the WebAssembly binary; all calculation and data 
+accumulation will occur in this separate process.
 
 ```javascript
 const worker = perspective.worker();
@@ -253,8 +257,9 @@ var data = [
 const table1 = worker.table(data);
 ```
 
-`tables()` are columnar data structures, and each column must have a single
-type. When passing data directly to the `table()` constructor, the type of each column is inferred automatically.
+`table()`s are columnar data structures, and each column must have a single
+type. When passing data directly to the `table()` constructor, the type of each 
+column is inferred automatically.
 
 Perspective supports the following types:
 
@@ -283,8 +288,8 @@ var schema = {
 const table2 = worker.table(schema);
 ```
 
-Once instatiated, a `table()` can be updated with new data via the
-`update()` method:
+Once instatiated, a `table()` can be updated with new data via the `update()` 
+method:
 
 ```javascript
 // Add a new row to each table
@@ -356,7 +361,7 @@ table.update([{ x: 3, y: null }]);
 
 `update()` calls do not need values for _all columns_ in the `table()` schema.
 Missing keys, or keys with values set to `undefined`, will be omitted from
-`tables()` with `index` set, or populated with `null` otherwise:
+`table()`s with `index` set, or populated with `null` otherwise:
 
 ```javascript
 // Only updates the 'y' column for row 3, leaving the 'z' column alone
@@ -365,7 +370,7 @@ table.update([{ x: 3, y: "Just Y" }]);
 
 #### Deleting rows with `remove()`
 
-Rows can be removed entirely from a `table()` with `index` set. Call the
+Rows can be removed entirely from a `table()` with `index` set. Call the 
 `remove()` method with a list of the `index` values to be removed:
 
 ```javascript

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -163,31 +163,6 @@ your project:
   and
   [binding a viewer to a remote view in Node.js](#remote-perspective-via-workerhost), you will likely need all Perspective modules.
 
-The core concepts of Perspective are the `table()`, `view()` and
-`<perspective-viewer>` web component, though your project need not necessarily
-use them all.
-
-A `table()` represents a single data set, and is the interface used to input
-static and streaming data into Perspective; in the Browser, `table()`s live in a
-Web Worker to isolate their runtime from the renderer.
-
-A `view()` represents a specific continuous query of a `table()`, and is used to
-read data or calculate analytics from a `table()`; `view()`s also live in a Web
-Worker when used in a Browser, and a single `table()` may have many `view()`s
-attached at once.
-
-`<perspective-viewer>` is a UI widget which allows the user to interact and
-create `view()`s on a loaded `table()`.
-
-Each `<perspective-viewer>` encapsulates and manages a single `view()` at a
-time, and optionally manages it's underlying `table()` for simple use cases,
-though you can instantiate this separately if you wish - this is helpful for
-e.g.
-[sharing a table](<(#sharing-a-table-between-multiple-perspective-viewers)>)
-between multiple `<perspective-viewer>`s.
-
-<img src="https://perspective.finos.org/svg/architecture.svg">
-
 ## `perspective` library
 
 As a library, `perspective` provides a suite of streaming pivot, aggregate,

--- a/docs/md/python.md
+++ b/docs/md/python.md
@@ -160,20 +160,6 @@ supported by `perspective.Table`.
 Additionally, when created with `client=true` as a keyword argument to
 `__init__`, it can be used without accessing the built C++ binary.
 
-## Client Mode
-
-For certain systems, it may be difficult or infeasible to build the C++ library
-for Perspective, which `perspective.Table` depends on. However, we can leverage
-`Perspective.js` in the browser to provide the same widget experience to users.
-If created with `client=true`, `PerspectiveWidget` will serialize the data to
-the best of its ability and pass it off to the browser's Perspective engine to
-load.
-
-If `perspective-python` cannot find the built C++ libraries, it automatically
-defaults to client mode when initializing the widget.
-
-## `PerspectiveWidget`
-
 Similar to the viewer API, `PerspectiveWidget` takes keyword arguments that
 transform the `View` under ownsership:
 
@@ -216,7 +202,19 @@ w = perspective.PerspectiveWidget(
 w.sort = [["date", Sort.DESC]]
 ```
 
-## Creating a widget
+### Client Mode
+
+For certain systems, it may be difficult or infeasible to build the C++ library
+for Perspective, which `perspective.Table` depends on. However, we can leverage
+`Perspective.js` in the browser to provide the same widget experience to users.
+If created with `client=true`, `PerspectiveWidget` will serialize the data to
+the best of its ability and pass it off to the browser's Perspective engine to
+load.
+
+If `perspective-python` cannot find the built C++ libraries, it automatically
+defaults to client mode when initializing the widget.
+
+### Creating a widget
 
 A widget is created through the `PerspectiveWidget` constructor, which takes as
 its first, required parameter a `perspective.Table`, a dataset, a schema, or
@@ -258,7 +256,7 @@ front-end `<perspective-viewer>`:
 widget
 ```
 
-## `load()`
+### `load()`
 
 Calling `load()` on the widget provides it with a dataset. If the widget already
 has a dataset, and the new data has different columns to the old one, then the
@@ -275,7 +273,7 @@ widget = PerspectiveWidget(None)
 widget.load(data)
 ```
 
-## `update()`
+### `update()`
 
 Call `update()` on the widget to update it with new data. When called in client
 mode, this method serializes the data and passes it off to the Perspective

--- a/docs/pages/en/index.js
+++ b/docs/pages/en/index.js
@@ -213,7 +213,7 @@ const GETTING_STARTED_TEXT = `
 \`\`\`bash
 $ yarn add --dev @finos/perspective-cli
 \`\`\`
-2. Run a test server on a CSV, JSON or [Apache Arrow]():
+2. Run a test server on a CSV, JSON or [Apache Arrow](https://arrow.apache.org/):
 \`\`\`bash
 $ yarn perspective host < superstore.arrow
 Listening on port 8080

--- a/docs/sidebars.json
+++ b/docs/sidebars.json
@@ -1,6 +1,6 @@
 {
   "docs": {
-    "Getting Started": ["md/installation", "md/concepts", "md/js", "md/python", "md/styles", "md/development"],
+    "Getting Started": ["md/installation", "md/js", "md/python", "md/concepts", "md/styles", "md/development"],
     "Javascript API": ["obj/perspective", "obj/perspective-viewer"],
     "Python API": ["obj/perspective-python"]
   }

--- a/docs/sidebars.json
+++ b/docs/sidebars.json
@@ -1,6 +1,6 @@
 {
   "docs": {
-    "Getting Started": ["md/installation", "md/js", "md/python", "md/styles", "md/development"],
+    "Getting Started": ["md/installation", "md/concepts", "md/js", "md/python", "md/styles", "md/development"],
     "Javascript API": ["obj/perspective", "obj/perspective-viewer"],
     "Python API": ["obj/perspective-python"]
   }

--- a/docs/siteConfig.js
+++ b/docs/siteConfig.js
@@ -34,7 +34,7 @@ const siteConfig = {
     copyright: "Copyright © " + new Date().getFullYear() + " Perspective Authors",
 
     highlight: {
-        theme: "monokai"
+        theme: "atom-one-light"
     },
 
     scripts: [
@@ -50,6 +50,7 @@ const siteConfig = {
     stylesheets: [
         "https://fonts.googleapis.com/css?family=Material+Icons",
         "https://fonts.googleapis.com/css?family=Open+Sans",
+        "https://fonts.googleapis.com/css?family=Public+Sans",
         "https://fonts.googleapis.com/css?family=Roboto+Mono",
         "https://fonts.googleapis.com/css?family=Source+Code+Pro:900&display=swap"
     ],

--- a/docs/siteConfig.js
+++ b/docs/siteConfig.js
@@ -6,7 +6,7 @@
  */
 
 const siteConfig = {
-    title: "" /* title for your website */,
+    title: "Perspective" /* title for your website */,
     tagline: "Streaming Analytics via WebAssembly",
     url: "https://perspective.finos.org/" /* your website url */,
     cname: "perspective.finos.org",

--- a/docs/static/css/concepts/index.css
+++ b/docs/static/css/concepts/index.css
@@ -1,0 +1,26 @@
+perspective-viewer {
+    display: block;
+    height: 500px;
+    flex: 1;
+    border: 1px solid #ccc;
+}
+
+#grid {
+    display: flex;
+    flex-direction: row;
+}
+
+#grid perspective-viewer {
+    margin-left: 3px;
+}
+
+@media (max-width: 1500px) { 
+    #grid {
+        flex-direction:column;
+    }
+    #grid perspective-viewer {
+        margin-left: 0px;
+        margin-bottom: 3px;
+    }
+    
+}

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -94,6 +94,11 @@ h2.headerTitle {
     height: 50% !important;
     opacity: 0;
     transition: opacity 0.2s;
+
+    /* hide alt text just in case */
+    text-indent: 100%;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .mainContainer .blockImage img {

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -76,10 +76,14 @@ body {
     color: #1A7DA1 !important;
 }
 
-h2.headerTitle, h2.headerTitleWithLogo {
+h2.headerTitle {
     font-family: "Public Sans", Arial, Helvetica, sans-serif;
     color: #f9f9f9 !important;
     transition: opacity 0.1s ease-in;
+}
+
+.fixedHeaderContainer header h2.headerTitleWithLogo {
+    display: none;
 }
 
 .sideNavVisible .logo {

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -77,7 +77,7 @@ body {
 }
 
 h2.headerTitle, h2.headerTitleWithLogo {
-    font-family: "Open Sans";
+    font-family: "Public Sans", Arial, Helvetica, sans-serif;
     color: #f9f9f9 !important;
     transition: opacity 0.1s ease-in;
 }
@@ -86,7 +86,7 @@ h2.headerTitle, h2.headerTitleWithLogo {
     opacity: 1;
 }
 .logo {
-    font-family: "Open Sans";
+    font-family: "Public Sans", Arial, Helvetica, sans-serif;
     height: 50% !important;
     opacity: 0;
     transition: opacity 0.2s;
@@ -107,7 +107,7 @@ h2.headerTitle, h2.headerTitleWithLogo {
 
 .homeContainer .projectTitle {
     color: #f9f9f9;
-    font-family: "Open Sans";
+    font-family: "Public Sans";
 }
 
 .homeContainer .projectTitle i {
@@ -183,12 +183,12 @@ ol li::before {
     font-weight: bold;
     font-size: 2rem;
     margin-right: 0.5rem;
-    font-family: "Open Sans", Helvetica;
+    font-family: "Public Sans", Arial, Helvetica, sans-serif;
     line-height: 1;
 }
 
 h1, h2, h3, h4, h5, h6 {
-    font-family: "Open Sans", monospace;
+    font-family: "Public Sans", Arial, Helvetica, sans-serif;
 }
 
 h1, h2 {
@@ -196,13 +196,18 @@ h1, h2 {
 }
 
 p, span, oi, li {
-    font-family: "Open Sans";
+    font-family: "Public Sans", Arial, Helvetica, sans-serif;
 }
 
 code *, pre * {
-    font-family: "Roboto Mono";
+    font-family: "Roboto Mono", monospace;
 }
 
 a {
     color: #1A7DA1;
+}
+
+.blockContent code.hljs.css.language-bash {
+    background: #000000;
+    color: #fff;
 }

--- a/docs/static/js/concepts/index.js
+++ b/docs/static/js/concepts/index.js
@@ -1,0 +1,14 @@
+const worker = perspective.worker();
+
+async function main() {
+    const arrow = await fetch("../../arrow/superstore.arrow");
+    const table = worker.table(await arrow.arrayBuffer());
+
+    const viewers = document.getElementsByTagName("perspective-viewer");
+    for (viewer of viewers) {
+        viewer.load(table);
+        viewer.toggleConfig();
+    }
+}
+
+main();

--- a/examples/simple/superstore-arrow.html
+++ b/examples/simple/superstore-arrow.html
@@ -33,16 +33,11 @@
     </perspective-viewer>
 
     <script>
-        window.addEventListener('WebComponentsReady', function() {
-            var xhr = new XMLHttpRequest();
-            xhr.open('GET', 'superstore.arrow', true);
-            xhr.responseType = "arraybuffer"
-            xhr.onload = function() {
-                var el = document.getElementsByTagName('perspective-viewer')[0];
-                el.load(xhr.response);
-                el.toggleConfig();
-            }
-            xhr.send(null);
+        window.addEventListener('WebComponentsReady', async function() {
+            const viewer = document.getElementsByTagName('perspective-viewer')[0];
+            const data = await fetch("superstore.arrow");
+            viewer.load(await data.arrayBuffer());
+            viewer.toggleConfig();
         });
     </script>
 

--- a/examples/simple/superstore-hypergrid.html
+++ b/examples/simple/superstore-hypergrid.html
@@ -33,15 +33,10 @@
 
     <script>
         window.addEventListener('WebComponentsReady', function() {
-            var xhr = new XMLHttpRequest();
-            xhr.open('GET', 'superstore.arrow', true);
-            xhr.responseType = "arraybuffer"
-            xhr.onload = function() {
-                var el = document.getElementsByTagName('perspective-viewer')[0];
-                el.load(xhr.response, {index: "Row ID"});
-                el.toggleConfig();
-            }
-            xhr.send(null);
+            const viewer = document.getElementsByTagName('perspective-viewer')[0];
+            const data = await fetch("superstore.arrow");
+            viewer.load(await data.arrayBuffer(), {index: "Row ID"});
+            viewer.toggleConfig();
         });
     </script>
 

--- a/packages/perspective-viewer/README.md
+++ b/packages/perspective-viewer/README.md
@@ -1,7 +1,7 @@
 <a name="module_perspective-viewer"></a>
 
 ## perspective-viewer
-Module for `<perspective-viewer>` custom element.  There are no exports fromthis module, however importing it has a side effect:  the[module:perspective_viewer~PerspectiveViewer](module:perspective_viewer~PerspectiveViewer) class is registered as acustom element, after which it can be used as a standard DOM element.  Thedocumentation in this module defines the instance structure of a`<perspective-viewer>` DOM object instantiated typically, through HTML or anyrelevent DOM method e.g. `document.createElement("perspective-viewer")` or`document.getElementsByTagName("perspective-viewer")`.
+Module for the `<perspective-viewer>` custom element.This module has no exports, but importing it has a sideeffect: the [module:perspective_viewer~PerspectiveViewer](module:perspective_viewer~PerspectiveViewer) class isregistered as a custom element, after which it can be used as a standard DOMelement.The documentation in this module defines the instance structure of a`<perspective-viewer>` DOM object instantiated typically, through HTML or anyrelevent DOM method e.g. `document.createElement("perspective-viewer")` or`document.getElementsByTagName("perspective-viewer")`.
 
 
 * [perspective-viewer](#module_perspective-viewer)
@@ -16,6 +16,7 @@ Module for `<perspective-viewer>` custom element.  There are no exports fromthi
         * [.column-pivots](#module_perspective-viewer..PerspectiveViewer+column-pivots) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
         * [.row-pivots](#module_perspective-viewer..PerspectiveViewer+row-pivots) : <code>[ &#x27;array&#x27; ].&lt;string&gt;</code>
         * [.editable](#module_perspective-viewer..PerspectiveViewer+editable) : <code>boolean</code>
+        * [.throttle](#module_perspective-viewer..PerspectiveViewer+throttle) : <code>integer</code> \| <code>string</code>
         * [.worker](#module_perspective-viewer..PerspectiveViewer+worker)
         * [.table](#module_perspective-viewer..PerspectiveViewer+table)
         * [.view](#module_perspective-viewer..PerspectiveViewer+view)
@@ -54,6 +55,7 @@ Module for `<perspective-viewer>` custom element.  There are no exports fromthi
     * [.column-pivots](#module_perspective-viewer..PerspectiveViewer+column-pivots) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
     * [.row-pivots](#module_perspective-viewer..PerspectiveViewer+row-pivots) : <code>[ &#x27;array&#x27; ].&lt;string&gt;</code>
     * [.editable](#module_perspective-viewer..PerspectiveViewer+editable) : <code>boolean</code>
+    * [.throttle](#module_perspective-viewer..PerspectiveViewer+throttle) : <code>integer</code> \| <code>string</code>
     * [.worker](#module_perspective-viewer..PerspectiveViewer+worker)
     * [.table](#module_perspective-viewer..PerspectiveViewer+table)
     * [.view](#module_perspective-viewer..PerspectiveViewer+view)
@@ -78,7 +80,7 @@ Module for `<perspective-viewer>` custom element.  There are no exports fromthi
 <a name="new_module_perspective-viewer..PerspectiveViewer_new"></a>
 
 #### new PerspectiveViewer()
-HTMLElement class for `<perspective-viewer>` custom element.  This class isnot exported, so this constructor cannot be invoked in the typical manner;instead, instances of the class are created through the Custom Elements DOMAPI.Properties of an instance of this class, such as [module:perspective_viewer~PerspectiveViewer#columns](module:perspective_viewer~PerspectiveViewer#columns),are reflected on the DOM element as Attributes, and should be accessed assuch - e.g. `instance.setAttribute("columns", JSON.stringify(["a", "b"]))`.
+The HTMLElement class for `<perspective-viewer>` custom element.This class is not exported, so this constructor cannot be invoked in thetypical manner; instead, instances of the class are created through theCustom Elements DOM API.Properties of an instance of this class, such as[module:perspective_viewer~PerspectiveViewer#columns](module:perspective_viewer~PerspectiveViewer#columns), are reflected onthe DOM element as Attributes, and should be accessed as such - e.g.`instance.setAttribute("columns", JSON.stringify(["a", "b"]))`.
 
 **Example**  
 ```js
@@ -161,7 +163,7 @@ The set of column aggregate configurations.
 **Emits**: <code>PerspectiveViewer#event:perspective-config-update</code>  
 **Params**
 
-- aggregates <code>object</code> - A dictionary whose keys are column names, andvalues are valid aggregations.  The `aggergates` attribute works as anoverride;  in lieu of a key for a column supplied by the developers, adefault will be selected and reflected to the attribute based on thecolumn's type.  See [perspective/src/js/defaults.js](perspective/src/js/defaults.js)
+- aggregates <code>object</code> - A dictionary whose keys are column names, andvalues are valid aggregations. The `aggregates` attribute works as anoverride; in lieu of a key for a column supplied by the developers, adefault will be selected and reflected to the attribute based on thecolumn's type.  See [perspective/src/js/defaults.js](perspective/src/js/defaults.js)
 
 **Example** *(via Javascript DOM)*  
 ```js
@@ -170,7 +172,8 @@ elem.setAttribute('aggregates', JSON.stringify({x: "distinct count"}));
 ```
 **Example** *(via HTML)*  
 ```js
-<perspective-viewer aggregates='{"x": "distinct count"}'></perspective-viewer>
+<perspective-viewer aggregates='{"x": "distinct count"}'>
+</perspective-viewer>
 ```
 
 * * *
@@ -193,7 +196,8 @@ elem.setAttribute('filters', JSON.stringify(filters));
 ```
 **Example** *(via HTML)*  
 ```js
-<perspective-viewer filters='[["x", "<", 3], ["y", "contains", "abc"]]'></perspective-viewer>
+<perspective-viewer filters='[["x", "<", 3], ["y", "contains", "abc"]]'>
+</perspective-viewer>
 ```
 
 * * *
@@ -238,10 +242,23 @@ Determines whether this viewer is editable or not (though it isultimately up to
 
 * * *
 
+<a name="module_perspective-viewer..PerspectiveViewer+throttle"></a>
+
+#### perspectiveViewer.throttle : <code>integer</code> \| <code>string</code>
+Determines the render throttling behavior. Can be an integer, formillisecond window to throttle render event; or, if `undefined`,will try to determine the optimal throttle time from this component'srender framerate.
+
+**Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
+**Example**  
+```js
+<!-- Only draws at most 1 frame/sec. --><perspective-viewer throttle="1000"></perspective-viewer>
+```
+
+* * *
+
 <a name="module_perspective-viewer..PerspectiveViewer+worker"></a>
 
 #### perspectiveViewer.worker
-This element's `perspective` worker instance.  This property is notreflected as an HTML attribute, and is readonly;  it can be effectivelyset however by calling the `load() method with a `perspective.table`instance from the preferred worker.
+This element's `perspective` worker instance. This property is notreflected as an HTML attribute, and is readonly; it can be effectivelyset however by calling the `load() method with a `perspective.table`instance from the preferred worker.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Read only**: true  
@@ -265,7 +282,7 @@ This element's `perspective.table` instance.
 <a name="module_perspective-viewer..PerspectiveViewer+view"></a>
 
 #### perspectiveViewer.view
-This element's `perspective.table.view` instance.  The instance itselfwill change after every `PerspectiveViewer#perspective-config-update` event.
+This element's `perspective.table.view` instance. The instance itselfwill change after every `PerspectiveViewer#perspective-config-update`event.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Read only**: true  
@@ -275,23 +292,15 @@ This element's `perspective.table.view` instance.  The instance itselfwill chan
 <a name="module_perspective-viewer..PerspectiveViewer+load"></a>
 
 #### perspectiveViewer.load(data) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
-Load data.  If `load` or `update` have already been called on thiselement, its internal `perspective.table` will also be deleted.
+Load data. If `load` or `update` have already been called on thiselement, its internal `perspective.table` will also be deleted.
 
 **Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code> - A promise which resolves once the data isloaded and a `perspective.view` has been created.  
-**Emits**: <code>module:perspective\_viewer~PerspectiveViewer#perspective-click PerspectiveViewer#event:perspective-view-update</code>  
+**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code> - A promise which resolves once the data is loadedand a `perspective.view` has been created.  
+**Emits**: <code>module:perspective\_viewer~PerspectiveViewer#perspective-clickPerspectiveViewer#perspective-view-update]);event:</code>  
 **Params**
 
 - data <code>any</code> - The data to load.  Works with the same input typessupported by `perspective.table`.
 
-**Example** *(Load JSON)*  
-```js
-const my_viewer = document.getElementById('#my_viewer');
-my_viewer.load([
-    {x: 1, y: 'a'},
-    {x: 2, y: 'b'}
-]);
-```
 **Example** *(Load CSV)*  
 ```js
 const my_viewer = document.getElementById('#my_viewer');

--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -23,11 +23,14 @@ import default_style from "../less/default.less";
 import {ActionElement} from "./viewer/action_element.js";
 
 /**
- * Module for `<perspective-viewer>` custom element.  There are no exports from
- * this module, however importing it has a side effect:  the
- * {@link module:perspective_viewer~PerspectiveViewer} class is registered as a
- * custom element, after which it can be used as a standard DOM element.  The
- * documentation in this module defines the instance structure of a
+ * Module for the `<perspective-viewer>` custom element.
+ *
+ * This module has no exports, but importing it has a side
+ * effect: the {@link module:perspective_viewer~PerspectiveViewer} class is
+ * registered as a custom element, after which it can be used as a standard DOM
+ * element.
+ *
+ * The documentation in this module defines the instance structure of a
  * `<perspective-viewer>` DOM object instantiated typically, through HTML or any
  * relevent DOM method e.g. `document.createElement("perspective-viewer")` or
  * `document.getElementsByTagName("perspective-viewer")`.
@@ -38,10 +41,11 @@ import {ActionElement} from "./viewer/action_element.js";
 const PERSISTENT_ATTRIBUTES = ["selectable", "editable", "plugin", "row-pivots", "column-pivots", "aggregates", "filters", "sort", "computed-columns", "columns"];
 
 /**
- * HTMLElement class for `<perspective-viewer>` custom element.  This class is
- * not exported, so this constructor cannot be invoked in the typical manner;
- * instead, instances of the class are created through the Custom Elements DOM
- * API.
+ * The HTMLElement class for `<perspective-viewer>` custom element.
+ *
+ * This class is not exported, so this constructor cannot be invoked in the
+ * typical manner; instead, instances of the class are created through the
+ * Custom Elements DOM API.
  *
  * Properties of an instance of this class, such as
  * {@link module:perspective_viewer~PerspectiveViewer#columns}, are reflected on
@@ -209,8 +213,8 @@ class PerspectiveViewer extends ActionElement {
      *
      * @kind member
      * @param {object} aggregates A dictionary whose keys are column names, and
-     * values are valid aggregations.  The `aggergates` attribute works as an
-     * override;  in lieu of a key for a column supplied by the developers, a
+     * values are valid aggregations. The `aggregates` attribute works as an
+     * override; in lieu of a key for a column supplied by the developers, a
      * default will be selected and reflected to the attribute based on the
      * column's type.  See {@link perspective/src/js/defaults.js}
      * @fires PerspectiveViewer#perspective-config-update
@@ -245,9 +249,9 @@ class PerspectiveViewer extends ActionElement {
      * The set of column filter configurations.
      *
      * @kind member
-     * @type {array} filters An arry of filter config objects.  A filter config
+     * @type {array} filters An array of filter config objects. A filter config
      * object is an array of three elements: * The column name. * The filter
-     * operation as a string.  See
+     * operation as a string. See
      * {@link perspective/src/js/config/constants.js} * The filter argument, as
      * a string, float or Array<string> as the filter operation demands.
      * @fires PerspectiveViewer#perspective-config-update
@@ -398,8 +402,8 @@ class PerspectiveViewer extends ActionElement {
     }
 
     /**
-     * Determines the render throttling behavior.  Can be an integer, for
-     * millisecond window to throttle render event;  or, if `undefined`,
+     * Determines the render throttling behavior. Can be an integer, for
+     * millisecond window to throttle render event; or, if `undefined`,
      * will try to determine the optimal throttle time from this component's
      * render framerate.
      *
@@ -442,8 +446,8 @@ class PerspectiveViewer extends ActionElement {
     }
 
     /**
-     * This element's `perspective` worker instance.  This property is not
-     * reflected as an HTML attribute, and is readonly;  it can be effectively
+     * This element's `perspective` worker instance. This property is not
+     * reflected as an HTML attribute, and is readonly; it can be effectively
      * set however by calling the `load() method with a `perspective.table`
      * instance from the preferred worker.
      *
@@ -467,7 +471,7 @@ class PerspectiveViewer extends ActionElement {
     }
 
     /**
-     * This element's `perspective.table.view` instance.  The instance itself
+     * This element's `perspective.table.view` instance. The instance itself
      * will change after every `PerspectiveViewer#perspective-config-update`
      * event.
      *
@@ -478,7 +482,7 @@ class PerspectiveViewer extends ActionElement {
     }
 
     /**
-     * Load data.  If `load` or `update` have already been called on this
+     * Load data. If `load` or `update` have already been called on this
      * element, its internal `perspective.table` will also be deleted.
      *
      * @param {any} data The data to load.  Works with the same input types

--- a/packages/perspective/README.md
+++ b/packages/perspective/README.md
@@ -1,26 +1,29 @@
 <a name="module_perspective"></a>
 
 ## perspective
-The main API module for Perspective.
+The main API module for `@finos/perspective`.
+
+For more information, see the
+[Javascript user guide](https://perspective.finos.org/docs/md/js.html).
 
 
 * [perspective](#module_perspective)
     * [~view](#module_perspective..view)
         * [new view()](#new_module_perspective..view_new)
-        * [.get_config()](#module_perspective..view+get_config) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;object&gt;</code>
+        * [.get_config()](#module_perspective..view+get_config) ⇒ <code>Promise.&lt;object&gt;</code>
         * [.delete()](#module_perspective..view+delete)
-        * [.schema()](#module_perspective..view+schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+        * [.schema()](#module_perspective..view+schema) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.column_paths()](#module_perspective..view+column_paths)
-        * [.to_columns([options])](#module_perspective..view+to_columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
-        * [.to_json([options])](#module_perspective..view+to_json) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
-        * [.to_csv([options])](#module_perspective..view+to_csv) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;string&gt;</code>
-        * [.col_to_js_typed_array(column_name, options)](#module_perspective..view+col_to_js_typed_array) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;TypedArray&gt;</code>
-        * [.to_arrow([options])](#module_perspective..view+to_arrow) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;ArrayBuffer&gt;</code>
-        * [.num_rows()](#module_perspective..view+num_rows) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
-        * [.num_columns()](#module_perspective..view+num_columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
-        * [.get_row_expanded()](#module_perspective..view+get_row_expanded) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;bool&gt;</code>
-        * [.expand()](#module_perspective..view+expand) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
-        * [.collapse()](#module_perspective..view+collapse) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
+        * [.to_columns([options])](#module_perspective..view+to_columns) ⇒ <code>Promise.&lt;Array&gt;</code>
+        * [.to_json([options])](#module_perspective..view+to_json) ⇒ <code>Promise.&lt;Array&gt;</code>
+        * [.to_csv([options])](#module_perspective..view+to_csv) ⇒ <code>Promise.&lt;string&gt;</code>
+        * [.col_to_js_typed_array(column_name, options)](#module_perspective..view+col_to_js_typed_array) ⇒ <code>Promise.&lt;TypedArray&gt;</code>
+        * [.to_arrow([options])](#module_perspective..view+to_arrow) ⇒ <code>Promise.&lt;ArrayBuffer&gt;</code>
+        * [.num_rows()](#module_perspective..view+num_rows) ⇒ <code>Promise.&lt;number&gt;</code>
+        * [.num_columns()](#module_perspective..view+num_columns) ⇒ <code>Promise.&lt;number&gt;</code>
+        * [.get_row_expanded()](#module_perspective..view+get_row_expanded) ⇒ <code>Promise.&lt;bool&gt;</code>
+        * [.expand()](#module_perspective..view+expand) ⇒ <code>Promise.&lt;void&gt;</code>
+        * [.collapse()](#module_perspective..view+collapse) ⇒ <code>Promise.&lt;void&gt;</code>
         * [.set_depth()](#module_perspective..view+set_depth)
         * [.on_update(callback)](#module_perspective..view+on_update)
         * [.on_delete(callback)](#module_perspective..view+on_delete)
@@ -32,15 +35,15 @@ The main API module for Perspective.
         * [.delete()](#module_perspective..table+delete)
         * [.on_delete(callback)](#module_perspective..table+on_delete)
         * [.remove_delete(callback)](#module_perspective..table+remove_delete)
-        * [.size()](#module_perspective..table+size) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
-        * [.schema(computed)](#module_perspective..table+schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-        * [.computed_schema()](#module_perspective..table+computed_schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+        * [.size()](#module_perspective..table+size) ⇒ <code>Promise.&lt;number&gt;</code>
+        * [.schema(computed)](#module_perspective..table+schema) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [.computed_schema()](#module_perspective..table+computed_schema) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.is_valid_filter([filter])](#module_perspective..table+is_valid_filter)
         * [.view([config])](#module_perspective..table+view) ⇒ <code>view</code>
         * [.update(data)](#module_perspective..table+update)
         * [.remove(data)](#module_perspective..table+remove)
         * [.add_computed(computed)](#module_perspective..table+add_computed)
-        * [.columns(computed)](#module_perspective..table+columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array.&lt;string&gt;&gt;</code>
+        * [.columns(computed)](#module_perspective..table+columns) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 
 
 * * *
@@ -52,20 +55,20 @@ The main API module for Perspective.
 
 * [~view](#module_perspective..view)
     * [new view()](#new_module_perspective..view_new)
-    * [.get_config()](#module_perspective..view+get_config) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;object&gt;</code>
+    * [.get_config()](#module_perspective..view+get_config) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.delete()](#module_perspective..view+delete)
-    * [.schema()](#module_perspective..view+schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+    * [.schema()](#module_perspective..view+schema) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.column_paths()](#module_perspective..view+column_paths)
-    * [.to_columns([options])](#module_perspective..view+to_columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
-    * [.to_json([options])](#module_perspective..view+to_json) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
-    * [.to_csv([options])](#module_perspective..view+to_csv) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;string&gt;</code>
-    * [.col_to_js_typed_array(column_name, options)](#module_perspective..view+col_to_js_typed_array) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;TypedArray&gt;</code>
-    * [.to_arrow([options])](#module_perspective..view+to_arrow) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;ArrayBuffer&gt;</code>
-    * [.num_rows()](#module_perspective..view+num_rows) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
-    * [.num_columns()](#module_perspective..view+num_columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
-    * [.get_row_expanded()](#module_perspective..view+get_row_expanded) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;bool&gt;</code>
-    * [.expand()](#module_perspective..view+expand) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
-    * [.collapse()](#module_perspective..view+collapse) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
+    * [.to_columns([options])](#module_perspective..view+to_columns) ⇒ <code>Promise.&lt;Array&gt;</code>
+    * [.to_json([options])](#module_perspective..view+to_json) ⇒ <code>Promise.&lt;Array&gt;</code>
+    * [.to_csv([options])](#module_perspective..view+to_csv) ⇒ <code>Promise.&lt;string&gt;</code>
+    * [.col_to_js_typed_array(column_name, options)](#module_perspective..view+col_to_js_typed_array) ⇒ <code>Promise.&lt;TypedArray&gt;</code>
+    * [.to_arrow([options])](#module_perspective..view+to_arrow) ⇒ <code>Promise.&lt;ArrayBuffer&gt;</code>
+    * [.num_rows()](#module_perspective..view+num_rows) ⇒ <code>Promise.&lt;number&gt;</code>
+    * [.num_columns()](#module_perspective..view+num_columns) ⇒ <code>Promise.&lt;number&gt;</code>
+    * [.get_row_expanded()](#module_perspective..view+get_row_expanded) ⇒ <code>Promise.&lt;bool&gt;</code>
+    * [.expand()](#module_perspective..view+expand) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.collapse()](#module_perspective..view+collapse) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.set_depth()](#module_perspective..view+set_depth)
     * [.on_update(callback)](#module_perspective..view+on_update)
     * [.on_delete(callback)](#module_perspective..view+on_delete)
@@ -78,11 +81,13 @@ The main API module for Perspective.
 
 #### new view()
 A View object represents a specific transform (configuration or pivot,
-filter, sort, etc) configuration on an underlying [table](#module_perspective..table). A View
-receives all updates from the [table](#module_perspective..table) from which it is derived, and
-can be serialized to JSON or trigger a callback when it is updated.  View
+filter, sort, etc) configuration on an underlying
+[table](#module_perspective..table). A View receives all updates from the
+[table](#module_perspective..table) from which it is derived, and can be
+serialized to JSON or trigger a callback when it is updated.  View
 objects are immutable, and will remain in memory and actively process
-updates until its [delete](#module_perspective..view+delete) method is called.
+updates until its [delete](#module_perspective..view+delete) method is
+called.
 
 <strong>Note</strong> This constructor is not public - Views are created
 by invoking the [view](#module_perspective..table+view) method.
@@ -97,21 +102,23 @@ table.view({row_pivots: ["name"]});
 
 <a name="module_perspective..view+get_config"></a>
 
-#### view.get\_config() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;object&gt;</code>
-A copy of the config object passed to the [table#view](table#view) method
-which created this [view](#module_perspective..view).
+#### view.get\_config() ⇒ <code>Promise.&lt;object&gt;</code>
+A copy of the config object passed to the [table#view](table#view) method which
+created this [view](#module_perspective..view).
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;object&gt;</code> - Shared the same key/values properties as [view](#module_perspective..view)  
+**Returns**: <code>Promise.&lt;object&gt;</code> - Shared the same key/values properties as
+[view](#module_perspective..view)  
 
 * * *
 
 <a name="module_perspective..view+delete"></a>
 
 #### view.delete()
-Delete this [view](#module_perspective..view) and clean up all resources associated with it.
-View objects do not stop consuming resources or processing updates when
-they are garbage collected - you must call this method to reclaim these.
+Delete this [view](#module_perspective..view) and clean up all resources
+associated with it. View objects do not stop consuming resources or
+processing updates when they are garbage collected - you must call this
+method to reclaim these.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
 
@@ -119,24 +126,28 @@ they are garbage collected - you must call this method to reclaim these.
 
 <a name="module_perspective..view+schema"></a>
 
-#### view.schema() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-The schema of this [view](#module_perspective..view). A schema is an Object, the keys of which
-are the columns of this [view](#module_perspective..view), and the values are their string type names.
-If this [view](#module_perspective..view) is aggregated, theses will be the aggregated types;
-otherwise these types will be the same as the columns in the underlying
-[table](#module_perspective..table)
+#### view.schema() ⇒ <code>Promise.&lt;Object&gt;</code>
+The schema of this [view](#module_perspective..view). A schema is an
+Object, the keys of which are the columns of this
+[view](#module_perspective..view), and the values are their string type
+names. If this [view](#module_perspective..view) is aggregated, theses will
+be the aggregated types; otherwise these types will be the same as the
+columns in the underlying [table](#module_perspective..table)
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code> - A Promise of this [view](#module_perspective..view)'s schema.  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - A Promise of this
+[view](#module_perspective..view)'s schema.  
 
 * * *
 
 <a name="module_perspective..view+column_paths"></a>
 
 #### view.column\_paths()
-Returns an array of strings containing the column paths of the View without any of the source columns.
+Returns an array of strings containing the column paths of the View
+without any of the source columns.
 
-A column path shows the columns that a given cell belongs to after pivots are applied.
+A column path shows the columns that a given cell belongs to after pivots
+are applied.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
 
@@ -144,179 +155,186 @@ A column path shows the columns that a given cell belongs to after pivots are ap
 
 <a name="module_perspective..view+to_columns"></a>
 
-#### view.to\_columns([options]) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
+#### view.to\_columns([options]) ⇒ <code>Promise.&lt;Array&gt;</code>
 Serializes this view to JSON data in a column-oriented format.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code> - A Promise resolving to An array of Objects
-representing the rows of this [view](#module_perspective..view).  If this [view](#module_perspective..view) had a
-"row_pivots" config parameter supplied when constructed, each row Object
-will have a "__ROW_PATH__" key, whose value specifies this row's
-aggregated path.  If this [view](#module_perspective..view) had a "column_pivots" config
-parameter supplied, the keys of this object will be comma-prepended with
-their comma-separated column paths.  
+**Returns**: <code>Promise.&lt;Array&gt;</code> - A Promise resolving to An array of Objects
+representing the rows of this [view](#module_perspective..view).  If this
+[view](#module_perspective..view) had a "row_pivots" config parameter
+supplied when constructed, each row Object will have a "__ROW_PATH__"
+key, whose value specifies this row's aggregated path.  If this
+[view](#module_perspective..view) had a "column_pivots" config parameter
+supplied, the keys of this object will be comma-prepended with their
+comma-separated column paths.  
 **Params**
 
 - [options] <code>Object</code> - An optional configuration object.
-    - .start_row <code>number</code> - The starting row index from which
-to serialize.
-    - .end_row <code>number</code> - The ending row index from which
-to serialize.
-    - .start_col <code>number</code> - The starting column index from which
-to serialize.
-    - .end_col <code>number</code> - The ending column index from which
-to serialize.
-    - [.index] <code>boolean</code> <code> = false</code> - Should the index from the underlying
-[table](#module_perspective..table) be in the output (as `"__INDEX__"`).
+    - .start_row <code>number</code> - The starting row index from which to
+serialize.
+    - .end_row <code>number</code> - The ending row index from which to
+serialize.
+    - .start_col <code>number</code> - The starting column index from which to
+serialize.
+    - .end_col <code>number</code> - The ending column index from which to
+serialize.
+    - [.index] <code>boolean</code> <code> = false</code> - Should the index from the
+underlying [table](#module_perspective..table) be in the output (as
+`"__INDEX__"`).
 
 
 * * *
 
 <a name="module_perspective..view+to_json"></a>
 
-#### view.to\_json([options]) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
+#### view.to\_json([options]) ⇒ <code>Promise.&lt;Array&gt;</code>
 Serializes this view to JSON data in a row-oriented format.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code> - A Promise resolving to An array of Objects
-representing the rows of this [view](#module_perspective..view).  If this [view](#module_perspective..view) had a
-"row_pivots" config parameter supplied when constructed, each row Object
-will have a "__ROW_PATH__" key, whose value specifies this row's
-aggregated path.  If this [view](#module_perspective..view) had a "column_pivots" config
-parameter supplied, the keys of this object will be comma-prepended with
-their comma-separated column paths.  
+**Returns**: <code>Promise.&lt;Array&gt;</code> - A Promise resolving to An array of Objects
+representing the rows of this [view](#module_perspective..view).  If this
+[view](#module_perspective..view) had a "row_pivots" config parameter
+supplied when constructed, each row Object will have a "__ROW_PATH__"
+key, whose value specifies this row's aggregated path.  If this
+[view](#module_perspective..view) had a "column_pivots" config parameter
+supplied, the keys of this object will be comma-prepended with their
+comma-separated column paths.  
 **Params**
 
 - [options] <code>Object</code> - An optional configuration object.
-    - .start_row <code>number</code> - The starting row index from which
-to serialize.
-    - .end_row <code>number</code> - The ending row index from which
-to serialize.
-    - .start_col <code>number</code> - The starting column index from which
-to serialize.
-    - .end_col <code>number</code> - The ending column index from which
-to serialize.
+    - .start_row <code>number</code> - The starting row index from which to
+serialize.
+    - .end_row <code>number</code> - The ending row index from which to
+serialize.
+    - .start_col <code>number</code> - The starting column index from which to
+serialize.
+    - .end_col <code>number</code> - The ending column index from which to
+serialize.
 
 
 * * *
 
 <a name="module_perspective..view+to_csv"></a>
 
-#### view.to\_csv([options]) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;string&gt;</code>
+#### view.to\_csv([options]) ⇒ <code>Promise.&lt;string&gt;</code>
 Serializes this view to CSV data in a standard format.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;string&gt;</code> - A Promise resolving to a string in CSV format
-representing the rows of this [view](#module_perspective..view).  If this [view](#module_perspective..view) had a
-"row_pivots" config parameter supplied when constructed, each row
-will have prepended those values specified by this row's
-aggregated path.  If this [view](#module_perspective..view) had a "column_pivots" config
-parameter supplied, the keys of this object will be comma-prepended with
-their comma-separated column paths.  
+**Returns**: <code>Promise.&lt;string&gt;</code> - A Promise resolving to a string in CSV format
+representing the rows of this [view](#module_perspective..view).  If this
+[view](#module_perspective..view) had a "row_pivots" config parameter
+supplied when constructed, each row will have prepended those values
+specified by this row's aggregated path.  If this
+[view](#module_perspective..view) had a "column_pivots" config parameter
+supplied, the keys of this object will be comma-prepended with their
+comma-separated column paths.  
 **Params**
 
 - [options] <code>Object</code> - An optional configuration object.
-    - .start_row <code>number</code> - The starting row index from which
-to serialize.
-    - .end_row <code>number</code> - The ending row index from which
-to serialize.
-    - .start_col <code>number</code> - The starting column index from which
-to serialize.
-    - .end_col <code>number</code> - The ending column index from which
-to serialize.
-    - .config <code>Object</code> - A config object for the Papaparse [https://www.papaparse.com/docs#json-to-csv](https://www.papaparse.com/docs#json-to-csv)
-config object.
+    - .start_row <code>number</code> - The starting row index from which to
+serialize.
+    - .end_row <code>number</code> - The ending row index from which to
+serialize.
+    - .start_col <code>number</code> - The starting column index from which to
+serialize.
+    - .end_col <code>number</code> - The ending column index from which to
+serialize.
+    - .config <code>Object</code> - A config object for the Papaparse
+[https://www.papaparse.com/docs#json-to-csv](https://www.papaparse.com/docs#json-to-csv) config object.
 
 
 * * *
 
 <a name="module_perspective..view+col_to_js_typed_array"></a>
 
-#### view.col\_to\_js\_typed\_array(column_name, options) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;TypedArray&gt;</code>
+#### view.col\_to\_js\_typed\_array(column_name, options) ⇒ <code>Promise.&lt;TypedArray&gt;</code>
 Serializes a view column into a TypedArray.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;TypedArray&gt;</code> - A promise resolving to a TypedArray
-representing the data of the column as retrieved from the [view](#module_perspective..view) - all
-pivots, aggregates, sorts, and filters have been applied onto the values
-inside the TypedArray. The TypedArray will be constructed based on data type -
-integers will resolve to Int8Array, Int16Array, or Int32Array. Floats resolve to
-Float32Array or Float64Array. If the column cannot be found, or is not of an
+**Returns**: <code>Promise.&lt;TypedArray&gt;</code> - A promise resolving to a TypedArray
+representing the data of the column as retrieved from the
+[view](#module_perspective..view) - all pivots, aggregates, sorts, and
+filters have been applied onto the values inside the TypedArray. The
+TypedArray will be constructed based on data type - integers will resolve
+to Int8Array, Int16Array, or Int32Array. Floats resolve to Float32Array
+or Float64Array. If the column cannot be found, or is not of an
 integer/float type, the Promise returns undefined.  
 **Params**
 
 - column_name <code>string</code> - The name of the column to serialize.
 - options <code>Object</code> - An optional configuration object.
-    - .data_slice <code>\*</code> - A data slice object from which to serialize.
-    - .start_row <code>number</code> - The starting row index from which
-to serialize.
-    - .end_row <code>number</code> - The ending row index from which
-to serialize.
+    - .data_slice <code>\*</code> - A data slice object from which to
+serialize.
+    - .start_row <code>number</code> - The starting row index from which to
+serialize.
+    - .end_row <code>number</code> - The ending row index from which to
+serialize.
 
 
 * * *
 
 <a name="module_perspective..view+to_arrow"></a>
 
-#### view.to\_arrow([options]) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;ArrayBuffer&gt;</code>
-Serializes a view to arrow.
+#### view.to\_arrow([options]) ⇒ <code>Promise.&lt;ArrayBuffer&gt;</code>
+Serializes a view to the Apache Arrow data format.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;ArrayBuffer&gt;</code> - A Table in the Apache Arrow format containing
-data from the view.  
+**Returns**: <code>Promise.&lt;ArrayBuffer&gt;</code> - An `ArrayBuffer` in the Apache Arrow
+format containing data from the view.  
 **Params**
 
 - [options] <code>Object</code> - An optional configuration object.
-    - .data_slice <code>\*</code> - A data slice object from which to serialize.
-    - .start_row <code>number</code> - The starting row index from which
-to serialize.
-    - .end_row <code>number</code> - The ending row index from which
-to serialize.
-    - .start_col <code>number</code> - The starting column index from which
-to serialize.
-    - .end_col <code>number</code> - The ending column index from which
-to serialize.
+    - .data_slice <code>\*</code> - A data slice object from which to
+serialize.
+    - .start_row <code>number</code> - The starting row index from which to
+serialize.
+    - .end_row <code>number</code> - The ending row index from which to
+serialize.
+    - .start_col <code>number</code> - The starting column index from which to
+serialize.
+    - .end_col <code>number</code> - The ending column index from which to
+serialize.
 
 
 * * *
 
 <a name="module_perspective..view+num_rows"></a>
 
-#### view.num\_rows() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
-The number of aggregated rows in this [view](#module_perspective..view).  This is affected by
-the "row_pivots" configuration parameter supplied to this [view](#module_perspective..view)'s
-contructor.
+#### view.num\_rows() ⇒ <code>Promise.&lt;number&gt;</code>
+The number of aggregated rows in this [view](#module_perspective..view).
+This is affected by the "row_pivots" configuration parameter supplied to
+this [view](#module_perspective..view)'s contructor.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code> - The number of aggregated rows.  
+**Returns**: <code>Promise.&lt;number&gt;</code> - The number of aggregated rows.  
 
 * * *
 
 <a name="module_perspective..view+num_columns"></a>
 
-#### view.num\_columns() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
-The number of aggregated columns in this [view](view).  This is affected by
-the "column_pivots" configuration parameter supplied to this [view](view)'s
-contructor.
+#### view.num\_columns() ⇒ <code>Promise.&lt;number&gt;</code>
+The number of aggregated columns in this [view](view).  This is affected
+by the "column_pivots" configuration parameter supplied to this
+[view](view)'s contructor.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code> - The number of aggregated columns.  
+**Returns**: <code>Promise.&lt;number&gt;</code> - The number of aggregated columns.  
 
 * * *
 
 <a name="module_perspective..view+get_row_expanded"></a>
 
-#### view.get\_row\_expanded() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;bool&gt;</code>
+#### view.get\_row\_expanded() ⇒ <code>Promise.&lt;bool&gt;</code>
 Whether this row at index `idx` is in an expanded or collapsed state.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;bool&gt;</code> - Whether this row is expanded.  
+**Returns**: <code>Promise.&lt;bool&gt;</code> - Whether this row is expanded.  
 
 * * *
 
 <a name="module_perspective..view+expand"></a>
 
-#### view.expand() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
+#### view.expand() ⇒ <code>Promise.&lt;void&gt;</code>
 Expands the row at index `idx`.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
@@ -325,7 +343,7 @@ Expands the row at index `idx`.
 
 <a name="module_perspective..view+collapse"></a>
 
-#### view.collapse() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
+#### view.collapse() ⇒ <code>Promise.&lt;void&gt;</code>
 Collapses the row at index `idx`.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
@@ -344,9 +362,9 @@ Set expansion `depth` of the pivot tree.
 <a name="module_perspective..view+on_update"></a>
 
 #### view.on\_update(callback)
-Register a callback with this [view](#module_perspective..view).  Whenever the [view](#module_perspective..view)'s
-underlying table emits an update, this callback will be invoked with the
-aggregated row deltas.
+Register a callback with this [view](#module_perspective..view).  Whenever
+the [view](#module_perspective..view)'s underlying table emits an update,
+this callback will be invoked with the aggregated row deltas.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
 **Params**
@@ -354,7 +372,8 @@ aggregated row deltas.
 - callback <code>function</code> - A callback function invoked on update.  The
 parameter to this callback is dependent on the `mode` parameter:
     - "none" (default): The callback is invoked without an argument.
-    - "cell": The callback is invoked with the new data for each updated cell, serialized to JSON format.
+    - "cell": The callback is invoked with the new data for each updated
+          cell, serialized to JSON format.
     - "row": The callback is invoked with an Arrow of the updated rows.
 
 
@@ -363,8 +382,9 @@ parameter to this callback is dependent on the `mode` parameter:
 <a name="module_perspective..view+on_delete"></a>
 
 #### view.on\_delete(callback)
-Register a callback with this [view](#module_perspective..view).  Whenever the [view](#module_perspective..view)
-is deleted, this callback will be invoked.
+Register a callback with this [view](#module_perspective..view).  Whenever
+the [view](#module_perspective..view) is deleted, this callback will be
+invoked.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
 **Params**
@@ -377,7 +397,8 @@ is deleted, this callback will be invoked.
 <a name="module_perspective..view+remove_delete"></a>
 
 #### view.remove\_delete(callback)
-Unregister a previously registered delete callback with this [view](#module_perspective..view).
+Unregister a previously registered delete callback with this
+[view](#module_perspective..view).
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
 **Params**
@@ -399,15 +420,15 @@ Unregister a previously registered delete callback with this [view](#module_pers
     * [.delete()](#module_perspective..table+delete)
     * [.on_delete(callback)](#module_perspective..table+on_delete)
     * [.remove_delete(callback)](#module_perspective..table+remove_delete)
-    * [.size()](#module_perspective..table+size) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
-    * [.schema(computed)](#module_perspective..table+schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-    * [.computed_schema()](#module_perspective..table+computed_schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+    * [.size()](#module_perspective..table+size) ⇒ <code>Promise.&lt;number&gt;</code>
+    * [.schema(computed)](#module_perspective..table+schema) ⇒ <code>Promise.&lt;Object&gt;</code>
+    * [.computed_schema()](#module_perspective..table+computed_schema) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.is_valid_filter([filter])](#module_perspective..table+is_valid_filter)
     * [.view([config])](#module_perspective..table+view) ⇒ <code>view</code>
     * [.update(data)](#module_perspective..table+update)
     * [.remove(data)](#module_perspective..table+remove)
     * [.add_computed(computed)](#module_perspective..table+add_computed)
-    * [.columns(computed)](#module_perspective..table+columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array.&lt;string&gt;&gt;</code>
+    * [.columns(computed)](#module_perspective..table+columns) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 
 
 * * *
@@ -420,8 +441,9 @@ typed - they have an immutable set of column names, and a known type for
 each.
 
 <strong>Note</strong> This constructor is not public - Tables are created
-by invoking the [table](#module_perspective..table) factory method, either on the perspective
-module object, or an a [module:perspective~worker](module:perspective~worker) instance.
+by invoking the [table](#module_perspective..table) factory method, either
+on the perspective module object, or an a
+[module:perspective~worker](module:perspective~worker) instance.
 
 
 * * *
@@ -429,8 +451,8 @@ module object, or an a [module:perspective~worker](module:perspective~worker) in
 <a name="module_perspective..table+clear"></a>
 
 #### table.clear()
-Remove all rows in this [table](#module_perspective..table) while preserving the schema and
-construction options.
+Remove all rows in this [table](#module_perspective..table) while preserving
+the schema and construction options.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 
@@ -448,9 +470,10 @@ Replace all rows in this [table](#module_perspective..table) the input data.
 <a name="module_perspective..table+delete"></a>
 
 #### table.delete()
-Delete this [table](#module_perspective..table) and clean up all resources associated with it.
-Table objects do not stop consuming resources or processing updates when
-they are garbage collected - you must call this method to reclaim these.
+Delete this [table](#module_perspective..table) and clean up all resources
+associated with it. Table objects do not stop consuming resources or
+processing updates when they are garbage collected - you must call this
+method to reclaim these.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 
@@ -459,8 +482,9 @@ they are garbage collected - you must call this method to reclaim these.
 <a name="module_perspective..table+on_delete"></a>
 
 #### table.on\_delete(callback)
-Register a callback with this [table](#module_perspective..table).  Whenever the [table](#module_perspective..table)
-is deleted, this callback will be invoked.
+Register a callback with this [table](#module_perspective..table).  Whenever
+the [table](#module_perspective..table) is deleted, this callback will be
+invoked.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 **Params**
@@ -475,7 +499,8 @@ is deleted, this callback will be invoked.
 <a name="module_perspective..table+remove_delete"></a>
 
 #### table.remove\_delete(callback)
-Unregister a previously registered delete callback with this [table](#module_perspective..table).
+Unregister a previously registered delete callback with this
+[table](#module_perspective..table).
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 **Params**
@@ -487,53 +512,60 @@ Unregister a previously registered delete callback with this [table](#module_per
 
 <a name="module_perspective..table+size"></a>
 
-#### table.size() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
-The number of accumulated rows in this [table](#module_perspective..table).  This is affected by
-the "index" configuration parameter supplied to this [view](#module_perspective..view)'s
-contructor - as rows will be overwritten when they share an idnex column.
+#### table.size() ⇒ <code>Promise.&lt;number&gt;</code>
+The number of accumulated rows in this [table](#module_perspective..table).
+This is affected by the "index" configuration parameter supplied to this
+[view](#module_perspective..view)'s contructor - as rows will be
+overwritten when they share an idnex column.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code> - The number of accumulated rows.  
+**Returns**: <code>Promise.&lt;number&gt;</code> - The number of accumulated rows.  
 
 * * *
 
 <a name="module_perspective..table+schema"></a>
 
-#### table.schema(computed) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-The schema of this [table](#module_perspective..table).  A schema is an Object whose keys are the
-columns of this [table](#module_perspective..table), and whose values are their string type names.
+#### table.schema(computed) ⇒ <code>Promise.&lt;Object&gt;</code>
+The schema of this [table](#module_perspective..table).  A schema is an
+Object whose keys are the columns of this
+[table](#module_perspective..table), and whose values are their string type
+names.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code> - A Promise of this [table](#module_perspective..table)'s schema.  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - A Promise of this
+[table](#module_perspective..table)'s schema.  
 **Params**
 
-- computed <code>boolean</code> - Should computed columns be included?
-(default false)
+- computed <code>boolean</code> - Should computed columns be included? (default
+false)
 
 
 * * *
 
 <a name="module_perspective..table+computed_schema"></a>
 
-#### table.computed\_schema() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-The computed schema of this [table](#module_perspective..table). Returns a schema of only computed
-columns added by the user, the keys of which are computed columns and the values an
-Object containing the associated column_name, column_type, and computation.
+#### table.computed\_schema() ⇒ <code>Promise.&lt;Object&gt;</code>
+The computed schema of this [table](#module_perspective..table). Returns a
+schema of only computed columns added by the user, the keys of which are
+computed columns and the values an Object containing the associated
+column_name, column_type, and computation.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code> - A Promise of this [table](#module_perspective..table)'s computed schema.  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - A Promise of this
+[table](#module_perspective..table)'s computed schema.  
 
 * * *
 
 <a name="module_perspective..table+is_valid_filter"></a>
 
 #### table.is\_valid\_filter([filter])
-Validates a filter configuration, i.e. that the value to filter by is not null or undefined.
+Validates a filter configuration, i.e. that the value to filter by is not
+null or undefined.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 **Params**
 
-- [filter] <code>[ &#x27;Array&#x27; ].&lt;string&gt;</code> - a filter configuration to test.
+- [filter] <code>Array.&lt;string&gt;</code> - a filter configuration to test.
 
 
 * * *
@@ -541,41 +573,45 @@ Validates a filter configuration, i.e. that the value to filter by is not null o
 <a name="module_perspective..table+view"></a>
 
 #### table.view([config]) ⇒ <code>view</code>
-Create a new [view](#module_perspective..view) from this table with a specified
-configuration.
+Create a new [view](#module_perspective..view) from this table with a
+specified configuration. For a conceptual understanding of the
+configuration options, see the [Conceptual Overview](https://perspective.finos.org/docs/md/installation.html).
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
-**Returns**: <code>view</code> - A new [view](#module_perspective..view) object for the supplied configuration,
-bound to this table  
+**Returns**: <code>view</code> - A new [view](#module_perspective..view) object for the
+supplied configuration, bound to this table  
 **Params**
 
-- [config] <code>Object</code> - The configuration object for this [view](#module_perspective..view).
-    - [.row_pivots] <code>[ &#x27;Array&#x27; ].&lt;string&gt;</code> - An array of column names
-to use as [Row Pivots](https://en.wikipedia.org/wiki/Pivot_table#Row_labels).
-    - [.column_pivots] <code>[ &#x27;Array&#x27; ].&lt;string&gt;</code> - An array of column names
-to use as [Column Pivots](https://en.wikipedia.org/wiki/Pivot_table#Column_labels).
-    - [.columns] <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code> - An array of column names for the
-output columns.  If none are provided, all columns are output.
-    - [.aggregates] <code>Object</code> - An object, the keys of which are column
-names, and their respective values are the aggregates calculations to use
-when this view has `row_pivots`.  A column provided to `config.columns`
-without an aggregate in this object, will use the default aggregate
-calculation for its type.
-    - [.filter] <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;string&gt;&gt;</code> - An Array of Filter configurations to
-apply.  A filter configuration is an array of 3 elements:  A column name,
-a supported filter comparison string (e.g. '===', '>'), and a value to compare.
-    - [.sort] <code>[ &#x27;Array&#x27; ].&lt;string&gt;</code> - An Array of Sort configurations to apply.
-A sort configuration is an array of 2 elements: A column name, and a sort direction,
-which are: "none", "asc", "desc", "col asc", "col desc", "asc abs", "desc abs", "col asc abs", "col desc abs".
+- [config] <code>Object</code> - The configuration object for this
+[view](#module_perspective..view).
+    - [.row_pivots] <code>Array.&lt;string&gt;</code> - An array of column names to
+use as [Row Pivots](https://en.wikipedia.org/wiki/Pivot_table#Row_labels).
+    - [.column_pivots] <code>Array.&lt;string&gt;</code> - An array of column names to
+use as [Column Pivots](https://en.wikipedia.org/wiki/Pivot_table#Column_labels).
+    - [.columns] <code>Array.&lt;Object&gt;</code> - An array of column names for the
+output columns. If none are provided, all columns are output.
+    - [.aggregates] <code>Object</code> - An object, the keys of which are
+column names, and their respective values are the aggregates calculations
+to use when this view has `row_pivots`. A column provided to
+`config.columns` without an aggregate in this object, will use the
+default aggregate calculation for its type.
+    - [.filter] <code>Array.&lt;Array.&lt;string&gt;&gt;</code> - An Array of Filter
+configurations to apply. A filter configuration is an array of 3
+elements: A column name, a supported filter comparison string (e.g.
+'===', '>'), and a value to compare.
+    - [.sort] <code>Array.&lt;string&gt;</code> - An Array of Sort configurations to
+apply. A sort configuration is an array of 2 elements: A column name, and
+a sort direction, which are: "none", "asc", "desc", "col asc", "col
+desc", "asc abs", "desc abs", "col asc abs", "col desc abs".
 
 **Example**  
 ```js
 var view = table.view({
-     row_pivots: ['region'],
+     row_pivots: ["region"],
      columns: ["region"],
      aggregates: {"region": "dominant"},
-     filter: [['client', 'contains', 'fred']],
-     sort: [['value', 'asc']]
+     filter: [["client", "contains", "fred"]],
+     sort: [["value", "asc"]]
 });
 ```
 
@@ -584,17 +620,19 @@ var view = table.view({
 <a name="module_perspective..table+update"></a>
 
 #### table.update(data)
-Updates the rows of a [table](#module_perspective..table). Updated rows are pushed down to any
-derived [view](#module_perspective..view) objects.
+Updates the rows of a [table](#module_perspective..table). Updated rows are
+pushed down to any derived [view](#module_perspective..view) objects.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 **See**: [table](#module_perspective..table)  
 **Params**
 
 - data <code>Object.&lt;string, Array&gt;</code> | <code>Array.&lt;Object&gt;</code> | <code>string</code> - The input data
-for this table.  The supported input types mirror the constructor options, minus
-the ability to pass a schema (Object<string, string>) as this table has
-already been constructed, thus its types are set in stone.
+for this table. [table](#module_perspective..table)s are immutable after
+creation, so this method cannot be called with a schema.
+
+Otherwise, the supported input types are the same as the
+[table](#module_perspective..table) constructor.
 
 
 * * *
@@ -602,14 +640,14 @@ already been constructed, thus its types are set in stone.
 <a name="module_perspective..table+remove"></a>
 
 #### table.remove(data)
-Removes the rows of a [table](#module_perspective..table). Removed rows are pushed down to any
-derived [view](#module_perspective..view) objects.
+Removes the rows of a [table](#module_perspective..table). Removed rows are
+pushed down to any derived [view](#module_perspective..view) objects.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 **See**: [table](#module_perspective..table)  
 **Params**
 
-- data <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code> - An array of primary keys to remove.
+- data <code>Array.&lt;Object&gt;</code> - An array of primary keys to remove.
 
 
 * * *
@@ -617,7 +655,8 @@ derived [view](#module_perspective..view) objects.
 <a name="module_perspective..table+add_computed"></a>
 
 #### table.add\_computed(computed)
-Create a new table with the addition of new computed columns (defined as javascript functions)
+Create a new table with the addition of new computed columns (defined as
+javascript functions)
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 **Params**
@@ -629,15 +668,16 @@ Create a new table with the addition of new computed columns (defined as javascr
 
 <a name="module_perspective..table+columns"></a>
 
-#### table.columns(computed) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array.&lt;string&gt;&gt;</code>
+#### table.columns(computed) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 The column names of this table.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Array.&lt;string&gt;&gt;</code> - An array of column names for this table.  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> - An array of column names for this
+table.  
 **Params**
 
-- computed <code>boolean</code> - Should computed columns be included?
-(default false)
+- computed <code>boolean</code> - Should computed columns be included? (default
+false)
 
 
 * * *

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -29,7 +29,11 @@ if (typeof self !== "undefined" && self.performance === undefined) {
 }
 
 /**
- * The main API module for Perspective.
+ * The main API module for `@finos/perspective`.
+ *
+ * For more information, see the Javascript user guide:
+ * https://perspective.finos.org/docs/md/js.html.
+ *
  * @module perspective
  */
 export default function(Module) {

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -31,8 +31,8 @@ if (typeof self !== "undefined" && self.performance === undefined) {
 /**
  * The main API module for `@finos/perspective`.
  *
- * For more information, see the Javascript user guide:
- * https://perspective.finos.org/docs/md/js.html.
+ * For more information, see the
+ * [Javascript user guide](https://perspective.finos.org/docs/md/js.html).
  *
  * @module perspective
  */
@@ -1127,7 +1127,8 @@ export default function(Module) {
 
     /**
      * Create a new {@link module:perspective~view} from this table with a
-     * specified configuration.
+     * specified configuration. For a conceptual understanding of the
+     * configuration options, see the [Conceptual Overview](https://perspective.finos.org/docs/md/installation.html).
      *
      * @param {Object} [config] The configuration object for this
      * {@link module:perspective~view}.
@@ -1136,15 +1137,15 @@ export default function(Module) {
      * @param {Array<string>} [config.column_pivots] An array of column names to
      * use as {@link https://en.wikipedia.org/wiki/Pivot_table#Column_labels Column Pivots}.
      * @param {Array<Object>} [config.columns] An array of column names for the
-     * output columns.  If none are provided, all columns are output.
+     * output columns. If none are provided, all columns are output.
      * @param {Object} [config.aggregates] An object, the keys of which are
      * column names, and their respective values are the aggregates calculations
-     * to use when this view has `row_pivots`.  A column provided to
+     * to use when this view has `row_pivots`. A column provided to
      * `config.columns` without an aggregate in this object, will use the
      * default aggregate calculation for its type.
      * @param {Array<Array<string>>} [config.filter] An Array of Filter
-     * configurations to apply.  A filter configuration is an array of 3
-     * elements:  A column name, a supported filter comparison string (e.g.
+     * configurations to apply. A filter configuration is an array of 3
+     * elements: A column name, a supported filter comparison string (e.g.
      * '===', '>'), and a value to compare.
      * @param {Array<string>} [config.sort] An Array of Sort configurations to
      * apply. A sort configuration is an array of 2 elements: A column name, and
@@ -1153,11 +1154,11 @@ export default function(Module) {
      *
      * @example
      * var view = table.view({
-     *      row_pivots: ['region'],
+     *      row_pivots: ["region"],
      *      columns: ["region"],
      *      aggregates: {"region": "dominant"},
-     *      filter: [['client', 'contains', 'fred']],
-     *      sort: [['value', 'asc']]
+     *      filter: [["client", "contains", "fred"]],
+     *      sort: [["value", "asc"]]
      * });
      *
      * @returns {view} A new {@link module:perspective~view} object for the
@@ -1221,7 +1222,7 @@ export default function(Module) {
         return v;
     };
 
-    /* eslint-enadle max-len */
+    /* eslint-enable max-len */
 
     let meter;
 
@@ -1248,9 +1249,11 @@ export default function(Module) {
      * pushed down to any derived {@link module:perspective~view} objects.
      *
      * @param {Object<string, Array>|Array<Object>|string} data The input data
-     * for this table.  The supported input types mirror the constructor
-     * options, minus the ability to pass a schema (Object<string, string>) as
-     * this table has already been constructed, thus its types are set in stone.
+     * for this table. {@link module:perspective~table}s are immutable after
+     * creation, so this method cannot be called with a schema.
+     *
+     * Otherwise, the supported input types are the same as the
+     * {@link module:perspective~table} constructor.
      *
      * @see {@link module:perspective~table}
      */
@@ -1412,7 +1415,7 @@ export default function(Module) {
         f(this);
     };
 
-    /******************************************************************************
+    /***************************************************************************
      *
      * Perspective
      *
@@ -1437,26 +1440,27 @@ export default function(Module) {
          * var table = perspective.table([{x: 1}, {x: 2}]);
          *
          * @example
-         * // Creating a table from a Web Worker (instantiated via the worker() method).
+         * // Creating a table from a Web Worker (instantiated via the worker()
+         * method).
          * var table = worker.table([{x: 1}, {x: 2}]);
          *
          * @param {Object<string, Array>|Object<string,
          *     string>|Array<Object>|string} data The input data for this table.
          *     When supplied an Object with string values, an empty table is
-         *     returned using this Object as a schema.  When an Object with
+         *     returned using this Object as a schema. When an Object with
          *     Array values is supplied, a table is returned using this object's
-         *     key/value pairs as name/columns respectively.  When an Array is
+         *     key/value pairs as name/columns respectively. When an Array is
          *     supplied, a table is constructed using this Array's objects as
-         *     rows.  When a string is supplied, the parameter as parsed as a
+         *     rows. When a string is supplied, the parameter as parsed as a
          *     CSV.
          * @param {Object} [options] An optional options dictionary.
          * @param {string} options.index The name of the column in the resulting
-         *     table to treat as an index.  When updating this table, rows
+         *     table to treat as an index. When updating this table, rows
          *     sharing an index of a new row will be overwritten. `index` is
-         *     mutually exclusive to `limit`
+         *     mutually exclusive to `limit`.
          * @param {integer} options.limit The maximum number of rows that can be
-         *     added to this table.  When exceeded, old rows will be overwritten
-         *     in the order they were inserted.  `limit` is mutually exclusive
+         *     added to this table. When exceeded, old rows will be overwritten
+         *     in the order they were inserted. `limit` is mutually exclusive
          *     to `index`.
          *
          * @returns {table} A new {@link module:perspective~table} object.
@@ -1550,8 +1554,8 @@ export default function(Module) {
          * When initialized, replace Perspective's internal `__MODULE` variable
          * with the WASM binary.
          *
-         * @param {ArrayBuffer} buffer an ArrayBuffer or Buffer containing the Perspective
-         * WASM code
+         * @param {ArrayBuffer} buffer an ArrayBuffer or Buffer containing the
+         * Perspective WASM code
          */
         init(msg) {
             if (typeof WebAssembly === "undefined") {

--- a/python/perspective/docs/perspective.table.rst
+++ b/python/perspective/docs/perspective.table.rst
@@ -1,6 +1,6 @@
 ``perspective.table`` contains ``Table`` and ``View``, the data primitives of Perspective. 
 
-For usage, see the User Guide from the sidebar.
+For usage, see the `Python User Guide </docs/md/python.html>`_.
 
 Table
 =====


### PR DESCRIPTION
This PR adds and edits several pieces of useful documentation, as well as styling improvements to Perspective's [website](https://perspective.finos.org).

- Adds a "Conceptual Overview", which is a language-agnostic look at Perspective's core concepts, explaining how `Table`, `View`, and various `View` options work. This guide helps to fill in the gaps in our API documentation/user guide about Perspective's concepts, and moves them to one centralized location.
- Restructure the installation guide, JS user guide, and Python user guide, adding content where necessary.
- Restyle the Perspective website with new fonts and code highlighting
- Regenerate READMEs for `perspective`, `perspective-viewer` and `perspective-python`