### PR TITLE
Fix #898 - week bucket overflows

### DIFF
--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -554,8 +554,8 @@ t_tscalar week_bucket<DTYPE_TIME>(t_tscalar x) {
     // Create a copy of the timestamp with day precision
     auto days = date::floor<date::days>(ts);
 
-    // Cast the `time_point` to contain year/month/day
-    auto ymd = date::year_month_day(days);
+    // Subtract Sunday from the ymd to get the beginning of the last day
+    date::year_month_day ymd = days - (date::weekday{days} - date::Monday);
 
     // Get the day of month and day of the week
     std::int32_t year = static_cast<std::int32_t>(ymd.year());
@@ -563,16 +563,9 @@ t_tscalar week_bucket<DTYPE_TIME>(t_tscalar x) {
     // date::month is [1-12], whereas `t_date.month()` is [0-11]
     std::uint32_t month = static_cast<std::uint32_t>(ymd.month()) - 1;
     std::uint32_t day = static_cast<std::uint32_t>(ymd.day());
-    auto weekday = date::year_month_weekday(days).weekday_indexed().weekday();
-
-    // Get the day of the week as an int from 0 to 6
-    auto day_of_week = (weekday - date::Sunday).count();
-
-    // Set the day to the beginning of the week
-    auto diff = day - day_of_week + (day_of_week == 0 ? - 6 : 1);
 
     // Return the new `t_date`
-    t_date new_date = t_date(year, month, diff);
+    t_date new_date = t_date(year, month, day);
     rval.set(new_date);
     return rval;
 }

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -526,17 +526,18 @@ t_tscalar week_bucket<DTYPE_DATE>(t_tscalar x) {
     // Convert to a `sys_days` representing no. of days since epoch
     date::sys_days days_since_epoch = ymd;
 
-    // Construct a `date::year_month_weekday` from `date::sys_days` since epoch
-    auto weekday = date::year_month_weekday(ymd).weekday_indexed().weekday();
-    
-    // Get the day of the week as an int from 0 to 6
-    auto day_of_week = (weekday - date::Sunday).count();
+    // Subtract Sunday from the ymd to get the beginning of the last day
+    ymd = days_since_epoch - (date::weekday{days_since_epoch} - date::Monday);
 
-    // Set the day to the beginning of the week
-    auto diff = static_cast<std::uint32_t>(val.day()) - day_of_week + (day_of_week == 0 ? - 6 : 1);
+    // Get the day of month and day of the week
+    std::int32_t year_int = static_cast<std::int32_t>(ymd.year());
+
+    // date::month is [1-12], whereas `t_date.month()` is [0-11]
+    std::uint32_t month_int = static_cast<std::uint32_t>(ymd.month()) - 1;
+    std::uint32_t day_int = static_cast<std::uint32_t>(ymd.day());
 
     // Return the new `t_date`
-    t_date new_date = t_date(val.year(), val.month(), diff);
+    t_date new_date = t_date(year_int, month_int, day_int);
     rval.set(new_date);
     return rval;
 }

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -325,7 +325,8 @@ export const install = function(grid) {
 
         const filters = config.filter.concat(row_filters).concat(column_filters);
 
-        // this only works for single row select (which is all we support right now)
+        // this only works for single row select (which is all we support
+        // right now)
         if (this.grid.properties.rowSelection) {
             const selected = this.grid.getSelectedRows()[0] === y;
             this.grid.canvas.dispatchEvent(

--- a/packages/perspective/test/js/computed.js
+++ b/packages/perspective/test/js/computed.js
@@ -1187,6 +1187,39 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Bucket (W), date shouldn't ever overflow at beginning of year", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (W)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2015, 0, 3, 15), new Date(2015, 0, 4)]
+                });
+
+                let result = await view.to_columns();
+
+                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => week_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
             it("Bucket (M), date", async function() {
                 const table = perspective.table({
                     a: "date"


### PR DESCRIPTION
This PR fixes a bug in the `week_bucket` computed function for date and datetime columns, replacing the calculation for week bucket with a more robust version from the `date.h` library.