### PR TITLE
Look for PyArrow relative to Perspective in @rpath

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -552,10 +552,11 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
         set(CMAKE_INSTALL_NAME_DIR "@rpath/")
 
+		# module_origin_path is the location of the binary
         if(MACOS)
-            set(module_install_rpath "@loader_path/")
+            set(module_origin_path "@loader_path/")
 	    else()
-            set(module_install_rpath "\$ORIGIN")
+            set(module_origin_path "\$ORIGIN")
 		endif()
 	else()
 		set(CMAKE_SHARED_LIBRARY_PREFIX lib)
@@ -584,8 +585,13 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 			set_property(TARGET binding PROPERTY SUFFIX .pyd)
 		else()
 			target_compile_options(binding PRIVATE -Wdeprecated-declarations)
-            set_property(TARGET psp PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${module_install_rpath}  ${PYTHON_PYARROW_LIBRARY_DIR})
-            set_property(TARGET binding PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${module_install_rpath}  ${PYTHON_PYARROW_LIBRARY_DIR})
+			# Add a relative path to search for PyArrow - when Perspective is
+			# installed from a wheel, PyArrow may not be in the same directory
+			# as the PyArrow which was used to build the wheel. Assuming that
+			# both Pyarrow and Perspective are installed in `site-packages`,
+			# the relative search path should be able to pick up pyarrow.
+            set_property(TARGET psp PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${module_origin_path} "${module_origin_path}/../../pyarrow" ${PYTHON_PYARROW_LIBRARY_DIR})
+            set_property(TARGET binding PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${module_origin_path} "${module_origin_path}/../../pyarrow" ${PYTHON_PYARROW_LIBRARY_DIR})
 		endif()
 
 		target_link_libraries(psp ${PYTHON_PYARROW_LIBRARIES})

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
         "build_python": "node scripts/build_python.js",
         "bench": "node scripts/bench.js",
         "bench_python": "python3 python/perspective/bench/perspective_benchmark.py",
+        "_wheel_python": "node scripts/_wheel_python.js",
         "setup": "node scripts/setup.js",
         "docs": "node scripts/docs.js",
         "test": "node scripts/test.js",

--- a/scripts/_wheel_python.js
+++ b/scripts/_wheel_python.js
@@ -1,0 +1,52 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const {execute, docker, clean, resolve, getarg, bash, python_image} = require("./script_utils.js");
+const fs = require("fs-extra");
+const IS_PY2 = getarg("--python2");
+const PYTHON = IS_PY2 ? "python2" : getarg("--python38") ? "python3.8" : "python3.7";
+const IMAGE = python_image(getarg("--manylinux2010") ? "manylinux2010" : getarg("--manylinux2014") ? "manylinux2014" : "", PYTHON);
+
+/**
+ * Using Perspective's docker images, create a wheel built for the image
+ * architecture and output it to the local filesystem.
+ */
+try {
+    console.log("Copying assets to `dist` folder");
+    const dist = resolve`${__dirname}/../python/perspective/dist`;
+    const cpp = resolve`${__dirname}/../cpp/perspective`;
+    const lic = resolve`${__dirname}/../LICENSE`;
+    const cmake = resolve`${__dirname}/../cmake`;
+    const dcmake = resolve`${dist}/cmake`;
+    const dlic = resolve`${dist}/LICENSE`;
+    const obj = resolve`${dist}/obj`;
+
+    fs.mkdirpSync(dist);
+    fs.copySync(cpp, dist, {preserveTimestamps: true});
+    fs.copySync(lic, dlic, {preserveTimestamps: true});
+    fs.copySync(cmake, dcmake, {preserveTimestamps: true});
+    clean(obj);
+
+    let cmd;
+
+    if (IS_PY2) {
+        // shutil_which is required in setup.py
+        cmd = bash`${PYTHON} -m pip install backports.shutil_which &&`;
+    } else {
+        cmd = bash``;
+    }
+
+    // Create a wheel
+    cmd = cmd + `${PYTHON} setup.py bdist_wheel`;
+    console.log(`Building wheel for \`perspective-python\` using ${IMAGE} in Docker`);
+    execute`${docker(IMAGE)} bash -c "cd python/perspective && ${cmd} "`;
+} catch (e) {
+    console.error(e.message);
+    process.exit(1);
+}


### PR DESCRIPTION
This PR adds an entry to `INSTALL_RPATH ` that allows the binary to look for PyArrow in a directory relative to `libbinding.so`. 

I ran into this problem when trying to push a Manylinux 2010 wheel of Perspective onto a Heroku dyno, which stores its Python packages in `/app/.heroku/`. Perspective was only looking for `pyarrow` using the path of `pyarrow` supplied to it from the machine that _built_ the wheel, which was different from the machine that the wheel was installed to.

Adding the new entry to `INSTALL_RPATH` makes the assumption that both `perspective-python` and `pyarrow` are installed to the same site-packages folder. This change is only useful for installing from wheel; if a user builds Perspective from source, the path to `pyarrow` has to be correct for the build to succeed.

Additionally, this PR adds a `_wheel_python` script to allow quick generation of wheels to the local filesystem using Perspective's Manylinux and Python docker containers. It supports the same command line arguments as `build_python`, allowing selection between Python 2/3 as well as Manylinux 2010/2014.