### PR TITLE
updates for compatibility with emscripten 1.39.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,14 @@ tramp
 package-lock.json
 
 # Intellij/WebStorm IDE
+*.iml
 /.idea
 
 # Visual Studio Code configuration
+*.code-workspace
+.history
 /jsconfig.json
+.vscode
 
 # Org-mode
 .org-id-locations

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -243,7 +243,6 @@ if (PSP_WASM_BUILD)
 		set(OPT_FLAGS " \
 			-O3 \
 			-g0 \
-			-s WASM_OBJECT_FILES=0 \
 			--llvm-lto 3 \
 			--closure 1 \
 			-s AGGRESSIVE_VARIABLE_ELIMINATION=1 \

--- a/cpp/perspective/src/include/perspective/utils.h
+++ b/cpp/perspective/src/include/perspective/utils.h
@@ -65,12 +65,12 @@ vec_to_set(const std::vector<DATA_T>& v, std::set<DATA_T>& out_s) {
 inline void
 ltrim_inplace(std::string& s) {
     s.erase(s.begin(),
-        std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+        std::find_if(s.begin(), s.end(), [](int c) {return !std::isspace(c);}));
 }
 
 inline void
 rtrim_inplace(std::string& s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace)))
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int c) {return !std::isspace(c);})
                 .base(),
         s.end());
 }


### PR DESCRIPTION
I was poking around at the build system. It looks like there's a bug in the last few releases of emscripten that would prevent us from using them. However, it just got fixed in emscripten-core/emscripten#10427. This PR has some related changes:

- tweaked some code in utils.h to remove some compiler warnings
- removed `WASM_OBJECT_FILES=0` flag, since the related flag was removed from emscripten. Trying to figure out if anything should go in it's place (see emscripten-core/emscripten#10619)

emscripten-core/emscripten#10427 should be part of the emscripten 1.39.9 release, so when that drops we should pull this PR in.