### PR TITLE
Fix `perspective-workspace` non-unique generated slotid bug

### DIFF
--- a/packages/perspective-workspace/src/js/workspace/workspace.js
+++ b/packages/perspective-workspace/src/js/workspace/workspace.js
@@ -575,7 +575,11 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
     }
 
     _gen_id() {
-        return `PERSPECTIVE_GENERATED_ID_${ID_COUNTER++}`;
+        let genId = `PERSPECTIVE_GENERATED_ID_${ID_COUNTER++}`;
+        if (this.element.querySelector(`[slot=${genId}]`)) {
+            genId = this._gen_id();
+        }
+        return genId;
     }
 
     _createNode(slotname) {

--- a/packages/perspective-workspace/test/js/integration/restore.spec.js
+++ b/packages/perspective-workspace/test/js/integration/restore.spec.js
@@ -103,6 +103,41 @@ utils.with_server({paths: PATHS}, () => {
                 },
                 {wait_for_update: false, timeout: 30000}
             );
+
+            test.capture(
+                "restore workspace with viewers with generated slotids",
+
+                async page => {
+                    const config = {
+                        viewers: {
+                            PERSPECTIVE_GENERATED_ID_0: {table: "superstore", name: "Test", "row-pivots": ["State"], columns: ["Sales", "Profit"]}
+                        },
+                        detail: {
+                            main: {
+                                currentIndex: 0,
+                                type: "tab-area",
+                                widgets: ["PERSPECTIVE_GENERATED_ID_0"]
+                            }
+                        }
+                    };
+
+                    await page.evaluate(config => {
+                        const workspace = document.getElementById("workspace");
+                        workspace.restore(config);
+                    }, config);
+
+                    await page.waitForSelector("perspective-workspace > perspective-viewer:not([updating])");
+
+                    await page.evaluate(() => {
+                        const workspace = document.getElementById("workspace").workspace;
+                        const widget = workspace.getAllWidgets()[0];
+                        workspace.duplicate(widget);
+                    });
+
+                    await page.waitForSelector("perspective-workspace > perspective-viewer:not([updating])");
+                },
+                {wait_for_update: false, timeout: 30000}
+            );
         },
         {root: TEST_ROOT}
     );

--- a/packages/perspective-workspace/test/results/linux.docker.json
+++ b/packages/perspective-workspace/test/results/linux.docker.json
@@ -2,7 +2,7 @@
     "index_restore_workspace_with_detail_only": "1168e9bee0eec492dfd5f50b2e087d84",
     "index_restore_workspace_with_master_only": "13ff739449bf9745d43f9af8bfc67c7c",
     "index_restore_workspace_with_master_and_detail": "aafccad40bfe1a921c220da2a0e07a30",
-    "__GIT_COMMIT__": "362140e29c4b9ef392e3e3550dab1d09d2e7cc57",
+    "__GIT_COMMIT__": "ed38f93b69ace120dd6be13d68905b2b3c6bfa4f",
     "index_HTML_Create_One": "9db49888a923c083fec35c90723fbf0f",
     "index_HTML_Create_Multiple": "9bf849cb0f3d724baa79df4ccfedb913",
     "index_HTML_Create_multiple_with_names": "0bed0974e891d51eb400070f99f78189",
@@ -10,5 +10,6 @@
     "index_appendChild_Create_One": "9db49888a923c083fec35c90723fbf0f",
     "index_appendChild_Create_multiple": "418ec5fe318631be277300adbc0f958c",
     "index_appendChild_With_name": "1168e9bee0eec492dfd5f50b2e087d84",
-    "index_appendChild_Without_slot": "9db49888a923c083fec35c90723fbf0f"
+    "index_appendChild_Without_slot": "9db49888a923c083fec35c90723fbf0f",
+    "index_restore_workspace_with_viewers_with_generated_slotids": "995ca0415729b7396b9c6c481a2e2218"
 }


### PR DESCRIPTION
This PR fixes a bug where `workspace` generated non-unique `slot` names. 

This bug was evident while restoring previously saved layouts with generated viewer slot names. While the layouts restored fine, subsequent `duplicate` calls generated non-unique slot names and rendered incorrectly.