### PR TITLE
Fix `perspective-workspace` initialize bug

### DIFF
--- a/examples/workspace/src/index.html
+++ b/examples/workspace/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <perspective-workspace id="workspace">
+        <perspective-viewer slot="One" name="Test Widget One" table="superstore"></perspective-viewer>
+        <perspective-viewer slot="Two" name="Test Widget Two" table="superstore"></perspective-viewer>
+        <perspective-viewer slot="Three" name="Test Widget Three" table="superstore"></perspective-viewer>
+    </perspective-workspace>
+</body>
+</html>

--- a/examples/workspace/src/index.js
+++ b/examples/workspace/src/index.js
@@ -8,10 +8,9 @@
  */
 
 import perspective from "@finos/perspective";
-import "@finos/perspective-workspace";
-
 import "@finos/perspective-viewer-hypergrid";
 import "@finos/perspective-viewer-d3fc";
+import "@finos/perspective-workspace";
 
 import "./index.less";
 
@@ -22,14 +21,6 @@ const datasource = async () => {
     const worker = perspective.shared_worker();
     return worker.table(buffer);
 };
-
-document.body.innerHTML = `
-<perspective-workspace id="workspace">
-    <perspective-viewer slot="One" name="Test Widget One" table="superstore"></perspective-viewer>
-    <perspective-viewer slot="Two" name="Test Widget Two" table="superstore"></perspective-viewer>
-    <perspective-viewer slot="Three" name="Test Widget Three" table="superstore"></perspective-viewer>
-</perspective-workspace>
-`;
 
 window.addEventListener("load", () => {
     window.workspace.tables.set("superstore", datasource());

--- a/examples/workspace/webpack.config.js
+++ b/examples/workspace/webpack.config.js
@@ -19,7 +19,8 @@ module.exports = {
     },
     plugins: [
         new HtmlWebPackPlugin({
-            title: "Workspace Example"
+            title: "Workspace Example",
+            template: "./src/index.html"
         }),
         new PerspectivePlugin({})
     ],

--- a/packages/perspective-workspace/src/js/index.js
+++ b/packages/perspective-workspace/src/js/index.js
@@ -202,7 +202,9 @@ class PerspectiveWorkspaceElement extends HTMLElement {
         this._register_light_dom_listener();
 
         // TODO: check we only insert one of these
-        this._injectStyle = injectStyles("workspace-injected-stylesheet", injectedStyles);
+        this._injectStyle = document.createElement("style");
+        this._injectStyle.innerHTML = injectedStyles;
+        document.head.appendChild(this._injectStyle);
 
         MessageLoop.sendMessage(this.workspace, Widget.Msg.BeforeAttach);
         container.insertBefore(this.workspace.node, null);
@@ -217,11 +219,3 @@ class PerspectiveWorkspaceElement extends HTMLElement {
         document.head.removeChild(this._injectStyle);
     }
 }
-
-const injectStyles = (name, style) => {
-    const node = document.createElement("style");
-    node.id = name;
-    node.innerHTML = style;
-    document.head.appendChild(node);
-    return node;
-};


### PR DESCRIPTION
This PR fixes a bug where `perspective-workspace` fails during page load.

The error only happens when `perspective-workspace` is declared in the html (see `workspace` example)