### PR TITLE
Update typings to include nodejs only components 

### DIFF
--- a/examples/remote-express-typescript/assets/index.css
+++ b/examples/remote-express-typescript/assets/index.css
@@ -1,0 +1,31 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+ perspective-viewer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+@media (max-width: 600px) {
+    html {
+        overflow: hidden;
+    }
+
+    body {
+        position: fixed;
+        height: 100%;
+        width: 100%;
+        margin: 0;
+        overflow: hidden;
+        touch-action: none;
+    }
+}

--- a/examples/remote-express-typescript/assets/index.html
+++ b/examples/remote-express-typescript/assets/index.html
@@ -1,0 +1,69 @@
+<!--
+   
+   Copyright (c) 2017, the Perspective Authors.
+   
+   This file is part of the Perspective library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+
+    <script src="perspective-viewer.js"></script>
+    <script src="perspective-viewer-hypergrid.js"></script>
+    <script src="perspective-viewer-d3fc.js"></script>
+
+    <script src="perspective.js"></script>
+
+    <link rel='stylesheet' href="index.css">
+    <link rel='stylesheet' href="material.dark.css">
+
+</head>
+
+<body>
+
+    <perspective-viewer 
+        id="view1"
+        plugin="d3_heatmap"
+        row-pivots='["client"]'
+        columns='["chg"]'
+        column-pivots='["name"]'>
+    
+    </perspective-viewer>
+
+    <script>
+
+        window.addEventListener('WebComponentsReady', async function() {
+
+            // Create two perspective interfaces, one remotely via WebSocket, 
+            // and one local via WebWorker.
+            
+            const websocket = perspective.websocket(`${window.location.origin.replace("http", "ws")}/subscribe`);
+            const worker = perspective.worker();
+            worker.initialize_profile_thread();
+
+            // Get a proxy for a view named "data_source_one", registered on
+            // the server with a reciprocal call to `host_view()`.
+            // No data is transferred, `view` is a virtual handle for data on
+            // the server.
+            const table = websocket.open_table('remote_table');
+
+            // Create a `table` from this, owned by the local WebWorker.
+            // Data is transferred from `view` to the local WebWorker, both
+            // the current state and all future updates, as Arrows.
+            // const table = worker.table(view, {limit: 10000});
+            
+            // Load this in the `<perspective-viewer>`.
+            document.getElementById('view1').load(table);
+        });
+
+    </script>
+
+</body>
+
+</html>

--- a/examples/remote-express-typescript/package.json
+++ b/examples/remote-express-typescript/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "remote-express-typescript",
+    "private": true,
+    "version": "0.4.5",
+    "description": "An example of 2 Perspectives, one client and one server, streaming via Apache Arrow.",
+    "scripts": {
+        "start": "tsc && node dist/server.js"
+    },
+    "keywords": [],
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@finos/perspective": "^0.4.5",
+        "@finos/perspective-viewer": "^0.4.5",
+        "@finos/perspective-viewer-d3fc": "^0.4.5",
+        "@finos/perspective-viewer-hypergrid": "^0.4.5"
+    },
+    "devDependencies": {
+        "@types/express": "^4.17.3",
+        "@types/express-ws": "^3.0.0"
+    }
+}

--- a/examples/remote-express-typescript/src/server.ts
+++ b/examples/remote-express-typescript/src/server.ts
@@ -1,0 +1,28 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import {WebSocketManager, perspective_assets, Table} from "@finos/perspective";
+import path from "path";
+import express from "express";
+import expressWs from "express-ws";
+import {AddressInfo} from "net";
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import {securities} from "../../datasources";
+
+const app = expressWs(express()).app;
+
+const manager = new WebSocketManager();
+securities().then((table: Table) => manager.host_table("remote_table", table));
+
+app.ws("/subscribe", ws => manager.add_connection(ws));
+app.use("/", perspective_assets([path.resolve(__dirname, "../assets")], true));
+
+const server = app.listen(8080, () => console.log(`Listening on port ${(server.address() as AddressInfo).port}`));

--- a/examples/remote-express-typescript/tsconfig.json
+++ b/examples/remote-express-typescript/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "target": "es6",
+        "noImplicitAny": true,
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "outDir": "./dist",
+        "baseUrl": ".",
+        "strict": true,
+        "alwaysStrict": true,
+    },
+    "include": [
+        "src/server.ts"
+    ],
+    "exclude": [
+        "node_modules",
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@babel/plugin-transform-runtime": "^7.8.3",
         "@babel/polyfill": "^7.8.3",
         "@babel/preset-env": "^7.8.4",
+        "@types/ws": "^7.2.2",
         "@typescript-eslint/eslint-plugin": "^2.4.0",
         "@typescript-eslint/parser": "^2.4.0",
         "arraybuffer-loader": "^1.0.2",

--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -1,4 +1,6 @@
 declare module "@finos/perspective" {
+    import * as ws from "ws";
+
     /**** object types ****/
     export enum TypeNames {
         STRING = "string",
@@ -123,7 +125,7 @@ declare module "@finos/perspective" {
         schema(): Promise<Schema>;
         size(): Promise<number>;
         update(data: TableData): void;
-        view(config: ViewConfig): View;
+        view(config?: ViewConfig): View;
     };
 
     /**** perspective ****/
@@ -135,19 +137,44 @@ declare module "@finos/perspective" {
         table(data: TableData, options?: TableOptions): Table;
     };
 
-    export type Client = {
+    export class WebSocketClient {
         open_table(name: string): Table;
         open_view(name: string): View;
+        terminate(): void;
+        initialize_profile_thread(): void;
+        send(msg: any): void;
+    }
+
+    export type WebSocketServerOptions = {
+        assets?: string[];
+        host_psp?: boolean;
+        port?: number;
+        on_start?: any;
     };
+
+    export class WebSocketManager {
+        add_connection(ws: ws): void;
+        host_table(name: string, table: Table): void;
+        host_view(name: string, view: View): void;
+        eject_table(name: string): void;
+        eject_view(name: string): void;
+    }
+
+    export class WebSocketServer extends WebSocketManager {
+        constructor(config?: WebSocketServerOptions);
+        close(): void;
+    }
+
+    export function perspective_assets(assets: string[], host_psp: boolean): (request: any, response: any) => void;
 
     type perspective = {
         TYPE_AGGREGATES: ValuesByType;
         TYPE_FILTERS: ValuesByType;
         SORT_ORDERS: SortOrders;
-        table(data_or_schema: TableData | Schema, options: TableOptions): Table;
+        table(data_or_schema: TableData | Schema, options?: TableOptions): Table;
         worker(): PerspectiveWorker;
         shared_worker(): PerspectiveWorker;
-        websocket(url: string): Client;
+        websocket(url: string): WebSocketClient;
         override: (x: any) => void;
     };
 

--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -1,85 +1,85 @@
-declare module '@finos/perspective' {
+declare module "@finos/perspective" {
     /**** object types ****/
     export enum TypeNames {
-        STRING = 'string',
-        FLOAT = 'float',
-        INTEGER = 'integer',
-        BOOLEAN = 'boolean',
-        DATE = 'date'
+        STRING = "string",
+        FLOAT = "float",
+        INTEGER = "integer",
+        BOOLEAN = "boolean",
+        DATE = "date"
     }
 
     export type ValuesByType = {
-        [ key in TypeNames ]: Array<string>
-    }
+        [key in TypeNames]: Array<string>;
+    };
 
     export type ValueByType = {
-        TypeNames: Array<string>
-    }
+        TypeNames: Array<string>;
+    };
 
     export enum SortOrders {
-        ASC = 'asc',
-        ASC_ABS = 'asc abs',
-        DESC = 'desc',
-        DESC_ABS = 'desc abs',
-        NONE = 'none',
+        ASC = "asc",
+        ASC_ABS = "asc abs",
+        DESC = "desc",
+        DESC_ABS = "desc abs",
+        NONE = "none"
     }
 
     enum NUMBER_AGGREGATES {
-        ANY = 'any',
-        AVERAGE = 'avg',
-        COUNT = 'count',
-        DISTINCT_COUNT = 'distinct count',
-        DOMINANT = 'dominant',
-        FIRST = 'first',
-        LAST = 'last',
-        HIGH = 'high',
-        LOW = 'low',
-        MEAN = 'mean',
-        MEDIAN = 'median',
-        PCT_SUM_PARENT = 'pct sum parent',
-        PCT_SUM_TOTAL = 'pct sum grand total',
-        SUM = 'sum',
-        SUM_ABS = 'sum abs',
-        SUM_NOT_NULL = 'sum not null',
-        UNIQUE = 'unique'
+        ANY = "any",
+        AVERAGE = "avg",
+        COUNT = "count",
+        DISTINCT_COUNT = "distinct count",
+        DOMINANT = "dominant",
+        FIRST = "first",
+        LAST = "last",
+        HIGH = "high",
+        LOW = "low",
+        MEAN = "mean",
+        MEDIAN = "median",
+        PCT_SUM_PARENT = "pct sum parent",
+        PCT_SUM_TOTAL = "pct sum grand total",
+        SUM = "sum",
+        SUM_ABS = "sum abs",
+        SUM_NOT_NULL = "sum not null",
+        UNIQUE = "unique"
     }
 
     enum STRING_AGGREGATES {
-        ANY = 'any',
-        COUNT = 'count',
-        DISTINCT_COUNT = 'distinct count',
-        DISTINCT_LEAF = 'distinct leaf',
-        DOMINANT = 'dominant',
-        FIRST = 'first',
-        LAST = 'last',
-        UNIQUE = 'unique'
+        ANY = "any",
+        COUNT = "count",
+        DISTINCT_COUNT = "distinct count",
+        DISTINCT_LEAF = "distinct leaf",
+        DOMINANT = "dominant",
+        FIRST = "first",
+        LAST = "last",
+        UNIQUE = "unique"
     }
 
     enum BOOLEAN_AGGREGATES {
-        AND = 'and',
-        ANY = 'any',
-        COUNT = 'count',
-        DISTINCT_COUNT = 'distinct count',
-        DISTINCT_LEAF = 'distinct leaf',
-        DOMINANT = 'dominant',
-        FIRST = 'first',
-        LAST = 'last',
-        OR ='or',
-        UNIQUE = 'unique'
+        AND = "and",
+        ANY = "any",
+        COUNT = "count",
+        DISTINCT_COUNT = "distinct count",
+        DISTINCT_LEAF = "distinct leaf",
+        DOMINANT = "dominant",
+        FIRST = "first",
+        LAST = "last",
+        OR = "or",
+        UNIQUE = "unique"
     }
 
     /**** Schema ****/
     type SchemaType = TypeNames | NUMBER_AGGREGATES | STRING_AGGREGATES | BOOLEAN_AGGREGATES;
 
     export type Schema = {
-        [ key: string ]: TypeNames ;
-    }
+        [key: string]: TypeNames;
+    };
 
     export interface SerializeConfig {
-        start_row: number,
-        end_row: number,
-        start_col: number,
-        end_col: number,
+        start_row: number;
+        end_row: number;
+        start_col: number;
+        end_col: number;
     }
 
     /**** View ****/
@@ -90,27 +90,27 @@ declare module '@finos/perspective' {
         on_delete(callback: Function): void;
         on_update(callback: UpdateCallback): void;
         schema(): Promise<Schema>;
-        to_arrow(options?: SerializeConfig & { data_slice: any }): Promise<ArrayBuffer>;
+        to_arrow(options?: SerializeConfig & {data_slice: any}): Promise<ArrayBuffer>;
         to_columns(options?: SerializeConfig): Promise<Array<object>>;
-        to_csv(options?: SerializeConfig & { config: object }): Promise<string>;
+        to_csv(options?: SerializeConfig & {config: object}): Promise<string>;
         to_json(options?: SerializeConfig): Promise<Array<object>>;
-    }
+    };
 
     /**** Table ****/
-    export type UpdateCallback = (data: Array<object>) => void
+    export type UpdateCallback = (data: Array<object>) => void;
 
-    export type TableData = string | Array<object> | { [key: string]: Array<object> } | { [key: string]: string }
+    export type TableData = string | Array<object> | {[key: string]: Array<object>} | {[key: string]: string};
 
     export type TableOptions = {
-        index?: string,
-        limit?: number
-    }
+        index?: string;
+        limit?: number;
+    };
 
     export type ViewConfig = {
         columns?: Array<string>;
         row_pivots?: Array<string>;
         column_pivots?: Array<string>;
-        aggregates?: { [column_name:string]: string; },
+        aggregates?: {[column_name: string]: string};
         sort?: Array<Array<string>>;
         filter?: Array<Array<string>>;
     };
@@ -124,33 +124,32 @@ declare module '@finos/perspective' {
         size(): Promise<number>;
         update(data: TableData): void;
         view(config: ViewConfig): View;
-    }
+    };
 
     /**** perspective ****/
     export enum PerspectiveEvents {
-        PERSPECTIVE_READY = 'perspective-ready'
+        PERSPECTIVE_READY = "perspective-ready"
     }
 
     export type PerspectiveWorker = {
         table(data: TableData, options?: TableOptions): Table;
-    }
-
+    };
 
     export type Client = {
-        open_table(name: string): Table,
-        open_view(name: string): View,
-    }
+        open_table(name: string): Table;
+        open_view(name: string): View;
+    };
 
     type perspective = {
-        TYPE_AGGREGATES: ValuesByType,
-        TYPE_FILTERS: ValuesByType,
-        SORT_ORDERS: SortOrders,
-        table(data_or_schema : TableData | Schema, options: TableOptions): Table,
-        worker(): PerspectiveWorker,
-        shared_worker(): PerspectiveWorker,
+        TYPE_AGGREGATES: ValuesByType;
+        TYPE_FILTERS: ValuesByType;
+        SORT_ORDERS: SortOrders;
+        table(data_or_schema: TableData | Schema, options: TableOptions): Table;
+        worker(): PerspectiveWorker;
+        shared_worker(): PerspectiveWorker;
         websocket(url: string): Client;
-        override: (x: any) => void
-    }
+        override: (x: any) => void;
+    };
 
     const impl: perspective;
 
@@ -169,4 +168,3 @@ declare module "@finos/perspective/build/psp.sync.wasm" {
 
 declare module "@finos/perspective/build/perspective.wasm.worker.js" {}
 declare module "@finos/perspective/build/perspective.asmjs.worker.js" {}
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,6 +1675,14 @@
     "@types/jquery" "*"
     "@types/underscore" "*"
 
+"@types/body-parser@*":
+  version "1.19.0"
+  resolved "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
+  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
 "@types/cheerio@^0.22.8":
   version "0.22.15"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.15.tgz#69040ffa92c309beeeeb7e92db66ac3f80700c0b"
@@ -1686,6 +1694,13 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/connect@*":
+  version "3.4.33"
+  resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
+  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
 
 "@types/d3-selection@1.0.10":
   version "1.0.10"
@@ -1706,6 +1721,32 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/express-serve-static-core@*":
+  version "4.17.2"
+  resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz#f6f41fa35d42e79dbf6610eccbb2637e6008a0cf"
+  integrity sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==
+  dependencies:
+    "@types/node" "*"
+    "@types/range-parser" "*"
+
+"@types/express-ws@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@types/express-ws/-/express-ws-3.0.0.tgz#89674edba2e9141916fc4d4d30fbd4f810e6b80b"
+  integrity sha512-GxsWec7Vp6h7sJuK0PwnZHeXNZnOwQn8kHAbCfvii66it5jXHTWzSg5cgHVtESwJfBLOe9SJ5wmM7C6gsDoyQw==
+  dependencies:
+    "@types/express" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/ws" "*"
+
+"@types/express@*", "@types/express@^4.17.3":
+  version "4.17.3"
+  resolved "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz#38e4458ce2067873b09a73908df488870c303bd9"
+  integrity sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
 
 "@types/glob@^7.1.1":
   version "7.1.1"
@@ -1758,6 +1799,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
+"@types/mime@*":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
+  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1783,6 +1829,11 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
 "@types/react-dom@^16.9.4":
   version "16.9.4"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.4.tgz#0b58df09a60961dcb77f62d4f1832427513420df"
@@ -1806,6 +1857,14 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/serve-static@*":
+  version "1.13.3"
+  resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
+  integrity sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
+
 "@types/sizzle@*":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
@@ -1820,6 +1879,13 @@
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.9.4.tgz#22d1a3e6b494608e430221ec085fa0b7ccee7f33"
   integrity sha512-CjHWEMECc2/UxOZh0kpiz3lEyX2Px3rQS9HzD20lxMvx571ivOBQKeLnqEjxUY0BMgp6WJWo/pQLRBwMW5v4WQ==
+
+"@types/ws@*", "@types/ws@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-7.2.2.tgz#1bd2038bc80aea60f8a20b2dcf08602a72e65063"
+  integrity sha512-oqnI3DbGCVI9zJ/WHdFo3CUE8jQ8CVQDUIKaDtlTcNeT4zs6UCg9Gvk5QrFx2QPkRszpM6yc8o0p4aGjCsTi+w==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "13.1.0"


### PR DESCRIPTION
This PR adds typings for `WebSocketServer`, `WebSocketManager` and other nodejs components. Also included a typescript nodejs example

Fixes #971