### PR TITLE
Fix tables `delete` bug in `perspective-workspace`

### DIFF
--- a/packages/perspective-workspace/src/js/workspace/workspace.js
+++ b/packages/perspective-workspace/src/js/workspace/workspace.js
@@ -40,15 +40,19 @@ class ObservableMap extends Map {
     }
 
     delete(name) {
-        this._delete_listener?.(name);
-        super.delete(name);
+        const result = this._delete_listener?.(name);
+        if (result) {
+            return super.delete(name);
+        } else {
+            return false;
+        }
     }
 
     addSetListener(listener) {
         this._set_listener = listener;
     }
 
-    addDeleteistener(listener) {
+    addDeleteListener(listener) {
         this._delete_listener = listener;
     }
 }
@@ -78,7 +82,7 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         this.listeners = new WeakMap();
         this._tables = new ObservableMap();
         this._tables.addSetListener(this._set_listener.bind(this));
-        this._tables.addDeleteistener(this._delete_listener.bind(this));
+        this._tables.addDeleteListener(this._delete_listener.bind(this));
         this.commands = createCommands(this);
         this.menuRenderer = new MenuRenderer(this.element);
 
@@ -269,12 +273,9 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         const isUsed = this.getAllWidgets().some(widget => widget.viewer.getAttribute("table") === name);
         if (isUsed) {
             console.error(`Cannot remove table: '${name}' because it's still bound to widget(s)`);
-        } else {
-            const result = this.tables.delete(name);
-            if (!result) {
-                console.warn(`Table: '${name}' does not exist`);
-            }
+            return false;
         }
+        return true;
     }
 
     update_widget_for_viewer(viewer) {

--- a/packages/perspective-workspace/test/js/unit/__mocks__/@finos/perspective-viewer.js
+++ b/packages/perspective-workspace/test/js/unit/__mocks__/@finos/perspective-viewer.js
@@ -16,6 +16,7 @@ document.createElement = name => {
 
 const patchUnknownElement = element => {
     let config = {};
+    element.load = jest.fn();
     element.save = () => config;
     element.restore = value => {
         config = {...config, ...value};

--- a/packages/perspective-workspace/test/js/unit/tables.spec.js
+++ b/packages/perspective-workspace/test/js/unit/tables.spec.js
@@ -1,0 +1,72 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import {PerspectiveWorkspace} from "../../../src/js/workspace/workspace";
+import perspective from "@finos/perspective";
+
+describe("tables", () => {
+    test("setting a table calls load on a subscribed viewer", () => {
+        const table = perspective.table([{a: 1}]);
+        const viewers = {One: {table: "test", name: "One"}};
+        const config = {
+            viewers,
+            detail: {
+                main: {
+                    currentIndex: 0,
+                    type: "tab-area",
+                    widgets: ["One"]
+                }
+            }
+        };
+
+        const workspace = new PerspectiveWorkspace(document.body);
+        workspace.restore(config);
+
+        const widget = workspace.getAllWidgets()[0];
+        expect(widget.viewer.load).not.toBeCalled();
+
+        workspace.tables.set("test", table);
+
+        expect(widget.viewer.load).toBeCalled();
+    });
+
+    test("delete a table without subscribers works", () => {
+        const table = perspective.table([{a: 1}]);
+        const workspace = new PerspectiveWorkspace(document.body);
+
+        workspace.tables.set("test", table);
+        expect(workspace.tables.has("test")).toBeTruthy();
+
+        expect(workspace.tables.delete("test")).toBeTruthy();
+        expect(workspace.tables.has("test")).toBeFalsy();
+    });
+
+    test("delete a table with subscribers fails", () => {
+        const table = perspective.table([{a: 1}]);
+        const viewers = {One: {table: "test", name: "One"}};
+        const config = {
+            viewers,
+            detail: {
+                main: {
+                    currentIndex: 0,
+                    type: "tab-area",
+                    widgets: ["One"]
+                }
+            }
+        };
+
+        const workspace = new PerspectiveWorkspace(document.body);
+        workspace.restore(config);
+        workspace.tables.set("test", table);
+        expect(workspace.tables.has("test")).toBeTruthy();
+
+        expect(workspace.tables.delete("test")).toBeFalsy();
+        expect(workspace.tables.has("test")).toBeTruthy();
+    });
+});


### PR DESCRIPTION
This PR fixes a bug in `perspective-workspace` where trying to delete a table threw a `Maximum call stack size exceeded` error