### PR TITLE
Fix selection styling on `@finos/perspective-viewer-hypergrid`

### DIFF
--- a/packages/perspective-viewer-hypergrid/src/js/styles.js
+++ b/packages/perspective-viewer-hypergrid/src/js/styles.js
@@ -18,6 +18,7 @@ properties.add_fonts({
     columnHeaderFont: `${title}-header`,
     columnHeaderForegroundSelectionFont: `${title}-header`,
     foregroundSelectionFont: `${title}-header`,
+    treeHeaderForegroundSelectionFont: [`${title}-tree-header-selection`, `${title}-header`],
     rowHeaderFont: title,
     treeHeaderFont: title
 });
@@ -26,8 +27,8 @@ properties.add_styles({
     treeHeaderBackgroundColor: `${title}-tree-header--background`,
     backgroundColor: `${title}--background`,
     treeHeaderColor: `${title}-tree-header--color`,
-    treeHeaderForegroundSelectionColor: `${title}-tree-header-selection--color`,
-    treeHeaderBackgroundSelectionColor: `${title}-tree-header-selection--background`,
+    treeHeaderForegroundSelectionColor: [`${title}-tree-header-selection--color`, `${title}--color`],
+    treeHeaderBackgroundSelectionColor: [`${title}-tree-header-selection--background`, `${title}-selection--background`],
     backgroundSelectionColor: `${title}-selection--background`,
     foregroundSelectionColor: [`${title}--color`, `color`],
     borderBottom: `${title}--border-bottom-color`,

--- a/packages/perspective-viewer/src/themes/material.less
+++ b/packages/perspective-viewer/src/themes/material.less
@@ -19,6 +19,8 @@ perspective-viewer, .perspective-viewer-material{
     
     --hypergrid-positive--color: #1078d1;
     --hypergrid-negative--color: #de3838;
+
+    --hypergrid-selection--background: rgba(0, 0, 0, 0.1);
 }
 
 .perspective-viewer-material-base(){
@@ -96,8 +98,6 @@ perspective-viewer, .perspective-viewer-material{
     --hypergrid-header--font-size: 12px;
     --hypergrid--font-family: "Open Sans";
     --hypergrid-header--font-family: "Open Sans";
-
-    --hypergrid-selection--background: rgba(0, 0, 0, 0.1);
 
     --d3fc-treedata-axis--lines: none;
 }


### PR DESCRIPTION
This PR allows the hypergrid selection styling on the tree column to fallback to the same style as  the rest of the grid if it's not explicitly set