### PR TITLE
`@finos/perspective-viewer-datagrid` Tree Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # [![Perspective](https://perspective.finos.org/img/logo_inverted_tiny.png)](https://perspective.finos.org/)
 
-[![Build Status](https://dev.azure.com/finosfoundation/perspective/_apis/build/status/finos.perspective?branchName=master)](https://dev.azure.com/finosfoundation/perspective/_build/latest?definitionId=1&branchName=master)
 [![npm](https://img.shields.io/npm/v/@finos/perspective.svg?style=flat-square)](https://www.npmjs.com/package/@finos/perspective)
 [![PyPI](https://img.shields.io/pypi/v/perspective-python.svg)](https://pypi.python.org/pypi/perspective-python)
+[![Build Status](https://dev.azure.com/finosfoundation/perspective/_apis/build/status/finos.perspective?branchName=master)](https://dev.azure.com/finosfoundation/perspective/_build/latest?definitionId=1&branchName=master)
 [![FINOS - Active](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-active.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Active)
 
 Perspective is an <i>interactive</i> visualization component for <i>large</i>, <i>real-time</i>
@@ -32,10 +32,14 @@ data or streaming updates via [Apache Arrow](https://arrow.apache.org/).
 ## Examples
 ||||
 |:--|:--|:--|
-|Olympics|Olympics 2|Custom Styles|
-|[![Olympics](http://bl.ocks.org/texodus/raw/efd4a857aca9a52ab6cddbb6e1f701c9/c6c0fb7611ca742830e05cce667678c25b6f288a/thumbnail.png)](https://bl.ocks.org/texodus/efd4a857aca9a52ab6cddbb6e1f701c9)|[![Olympics 2](https://bl.ocks.org/texodus/raw/d4dbf43e52da78e48ade1af4fa9093f4/81fceedb267df95248ceb91db704c6955df2113b/thumbnail.png)](https://bl.ocks.org/texodus/d4dbf43e52da78e48ade1af4fa9093f4)|[![Custom Styles](http://bl.ocks.org/texodus/raw/c42f3189699bd29cf20bbe7dce767b07/62d75a47e049602312ba2597bfd37eb032b156f0/thumbnail.png)](http://bl.ocks.org/texodus/c42f3189699bd29cf20bbe7dce767b07)|
+|Superstore|Olympics|Custom Styles|
+|[![Superstore](https://bl.ocks.org/texodus/raw/803de90736a3641ad91c5c7a1b49d0a7/thumbnail.png)](https://bl.ocks.org/texodus/803de90736a3641ad91c5c7a1b49d0a7)|[![Olympics](http://bl.ocks.org/texodus/raw/efd4a857aca9a52ab6cddbb6e1f701c9/c6c0fb7611ca742830e05cce667678c25b6f288a/thumbnail.png)](https://bl.ocks.org/texodus/efd4a857aca9a52ab6cddbb6e1f701c9)|[![Custom Styles](http://bl.ocks.org/texodus/raw/c42f3189699bd29cf20bbe7dce767b07/62d75a47e049602312ba2597bfd37eb032b156f0/thumbnail.png)](http://bl.ocks.org/texodus/c42f3189699bd29cf20bbe7dce767b07)|
 |Editable|Streaming|CSV|
 |[![Editable](https://bl.ocks.org/texodus/raw/45b868833c9f456bd39a51e606412c5d/e590d237a5237790694946018680719c9fef56cb/thumbnail.png)](https://bl.ocks.org/texodus/45b868833c9f456bd39a51e606412c5d)|[![Streaming](https://bl.ocks.org/texodus/raw/9bec2f8041471bafc2c56db2272a9381/c69c2cfacb23015f3aaeab3555a0035702ffdb1c/thumbnail.png)](https://bl.ocks.org/texodus/9bec2f8041471bafc2c56db2272a9381)|[![CSV](https://bl.ocks.org/texodus/raw/02d8fd10aef21b19d6165cf92e43e668/5e78be024893aa651fcdfac816841d54777ccdec/thumbnail.png)](https://bl.ocks.org/texodus/02d8fd10aef21b19d6165cf92e43e668)|
+|IEX Cloud|NYC Citibike||
+|[![IEX Cloud](https://bl.ocks.org/texodus/raw/eb151fdd9f98bde987538cbc20e003f6/79d409006f50b24f1607758945144b392e4921a2/thumbnail.png)](https://bl.ocks.org/texodus/eb151fdd9f98bde987538cbc20e003f6)|[![NYC Citibike](https://bl.ocks.org/texodus/raw/bc8d7e6f72e09c9dbd7424b4332cacad/f704ce53a3f453f8fe66bd9ff4ead831786384ea/thumbnail.png)](https://bl.ocks.org/texodus/bc8d7e6f72e09c9dbd7424b4332cacad)||
+
+
 
 ## Documentation
 

--- a/examples/simple/superstore.html
+++ b/examples/simple/superstore.html
@@ -21,7 +21,7 @@
     <script src="perspective.js"></script>
 
     <link rel='stylesheet' href="index.css">
-    <link rel='stylesheet' href="material.css" is="custom-style">
+    <link rel='stylesheet' href="material-dense.css" is="custom-style">
     
 
 </head>

--- a/packages/perspective-viewer-datagrid/babel-plugin-transform-tagged-literal.js
+++ b/packages/perspective-viewer-datagrid/babel-plugin-transform-tagged-literal.js
@@ -1,0 +1,29 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const pattern = new RegExp("[\n\t ]+", "g");
+
+// Replace whitespace in `html` tagged literals for minification.
+module.exports = function(babel) {
+    const t = babel.types;
+    return {
+        visitor: {
+            TaggedTemplateExpression(path) {
+                const node = path.node;
+                if (t.isIdentifier(node.tag, {name: "html"})) {
+                    for (const type of ["raw", "cooked"]) {
+                        for (const element of node.quasi.quasis) {
+                            element.value[type] = element.value[type].replace(pattern, " ");
+                        }
+                    }
+                }
+            }
+        }
+    };
+};

--- a/packages/perspective-viewer-datagrid/babel.config.js
+++ b/packages/perspective-viewer-datagrid/babel.config.js
@@ -20,6 +20,7 @@ module.exports = {
         ["@babel/plugin-proposal-decorators", {legacy: true}],
         "transform-custom-element-classes",
         "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-proposal-optional-chaining"
+        "@babel/plugin-proposal-optional-chaining",
+        "./babel-plugin-transform-tagged-literal.js"
     ]
 };

--- a/packages/perspective-viewer-datagrid/src/js/datagrid.js
+++ b/packages/perspective-viewer-datagrid/src/js/datagrid.js
@@ -83,11 +83,12 @@ export class DatagridViewModel extends DatagridViewEventModel {
 
     async set_view(view) {
         const config = await view.get_config();
+        const table_schema = await this._render_element.table.schema();
         const schema = await view.schema();
         const column_paths = await view.column_paths();
         this._invalid_schema = true;
         const options = this.infer_options(config);
-        this._view_cache = {view, config, column_paths, schema};
+        this._view_cache = {view, config, column_paths, schema, table_schema};
         return options;
     }
 

--- a/packages/perspective-viewer-datagrid/src/js/events.js
+++ b/packages/perspective-viewer-datagrid/src/js/events.js
@@ -90,7 +90,7 @@ export class DatagridViewEventModel extends DatagridVirtualTableViewModel {
                 td.style.maxWidth = "none";
                 td.classList.remove("pd-cell-clip");
             }
-            await this.draw({invalid_viewport: true, preserve_scroll_position: true});
+            await this.draw({invalid_viewport: true});
         }
     }
 
@@ -141,7 +141,7 @@ export class DatagridViewEventModel extends DatagridVirtualTableViewModel {
             document.removeEventListener("mouseup", up);
             const override_width = this._column_sizes.override[metadata.size_key];
             this._column_sizes.indices[metadata.cidx] = override_width;
-            await this.draw({invalid_viewport: true, preserve_scroll_position: true});
+            await this.draw({invalid_viewport: true});
         };
         document.addEventListener("mousemove", move);
         document.addEventListener("mouseup", up);
@@ -171,8 +171,9 @@ export class DatagridViewEventModel extends DatagridVirtualTableViewModel {
             td.style.maxWidth = td.style.minWidth = override_width + "px";
             td.classList.toggle("pd-cell-clip", auto_width > override_width);
         }
+
         if (diff < 0) {
-            await this.draw({invalid_viewport: true, preserve_scroll_position: true, preserve_width: true});
+            await this.draw({invalid_viewport: true, preserve_width: true});
         }
     }
 
@@ -234,7 +235,7 @@ export class DatagridViewEventModel extends DatagridVirtualTableViewModel {
                 await this._view_cache.view.expand(metadata.ridx);
             }
         }
-        await this.draw({invalid_viewport: true, preserve_scroll_position: true});
+        await this.draw({invalid_viewport: true});
     }
 
     /**

--- a/packages/perspective-viewer-datagrid/src/js/events.js
+++ b/packages/perspective-viewer-datagrid/src/js/events.js
@@ -52,10 +52,11 @@ export class DatagridViewEventModel extends DatagridVirtualTableViewModel {
         }
         event.preventDefault();
         event.returnValue = false;
-        const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - this._scroll_container.offsetHeight);
-        const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - this._scroll_container.offsetWidth);
-        this._scroll_container.scrollTop = Math.min(total_scroll_height, this._scroll_container.scrollTop + event.deltaY);
-        this._scroll_container.scrollLeft = Math.min(total_scroll_width, this._scroll_container.scrollLeft + event.deltaX);
+        const {offsetWidth, offsetHeight, scrollTop, scrollLeft} = this._scroll_container;
+        const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - offsetHeight);
+        const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - offsetWidth);
+        this._scroll_container.scrollTop = Math.min(total_scroll_height, scrollTop + event.deltaY);
+        this._scroll_container.scrollLeft = Math.min(total_scroll_width, scrollLeft + event.deltaX);
         this._on_scroll(event);
     }
 
@@ -78,9 +79,9 @@ export class DatagridViewEventModel extends DatagridVirtualTableViewModel {
         const metadata = METADATA_MAP.get(element);
         if (is_resize) {
             await new Promise(setTimeout);
-            this._column_sizes.override[metadata.size_key] = undefined;
-            this._column_sizes.auto[metadata.size_key] = undefined;
-            this._column_sizes.indices[metadata.cidx] = undefined;
+            delete this._column_sizes.override[metadata.size_key];
+            delete this._column_sizes.auto[metadata.size_key];
+            delete this._column_sizes.indices[metadata.cidx];
             element.style.minWidth = "0";
             element.style.maxWidth = "none";
             for (const row of this.table_model.body.cells) {

--- a/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
+++ b/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
@@ -113,16 +113,16 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
      * Calculates the `viewport` argument for perspective's `to_columns` method.
      *
      * @param {*} nrows
-     * @param {*} preserve_scroll_position
+     * @param {*} reset_scroll_position
      * @returns
      * @memberof DatagridVirtualTableViewModel
      */
-    _calculate_viewport(nrows, preserve_scroll_position) {
+    _calculate_viewport(nrows, reset_scroll_position) {
         const id = this._view_cache.config.row_pivots.length > 0;
         if (this._virtual_scrolling_disabled) {
             return {id};
         }
-        const {start_row, end_row} = this._calculate_row_range(nrows, preserve_scroll_position);
+        const {start_row, end_row} = this._calculate_row_range(nrows, reset_scroll_position);
         const {start_col, end_col} = this._calculate_column_range();
         this._nrows = nrows;
         return {start_col, end_col, start_row, end_row, id};
@@ -162,17 +162,17 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
      *  600px +--------------------------+
      *
      * @param {*} nrows
-     * @param {*} preserve_scroll_position
+     * @param {*} reset_scroll_position
      * @returns
      * @memberof DatagridVirtualTableViewModel
      */
-    _calculate_row_range(nrows, preserve_scroll_position) {
+    _calculate_row_range(nrows, reset_scroll_position) {
         const {height} = this._container_size;
         const header_levels = this._view_cache.config.column_pivots.length + 1;
         const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - height);
         const percent_scroll = this._scroll_container.scrollTop / total_scroll_height;
         const virtual_panel_row_height = Math.floor(height / ROW_HEIGHT);
-        const relative_nrows = preserve_scroll_position ? this._nrows || 0 : nrows;
+        const relative_nrows = !reset_scroll_position ? this._nrows || 0 : nrows;
         const scroll_rows = Math.max(0, relative_nrows + (header_levels - virtual_panel_row_height));
         let start_row = Math.floor(scroll_rows * percent_scroll);
         let end_row = start_row + virtual_panel_row_height;
@@ -271,8 +271,8 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
      * @returns
      * @memberof DatagridVirtualTableViewModel
      */
-    _needs_swap({invalid_schema, invalid_row, invalid_column}) {
-        return (DOUBLE_BUFFER_RECREATE && invalid_schema) || (DOUBLE_BUFFER_COLUMN && (invalid_column || invalid_schema)) || (DOUBLE_BUFFER_ROW && (invalid_row || invalid_schema));
+    _needs_swap({invalid_row, invalid_column}) {
+        return (DOUBLE_BUFFER_RECREATE && this._invalid_schema) || (DOUBLE_BUFFER_COLUMN && (invalid_column || this._invalid_schema)) || (DOUBLE_BUFFER_ROW && (invalid_row || this._invalid_schema));
     }
 
     /**
@@ -363,7 +363,7 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
         const old_config = Object.assign({}, this._view_cache.config);
         delete old_config["sort"];
         delete config["sort"];
-        return {preserve_scroll_position: isEqual(config, old_config)};
+        return {reset_scroll_position: !isEqual(config, old_config)};
     }
 
     /**
@@ -371,27 +371,27 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
      * the implementor to fine tune the individual render frames based on the
      * interaction and previous render state.
      *
-     * `preserve_scroll_position` will prevent the viewport from moving as
+     * `reset_scroll_position` will not prevent the viewport from moving as
      * `draw()` may change the dmiensions of the virtual_panel (and thus,
      * absolute scroll offset).  This calls `reset_scroll`, which will
      * trigger `_on_scroll` and ultimately `draw()` again;  however, this call
      * to `draw()` will be for the same viewport and will not actually cause
      * a render.
      *
-     * @param {*} [options={preserve_scroll_position = true, preserve_width = false, invalid_viewport = false}]
+     * @param {*} [options={reset_scroll_position = false, preserve_width = false, invalid_viewport = false}]
      * @returns
      * @memberof DatagridVirtualTableViewModel
      */
     @throttlePromise
     async draw(options = {}) {
         const __debug_start_time__ = DEBUG && performance.now();
-        const {preserve_scroll_position = true, preserve_width = false, invalid_viewport = false} = options;
+        const {reset_scroll_position = false, preserve_width = false, invalid_viewport = false} = options;
 
         if (this._view_cache.column_paths === undefined) {
             return;
         }
 
-        if (!preserve_scroll_position) {
+        if (reset_scroll_position) {
             this.reset_scroll();
         }
 
@@ -406,16 +406,17 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
             };
         }
 
-        const viewport = this._calculate_viewport(nrows, preserve_scroll_position);
-        const {invalid_row, invalid_column} = this._validate_viewport(viewport);
+        const viewport = this._calculate_viewport(nrows, reset_scroll_position);
+        const swap_args = this._validate_viewport(viewport);
+        const {invalid_row, invalid_column} = swap_args;
         this._update_virtual_panel_height(nrows);
 
         if (this._invalid_schema || invalid_row || invalid_column || invalid_viewport) {
-            this._swap_in(options);
+            this._swap_in(swap_args);
             await this.table_model.draw(this._container_size, this._view_cache, this._selected_id, preserve_width, viewport);
-            this._swap_out(options);
+            this._swap_out(swap_args);
             if (!preserve_width) {
-                this._update_virtual_panel_width(this._invalid_schema || invalid_column);
+                this._update_virtual_panel_width(this._invalid_schema || invalid_column || invalid_viewport);
             }
             this._invalid_schema = false;
         }

--- a/packages/perspective-viewer-datagrid/src/js/tbody.js
+++ b/packages/perspective-viewer-datagrid/src/js/tbody.js
@@ -29,39 +29,35 @@ export class DatagridBodyViewModel extends ViewModel {
         const metadata = this._get_or_create_metadata(td);
         metadata.id = id;
         metadata.cidx = cidx + cidx_offset;
-        if (metadata.value !== val || metadata.type !== type) {
-            td.className = `pd-${type}`;
-            metadata.type = type;
-            metadata.column = column;
-            metadata.size_key = `${column}|${type}`;
-            const override_width = this._column_sizes.override[metadata.size_key];
-            if (override_width) {
-                const auto_width = this._column_sizes.auto[metadata.size_key];
-                td.classList.toggle("pd-cell-clip", auto_width > override_width);
-                td.style.minWidth = override_width + "px";
-                td.style.maxWidth = override_width + "px";
-            } else {
-                td.classList.remove("pd-cell-clip");
-                td.style.minWidth = "0";
-                td.style.maxWidth = "none";
-            }
-            const formatter = this._format(type);
-            if (val === undefined || val === null) {
-                td.textContent = "-";
-                metadata.value = null;
-                metadata.row_path = null;
-                metadata.ridx = ridx + ridx_offset;
-            } else if (formatter) {
-                formatter.format(td, val, type, val.length === depth, is_open);
-                metadata.value = Array.isArray(val) ? val[val.length - 1] : val;
-                metadata.row_path = val;
-                metadata.ridx = ridx + ridx_offset;
-                metadata.is_open = is_open;
-            } else {
-                td.textContent = val;
-                metadata.value = val;
-                metadata.ridx = ridx + ridx_offset;
-            }
+        metadata.type = type;
+        metadata.column = column;
+        metadata.size_key = `${column}|${type}`;
+        metadata.ridx = ridx + ridx_offset;
+        td.className = `pd-${type}`;
+        const override_width = this._column_sizes.override[metadata.size_key];
+        if (override_width) {
+            const auto_width = this._column_sizes.auto[metadata.size_key];
+            td.classList.toggle("pd-cell-clip", auto_width > override_width);
+            td.style.minWidth = override_width + "px";
+            td.style.maxWidth = override_width + "px";
+        } else {
+            td.classList.remove("pd-cell-clip");
+            td.style.minWidth = "0";
+            td.style.maxWidth = "none";
+        }
+        const formatter = this._format(type);
+        if (val === undefined || val === null) {
+            td.textContent = "-";
+            metadata.value = null;
+            metadata.row_path = null;
+        } else if (formatter) {
+            formatter.format(td, val, type, val.length === depth, is_open);
+            metadata.value = Array.isArray(val) ? val[val.length - 1] : val;
+            metadata.row_path = val;
+            metadata.is_open = is_open;
+        } else {
+            td.textContent = val;
+            metadata.value = val;
         }
 
         return {td, metadata};

--- a/packages/perspective-viewer-datagrid/src/js/tbody.js
+++ b/packages/perspective-viewer-datagrid/src/js/tbody.js
@@ -30,7 +30,7 @@ export class DatagridBodyViewModel extends ViewModel {
         metadata.id = id;
         metadata.cidx = cidx + cidx_offset;
         if (metadata.value !== val || metadata.type !== type) {
-            td.className = type;
+            td.className = `pd-${type}`;
             metadata.type = type;
             metadata.column = column;
             metadata.size_key = `${column}|${type}`;
@@ -42,7 +42,6 @@ export class DatagridBodyViewModel extends ViewModel {
                 td.style.maxWidth = override_width + "px";
             } else {
                 td.classList.remove("pd-cell-clip");
-
                 td.style.minWidth = "0";
                 td.style.maxWidth = "none";
             }
@@ -53,7 +52,7 @@ export class DatagridBodyViewModel extends ViewModel {
                 metadata.row_path = null;
                 metadata.ridx = ridx + ridx_offset;
             } else if (formatter) {
-                formatter.format(td, val, val.length === depth, is_open);
+                formatter.format(td, val, type, val.length === depth, is_open);
                 metadata.value = Array.isArray(val) ? val[val.length - 1] : val;
                 metadata.row_path = val;
                 metadata.ridx = ridx + ridx_offset;

--- a/packages/perspective-viewer-datagrid/src/js/thead.js
+++ b/packages/perspective-viewer-datagrid/src/js/thead.js
@@ -117,7 +117,7 @@ export class DatagridHeaderViewModel extends ViewModel {
             }
         }
 
-        if (header_levels === 1 && type === undefined) {
+        if (header_levels === 1 && Array.isArray(type)) {
             th.classList.add("pd-group-header");
         }
         const metadata = this._get_or_create_metadata(th);

--- a/packages/perspective-viewer-datagrid/src/js/thead.js
+++ b/packages/perspective-viewer-datagrid/src/js/thead.js
@@ -10,12 +10,6 @@
 import {ViewModel} from "./view_model";
 import {ICON_MAP} from "./constants";
 
-/******************************************************************************
- *
- * Utilities
- *
- */
-
 /**
  * <thead> view model.  This model accumulates state in the form of
  * column_sizes, which leverages <tables> autosize behavior across

--- a/packages/perspective-viewer-datagrid/src/js/thead.js
+++ b/packages/perspective-viewer-datagrid/src/js/thead.js
@@ -75,7 +75,7 @@ export class DatagridHeaderViewModel extends ViewModel {
         metadata.size_key = `${column}|${type}`;
         const auto_width = this._column_sizes.auto[metadata.size_key];
         const override_width = this._column_sizes.override[metadata.size_key];
-        th.classList.add(type);
+        th.classList.add(`pd-${type}`);
         if (override_width) {
             th.classList.toggle("pd-cell-clip", auto_width > override_width);
             th.style.minWidth = override_width + "px";

--- a/packages/perspective-viewer-datagrid/src/js/tree_row_header.js
+++ b/packages/perspective-viewer-datagrid/src/js/tree_row_header.js
@@ -1,0 +1,51 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import {html} from "./utils";
+
+function _tree_header_classes(name, type, is_leaf) {
+    const cls = this._format_class(type)(name);
+    const header_classes = ["pd-group-name"];
+    if (is_leaf) {
+        header_classes.push("pd-group-leaf");
+    }
+
+    if (cls) {
+        header_classes.push(cls);
+    }
+
+    return header_classes.join(" ");
+}
+
+function _tree_header_levels(path, is_open, is_leaf) {
+    const tree_levels = path.map(() => `<span class="pd-tree-group"></span>`);
+    if (!is_leaf) {
+        const group_icon = is_open ? "remove" : "add";
+        const tree_button = `<span class="pd-row-header-icon">${group_icon}</span>`;
+        tree_levels.push(tree_button);
+    }
+
+    return tree_levels.join("");
+}
+
+export function tree_header(td, path, types, is_leaf, is_open) {
+    const type = types[path.length - 1];
+    const name = path[path.length - 1] || "TOTAL";
+    const header_classes = _tree_header_classes.call(this, name, type, is_leaf);
+    const tree_levels = _tree_header_levels(path, is_open, is_leaf);
+    const header_text = this._format_text(type)(name);
+
+    td.classList.add("pd-group-header");
+    td.innerHTML = html`
+        <div style="display:flex;align-items:stretch">
+            ${tree_levels}
+            <span class="${header_classes}">${header_text}</span>
+        </div>
+    `;
+}

--- a/packages/perspective-viewer-datagrid/src/js/utils.js
+++ b/packages/perspective-viewer-datagrid/src/js/utils.js
@@ -107,3 +107,14 @@ export function column_path_2_type(schema, column) {
     let parts = column.split("|");
     return schema[parts[parts.length - 1]];
 }
+
+/**
+ * Identical to a non-tagger template literal, this is only used to indicate to
+ * babel that this string should be HTML-minified on production builds.
+ */
+export const html = (strings, ...args) =>
+    strings
+        .map((str, i) => [str, args[i]])
+        .flat()
+        .filter(a => !!a)
+        .join("");

--- a/packages/perspective-viewer-datagrid/src/less/material.less
+++ b/packages/perspective-viewer-datagrid/src/less/material.less
@@ -13,31 +13,31 @@ th {
     text-align: center;
 }
 
-thead tr:last-child th.float,
-tbody td.float {
+thead tr:last-child .pd-float,
+tbody .pd-float {
     text-align: right;
 }
 
-thead th.integer,
-tbody td.integer {
+thead .pd-integer,
+tbody .pd-integer {
     text-align: right;
 }
 
 
-td.pd-positive {
+.pd-positive {
     color: #1078d1;
 }
 
-td.pd-negative {
+.pd-negative {
     color: #de3838;
 }
 
-thead th.string,
-tbody td.string,
-thead th.date,
-tbody td.date,
-thead th.datetime,
-tbody td.datetime  {
+thead .pd-string,
+tbody .pd-string,
+thead .pd-date,
+tbody .pd-date,
+thead .pd-datetime,
+tbody .pd-datetime  {
     text-align: left;
 }
 

--- a/packages/perspective-viewer-datagrid/test/results/linux.docker.json
+++ b/packages/perspective-viewer-datagrid/test/results/linux.docker.json
@@ -1,15 +1,15 @@
 {
     "superstore_replaces_all_rows_": "7f95361aa2a268a8ee842c4632513578",
-    "__GIT_COMMIT__": "dd2cf3b493844a1995bd52a08d270e241e219814",
+    "__GIT_COMMIT__": "8a1e33ce823d86e0b6dbbdcdac15cff5910c2fc8",
     "empty_empty_grids_do_not_explode": "deb15d155a84145e67da078c803e3eec",
     "regressions_Updates_should_not_render_an_extra_row_for_column_only_views": "676bcaac0bc0d63a2bfa3bd254443b0c",
-    "regressions_Updates_regular_updates": "b1633116a02ca923b95bc277c10adba5",
-    "regressions_Updates_saving_a_computed_column_does_not_interrupt_update_rendering": "718884fdbb8e976354ec18b3eddbb370",
+    "regressions_Updates_regular_updates": "86561ee0ebe91f656f56941e7ff1cf35",
+    "regressions_Updates_saving_a_computed_column_does_not_interrupt_update_rendering": "17f79bc23ea6ea8b54aea4ee367aedd0",
     "superstore_shows_a_grid_without_any_settings_applied_": "4fb387275da7c37f5aaf25af52d9e8d5",
-    "superstore_pivots_by_a_row_": "e902ab3ebaad2199480b456f2e33d656",
+    "superstore_pivots_by_a_row_": "e64d28c2d3e0db45becc230dfc2e6074",
     "superstore_pivots_by_two_rows_": "d0a51ead0b7e397be9b554a56a66e7d4",
     "superstore_pivots_by_a_column_": "ba5ffdc9676ffb53c22f1f5f40bd5c3d",
-    "superstore_pivots_by_a_row_and_a_column_": "fec839043c2c94bc65c4cf12e1762ac1",
+    "superstore_pivots_by_a_row_and_a_column_": "f49e287f55f90a9e583e35ed1d83561b",
     "superstore_pivots_by_two_rows_and_two_columns_": "7e6c8016d402fadd880b162aa38f9bd1",
     "superstore_sorts_by_a_hidden_column_": "f0beae68b6506d75f3126db285d03290",
     "superstore_sorts_by_a_numeric_column_": "b598f9af4aa390f51435e8a8f1fc3020",
@@ -18,6 +18,6 @@
     "superstore_highlights_invalid_filter_": "311401a388e8cf89d0f9a5c5a1eb9146",
     "superstore_sorts_by_an_alpha_column_": "bc2c035e1c21eab541ae2e1119289913",
     "superstore_displays_visible_columns_": "f7ab6c498375d5b98b47ef582105ea25",
-    "superstore_resets_viewable_area_when_the_logical_size_expands_": "8ec6f8f7d4a24c50a006adae19f52913",
+    "superstore_resets_viewable_area_when_the_logical_size_expands_": "a7262cf9d6810d3effd2c00a8e1a464b",
     "superstore_resets_viewable_area_when_the_physical_size_expands_": "4fb387275da7c37f5aaf25af52d9e8d5"
 }

--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -307,7 +307,8 @@ class PerspectiveViewer extends ActionElement {
     }
 
     /**
-     * Sets the currently selected plugin, via its `name` field.
+     * Sets the currently selected plugin, via its `name` field, and removes
+     * any children the previous plugin may have left behind in the light DOM.
      *
      * @type {string}
      * @fires PerspectiveViewer#perspective-config-update
@@ -317,7 +318,7 @@ class PerspectiveViewer extends ActionElement {
             this.setAttribute("plugin", this._vis_selector.options[0].value);
             return;
         }
-
+        this.innerHTML = "";
         const plugin_names = Object.keys(renderers.getInstance());
         if (this.hasAttribute("plugin")) {
             let plugin = this.getAttribute("plugin");


### PR DESCRIPTION
Adds type-aware formatting and customization to tree headers.

<img width="381" alt="Screen Shot 2020-03-27 at 2 43 19 AM" src="https://user-images.githubusercontent.com/60666/77861828-6ab64100-71e5-11ea-99c4-c1f308458f2e.png">

Also cleans up DOM initialization methods in `scroll_panel.js` and `view_model.js` (now `tree_row_header.js`);  these now use `innerHTML` and template literal strings, but with a custom babel plugin `babel-plugin-transform-tagged-literal.js` which strips format whitespace, which would otherwise be ignored by the minifier (Terser).