### PR TITLE
Fix widget title in `perspective-workspace`

### DIFF
--- a/packages/perspective-workspace/package.json
+++ b/packages/perspective-workspace/package.json
@@ -25,7 +25,7 @@
         "test:run": "jest --rootDir=. --config=../perspective-test/jest.config.js  --color 2>&1",
         "test:unit": "jest  --color --config=./config/jest.unit.config.js 2>&1",
         "test:integration": "jest --color  --config=./config/jest.integration.config.js 2>&1",
-        "watch": "webpack --color --watch --config config/watch.config.js"
+        "watch": "PSP_DEBUG=1 webpack --color --watch --config config/watch.config.js"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/perspective-workspace/src/js/workspace/tabbar.js
+++ b/packages/perspective-workspace/src/js/workspace/tabbar.js
@@ -89,9 +89,8 @@ export class PerspectiveTabBar extends TabBar {
         const onEnter = event => {
             if (event.keyCode === 13) {
                 removeEventListeners();
-                this.currentTitle.label = event.target.value;
+                this.currentTitle.owner.name = event.target.value;
                 event.target.value = event.target.value || DEFAULT_TITLE;
-                this.currentTitle.owner.viewer.setAttribute("name", event.target.value);
                 event.target.setAttribute("readonly", "");
                 event.target.blur();
             }

--- a/packages/perspective-workspace/src/js/workspace/widget.js
+++ b/packages/perspective-workspace/src/js/workspace/widget.js
@@ -11,10 +11,8 @@ import "@finos/perspective-viewer";
 import {Widget} from "@phosphor/widgets";
 
 export class PerspectiveViewerWidget extends Widget {
-    constructor({name, viewer, node}) {
+    constructor({viewer, node}) {
         super({node});
-        viewer.setAttribute("name", name);
-        this.title.label = name;
         this.viewer = viewer;
         this.master = false;
     }
@@ -45,6 +43,18 @@ export class PerspectiveViewerWidget extends Widget {
         return this.viewer.table;
     }
 
+    set name(value) {
+        if (value != null) {
+            this.viewer.setAttribute("name", value);
+            this.title.label = value;
+            this._name = value;
+        }
+    }
+
+    get name() {
+        return this._name;
+    }
+
     toggleConfig() {
         return this.viewer.toggleConfig();
     }
@@ -52,12 +62,9 @@ export class PerspectiveViewerWidget extends Widget {
     restore(config) {
         const {master, table, name, ...viewerConfig} = config;
         this.master = master;
+        this.name = name;
         if (table) {
             this.viewer.setAttribute("table", table);
-        }
-        if (name) {
-            this.viewer.setAttribute("name", name);
-            this.title.label = name;
         }
         this.viewer.restore({...viewerConfig});
     }

--- a/packages/perspective-workspace/src/js/workspace/workspace.js
+++ b/packages/perspective-workspace/src/js/workspace/workspace.js
@@ -601,7 +601,7 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
     }
 
     _createWidget({config, node, viewer}) {
-        const name = config.name || viewer.getAttribute("name");
+        config.name = config.name || viewer.getAttribute("name");
         if (!node) {
             const slotname = viewer.getAttribute("slot");
             node = this.node.querySelector(`slot[name=${slotname}]`);
@@ -612,7 +612,7 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
             }
         }
         const table = this.tables.get(viewer.getAttribute("table") || config.table);
-        const widget = new PerspectiveViewerWidget({name, table, node, viewer});
+        const widget = new PerspectiveViewerWidget({node, viewer});
         const event = new CustomEvent("workspace-new-view", {
             detail: {config, widget}
         });


### PR DESCRIPTION
This PR fixes a bug when you duplicate an untitled widget.