### PR TITLE
Event regression fix

### DIFF
--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -201,7 +201,7 @@ t_view_config::fill_aggspecs(const t_schema& schema) {
             t_aggtype agg_type;
 
             // use the `any` agg for columns used as pivots/column_only views
-            if (is_pivot || m_row_pivots.size() == 0 || m_column_only) {
+            if (m_row_pivots.size() == 0 || m_column_only) {
                 agg_type = t_aggtype::AGGTYPE_ANY;      
             } else if (m_aggregates.count(column) > 0) {
                 auto col = m_aggregates.at(column);
@@ -211,6 +211,8 @@ t_view_config::fill_aggspecs(const t_schema& schema) {
                 } else {
                     agg_type = str_to_aggtype(col.at(0));
                 }
+            } else if (is_pivot) {
+                agg_type = t_aggtype::AGGTYPE_ANY;
             } else {
                 t_dtype dtype = schema.get_dtype(column);
                 agg_type = _get_default_aggregate(dtype);

--- a/packages/perspective-viewer-d3fc/src/js/axis/ordinalAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/ordinalAxis.js
@@ -128,7 +128,7 @@ export const component = settings => {
     const axisGroups = domain => {
         const groups = [];
         domain.forEach(tick => {
-            const split = tick.split ? tick.split("|") : [tick];
+            const split = tick && tick.split ? tick.split("|") : [tick];
             split.forEach((s, i) => {
                 while (groups.length <= i) groups.push([]);
 
@@ -145,16 +145,16 @@ export const component = settings => {
 
     const getGroupTickLayout = group => {
         const width = settings.size.width;
-        const maxLength = Math.max(...group.map(g => g.text.length));
+        const maxLength = Math.max(...group.map(g => (g.text ? g.text.length : 0)));
 
         if (orient === "horizontal") {
             // x-axis may rotate labels and expand the available height
-            if (group.length * 16 > width - 100) {
+            if (group && group.length * 16 > width - 100) {
                 return {
                     size: maxLength * 5 + 10,
                     rotation: 90
                 };
-            } else if (group.length * (maxLength * 6 + 10) > width - 100) {
+            } else if (group && group.length * (maxLength * 6 + 10) > width - 100) {
                 return {
                     size: maxLength * 3 + 20,
                     rotation: 45

--- a/packages/perspective-workspace/src/js/workspace/workspace.js
+++ b/packages/perspective-workspace/src/js/workspace/workspace.js
@@ -609,6 +609,10 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         }
         const table = this.tables.get(viewer.getAttribute("table") || config.table);
         const widget = new PerspectiveViewerWidget({name, table, node, viewer});
+        const event = new CustomEvent("workspace-new-view", {
+            detail: {config, widget}
+        });
+        this.element.dispatchEvent(event);
         widget.title.closable = true;
         this.element.appendChild(widget.viewer);
         this._addWidgetEventListeners(widget);
@@ -650,9 +654,12 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         return [...this.masterPanel.widgets, ...toArray(this.dockpanel.widgets())];
     }
 
-    /*********************************************************************
-     * Workspace updated event
+    /***************************************************************************
+     *
+     * `workspace-layout-update` event
+     *
      */
+
     _fireUpdateEvent() {
         const layout = this.save();
         if (layout) {


### PR DESCRIPTION
* Fixes a regression in #901 which eliminated an event dispatch.
* Fixes a D3FC plugin bug which caused `null` groups to not work on `ordinalAxis`.
* Fixes a sort-ordering bug when an aggregate is specified to override a non-displayed sort column.