### PR TITLE
Update FINOS README badge to INCUBATING

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Appveyor](https://ci.appveyor.com/api/projects/status/github/finos/perspective?svg=true)](https://ci.appveyor.com/project/neilslinger/perspective)
 [![npm](https://img.shields.io/npm/v/@finos/perspective.svg?style=flat-square)](https://www.npmjs.com/package/@finos/perspective)
 [![PyPI](https://img.shields.io/pypi/v/perspective-python.svg)](https://pypi.python.org/pypi/perspective-python)
-[![FINOS - Operating](https://cdn.rawgit.com/finos/contrib-toolbox/master/images/badge-operating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Operating)
+[![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Incubating)
 
 
 A streaming data visualization engine for Javascript, Perspective makes it


### PR DESCRIPTION
## Description 
### Project Lifecycle Badge to Incubating
A pull request to update the FINOS Project Lifecycle badge to `INCUBATING` in the project README whilst FINOS and Perspective teams activate the project together in 2020 Q1.

[![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Incubating)

### 2020 Q1 Activation Goal

The goal of 2020 Q1 project activation is to replace the `INCUBATING` badge with `ACTIVE` by following and demonstrating the [FINOS Activation Criteria](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530376/Activation) between the FINOS and Perspective teams.

This joint effort will replace the incubating badge with the following badge once complete.

[![FINOS - Active](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-active.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Active)