### PR TITLE
Add 'workspace-layout-update' event and css class selector names cleanup 

### DIFF
--- a/examples/workspace/src/index.js
+++ b/examples/workspace/src/index.js
@@ -31,8 +31,8 @@ window.addEventListener("load", async () => {
     const config = {
         master: {
             widgets: [
-                {table: "superstore", name: "Three", "row-pivots": ["State"], columns: ["Sales", "Profit"]},
-                {table: "superstore", name: "Four", "row-pivots": ["Category", "Sub-Category"], columns: ["Sales", "Profit"]}
+                {table: "superstore", title: "Three", "row-pivots": ["State"], columns: ["Sales", "Profit"]},
+                {table: "superstore", title: "Four", "row-pivots": ["Category", "Sub-Category"], columns: ["Sales", "Profit"]}
             ]
         },
         detail: {
@@ -40,8 +40,8 @@ window.addEventListener("load", async () => {
                 currentIndex: 0,
                 type: "tab-area",
                 widgets: [
-                    {table: "superstore", name: "One"},
-                    {table: "superstore", name: "Two"}
+                    {table: "superstore", title: "One"},
+                    {table: "superstore", title: "Two"}
                 ]
             }
         }

--- a/examples/workspace/src/index.js
+++ b/examples/workspace/src/index.js
@@ -47,6 +47,7 @@ window.addEventListener("load", async () => {
         }
     };
 
+    workspace.addEventListener("workspace-layout-update", console.log);
     workspace.restore(config);
     window.workspace = workspace;
 });

--- a/packages/perspective-workspace/src/js/workspace/commands.js
+++ b/packages/perspective-workspace/src/js/workspace/commands.js
@@ -14,28 +14,28 @@ export const createCommands = workspace => {
 
     commands.addCommand("workspace:export", {
         execute: args => args.widget.viewer.download(),
-        iconClass: "p-MenuItem-export",
+        iconClass: "menu-export",
         label: "Export CSV",
         mnemonic: 0
     });
 
     commands.addCommand("workspace:copy", {
         execute: args => args.widget.viewer.copy(),
-        iconClass: "p-MenuItem-copy",
+        iconClass: "menu-copy",
         label: "Copy To Clipboard",
         mnemonic: 0
     });
 
     commands.addCommand("workspace:reset", {
         execute: args => args.widget.viewer.reset(),
-        iconClass: "p-MenuItem-reset",
+        iconClass: "menu-reset",
         label: "Reset",
         mnemonic: 0
     });
 
     commands.addCommand("workspace:duplicate", {
         execute: ({widget}) => workspace.duplicate(widget),
-        iconClass: "p-MenuItem-duplicate",
+        iconClass: "menu-duplicate",
         isVisible: args => (args.widget.parent === workspace.dockpanel ? true : false),
         label: "Duplicate",
         mnemonic: 0
@@ -43,7 +43,7 @@ export const createCommands = workspace => {
 
     commands.addCommand("workspace:master", {
         execute: args => workspace.toggleMasterDetail(args.widget),
-        iconClass: args => (args.widget.parent === workspace.dockpanel ? "p-MenuItem-master" : "p-MenuItem-detail"),
+        iconClass: args => (args.widget.parent === workspace.dockpanel ? "menu-master" : "menu-detail"),
         label: args => (args.widget.parent === workspace.dockpanel ? "Create Global Filter" : "Remove Global Filter"),
         mnemonic: 0
     });
@@ -51,7 +51,7 @@ export const createCommands = workspace => {
     commands.addCommand("workspace:maximize", {
         execute: args => workspace.toggleSingleDocument(args.widget),
         isVisible: args => args.widget.parent === workspace.dockpanel && workspace.dockpanel.mode !== "single-document",
-        iconClass: "p-MenuItem-maximize",
+        iconClass: "menu-maximize",
         label: () => "Maximize",
         mnemonic: 0
     });
@@ -59,7 +59,7 @@ export const createCommands = workspace => {
     commands.addCommand("workspace:minimize", {
         execute: args => workspace.toggleSingleDocument(args.widget),
         isVisible: args => args.widget.parent === workspace.dockpanel && workspace.dockpanel.mode === "single-document",
-        iconClass: "p-MenuItem-minimize",
+        iconClass: "menu-minimize",
         label: () => "Minimize",
         mnemonic: 0
     });

--- a/packages/perspective-workspace/src/js/workspace/discrete.js
+++ b/packages/perspective-workspace/src/js/workspace/discrete.js
@@ -9,6 +9,7 @@
 
 import {DockPanel, SplitPanel} from "@phosphor/widgets";
 import {toArray} from "@phosphor/algorithm";
+import {Signal} from "@phosphor/signaling";
 
 const DISCRETE_STEP_SIZE = 1;
 
@@ -134,6 +135,16 @@ function extend(base, handle) {
 
 export class DiscreteDockPanel extends extend(DockPanel, "p-DockPanel-handle") {}
 export class DiscreteSplitPanel extends extend(SplitPanel, "p-SplitPanel-handle") {
+    constructor(...args) {
+        super(...args);
+        this.layoutModified = new Signal(this);
+    }
+
+    onUpdateRequest(...args) {
+        super.onUpdateRequest(...args);
+        this.layoutModified.emit();
+    }
+
     onResize(msg) {
         for (const widget of toArray(this.widgets)) {
             widget.node.style.minWidth = `300px`;

--- a/packages/perspective-workspace/src/js/workspace/dockpanel.js
+++ b/packages/perspective-workspace/src/js/workspace/dockpanel.js
@@ -30,11 +30,11 @@ export class PerspectiveDockPanel extends DiscreteDockPanel {
         super._onTabDetachRequested(sender, args);
         // blur widget on when it's being moved
         const widget = sender.titles[0].owner;
-        widget.addClass("p-Blur");
+        widget.addClass("widget-blur");
 
         if (this._drag) {
             this._drag._promise.then(() => {
-                widget.removeClass("p-Blur");
+                widget.removeClass("widget-blur");
             });
         }
     }

--- a/packages/perspective-workspace/src/js/workspace/menu.js
+++ b/packages/perspective-workspace/src/js/workspace/menu.js
@@ -20,7 +20,8 @@ export class MenuRenderer extends Menu.Renderer {
         const name = data.item.command.split(":").pop();
         const content = getComputedStyle(this.workspace)
             .getPropertyValue(`--menu-${name}--content`)
-            .replace(/['"]+/g, "");
+            .replace(/['"]+/g, "")
+            .trim();
         return h.div({className, content}, data.item.iconLabel);
     }
 }

--- a/packages/perspective-workspace/src/js/workspace/workspace.js
+++ b/packages/perspective-workspace/src/js/workspace/workspace.js
@@ -31,14 +31,14 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
     constructor(element, options = {}) {
         super({orientation: "horizontal"});
 
-        this.addClass("p-PerspectiveWorkspace");
+        this.addClass("perspective-workspace");
         this.dockpanel = new PerspectiveDockPanel("main", {enableContextMenu: false});
         this.detailPanel = new Panel();
         this.detailPanel.layout.fitPolicy = "set-no-constraint";
-        this.detailPanel.addClass("p-PerspectiveScrollPanel");
+        this.detailPanel.addClass("perspective-scroll-panel");
         this.detailPanel.addWidget(this.dockpanel);
         this.masterPanel = new DiscreteSplitPanel({orientation: "vertical"});
-        this.masterPanel.addClass("p-MasterPanel");
+        this.masterPanel.addClass("master-panel");
 
         this.dockpanel.layoutModified.connect(() => this.workspaceUpdated());
         this.masterPanel.layoutModified.connect(() => this.workspaceUpdated());
@@ -53,6 +53,8 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         this.tables = new Map();
         this.commands = createCommands(this);
         this.menuRenderer = new MenuRenderer(this.element);
+
+        this.customCommands = [];
     }
 
     /*********************************************************************
@@ -62,7 +64,7 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         this.tables.set(name, table);
         this.getAllWidgets().forEach(widget => {
             if (widget.tableName === name) {
-                widget.table = table;
+                widget.loadTable(table);
             }
         });
     }
@@ -140,11 +142,7 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
 
         if (layout.master) {
             layout.master.widgets.forEach(widgetConfig => {
-                const widget = this._createWidget({
-                    title: widgetConfig.name,
-                    table: this.getTable(widgetConfig.table),
-                    config: {master: true, ...widgetConfig}
-                });
+                const widget = this._createWidget({master: true, ...widgetConfig});
                 widget.viewer.addEventListener("perspective-select", this.onPerspectiveSelect);
                 widget.viewer.addEventListener("perspective-click", this.onPerspectiveSelect);
                 this.masterPanel.addWidget(widget);
@@ -154,11 +152,7 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
 
         if (layout.detail) {
             const detailLayout = PerspectiveDockPanel.mapWidgets(widgetConfig => {
-                const widget = this._createWidget({
-                    title: widgetConfig.name,
-                    table: this.getTable(widgetConfig.table),
-                    config: {master: false, ...widgetConfig}
-                });
+                const widget = this._createWidget({master: false, ...widgetConfig});
                 return widget;
             }, layout.detail);
             this.dockpanel.restoreLayout(detailLayout);
@@ -172,7 +166,9 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         if (this.dockpanel.mode === "single-document") {
             this.toggleSingleDocument(widget);
         }
-        const duplicate = this._createWidget({title: "duplicate", table: widget.table, config: widget.save()});
+        const config = widget.save();
+        const title = config.title ? `${config.title} (duplicate)` : "";
+        const duplicate = this._createWidget({...config, title});
         if (widget.master) {
             const index = this.masterPanel.widgets.indexOf(widget) + 1;
             this.masterPanel.insertWidget(index, duplicate);
@@ -182,27 +178,47 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
     }
 
     toggleMasterDetail(widget) {
-        if (widget.parent === this.dockpanel) {
+        const isGlobalFilter = widget.parent !== this.dockpanel;
+
+        this.element.dispatchEvent(
+            new CustomEvent("workspace-toggle-global-filter", {
+                detail: {
+                    widget,
+                    isGlobalFilter: !isGlobalFilter
+                }
+            })
+        );
+
+        if (isGlobalFilter) {
+            this.makeDetail(widget);
+        } else {
             if (this.dockpanel.mode === "single-document") {
                 this.toggleSingleDocument(widget);
             }
             this.makeMaster(widget);
-        } else {
-            this.makeDetail(widget);
         }
+    }
+
+    _maximize(widget) {
+        widget.viewer.classList.add("widget-maximize");
+        this._minimizedLayout = this.dockpanel.saveLayout();
+        this._maximizedWidget = widget;
+        this.dockpanel.mode = "single-document";
+        this.dockpanel.activateWidget(widget);
+        widget.notifyResize();
+    }
+
+    _unmaximize() {
+        this._maximizedWidget.viewer.classList.remove("widget-maximize");
+        this.dockpanel.mode = "multiple-document";
+        this.dockpanel.restoreLayout(this._minimizedLayout);
     }
 
     toggleSingleDocument(widget) {
         if (this.dockpanel.mode !== "single-document") {
-            widget.viewer.classList.add("p-Maximize");
-            this.single_document_prev_layout = this.dockpanel.saveLayout();
-            this.dockpanel.mode = "single-document";
-            this.dockpanel.activateWidget(widget);
-            widget.notifyResize();
+            this._maximize(widget);
         } else {
-            widget.viewer.classList.remove("p-Maximize");
-            this.dockpanel.mode = "multiple-document";
-            this.dockpanel.restoreLayout(this.single_document_prev_layout);
+            this._unmaximize();
         }
     }
 
@@ -238,8 +254,12 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
      * Master/Detail methods
      */
 
-    makeMaster(widget) {
+    async makeMaster(widget) {
         widget.master = true;
+
+        if (widget.viewer.hasAttribute("settings")) {
+            await widget.toggleConfig();
+        }
 
         if (!this.masterPanel.isAttached) {
             this.detailPanel.close();
@@ -288,6 +308,13 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         contextMenu.addItem({command: "workspace:export", args: {widget}});
         contextMenu.addItem({command: "workspace:copy", args: {widget}});
         contextMenu.addItem({command: "workspace:reset", args: {widget}});
+
+        if (this.customCommands.length > 0) {
+            contextMenu.addItem({type: "separator"});
+            this.customCommands.forEach(command => {
+                contextMenu.addItem({command, args: {widget}});
+            });
+        }
         return contextMenu;
     }
 
@@ -295,27 +322,39 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         const menu = this.createContextMenu(widget);
         const tabbar = find(this.dockpanel.tabBars(), bar => bar.currentTitle.owner === widget);
 
-        widget.addClass("p-ContextFocus");
-        tabbar && tabbar.node.classList.add("p-ContextFocus");
-        this.element.classList.add("p-ContextMenu");
-        this.addClass("p-ContextMenu");
-        if (widget.viewer.classList.contains("p-Master")) {
-            menu.node.classList.add("p-Master");
+        widget.addClass("context-focus");
+        widget.viewer.classList.add("context-focus");
+        tabbar && tabbar.node.classList.add("context-focus");
+        this.element.classList.add("context-menu");
+        this.addClass("context-menu");
+
+        if (widget.viewer.classList.contains("workspace-master-widget")) {
+            menu.node.classList.add("workspace-master-menu");
         } else {
-            menu.node.classList.remove("p-Master");
+            menu.node.classList.remove("workspace-master-menu");
         }
         this._menu_opened = true;
 
         menu.aboutToClose.connect(() => {
-            this.element.classList.remove("p-ContextMenu");
-            this.removeClass("p-ContextMenu");
-            widget.removeClass("p-ContextFocus");
-            tabbar?.node?.classList.remove("p-ContextFocus");
+            this.element.classList.remove("context-menu");
+            this.removeClass("context-menu");
+            widget.removeClass("context-focus");
+            tabbar?.node?.classList.remove("context-focus");
         });
 
         menu.open(event.clientX, event.clientY);
         event.preventDefault();
         event.stopPropagation();
+    }
+
+    _addContextMenuItem(item) {
+        this.customCommands.push(item.id);
+        this.commands.addCommand(item.id, {
+            execute: args => item.execute({widget: args.widget}),
+            label: item.label,
+            isVisible: args => item.isVisible({widget: args.widget}),
+            mnemonic: 0
+        });
     }
 
     /*********************************************************************
@@ -350,6 +389,9 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
 
     addViewer(config) {
         const widget = this._createWidget(config);
+        if (this.dockpanel.mode === "single-document") {
+            this.toggleSingleDocument();
+        }
         if (config.master) {
             if (!this.masterPanel.isAttached) {
                 this.setupMasterPanel(DEFAULT_WORKSPACE_SIZE);
@@ -364,11 +406,20 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         this.update();
     }
 
-    _createWidget({title, table, config}) {
-        const widget = new PerspectiveViewerWidget({title, table});
+    _createWidget(config) {
+        const widget = new PerspectiveViewerWidget();
+        this.element.dispatchEvent(
+            new CustomEvent("workspace-new-view", {
+                detail: {
+                    config,
+                    widget
+                }
+            })
+        );
         widget.title.closable = true;
         this.element.appendChild(widget.viewer);
         this._addWidgetEventListeners(widget);
+        widget.loadTable(this.getTable(config.table));
         widget.restore(config);
         return widget;
     }
@@ -378,18 +429,22 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
             this.listeners.get(widget)();
         }
         const settings = event => {
-            widget.title.className = event.detail && "settings_open";
+            if (event.detail) {
+                widget.title.className += " settings_open";
+            } else {
+                widget.title.className = widget.title.className.replace(/settings_open/g, "");
+            }
         };
         const contextMenu = event => this.showContextMenu(widget, event);
         const updated = () => this.workspaceUpdated();
 
-        widget.viewer.addEventListener("contextmenu", contextMenu);
+        widget.node.addEventListener("contextmenu", contextMenu);
         widget.viewer.addEventListener("perspective-toggle-settings", settings);
         widget.viewer.addEventListener("perspective-config-update", updated);
         widget.title.changed.connect(updated);
 
         this.listeners.set(widget, () => {
-            widget.viewer.removeEventListener("contextmenu", contextMenu);
+            widget.node.removeEventListener("contextmenu", contextMenu);
             widget.viewer.removeEventListener("perspective-toggle-settings", settings);
             widget.viewer.removeEventListener("perspective-config-update", updated);
             widget.title.changed.disconnect(updated);

--- a/packages/perspective-workspace/src/less/dockpanel.less
+++ b/packages/perspective-workspace/src/less/dockpanel.less
@@ -18,20 +18,20 @@
     bottom: 0;
 }
 
-.p-PerspectiveScrollPanel::-webkit-scrollbar {
+.perspective-scroll-panel::-webkit-scrollbar {
     width: 1em;
     height: 1em;
 }
 
-.p-PerspectiveScrollPanel::-webkit-scrollbar-track {
+.perspective-scroll-panel::-webkit-scrollbar-track {
     background-color: #eee;
 }
 
-.p-PerspectiveScrollPanel::-webkit-scrollbar-corner  {
+.perspective-scroll-panel::-webkit-scrollbar-corner  {
     background-color: #eee;
 }
 
-.p-PerspectiveScrollPanel::-webkit-scrollbar-thumb {
+.perspective-scroll-panel::-webkit-scrollbar-thumb {
   background-color: #aaa;
   //outline: 1px solid #666;
   height: 0.8em;
@@ -49,7 +49,7 @@
     cursor: ns-resize !important;
 }
 
-.p-Master {
+.workspace-master-widget {
     min-width: 300px;
 }
 
@@ -61,7 +61,7 @@
     background-color: rgba(0,0,0,0.05);
 }
 
-.p-PerspectiveScrollPanel {
+.perspective-scroll-panel {
     overflow: auto !important;
 }
 

--- a/packages/perspective-workspace/src/less/menu.less
+++ b/packages/perspective-workspace/src/less/menu.less
@@ -24,7 +24,7 @@
         rgba(0, 0, 0, 0.12) 0px 1px 5px 0px;
 }
 
-.p-Menu.p-Master {
+.p-Menu.workspace-master-menu {
     background: rgb(42, 47, 54);
     color: #ccc;
     border: 1px solid rgb(85, 94, 107);;

--- a/packages/perspective-workspace/src/less/tabbar.less
+++ b/packages/perspective-workspace/src/less/tabbar.less
@@ -16,13 +16,15 @@
     cursor: pointer;
 }
 
+
+.p-TabBar-tabLabel[value='[untitled]']{
+    color: #ddd !important
+}
+
 .p-TabBar-tabLabel:focus{
     outline: none;
     color: #666 !important;
     cursor: text;
-}
-.p-TabBar-tabLabel[value='[untitled]']{
-    color: #ddd
 }
 
 .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:before {
@@ -314,11 +316,12 @@
     background-color: #ccc;
 }
 
-.p-PerspectiveWorkspace.p-ContextMenu * .p-TabBar.p-ContextFocus{
+
+.perspective-workspace.context-menu * .p-TabBar.context-focus{
     opacity: 1;
 }
 
-.p-PerspectiveWorkspace.p-ContextMenu  * .p-TabBar {
+.perspective-workspace.context-menu  * .p-TabBar{
     opacity: 0.2;
     transition: opacity 0.2s ease-out;
 }

--- a/packages/perspective-workspace/src/less/viewer.less
+++ b/packages/perspective-workspace/src/less/viewer.less
@@ -1,18 +1,18 @@
 @border-color: 1px solid #eaeaea;
 
-.p-Master{
+.workspace-master-widget{
    --settings-button--content: var(--open-settings-button--content, "\1F527") !important;
 }
 
-.p-Master[settings] {
+.workspace-master-widget[settings] {
    --settings-button--content: var(--close-settings-button--content, "\1F527") !important;;
 }
 
-.p-Detail.p-Maximize{
+.workspace-detail-widget.widget-maximize{
    --settings-button--content: var(--open-settings-button--content, "\1F527") !important;
 }
 
-.p-Detail.p-Maximize[settings] {
+.workspace-detail-widget.widget-maximize[settings]{
    --settings-button--content: var(--close-settings-button--content, "\1F527") !important;
 }
 
@@ -24,38 +24,34 @@
    min-height: 200px;
 }
 
-.p-Detail {
-   min-width: 300px;
-   min-height: 200px;
+.workspace-detail-widget{
    --settings-button--content: "" !important;
    --plugin--border: 1px solid #eaeaea;
 }
 
-perspective-viewer.p-Blur{
+perspective-viewer.widget-blur{
    opacity: 0.5;
 }
 
-.p-ContextMenu > perspective-viewer.p-ContextFocus {
+.context-menu > perspective-viewer.context-focus{
    opacity: 1;
 
 }
 
-.p-ContextMenu > perspective-viewer {
+.context-menu > perspective-viewer {
    opacity: 0.2;
 }
 
 perspective-viewer {
    flex: 1;
-   display: flex;
+   position: relative;
+   display: block;
    align-items: center;
    justify-content: center;
    flex-direction: column;
-   position: absolute;
-   top: 0;
-   left: 0px;
-   right: 0px;
-   bottom: 0px;
+   width: 100%;
+   height: 100%;
    overflow: visible !important;
    font-family: "Open Sans", Arial, sans-serif;
    transition: opacity 0.2s ease-out;
-}
+ }

--- a/packages/perspective-workspace/src/less/widget.less
+++ b/packages/perspective-workspace/src/less/widget.less
@@ -9,30 +9,17 @@
 
 @border-color: 1px solid #eaeaea;
 
-.p-Master{
-    --settings-button--content: var(--open-settings-button--content, "\1F527");
- }
-
-.p-Master[settings] {
-    --settings-button--content: var(--close-settings-button--content, "\1F527");
+.viewer-container{
+     flex: 1;
+     height: 100%;
+     overflow: hidden;
 }
  
-.p-Detail{
-    min-width: 300px;
-    min-height: 200px;
-    --settings-button--content: "";
- }
-
-.p-DockPanel-widget{
+.workspace-widget{
+    display: flex;
+    flex-direction: column;
     border: @border-color;
     border-width: 0px !important;
     min-width: 300px;
     min-height: 200px;
-}
-
-.p-Detail{
-    min-width: 300px;
-    min-height: 200px;
-    --settings-button--content: "";
-    --plugin--border: 1px solid #eaeaea;
 }

--- a/packages/perspective-workspace/src/less/workspace.less
+++ b/packages/perspective-workspace/src/less/workspace.less
@@ -31,15 +31,15 @@
       background-color: var(--master-divider--background-color);
     }
 
-    .p-MasterPanel {
+    .master-panel {
         background-color: rgb(47, 49, 54);
     }
 
-    .p-PerspectiveWorkspace.p-ContextMenu * .p-SplitPanel-handle{
+    .perspective-workspace.context-menu * .p-SplitPanel-handle{
         opacity: 0.2;
     }
 
-    .p-PerspectiveWorkspace.p-ContextMenu > .p-SplitPanel-handle{
+    .perspective-workspace.context-menu > .p-SplitPanel-handle{
         opacity: 0.2;
     }
   

--- a/packages/perspective-workspace/src/theme/material.less
+++ b/packages/perspective-workspace/src/theme/material.less
@@ -6,11 +6,11 @@ perspective-workspace{
     .perspective-workspace-material-base();
 }
 
-perspective-viewer.p-Detail{
+perspective-viewer.workspace-detail-widget{
     .perspective-viewer-material-dense();
 }
 
-perspective-viewer.p-Master{
+perspective-viewer.workspace-master-widget{
     .perspective-viewer-material-dense-dark();
 }
 

--- a/packages/perspective-workspace/src/theme/vaporwave.less
+++ b/packages/perspective-workspace/src/theme/vaporwave.less
@@ -23,7 +23,7 @@ perspective-workspace {
     --master-divider--background-color: #0e0611;
 }
 
-perspective-viewer.p-Detail {
+perspective-viewer.workspace-detail-widget {
     .perspective-viewer-vaporwave();
     padding: 0px;
     --hypergrid-header--background: #150442;
@@ -35,7 +35,7 @@ perspective-viewer.p-Detail {
     --settings-button--content: "";
 }
 
-perspective-viewer.p-Master {
+perspective-viewer.workspace-master-widget {
     .perspective-viewer-vaporwave();
     padding: 0px;
     --plugin--border: 0px solid #0e0611;

--- a/packages/perspective-workspace/test/js/integration/restore.spec.js
+++ b/packages/perspective-workspace/test/js/integration/restore.spec.js
@@ -32,7 +32,7 @@ utils.with_server({paths: PATHS}, () => {
                             main: {
                                 currentIndex: 0,
                                 type: "tab-area",
-                                widgets: [{id: "viewer", table: "superstore", name: "One"}]
+                                widgets: [{id: "viewer", table: "superstore", title: "One"}]
                             }
                         }
                     };
@@ -53,7 +53,7 @@ utils.with_server({paths: PATHS}, () => {
                 async page => {
                     const config = {
                         master: {
-                            widgets: [{table: "superstore", name: "Test", "row-pivots": ["State"], columns: ["Sales", "Profit"]}]
+                            widgets: [{table: "superstore", title: "Test", "row-pivots": ["State"], columns: ["Sales", "Profit"]}]
                         }
                     };
 
@@ -73,13 +73,13 @@ utils.with_server({paths: PATHS}, () => {
                 async page => {
                     const config = {
                         master: {
-                            widgets: [{table: "superstore", name: "Test", "row-pivots": ["State"], columns: ["Sales", "Profit"]}]
+                            widgets: [{table: "superstore", title: "Test", "row-pivots": ["State"], columns: ["Sales", "Profit"]}]
                         },
                         detail: {
                             main: {
                                 currentIndex: 0,
                                 type: "tab-area",
-                                widgets: [{id: "viewer", table: "superstore", name: "One"}]
+                                widgets: [{id: "viewer", table: "superstore", title: "One"}]
                             }
                         }
                     };

--- a/packages/perspective-workspace/test/js/unit/workspace.spec.js
+++ b/packages/perspective-workspace/test/js/unit/workspace.spec.js
@@ -12,7 +12,7 @@ import {toArray} from "@phosphor/algorithm";
 
 describe("workspace", () => {
     test("restores detail to dockpanel", () => {
-        const widget = {table: "superstore", name: "One"};
+        const widget = {table: "superstore", title: "One"};
         const config = {
             detail: {
                 main: {
@@ -28,13 +28,13 @@ describe("workspace", () => {
 
         const widgets = toArray(workspace.dockpanel.widgets());
 
-        const expected = {table: "superstore", name: "One", master: false};
+        const expected = {table: "superstore", title: "One", master: false};
         expect(widgets.length).toBe(1);
         expect(widgets[0].save()).toStrictEqual(expected);
     });
 
     test("restores master to masterpanel", () => {
-        const widget = {table: "superstore", name: "One"};
+        const widget = {table: "superstore", title: "One"};
         const config = {
             master: {
                 widgets: [widget]
@@ -46,7 +46,7 @@ describe("workspace", () => {
 
         const widgets = workspace.masterPanel.widgets;
 
-        const expected = {table: "superstore", name: "One", master: true};
+        const expected = {table: "superstore", title: "One", master: true};
         expect(widgets.length).toBe(1);
         expect(widgets[0].save()).toStrictEqual(expected);
     });
@@ -54,13 +54,13 @@ describe("workspace", () => {
     test("restores master to masterpanel and detail to dockpanel", () => {
         const config = {
             master: {
-                widgets: [{table: "superstore", name: "One"}]
+                widgets: [{table: "superstore", title: "One"}]
             },
             detail: {
                 main: {
                     currentIndex: 0,
                     type: "tab-area",
-                    widgets: [{table: "superstore", name: "Two"}]
+                    widgets: [{table: "superstore", title: "Two"}]
                 }
             }
         };
@@ -71,8 +71,8 @@ describe("workspace", () => {
         const masterWidgets = workspace.masterPanel.widgets;
         const detailWidgets = toArray(workspace.dockpanel.widgets());
 
-        const master = {table: "superstore", name: "One", master: true};
-        const detail = {table: "superstore", name: "Two", master: false};
+        const master = {table: "superstore", title: "One", master: true};
+        const detail = {table: "superstore", title: "Two", master: false};
 
         expect(masterWidgets.length).toBe(1);
         expect(masterWidgets[0].save()).toStrictEqual(master);


### PR DESCRIPTION
This PR adds a new `workspace-layout-update` event  to `perspective-workspace`that is fired whenever the user modifies the layout or any of the `perspective-viewers`.

This PR also contains css class names cleanup which should help differentiate between `@phosphor` and `perspective-workspace` class selectors