### PR TITLE
PerspectiveManager no longer treats `str` as `bytes` in Python 2

### DIFF
--- a/python/perspective/perspective/manager/manager.py
+++ b/python/perspective/perspective/manager/manager.py
@@ -231,8 +231,11 @@ class PerspectiveManager(object):
                 elif msg["method"] != "delete":
                     # otherwise parse args as list
                     result = getattr(table_or_view, msg["method"])(*args)
-                if type(result) == bytes:
-                    # return result to the client without JSON serialization
+                if isinstance(result, bytes) and msg["method"] != "to_csv":
+                    # return a binary to the client without JSON serialization,
+                    # i.e. when we return an Arrow. If a method is added that
+                    # returns a string, this condition needs to be updated as
+                    # an Arrow binary is both `str` and `bytes` in Python 2.
                     self._process_bytes(result, msg, post_callback)
                 else:
                     # return the result to the client


### PR DESCRIPTION
This PR fixes a small issue with `PerspectiveManager`, which treated `str` return values as `bytes` and attempted to pass them with the `binary` kwarg set to True. This broke the copy and download features in JupyterLab when running a Python 2 kernel, specifically when calling `to_csv` using the widget.