### PR TITLE
Fix column ordering in Python, null handling for computed columns

### DIFF
--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -42,6 +42,7 @@ using float64 = double;
 #define POW(T)                                                      \
     t_tscalar pow_##T(t_tscalar x) {                                \
         t_tscalar rval = mknone();                                  \
+        if (x.is_none() || !x.is_valid()) return rval;              \
         rval.set(static_cast<float64>(                              \
             pow(static_cast<float64>(x.get<T>()), 2)                \
         ));                                                         \
@@ -51,6 +52,7 @@ using float64 = double;
 #define INVERT(T)                                                   \
     t_tscalar invert_##T(t_tscalar x) {                             \
         t_tscalar rval = mknone();                                  \
+        if (x.is_none() || !x.is_valid()) return rval;              \
         float64 rhs = static_cast<float64>(x.get<T>());             \
         if (rhs != 0) rval.set(static_cast<float64>(1 / rhs));      \
         return rval;                                                \
@@ -59,6 +61,7 @@ using float64 = double;
 #define SQRT(T)                                                     \
     t_tscalar sqrt_##T(t_tscalar x) {                               \
         t_tscalar rval = mknone();                                  \
+        if (x.is_none() || !x.is_valid()) return rval;              \
         float64 val = static_cast<float64>(x.get<T>());             \
          rval.set(static_cast<float64>(sqrt(val)));                 \
         return rval;                                                \
@@ -66,7 +69,8 @@ using float64 = double;
 
 #define ABS(T)                                                      \
     t_tscalar abs_##T(t_tscalar x) {                                \
-        t_tscalar rval;                                             \
+        t_tscalar rval = mknone();                                  \
+        if (x.is_none() || !x.is_valid()) return rval;              \
         rval.set(static_cast<float64>(                              \
             std::abs(static_cast<float64>(x.get<T>()))));           \
         return rval;                                                \
@@ -74,7 +78,8 @@ using float64 = double;
 
 #define BUCKET_10(T)                                                \
     t_tscalar bucket_10_##T(t_tscalar x) {                          \
-        t_tscalar rval;                                             \
+        t_tscalar rval = mknone();                                  \
+        if (x.is_none() || !x.is_valid()) return rval;              \
         T val = x.get<T>();                                         \
         rval.set(static_cast<float64>(                              \
             floor(static_cast<float64>(val) / 10)) * 10);           \
@@ -83,7 +88,8 @@ using float64 = double;
 
 #define BUCKET_100(T)                                               \
     t_tscalar bucket_100_##T(t_tscalar x) {                         \
-        t_tscalar rval;                                             \
+        t_tscalar rval = mknone();                                  \
+        if (x.is_none() || !x.is_valid()) return rval;              \
         T val = x.get<T>();                                         \
         rval.set(static_cast<float64>(                              \
             floor(static_cast<float64>(val) / 100)) * 100);         \
@@ -92,7 +98,8 @@ using float64 = double;
 
 #define BUCKET_1000(T)                                              \
     t_tscalar bucket_1000_##T(t_tscalar x) {                        \
-        t_tscalar rval;                                             \
+        t_tscalar rval = mknone();                                  \
+        if (x.is_none() || !x.is_valid()) return rval;              \
         T val = x.get<T>();                                         \
         rval.set(static_cast<float64>(                              \
             floor(static_cast<float64>(val) / 1000)) * 1000);       \
@@ -101,7 +108,8 @@ using float64 = double;
 
 #define BUCKET_0_1(T)                                               \
     t_tscalar bucket_0_1_##T(t_tscalar x) {                         \
-        t_tscalar rval;                                             \
+        t_tscalar rval = mknone();                                  \
+        if (x.is_none() || !x.is_valid()) return rval;              \
         T val = x.get<T>();                                         \
         rval.set(static_cast<float64>(                              \
             floor(static_cast<float64>(val) / 0.1)) * 0.1);         \
@@ -110,7 +118,8 @@ using float64 = double;
 
 #define BUCKET_0_0_1(T)                                             \
     t_tscalar bucket_0_0_1_##T(t_tscalar x) {                       \
-        t_tscalar rval;                                             \
+        t_tscalar rval = mknone();                                  \
+        if (x.is_none() || !x.is_valid()) return rval;              \
         T val = x.get<T>();                                         \
         rval.set(static_cast<float64>(                              \
             floor(static_cast<float64>(val) / 0.01)) * 0.01);       \
@@ -119,7 +128,8 @@ using float64 = double;
 
 #define BUCKET_0_0_0_1(T)                                               \
     t_tscalar bucket_0_0_0_1_##T(t_tscalar x) {                         \
-        t_tscalar rval;                                                 \
+        t_tscalar rval = mknone();                                      \
+        if (x.is_none() || !x.is_valid()) return rval;                  \
         T val = x.get<T>();                                             \
         rval.set(static_cast<float64>(                                  \
             floor(static_cast<float64>(val) / 0.001)) * 0.001);         \
@@ -244,21 +254,27 @@ NUMERIC_FUNCTION_1(BUCKET_0_0_0_1);
 
 #define ADD(T1, T2)                                                 \
     t_tscalar add_##T1##_##T2(t_tscalar x, t_tscalar y) {           \
-        t_tscalar rval;                                             \
+        t_tscalar rval = mknone();                                  \
+        if ((x.is_none() || !x.is_valid())                          \
+            || (y.is_none() || !y.is_valid())) return rval;         \
         rval.set(static_cast<float64>(x.get<T1>() + y.get<T2>()));  \
         return rval;                                                \
     }
 
 #define SUBTRACT(T1, T2)                                                 \
     t_tscalar subtract_##T1##_##T2(t_tscalar x, t_tscalar y) {           \
-        t_tscalar rval;                                                  \
+        t_tscalar rval = mknone();                                       \
+        if ((x.is_none() || !x.is_valid())                               \
+            || (y.is_none() || !y.is_valid())) return rval;              \
         rval.set(static_cast<float64>(x.get<T1>() - y.get<T2>()));       \
         return rval;                                                     \
     }
 
 #define MULTIPLY(T1, T2)                                                \
     t_tscalar multiply_##T1##_##T2(t_tscalar x, t_tscalar y) {          \
-        t_tscalar rval;                                                 \
+        t_tscalar rval = mknone();                                      \
+        if ((x.is_none() || !x.is_valid())                              \
+            || (y.is_none() || !y.is_valid())) return rval;             \
         rval.set(static_cast<float64>(x.get<T1>() * y.get<T2>()));      \
         return rval;                                                    \
     }
@@ -266,6 +282,8 @@ NUMERIC_FUNCTION_1(BUCKET_0_0_0_1);
 #define DIVIDE(T1, T2)                                                         \
     t_tscalar divide_##T1##_##T2(t_tscalar x, t_tscalar y) {                   \
         t_tscalar rval = mknone();                                             \
+        if ((x.is_none() || !x.is_valid())                                     \
+            || (y.is_none() || !y.is_valid())) return rval;                    \
         float64 lhs = static_cast<float64>(x.get<T1>());                       \
         float64 rhs = static_cast<float64>(y.get<T2>());                       \
         if (rhs != 0) rval.set(static_cast<float64>(lhs / rhs));               \
@@ -275,6 +293,8 @@ NUMERIC_FUNCTION_1(BUCKET_0_0_0_1);
 #define PERCENT_OF(T1, T2)                                                     \
     t_tscalar percent_of_##T1##_##T2(t_tscalar x, t_tscalar y) {               \
         t_tscalar rval = mknone();                                             \
+        if ((x.is_none() || !x.is_valid())                                     \
+            || (y.is_none() || !y.is_valid())) return rval;                    \
         float64 lhs = static_cast<float64>(x.get<T1>());                       \
         float64 rhs = static_cast<float64>(y.get<T2>());                       \
         if (rhs != 0) rval.set(static_cast<float64>(lhs / rhs) * 100);         \
@@ -336,7 +356,7 @@ NUMERIC_FUNCTION_2_DISPATCH_ALL_TYPES(percent_of);
 t_tscalar length(t_tscalar x) {
     t_tscalar rval = mknone();
 
-    if (x.get_dtype() != DTYPE_STR) {
+    if (x.is_none() || !x.is_valid() || x.get_dtype() != DTYPE_STR) {
         return rval;
     }
 
@@ -346,7 +366,7 @@ t_tscalar length(t_tscalar x) {
 }
 
 void uppercase(t_tscalar x, std::int32_t idx, std::shared_ptr<t_column> output_column) {
-    if (x.get_dtype() != DTYPE_STR) {
+    if (x.is_none() || !x.is_valid() || x.get_dtype() != DTYPE_STR) {
         output_column->set_scalar(idx, mknone());
         output_column->set_valid(idx, false);
         return;
@@ -358,7 +378,7 @@ void uppercase(t_tscalar x, std::int32_t idx, std::shared_ptr<t_column> output_c
 }
 
 void lowercase(t_tscalar x, std::int32_t idx, std::shared_ptr<t_column> output_column) {
-    if (x.get_dtype() != DTYPE_STR) {
+    if (x.is_none() || !x.is_valid() || x.get_dtype() != DTYPE_STR) {
         output_column->set_scalar(idx, mknone());
         output_column->set_valid(idx, false);
         return;
@@ -370,7 +390,8 @@ void lowercase(t_tscalar x, std::int32_t idx, std::shared_ptr<t_column> output_c
 }
 
 void concat_space(t_tscalar x, t_tscalar y, std::int32_t idx, std::shared_ptr<t_column> output_column) {
-    if (x.get_dtype() != DTYPE_STR || y.get_dtype() != DTYPE_STR) {
+    if ((x.is_none() || !x.is_valid() || x.get_dtype() != DTYPE_STR)
+        || (y.is_none() || !y.is_valid() || y.get_dtype() != DTYPE_STR)) {
         output_column->set_scalar(idx, mknone());
         output_column->set_valid(idx, false);
         return;
@@ -380,7 +401,8 @@ void concat_space(t_tscalar x, t_tscalar y, std::int32_t idx, std::shared_ptr<t_
 }
 
 void concat_comma(t_tscalar x, t_tscalar y, std::int32_t idx, std::shared_ptr<t_column> output_column) {
-    if (x.get_dtype() != DTYPE_STR || y.get_dtype() != DTYPE_STR) {
+    if ((x.is_none() || !x.is_valid() || x.get_dtype() != DTYPE_STR)
+        || (y.is_none() || !y.is_valid() || y.get_dtype() != DTYPE_STR)) {
         output_column->set_scalar(idx, mknone());
         output_column->set_valid(idx, false);
         return;
@@ -393,7 +415,8 @@ void concat_comma(t_tscalar x, t_tscalar y, std::int32_t idx, std::shared_ptr<t_
 // Date/Datetime functions
 template<>
 t_tscalar hour_of_day<DTYPE_DATE>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
     // Hour of day for a date is always midnight, i.e. 0
     rval.set(static_cast<std::int64_t>(0));
     return rval;
@@ -401,7 +424,8 @@ t_tscalar hour_of_day<DTYPE_DATE>(t_tscalar x) {
 
 template<>
 t_tscalar hour_of_day<DTYPE_TIME>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
 
     // Convert the int64 to a milliseconds duration timestamp
     std::chrono::milliseconds timestamp(x.to_int64());
@@ -422,13 +446,15 @@ t_tscalar hour_of_day<DTYPE_TIME>(t_tscalar x) {
 
 template<>
 t_tscalar second_bucket<DTYPE_DATE>(t_tscalar x) {
+    if (x.is_none() || !x.is_valid()) return mknone();
     return x;
 }
 
 template<>
 t_tscalar second_bucket<DTYPE_TIME>(t_tscalar x) {
     // Retrieve the timestamp as an integer and bucket it
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
     auto int_ts = x.to_int64();
     std::int64_t bucketed_ts = (static_cast<double>(int_ts) / 1000) * 1000;
     rval.set(t_time(bucketed_ts));
@@ -437,12 +463,14 @@ t_tscalar second_bucket<DTYPE_TIME>(t_tscalar x) {
 
 template<>
 t_tscalar minute_bucket<DTYPE_DATE>(t_tscalar x) {
+    if (x.is_none() || !x.is_valid()) return mknone();
     return x;
 }
 
 template<>
 t_tscalar minute_bucket<DTYPE_TIME>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
 
     // Convert the int64 to a milliseconds duration timestamp
     std::chrono::milliseconds ms_timestamp(x.to_int64());
@@ -458,12 +486,14 @@ t_tscalar minute_bucket<DTYPE_TIME>(t_tscalar x) {
 
 template<>
 t_tscalar hour_bucket<DTYPE_DATE>(t_tscalar x) {
+    if (x.is_none() || !x.is_valid()) return mknone();
     return x;
 }
 
 template<>
 t_tscalar hour_bucket<DTYPE_TIME>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
 
     // Convert the int64 to a millisecond duration timestamp
     std::chrono::milliseconds ms_timestamp(x.to_int64());
@@ -479,12 +509,14 @@ t_tscalar hour_bucket<DTYPE_TIME>(t_tscalar x) {
 
 template<>
 t_tscalar day_bucket<DTYPE_DATE>(t_tscalar x) {
+    if (x.is_none() || !x.is_valid()) return mknone();
     return x;
 }
 
 template<>
 t_tscalar day_bucket<DTYPE_TIME>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
 
     // Convert the int64 to a milliseconds duration timestamp
     std::chrono::milliseconds ms_timestamp(x.to_int64());
@@ -510,7 +542,8 @@ t_tscalar day_bucket<DTYPE_TIME>(t_tscalar x) {
 
 template<>
 t_tscalar week_bucket<DTYPE_DATE>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
 
     // Retrieve the `t_date` struct from the scalar
     t_date val = x.get<t_date>();
@@ -544,7 +577,8 @@ t_tscalar week_bucket<DTYPE_DATE>(t_tscalar x) {
 
 template<>
 t_tscalar week_bucket<DTYPE_TIME>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
 
     // Convert the int64 to a milliseconds duration timestamp
     std::chrono::milliseconds timestamp(x.to_int64());
@@ -573,7 +607,8 @@ t_tscalar week_bucket<DTYPE_TIME>(t_tscalar x) {
 
 template<>
 t_tscalar month_bucket<DTYPE_DATE>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
     t_date val = x.get<t_date>();
     rval.set(t_date(val.year(), val.month(), 1));
     return rval;
@@ -581,7 +616,8 @@ t_tscalar month_bucket<DTYPE_DATE>(t_tscalar x) {
 
 template<>
 t_tscalar month_bucket<DTYPE_TIME>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
 
     // Convert the int64 to a milliseconds duration timestamp
     std::chrono::milliseconds timestamp(x.to_int64());
@@ -608,16 +644,17 @@ t_tscalar month_bucket<DTYPE_TIME>(t_tscalar x) {
 
 template<>
 t_tscalar year_bucket<DTYPE_DATE>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
     t_date val = x.get<t_date>();
     rval.set(t_date(val.year(), 0, 1));
-    std::cout << rval << std::endl;
     return rval;
 }
 
 template<>
 t_tscalar year_bucket<DTYPE_TIME>(t_tscalar x) {
-    t_tscalar rval;
+    t_tscalar rval = mknone();
+    if (x.is_none() || !x.is_valid()) return rval;
 
     // Convert the int64 to a milliseconds duration timestamp
     std::chrono::milliseconds timestamp(x.to_int64());
@@ -666,6 +703,12 @@ const std::string months_of_year[12] = {
 template <>
 void day_of_week<DTYPE_DATE>(
     t_tscalar x, std::int32_t idx, std::shared_ptr<t_column> output_column) {
+    if (x.is_none() || !x.is_valid()) {
+        output_column->set_scalar(idx, mknone());
+        output_column->set_valid(idx, false);
+        return;
+    }
+
     // Retrieve the `t_date` struct from the scalar
     t_date val = x.get<t_date>();
 
@@ -691,6 +734,12 @@ void day_of_week<DTYPE_DATE>(
 template <>
 void day_of_week<DTYPE_TIME>(
     t_tscalar x, std::int32_t idx, std::shared_ptr<t_column> output_column) {
+    if (x.is_none() || !x.is_valid()) {
+        output_column->set_scalar(idx, mknone());
+        output_column->set_valid(idx, false);
+        return;
+    }
+
     // Convert the int64 to a milliseconds duration timestamp
     std::chrono::milliseconds timestamp(x.to_int64());
 
@@ -710,6 +759,12 @@ void day_of_week<DTYPE_TIME>(
 template <>
 void month_of_year<DTYPE_DATE>(
     t_tscalar x, std::int32_t idx, std::shared_ptr<t_column> output_column) {
+    if (x.is_none() || !x.is_valid()) {
+        output_column->set_scalar(idx, mknone());
+        output_column->set_valid(idx, false);
+        return;
+    }
+
     t_date val = x.get<t_date>();
 
     // `t_date.month()` is [0-11]
@@ -721,6 +776,12 @@ void month_of_year<DTYPE_DATE>(
 template <>
 void month_of_year<DTYPE_TIME>(
     t_tscalar x, std::int32_t idx, std::shared_ptr<t_column> output_column) {
+    if (x.is_none() || !x.is_valid()) {
+        output_column->set_scalar(idx, mknone());
+        output_column->set_valid(idx, false);
+        return;
+    }
+
     // Convert the int64 to a milliseconds duration timestamp
     std::chrono::milliseconds timestamp(x.to_int64());
 

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -23,7 +23,7 @@ var Borders = cellRenderersRegistry.BaseClass.extend("Borders", {
         var color;
 
         gc.save();
-        gc.translate(-0.5, 0.5); // paint "sharp" lines on pixels instead of "blury" lines between pixels
+        gc.translate(-0.5, 0.5); // paint "sharp" lines on pixels instead of "blurry" lines between pixels
         gc.cache.lineWidth = 1;
 
         color = config.borderTop;

--- a/packages/perspective/test/js/computed.js
+++ b/packages/perspective/test/js/computed.js
@@ -115,6 +115,25 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Square root of int, nulls", async function() {
+                const table = perspective
+                    .table({
+                        a: [4, 9, null, undefined, 16]
+                    })
+                    .add_computed([
+                        {
+                            column: "sqrt",
+                            computed_function_name: "sqrt",
+                            inputs: ["a"]
+                        }
+                    ]);
+                let view = table.view({columns: ["sqrt"]});
+                let result = await view.to_columns();
+                expect(result.sqrt).toEqual([2, 3, null, null, 4]);
+                view.delete();
+                table.delete();
+            });
+
             it("Square root of float", async function() {
                 var table = perspective.table({
                     a: [4.5, 9.5, 16.5, 20.5, 81.5, 1000.5]
@@ -130,6 +149,26 @@ module.exports = perspective => {
                 let view = table2.view({columns: ["sqrt"]});
                 let result = await view.to_columns();
                 expect(result.sqrt).toEqual([2.1213203435596424, 3.082207001484488, 4.06201920231798, 4.527692569068709, 9.027735042633894, 31.63068130786942]);
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Square root of float, null", async function() {
+                var table = perspective.table({
+                    a: [4.5, 9.5, null, undefined, 16.5]
+                });
+
+                let table2 = table.add_computed([
+                    {
+                        column: "sqrt",
+                        computed_function_name: "sqrt",
+                        inputs: ["a"]
+                    }
+                ]);
+                let view = table2.view({columns: ["sqrt"]});
+                let result = await view.to_columns();
+                expect(result.sqrt).toEqual([2.1213203435596424, 3.082207001484488, null, null, 4.06201920231798]);
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -155,6 +194,26 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Pow^2 of int, nulls", async function() {
+                var table = perspective.table({
+                    a: [2, 4, null, undefined, 10]
+                });
+
+                let table2 = table.add_computed([
+                    {
+                        column: "pow2",
+                        computed_function_name: "x^2",
+                        inputs: ["a"]
+                    }
+                ]);
+                let view = table2.view({columns: ["pow2"]});
+                let result = await view.to_columns();
+                expect(result.pow2).toEqual([4, 16, null, null, 100]);
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
             it("Pow^2 of float", async function() {
                 var table = perspective.table({
                     a: [2.5, 4.5, 6.5, 8.5, 10.5]
@@ -170,6 +229,26 @@ module.exports = perspective => {
                 let view = table2.view({columns: ["pow2"]});
                 let result = await view.to_columns();
                 expect(result.pow2).toEqual([6.25, 20.25, 42.25, 72.25, 110.25]);
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Pow^2 of float, nulls", async function() {
+                var table = perspective.table({
+                    a: [2.5, 4.5, null, undefined, 10.5]
+                });
+
+                let table2 = table.add_computed([
+                    {
+                        column: "pow2",
+                        computed_function_name: "x^2",
+                        inputs: ["a"]
+                    }
+                ]);
+                let view = table2.view({columns: ["pow2"]});
+                let result = await view.to_columns();
+                expect(result.pow2).toEqual([6.25, 20.25, null, null, 110.25]);
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -195,6 +274,26 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Invert int, nulls", async function() {
+                var table = perspective.table({
+                    a: [2, 4, null, undefined, 10]
+                });
+
+                let table2 = table.add_computed([
+                    {
+                        column: "invert",
+                        computed_function_name: "1/x",
+                        inputs: ["a"]
+                    }
+                ]);
+                let view = table2.view({columns: ["invert"]});
+                let result = await view.to_columns();
+                expect(result.invert).toEqual([0.5, 0.25, null, null, 0.1]);
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
             it("Invert float", async function() {
                 var table = perspective.table({
                     a: [2.5, 4.5, 6.5, 8.5, 10.5]
@@ -210,6 +309,26 @@ module.exports = perspective => {
                 let view = table2.view({columns: ["invert"]});
                 let result = await view.to_columns();
                 expect(result.invert).toEqual([0.4, 0.2222222222222222, 0.15384615384615385, 0.11764705882352941, 0.09523809523809523]);
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Invert float, nulls", async function() {
+                var table = perspective.table({
+                    a: [2.5, 4.5, null, undefined, 10.5]
+                });
+
+                let table2 = table.add_computed([
+                    {
+                        column: "invert",
+                        computed_function_name: "1/x",
+                        inputs: ["a"]
+                    }
+                ]);
+                let view = table2.view({columns: ["invert"]});
+                let result = await view.to_columns();
+                expect(result.invert).toEqual([0.4, 0.2222222222222222, null, null, 0.09523809523809523]);
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -299,7 +418,7 @@ module.exports = perspective => {
             it("Computed column of arity 2, add with null", async function() {
                 var table = perspective.table({
                     a: [1, 2, null, 3, 4],
-                    b: [1.5, null, 2.5, 3.5, 4.5]
+                    b: [1.5, undefined, 2.5, 3.5, 4.5]
                 });
 
                 let table2 = table.add_computed([
@@ -381,7 +500,7 @@ module.exports = perspective => {
             it("Computed column of arity 2, subtract with null", async function() {
                 var table = perspective.table({
                     a: [1, 2, null, 3, 4],
-                    b: [1.5, null, 2.5, 3.5, 4.5]
+                    b: [1.5, undefined, 2.5, 3.5, 4.5]
                 });
 
                 let table2 = table.add_computed([
@@ -460,7 +579,7 @@ module.exports = perspective => {
             it("Computed column of arity 2, multiply with null", async function() {
                 var table = perspective.table({
                     a: [1, 2, null, 3, 4],
-                    b: [1.5, null, 2.5, 3.5, 4.5]
+                    b: [1.5, undefined, 2.5, 3.5, 4.5]
                 });
 
                 let table2 = table.add_computed([
@@ -539,7 +658,7 @@ module.exports = perspective => {
             it("Computed column of arity 2, divide with null", async function() {
                 var table = perspective.table({
                     a: [1, 2, null, 3, 4],
-                    b: [1.5, null, 2.5, 3.5, 4.5]
+                    b: [1.5, undefined, 2.5, 3.5, 4.5]
                 });
 
                 let table2 = table.add_computed([
@@ -622,7 +741,7 @@ module.exports = perspective => {
                 const table = perspective
                     .table({
                         a: [100, null, 50, 25, 10, 1],
-                        b: [100, 100, 100, 100, null, 100]
+                        b: [100, 100, 100, 100, undefined, 100]
                     })
                     .add_computed([
                         {
@@ -756,6 +875,25 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Length with null", async function() {
+                const table = perspective
+                    .table({
+                        a: ["abc", "deeeeef", null, undefined, "abcdefghijk"]
+                    })
+                    .add_computed([
+                        {
+                            column: "length",
+                            computed_function_name: "length",
+                            inputs: ["a"]
+                        }
+                    ]);
+                let view = table.view();
+                let result = await view.to_columns();
+                expect(result.length).toEqual(result.a.map(x => (x ? x.length : null)));
+                view.delete();
+                table.delete();
+            });
+
             it("Uppercase", async function() {
                 const table = perspective
                     .table({
@@ -775,6 +913,25 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Uppercase with null", async function() {
+                const table = perspective
+                    .table({
+                        a: ["abc", "deeeeef", null, undefined, "abcdefghijk"]
+                    })
+                    .add_computed([
+                        {
+                            column: "upper",
+                            computed_function_name: "Uppercase",
+                            inputs: ["a"]
+                        }
+                    ]);
+                let view = table.view();
+                let result = await view.to_columns();
+                expect(result.upper).toEqual(result.a.map(x => (x ? x.toUpperCase() : null)));
+                view.delete();
+                table.delete();
+            });
+
             it("Lowercase", async function() {
                 const table = perspective
                     .table({
@@ -782,14 +939,33 @@ module.exports = perspective => {
                     })
                     .add_computed([
                         {
-                            column: "length",
+                            column: "lower",
                             computed_function_name: "Lowercase",
                             inputs: ["a"]
                         }
                     ]);
                 let view = table.view();
                 let result = await view.to_columns();
-                expect(result.length).toEqual(result.a.map(x => x.toLowerCase()));
+                expect(result.lower).toEqual(result.a.map(x => x.toLowerCase()));
+                view.delete();
+                table.delete();
+            });
+
+            it("Lowercase with null", async function() {
+                const table = perspective
+                    .table({
+                        a: ["ABC", "DEF", null, undefined, "lMNoP"]
+                    })
+                    .add_computed([
+                        {
+                            column: "lower",
+                            computed_function_name: "Lowercase",
+                            inputs: ["a"]
+                        }
+                    ]);
+                let view = table.view();
+                let result = await view.to_columns();
+                expect(result.lower).toEqual(result.a.map(x => (x ? x.toLowerCase() : null)));
                 view.delete();
                 table.delete();
             });
@@ -840,7 +1016,7 @@ module.exports = perspective => {
                 const table = perspective
                     .table({
                         a: ["ABC", "DEF", null, "HIjK", "lMNoP"],
-                        b: ["ABC", null, "EfG", "HIjK", "lMNoP"]
+                        b: ["ABC", undefined, "EfG", "HIjK", "lMNoP"]
                     })
                     .add_computed([
                         {
@@ -862,7 +1038,7 @@ module.exports = perspective => {
             it("Concats with comma, nulls", async function() {
                 const table = perspective
                     .table({
-                        a: ["ABC", "DEF", null, "HIjK", "lMNoP"],
+                        a: ["ABC", "DEF", undefined, "HIjK", "lMNoP"],
                         b: ["ABC", null, "EfG", "HIjK", "lMNoP"]
                     })
                     .add_computed([
@@ -886,7 +1062,7 @@ module.exports = perspective => {
                 const table = perspective
                     .table({
                         a: ["ABC".repeat(10), "DEF".repeat(10), null, "HIjK".repeat(10), "lMNoP".repeat(10)],
-                        b: ["ABC", null, "EfG", "HIjK", "lMNoP"]
+                        b: ["ABC", undefined, "EfG", "HIjK", "lMNoP"]
                     })
                     .add_computed([
                         {
@@ -908,7 +1084,7 @@ module.exports = perspective => {
             it("Concats with comma, extra long", async function() {
                 const table = perspective
                     .table({
-                        a: ["ABC".repeat(10), "DEF".repeat(10), null, "HIjK".repeat(10), "lMNoP".repeat(10)],
+                        a: ["ABC".repeat(10), "DEF".repeat(10), undefined, "HIjK".repeat(10), "lMNoP".repeat(10)],
                         b: ["ABC", null, "EfG", "HIjK", "lMNoP"]
                     })
                     .add_computed([
@@ -962,6 +1138,38 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Hour of day, date with null", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "hour",
+                        computed_function_name: "Hour of Day",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    hour: "integer"
+                });
+
+                table2.update({
+                    a: [new Date(), null, undefined, new Date()]
+                });
+
+                let result = await view.to_columns();
+                expect(result.hour).toEqual([0, null, null, 0]);
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
             it("Day of week, date", async function() {
                 const table = perspective.table({
                     a: "date"
@@ -990,6 +1198,39 @@ module.exports = perspective => {
                 let result = await view.to_columns();
                 console.error(result);
                 expect(result.day).toEqual(result.a.map(x => days_of_week[new Date(x).getDay()]));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Day of week, date with null", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "day",
+                        computed_function_name: "Day of Week",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    day: "string"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 26), null, undefined, new Date(2020, 0, 29), new Date(2020, 0, 30)]
+                });
+
+                let result = await view.to_columns();
+                console.error(result);
+                expect(result.day).toEqual(result.a.map(x => (x ? days_of_week[new Date(x).getDay()] : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1027,6 +1268,38 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Month of year, date with null", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "month",
+                        computed_function_name: "Month of Year",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    month: "string"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 15), null, undefined, new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.month).toEqual(result.a.map(x => (x ? months_of_year[new Date(x).getMonth()] : null)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
             it("Bucket (s), date", async function() {
                 const table = perspective.table({
                     a: "date"
@@ -1059,7 +1332,7 @@ module.exports = perspective => {
                 table.delete();
             });
 
-            it("Bucket (m), date", async function() {
+            it("Bucket (s), date", async function() {
                 const table = perspective.table({
                     a: "date"
                 });
@@ -1067,7 +1340,7 @@ module.exports = perspective => {
                 const table2 = table.add_computed([
                     {
                         column: "bucket",
-                        computed_function_name: "Bucket (m)",
+                        computed_function_name: "Bucket (s)",
                         inputs: ["a"]
                     }
                 ]);
@@ -1081,107 +1354,11 @@ module.exports = perspective => {
                 });
 
                 table2.update({
-                    a: [new Date(2020, 0, 15), new Date(2020, 1, 27), new Date(2020, 2, 28), new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
+                    a: [new Date(2020, 0, 15), null, undefined, new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
                 });
 
                 let result = await view.to_columns();
-                expect(result.bucket).toEqual(result.a);
-                view.delete();
-                table2.delete();
-                table.delete();
-            });
-
-            it("Bucket (h), date", async function() {
-                const table = perspective.table({
-                    a: "date"
-                });
-
-                const table2 = table.add_computed([
-                    {
-                        column: "bucket",
-                        computed_function_name: "Bucket (h)",
-                        inputs: ["a"]
-                    }
-                ]);
-
-                let view = table2.view();
-
-                const schema = await table2.schema();
-                expect(schema).toEqual({
-                    a: "date",
-                    bucket: "date"
-                });
-                table2.update({
-                    a: [new Date(2020, 0, 15), new Date(2020, 1, 27), new Date(2020, 2, 28), new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
-                });
-
-                let result = await view.to_columns();
-                expect(result.bucket).toEqual(result.a);
-                view.delete();
-                table2.delete();
-                table.delete();
-            });
-
-            it("Bucket (D), date", async function() {
-                const table = perspective.table({
-                    a: "date"
-                });
-
-                const table2 = table.add_computed([
-                    {
-                        column: "bucket",
-                        computed_function_name: "Bucket (D)",
-                        inputs: ["a"]
-                    }
-                ]);
-
-                let view = table2.view();
-
-                const schema = await table2.schema();
-                expect(schema).toEqual({
-                    a: "date",
-                    bucket: "date"
-                });
-
-                table2.update({
-                    a: [new Date(2020, 0, 15), new Date(2020, 1, 27), new Date(2020, 2, 28), new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
-                });
-
-                let result = await view.to_columns();
-                expect(result.bucket).toEqual(result.a);
-                view.delete();
-                table2.delete();
-                table.delete();
-            });
-
-            it("Bucket (W), date", async function() {
-                const table = perspective.table({
-                    a: "date"
-                });
-
-                const table2 = table.add_computed([
-                    {
-                        column: "bucket",
-                        computed_function_name: "Bucket (W)",
-                        inputs: ["a"]
-                    }
-                ]);
-
-                let view = table2.view();
-
-                const schema = await table2.schema();
-                expect(schema).toEqual({
-                    a: "date",
-                    bucket: "date"
-                });
-
-                table2.update({
-                    a: [new Date(2020, 0, 12), new Date(2020, 0, 15), new Date(2020, 0, 17), new Date(2020, 0, 18), new Date(2020, 0, 29)]
-                });
-
-                let result = await view.to_columns();
-
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => week_bucket(x)));
+                expect(result.bucket).toEqual(result.a.map(x => (x ? x : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1228,6 +1405,262 @@ module.exports = perspective => {
                 const table2 = table.add_computed([
                     {
                         column: "bucket",
+                        computed_function_name: "Bucket (m)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 15), new Date(2020, 1, 27), new Date(2020, 2, 28), new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket).toEqual(result.a);
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (m), date with nulls", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (m)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 15), null, undefined, new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket).toEqual(result.a.map(x => (x ? x : null)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (h), date", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (h)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+                table2.update({
+                    a: [new Date(2020, 0, 15), new Date(2020, 1, 27), new Date(2020, 2, 28), new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket).toEqual(result.a);
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (h), date with nulls", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (h)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+                table2.update({
+                    a: [new Date(2020, 0, 15), null, undefined, new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket).toEqual(result.a.map(x => (x ? x : null)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (D), date", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (D)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 15), new Date(2020, 1, 27), new Date(2020, 2, 28), new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket).toEqual(result.a);
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (D), date null", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (D)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 15), null, undefined, new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket).toEqual(result.a.map(x => (x ? x : null)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (W), date", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (W)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 12), new Date(2020, 0, 15), new Date(2020, 0, 17), new Date(2020, 0, 18), new Date(2020, 0, 29)]
+                });
+
+                let result = await view.to_columns();
+
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => week_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (W), date with null", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (W)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 12), new Date(2020, 0, 15), new Date(2020, 0, 17), new Date(2020, 0, 18), new Date(2020, 0, 29)]
+                });
+
+                let result = await view.to_columns();
+
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? week_bucket(x) : null)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (M), date", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
                         computed_function_name: "Bucket (M)",
                         inputs: ["a"]
                     }
@@ -1247,7 +1680,40 @@ module.exports = perspective => {
 
                 let result = await view.to_columns();
 
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => month_bucket(x)));
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => month_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (M), date with null", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (M)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 12), null, undefined, new Date(2020, 2, 18), new Date(2020, 2, 29)]
+                });
+
+                let result = await view.to_columns();
+
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? month_bucket(x) : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1280,7 +1746,40 @@ module.exports = perspective => {
 
                 let result = await view.to_columns();
 
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => year_bucket(x)));
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => year_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (Y), date with null", async function() {
+                const table = perspective.table({
+                    a: "date"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (Y)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "date",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 12), null, undefined, new Date(2019, 2, 18), new Date(2019, 2, 29)]
+                });
+
+                let result = await view.to_columns();
+
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? year_bucket(x) : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1319,6 +1818,37 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Hour of day, datetime with null", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "hour",
+                        computed_function_name: "Hour of Day",
+                        inputs: ["a"]
+                    }
+                ]);
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    hour: "integer"
+                });
+
+                table2.update({
+                    a: [new Date(), null, undefined, new Date()]
+                });
+
+                let result = await view.to_columns();
+                expect(result.hour).toEqual(result.a.map(x => (x ? new Date(x).getUTCHours() : null)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
             it("Day of week, datetime", async function() {
                 const table = perspective.table({
                     a: "datetime"
@@ -1347,6 +1877,39 @@ module.exports = perspective => {
                 let result = await view.to_columns();
                 console.error(result);
                 expect(result.day).toEqual(result.a.map(x => days_of_week[new Date(x).getUTCDay()]));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Day of week, datetime with null", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "day",
+                        computed_function_name: "Day of Week",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    day: "string"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 26, 1), null, undefined, new Date(2020, 0, 29, 4), new Date(2020, 0, 30, 5)]
+                });
+
+                let result = await view.to_columns();
+                console.error(result);
+                expect(result.day).toEqual(result.a.map(x => (x ? days_of_week[new Date(x).getUTCDay()] : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1384,6 +1947,38 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("Month of year, datetime", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "month",
+                        computed_function_name: "Month of Year",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    month: "string"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 15), null, undefined, new Date(2020, 3, 29), new Date(2020, 4, 30), new Date(2020, 5, 31), new Date(2020, 6, 1)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.month).toEqual(result.a.map(x => (x ? months_of_year[new Date(x).getUTCMonth()] : null)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
             it("Bucket (s), datetime", async function() {
                 const table = perspective.table({
                     a: "datetime"
@@ -1410,7 +2005,39 @@ module.exports = perspective => {
                 });
 
                 let result = await view.to_columns();
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => second_bucket(x)));
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => second_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (s), datetime with null", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (s)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                table2.update({
+                    a: [new Date(2020, 0, 15, 1, 30, 15), null, undefined, new Date(2020, 3, 29, 1, 30, 0), new Date(2020, 4, 30, 1, 30, 15)]
+                });
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    bucket: "datetime"
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? second_bucket(x) : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1442,7 +2069,39 @@ module.exports = perspective => {
                 });
 
                 let result = await view.to_columns();
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => minute_bucket(x)));
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => minute_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (m), datetime with null", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (m)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    bucket: "datetime"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 15, 1, 30, 15), null, undefined, new Date(2020, 3, 29, 1, 30, 0), new Date(2020, 4, 30, 1, 30, 15)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? minute_bucket(x) : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1474,7 +2133,39 @@ module.exports = perspective => {
                 });
 
                 let result = await view.to_columns();
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => hour_bucket(x)));
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => hour_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (h), datetime with null", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (h)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    bucket: "datetime"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 15, 1, 30, 15), null, undefined, new Date(2020, 3, 29, 1, 30, 0), new Date(2020, 4, 30, 1, 30, 15)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? hour_bucket(x) : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1506,7 +2197,39 @@ module.exports = perspective => {
                 });
 
                 let result = await view.to_columns();
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => day_bucket(x)));
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => day_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (D), datetime with null", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (D)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 15, 1, 30, 15), null, undefined, new Date(2020, 3, 29, 1, 30, 0), new Date(2020, 4, 30, 1, 30, 15)]
+                });
+
+                let result = await view.to_columns();
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? day_bucket(x) : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1539,7 +2262,40 @@ module.exports = perspective => {
 
                 let result = await view.to_columns();
 
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => week_bucket(x)));
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => week_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (W), datetime with null", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (W)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 12), null, undefined, new Date(2020, 0, 18), new Date(2020, 0, 29)]
+                });
+
+                let result = await view.to_columns();
+
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? week_bucket(x) : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1605,7 +2361,40 @@ module.exports = perspective => {
 
                 let result = await view.to_columns();
 
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => month_bucket(x)));
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => month_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (M), datetime with nulls", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (M)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 12), null, undefined, new Date(2020, 2, 18), new Date(2020, 2, 29)]
+                });
+
+                let result = await view.to_columns();
+
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? month_bucket(x) : null)));
                 view.delete();
                 table2.delete();
                 table.delete();
@@ -1638,7 +2427,40 @@ module.exports = perspective => {
 
                 let result = await view.to_columns();
 
-                expect(result.bucket.map(x => new Date(x))).toEqual(result.a.map(x => year_bucket(x)));
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => year_bucket(x)));
+                view.delete();
+                table2.delete();
+                table.delete();
+            });
+
+            it("Bucket (Y), datetime with nulls", async function() {
+                const table = perspective.table({
+                    a: "datetime"
+                });
+
+                const table2 = table.add_computed([
+                    {
+                        column: "bucket",
+                        computed_function_name: "Bucket (Y)",
+                        inputs: ["a"]
+                    }
+                ]);
+
+                let view = table2.view();
+
+                const schema = await table2.schema();
+                expect(schema).toEqual({
+                    a: "datetime",
+                    bucket: "date"
+                });
+
+                table2.update({
+                    a: [new Date(2020, 0, 12), null, undefined, new Date(2019, 2, 18), new Date(2019, 2, 29)]
+                });
+
+                let result = await view.to_columns();
+
+                expect(result.bucket.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? year_bucket(x) : null)));
                 view.delete();
                 table2.delete();
                 table.delete();

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -120,16 +120,18 @@ make_view_config(const t_schema& schema, t_val date_parser, t_val config) {
 
     // to preserve order, do not cast to std::map - use keys and python 3.7's guarantee that dicts respect insertion order
     auto p_aggregates = py::dict(config.attr("get_aggregates")());
-    auto aggregate_keys = py::list(p_aggregates.attr("keys")());
     tsl::ordered_map<std::string, std::vector<std::string>> aggregates;
 
-    for (auto& key : aggregate_keys) {
-        const std::string key_str = key.cast<std::string>();
-        if (py::isinstance<py::str>(p_aggregates[key])) {
-            std::vector<std::string> agg{p_aggregates[key].cast<std::string>()};
-            aggregates[key_str] = agg;
-        } else {
-            aggregates[key_str] = p_aggregates[key].cast<std::vector<std::string>>();
+    for (auto& column : columns) {
+        py::str py_column_name = py::str(column);
+        if (p_aggregates.contains(py_column_name)) {
+            if (py::isinstance<py::str>(p_aggregates[py_column_name])) {
+                std::vector<std::string> agg{
+                    p_aggregates[py_column_name].cast<std::string>()};
+                aggregates[column] = agg;
+            } else {
+                aggregates[column] = p_aggregates[py_column_name].cast<std::vector<std::string>>();
+            }
         }
     };
 

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -113,6 +113,7 @@ class _PerspectiveAccessor(object):
                     raise PerspectiveError("Mixed datasets of numpy.ndarray and lists are not supported.")
 
                 dtype = array.dtype
+
                 if name == "index" and isinstance(data_or_schema.index, pandas.DatetimeIndex):
                     # use the index of the original, unflattened dataframe
                     dtype = _parse_datetime_index(data_or_schema.index)

--- a/python/perspective/perspective/tests/table/test_table_numpy.py
+++ b/python/perspective/perspective/tests/table/test_table_numpy.py
@@ -28,6 +28,26 @@ class TestTableNumpy(object):
             "b": [4, 5, 6]
         }
 
+    def test_table_int_lots_of_columns(self):
+        data = {
+            "a": np.array([1, 2, 3]),
+            "b": np.array([4, 5, 6]),
+            "c": np.array([4, 5, 6]),
+            "d": np.array([4, 5, 6]),
+            "e": np.array([4, 5, 6]),
+            "f": np.array([4, 5, 6]),
+        }
+        tbl = Table(data)
+        assert tbl.size() == 3
+        assert tbl.view().to_dict() == {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6],
+            "c": [4, 5, 6],
+            "d": [4, 5, 6],
+            "e": [4, 5, 6],
+            "f": [4, 5, 6]
+        }
+
     def test_table_int_with_None(self):
         data = {"a": np.array([1, 2, 3, None, None]), "b": np.array([4, 5, 6, None, None])}
         tbl = Table(data)
@@ -737,6 +757,36 @@ class TestTableNumpy(object):
         })
         table.update(df)
         assert table.view().to_dict()["a"] == data
+
+    # partial update
+
+    def test_table_numpy_partial_update(self):
+        data = ["a", None, "b", None, "c"]
+        df = {"a": np.array([1, 2, 3, 4, 5]), "b": np.array(data), "c": np.array(data)}
+        table = Table(df, index="a")
+        table.update({
+            "a": np.array([2, 4, 5]),
+            "b": np.array(["x", "y", "z"])
+        })
+        assert table.view().to_dict() == {
+            "a": [1, 2, 3, 4, 5],
+            "b": ["a", "x", "b", "y", "z"],
+            "c": ["a", None, "b", None, "c"]
+        }
+
+    def test_table_numpy_partial_update_implicit(self):
+        data = ["a", None, "b", None, "c"]
+        df = {"a": np.array([1, 2, 3, 4, 5]), "b": np.array(data), "c": np.array(data)}
+        table = Table(df)
+        table.update({
+            "__INDEX__": np.array([1, 3, 4]),
+            "b": np.array(["x", "y", "z"])
+        })
+        assert table.view().to_dict() == {
+            "a": [1, 2, 3, 4, 5],
+            "b": ["a", "x", "b", "y", "z"],
+            "c": ["a", None, "b", None, "c"]
+        }
 
     # structured array
 

--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -35,6 +35,20 @@ class TestTablePandas(object):
             {"a": 3, "b": 4, "index": 1}
         ]
 
+    def test_table_dataframe_column_order(self):
+        d = [{"a": 1, "b": 2, "c": 3, "d": 4}, {"a": 3, "b": 4, "c": 5, "d": 6}]
+        data = pd.DataFrame(d, columns=["b", "c", "a", "d"])
+        tbl = Table(data)
+        assert tbl.size() == 2
+        assert tbl.columns() == ["index", "b", "c", "a", "d"]
+
+    def test_table_dataframe_selective_column_order(self):
+        d = [{"a": 1, "b": 2, "c": 3, "d": 4}, {"a": 3, "b": 4, "c": 5, "d": 6}]
+        data = pd.DataFrame(d, columns=["b", "c", "a"])
+        tbl = Table(data)
+        assert tbl.size() == 2
+        assert tbl.columns() == ["index", "b", "c", "a"]
+
     def test_table_dataframe_does_not_mutate(self):
         # make sure we don't mutate the dataframe that a user passes in
         data = pd.DataFrame({

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -6,17 +6,17 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
+import pandas as pd
 import numpy as np
-from pytest import raises
 from perspective.table import Table
 from datetime import date, datetime
-
 
 
 def compare_delta(received, expected):
     """Compare an arrow-serialized row delta by constructing a Table."""
     tbl = Table(received)
     assert tbl.view().to_dict() == expected
+
 
 class TestView(object):
     def test_view_zero(self):
@@ -248,6 +248,19 @@ class TestView(object):
         tbl = Table(data)
         view = tbl.view(columns=["b", "a"])
         assert view.to_records() == [{"b": 2, "a": 1}, {"b": 4, "a": 3}]
+
+    def test_view_dataframe_column_order(self):
+        table = Table(pd.DataFrame({
+            "0.1": [5, 6, 7, 8],
+            "-0.05": [5, 6, 7, 8],
+            "0.0": [1, 2, 3, 4],
+            "-0.1": [1, 2, 3, 4],
+            "str": ["a", "b", "c", "d"]
+        }))
+        view = table.view(
+            columns=["-0.1", "-0.05", "0.0", "0.1"], row_pivots=["str"])
+        assert view.column_paths() == [
+            "__ROW_PATH__", "-0.1", "-0.05", "0.0", "0.1"]
 
     def test_view_aggregate_order(self):
         '''In Python 3.7 and above, a dict's insertion order is guaranteed. We use this guarantee to ensure that

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -262,40 +262,35 @@ class TestView(object):
         assert view.column_paths() == [
             "__ROW_PATH__", "-0.1", "-0.05", "0.0", "0.1"]
 
-    def test_view_aggregate_order(self):
-        '''In Python 3.7 and above, a dict's insertion order is guaranteed. We use this guarantee to ensure that
-        the order of columns shown is the same as the order of keys in a schema/data passed in by the user.
-
-        In the Python 2 runtime, order cannot be guaranteed without the usage of OrderedMap in C++.
-        '''
-        import six
+    def test_view_aggregate_order_with_columns(self):
+        '''If `columns` is provided, order is always guaranteed.'''
         data = [{"a": 1, "b": 2, "c": 3, "d": 4}, {"a": 3, "b": 4, "c": 5, "d": 6}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            columns=["a", "b", "c", "d"],
+            aggregates={"d": "avg", "c": "avg", "b": "last", "a": "last"}
+        )
+
+        order = ["__ROW_PATH__", "a", "b", "c", "d"]
+        assert view.column_paths() == order
+
+    def test_view_df_aggregate_order_with_columns(self):
+        '''If `columns` is provided, order is always guaranteed.'''
+        data = pd.DataFrame({
+            "a": [1, 2, 3],
+            "b": [2, 3, 4],
+            "c": [3, 4, 5],
+            "d": [4, 5, 6]
+        }, columns=["d", "a", "c", "b"])
         tbl = Table(data)
         view = tbl.view(
             row_pivots=["a"],
             aggregates={"d": "avg", "c": "avg", "b": "last", "a": "last"}
         )
 
-        order = ["__ROW_PATH__", "d", "c", "b", "a"]
-        records = view.to_records()
-
-        assert records == [
-            {"__ROW_PATH__": [], "d": 5.0, "c": 4.0, "b": 4, "a": 3},
-            {"__ROW_PATH__": ["1"], "d": 4.0, "c": 3.0, "b": 2, "a": 1},
-            {"__ROW_PATH__": ["3"], "d": 6.0, "c": 5.0, "b": 4, "a": 3}
-        ]
-
-        if six.PY2:
-            # only test for presence, not order
-            for record in records:
-                keys = list(record.keys())
-                for key in keys:
-                    assert key in order
-        else:
-            for record in records:
-                keys = list(record.keys())
-                for i in range(len(keys)):
-                    assert keys[i] == order[i]
+        order = ["__ROW_PATH__", "index", "d", "a", "c", "b"]
+        assert view.column_paths() == order
 
     def test_view_aggregates_with_no_columns(self):
         data = [{"a": 1, "b": 2, "c": 3, "d": 4}, {"a": 3, "b": 4, "c": 5, "d": 6}]
@@ -312,8 +307,8 @@ class TestView(object):
         ]
 
     def test_view_aggregates_column_order(self):
-        '''Again, dict insertion order is not guaranteed in Python <3.7.'''
-        import six
+        '''Order of columns are entirely determined by the `columns` kwarg. If
+        it is not provided, order of columns is undefined behavior.'''
         data = [{"a": 1, "b": 2, "c": 3, "d": 4}, {"a": 3, "b": 4, "c": 5, "d": 6}]
         tbl = Table(data)
         view = tbl.view(
@@ -322,26 +317,8 @@ class TestView(object):
             columns=["a", "c"]
         )
 
-        order = ["__ROW_PATH__", "c", "a"]
-        records = view.to_records()
-
-        assert records == [
-            {"__ROW_PATH__": [], "c": 4.0, "a": 3},
-            {"__ROW_PATH__": ["1"], "c": 3.0, "a": 1},
-            {"__ROW_PATH__": ["3"], "c": 5.0, "a": 3}
-        ]
-
-        if six.PY2:
-            # only test for presence, not order
-            for record in records:
-                keys = list(record.keys())
-                for key in keys:
-                    assert key in order
-        else:
-            for record in records:
-                keys = list(record.keys())
-                for i in range(len(keys)):
-                    assert keys[i] == order[i]
+        order = ["__ROW_PATH__", "a", "c"]
+        assert view.column_paths() == order
 
     def test_view_column_pivot_datetime_names(self):
         data = {"a": [datetime(2019, 7, 11, 12, 30)], "b": [1]}

--- a/python/perspective/perspective/tornado_handler/tornado_handler.py
+++ b/python/perspective/perspective/tornado_handler/tornado_handler.py
@@ -28,7 +28,7 @@ class PerspectiveTornadoHandler(tornado.websocket.WebSocketHandler):
     next free iteration of the event loop.
 
     Examples:
-        >>> MANAGER = PerspectiveViewer()
+        >>> MANAGER = PerspectiveManager()
         >>> MANAGER.host_table("data_source_one", Table(
         ...     pd.read_csv("superstore.csv")))
         >>> app = tornado.web.Application([


### PR DESCRIPTION
This PR provides several fixes for issues with `PerspectivePython`:

- When passing in a `pandas.DataFrame`, Perspective will read the `columns` property and load the dataframe in the specified order. Perspective will continue to call `.keys()` for datasets composed of Python `dict` and `list` values, and the canonical way to determine column order should be through creating a `View` with the `columns` kwarg set. This change simply makes Perspective's column layout more symmetrical with that of the provided DataFrame.
- When creating a `View`, columns included in `aggregates` but not in `columns` will not have their aggregates applied. This fixes issue #904, which occurred because the order of `.keys()` in `aggregates `!=` the order of `columns`.
- Computed columns will write `null` to the output column if any value provided to the computed function is `null` or `undefined`.