### PR TITLE
Added Azure compatible reporting for tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,12 @@ jobs:
       env:
         PSP_DOCKER: 1
 
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testRunner: JUnit
+        testResultsFiles: 'junit.xml'
+
 
 - job: 'Linux'
   pool:
@@ -76,6 +82,16 @@ jobs:
       env:
         PSP_DOCKER: 1
 
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: 'python/perspective/python_junit.xml'
+        testRunTitle: 'Publish test results for Python $(python.version) $(manylinux_flag)'
+
+    - task: PublishCodeCoverageResults@1
+      inputs: 
+        codeCoverageTool: Cobertura
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/*coverage.xml'
 
 # - job: 'Windows'
 #   pool:
@@ -163,5 +179,16 @@ jobs:
     - script: yarn
       displayName: 'Install Deps'
 
-    - script: yarn build_python  --ci $(python_flag)
+    - script: yarn build_python --ci $(python_flag)
       displayName: 'build'
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: 'python/perspective/python_junit.xml'
+        testRunTitle: 'Publish test results for Python $(python.version)'
+
+    - task: PublishCodeCoverageResults@1
+      inputs: 
+        codeCoverageTool: Cobertura
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/*coverage.xml'

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "html-loader-jest": "^0.2.1",
         "inquirer": "^7.0.0",
         "jest": "^24.5.0",
+        "jest-junit": "^10.0.0",
         "js-beautify": "^1.8.6",
         "jsdoc": "3.5.5",
         "jsdoc-babel": "^0.5.0",

--- a/packages/perspective-test/jest.all.config.js
+++ b/packages/perspective-test/jest.all.config.js
@@ -16,7 +16,7 @@ module.exports = {
     transformIgnorePatterns: ["/node_modules/(?!lit-html).+$"],
     automock: false,
     setupFiles: ["@finos/perspective-test/src/js/beforeEachSpec.js"],
-    reporters: ["default", "@finos/perspective-test/src/js/reporter.js"],
+    reporters: ["default", "@finos/perspective-test/src/js/reporter.js", "jest-junit"],
     globalSetup: "@finos/perspective-test/src/js/globalSetup.js",
     globalTeardown: "@finos/perspective-test/src/js/globalTeardown.js"
 };

--- a/scripts/build_python.js
+++ b/scripts/build_python.js
@@ -42,8 +42,9 @@ try {
             `${PYTHON} -m pip install -e .[dev] && \
             ${PYTHON} -m flake8 perspective && echo OK && \
             ${PYTHON} -m pytest -vvv --noconftest perspective/tests/client && \
-            ${PYTHON} -m pytest -vvv perspective
-            --ignore=perspective/tests/client
+            ${PYTHON} -m pytest -vvv perspective \
+            --ignore=perspective/tests/client \
+            --junitxml=python_junit.xml --cov-report=xml --cov-branch \
             --cov=perspective`;
         if (IMAGE == "python") {
             cmd =

--- a/yarn.lock
+++ b/yarn.lock
@@ -8456,6 +8456,17 @@ jest-jasmine2@^24.9.0:
     pretty-format "^24.9.0"
     throat "^4.0.0"
 
+jest-junit@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-10.0.0.tgz#c94b91c24920a327c9d2a075e897b2dba4af494b"
+  integrity sha512-dbOVRyxHprdSpwSAR9/YshLwmnwf+RSl5hf0kCGlhAcEeZY9aRqo4oNmaT0tLC16Zy9D0zekDjWkjHGjXlglaQ==
+  dependencies:
+    jest-validate "^24.9.0"
+    mkdirp "^0.5.1"
+    strip-ansi "^5.2.0"
+    uuid "^3.3.3"
+    xml "^1.0.1"
+
 jest-leak-detector@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
@@ -14360,6 +14371,11 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
+uuid@^3.3.3:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 v8-compile-cache@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
@@ -14812,6 +14828,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlbuilder@^13.0.0:
   version "13.0.2"


### PR DESCRIPTION
Adds `jest` and `pytest` `junit` output, and publish these results to Azure Devops for [pretty build analytics](https://dev.azure.com/finosfoundation/perspective/_build/results?buildId=18&view=ms.vss-test-web.build-test-results-tab).