### PR TITLE
Update Python README

### DIFF
--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -115,9 +115,11 @@ In addition to supporting row/columnar formats of data using `dict` and `list`,
 `pandas.DataFrame`, dictionaries of NumPy arrays, NumPy structured arrays, and
 NumPy record arrays are all supported in `perspective-python`.
 
-`perspective-python` can be installed from `pip`:
+After installing `pyarrow` 0.15.1, `perspective-python` can be installed from 
+`pip`:
 
 ```bash
+pip install pyarrow==0.15.1
 pip install perspective-python
 ```
 

--- a/python/perspective/README.md
+++ b/python/perspective/README.md
@@ -12,11 +12,9 @@ Python APIs for [perspective](https://github.com/finos/perspective) front end
 
 ### Dependencies
 
-You need to have [https://github.com/intel/tbb](TBB) installed as a system dependency:
+*PyArrow 0.15.1* is a required dependency for Perspective. Install it first:
 
-On MacOS:
-
-`brew install tbb`
+`pip install pyarrow==0.15.1`
 
 ### Installation
 
@@ -24,23 +22,18 @@ To install the base package from pip:
 
 `pip install perspective-python`
 
-To Install from source:
-
-`make install`
-
 To install the JupyterLab extension:
 
 `jupyter labextension install @finos/perspective-jupyterlab`
 
-or from source:
-
-`make labextension`
-
 ## Getting Started
 
-[Example Notebooks](https://github.com/finos/perspective/tree/master/python/perspective/examples)
+[Python User Guide](https://perspective.finos.org/docs/md/python.html)
+[Python API](https://perspective.finos.org/docs/obj/perspective-python.html)
+[Examples](https://github.com/finos/perspective/tree/master/python/perspective/examples)
 
 ## Developing
+
 To build `perspective-python` from source, you'll need the following C++ dependencies:
 
 - Python 3.7

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -207,6 +207,7 @@ setup(
     version=version,
     description='Python bindings and JupyterLab integration for Perspective',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/finos/perspective',
     author='Perspective Authors',
     author_email='open_source@jpmorgan.com',


### PR DESCRIPTION
This PR edits the Python README to include instructions for installing `pyarrow`, and edits `setup.py` for Pypi to read the README properly as markdown instead of RST.