### PR TITLE
Update Python benchmarks to include results for `update` calls

### DIFF
--- a/python/perspective/bench/bench.py
+++ b/python/perspective/bench/bench.py
@@ -12,6 +12,7 @@ import signal
 import subprocess
 import venv
 import tornado
+from datetime import datetime
 from timeit import timeit
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
 from perspective import Table, PerspectiveManager, PerspectiveTornadoHandler  # noqa: E402
@@ -207,8 +208,9 @@ class Runner(object):
     def write_results(self):
         if self._table is None:
             return
-        logging.info("Writing results to `benchmark.arrow`")
-        arrow_path = os.path.join(os.path.dirname(__file__), "benchmark.arrow")
+        name = "benchmark_{}_.arrow".format(datetime.now().isoformat())
+        logging.info("Writing results to `{}`".format(name))
+        arrow_path = os.path.join(os.path.dirname(__file__), name)
         with open(arrow_path, "wb") as file:
             arrow = self._table.view().to_arrow()
             file.write(arrow)

--- a/python/perspective/bench/run_perspective_benchmark.py
+++ b/python/perspective/bench/run_perspective_benchmark.py
@@ -41,8 +41,7 @@ if __name__ == "__main__":
     for version in VERSIONS[1:]:
         print("Installing perspective-python=={}".format(version))
         subprocess.check_output(
-            "yes | python3 -m pip uninstall perspective-python".format(version),
-            shell=True)
+            "yes | python3 -m pip uninstall perspective-python", shell=True)
         subprocess.check_output(
             "yes | python3 -m pip install perspective-python=={}".format(version),
             shell=True)


### PR DESCRIPTION
This PR improves the Python benchmarks by adding tests for calls to `update`, which is now benchmarked for both JSON and `pandas.DataFrame` when 10 views of various pivots are created and forced to be notified on each update. The benchmark measures the amount of time it takes to call `update` and then `Table.size()`, which forces processing of the update before returning a value.