### PR TITLE
Fixed React types.

### DIFF
--- a/packages/perspective-viewer/index.d.ts
+++ b/packages/perspective-viewer/index.d.ts
@@ -62,7 +62,7 @@ interface PerspectiveViewerHTMLAttributes extends Pick<PerspectiveViewerOptions,
     columns?: string;
 }
 
-interface ReactPerspectiveViewerHTMLAttributes<T> extends PerspectiveViewerHTMLAttributes, React.HTMLAttributes<T> {}
+interface HTMLPerspectiveViewerElement extends PerspectiveViewerHTMLAttributes, HTMLElement {}
 
 type PerspectiveElement = React.DetailedHTMLProps<ReactPerspectiveViewerHTMLAttributes<HTMLPerspectiveViewerElement>, HTMLPerspectiveViewerElement>;
 


### PR DESCRIPTION
Fixes React types to inherit from `HTMLElement` rather than `React.HTMLAttributes<T>`, such that is is properly treated as a Custom Element - see #865 