### PR TITLE
When updating tables typed as `int` with `float64` numpy arrays, copy instead of filling iteratively

### DIFF
--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -170,43 +170,43 @@ get_dtype_descr(t_dtype dtype) {
             return "none";
         } break;
         case DTYPE_INT64: {
-            return "i64";
+            return "int64";
         } break;
         case DTYPE_INT32: {
-            return "i32";
+            return "int32";
         } break;
         case DTYPE_INT16: {
-            return "i16";
+            return "int16";
         } break;
         case DTYPE_INT8: {
-            return "i8";
+            return "int8";
         } break;
         case DTYPE_UINT64: {
-            return "u64";
+            return "uint64";
         } break;
         case DTYPE_UINT32: {
-            return "u32";
+            return "uint32";
         } break;
         case DTYPE_UINT16: {
-            return "u16";
+            return "uint16";
         } break;
         case DTYPE_UINT8: {
-            return "u8";
+            return "uint8";
         } break;
         case DTYPE_BOOL: {
             return "bool";
         } break;
         case DTYPE_FLOAT64: {
-            return "f64";
+            return "float64";
         } break;
         case DTYPE_FLOAT32: {
-            return "f32";
+            return "float32";
         } break;
         case DTYPE_STR: {
             return "str";
         } break;
         case DTYPE_TIME: {
-            return "time";
+            return "datetime";
         } break;
         case DTYPE_DATE: {
             return "date";

--- a/python/perspective/perspective/core/data/__init__.py
+++ b/python/perspective/perspective/core/data/__init__.py
@@ -6,5 +6,5 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
-from .np import deconstruct_numpy   # noqa: F401
+from .np import deconstruct_numpy, make_null_mask   # noqa: F401
 from .pd import deconstruct_pandas  # noqa: F401

--- a/python/perspective/perspective/core/data/np.py
+++ b/python/perspective/perspective/core/data/np.py
@@ -13,17 +13,18 @@ from datetime import datetime
 DATE_DTYPES = [np.dtype("datetime64[D]"), np.dtype("datetime64[W]"), np.dtype("datetime64[M]"), np.dtype("datetime64[Y]")]
 
 
-def deconstruct_numpy(array):
-    '''Given a numpy array, parse it and return the data as well as a numpy
-    array of null indices.
+def make_null_mask(array):
+    """Given a numpy array, return a numpy array of int64s containing the
+    indices of `array` where the value is either invalid or null.
+
+    Invalid values are:
+        - None
+        - numpy.nat
+        - numpy.nan
 
     Args:
-        array (numpy.array)
-
-    Returns:
-        `dict`: `array` is the original array, and `mask` is an array of
-            booleans where `True` represents a nan/None value.
-    '''
+        array (:obj:`numpy.array`)
+    """
     mask = []
 
     is_object_or_string_dtype = np.issubdtype(array.dtype, np.str_) or\
@@ -46,6 +47,26 @@ def deconstruct_numpy(array):
 
         if invalid:
             mask.append(i)
+
+    return mask
+
+
+def deconstruct_numpy(array, mask=None):
+    '''Given a numpy array, parse it and return the data as well as a numpy
+    array of null indices.
+
+    Args:
+        array (:obj:`numpy.array`)
+
+    Keyword Args:
+        mask (:obj:`numpy.array`)
+
+    Returns:
+        (:obj:`dict`): `array` is the original array, and `mask` is an array of
+            booleans where `True` represents a nan/None value.
+    '''
+    if mask is None:
+        mask = make_null_mask(array)
 
     if array.dtype == bool or array.dtype == "?":
         # bool => byte

--- a/python/perspective/perspective/include/perspective/python/numpy.h
+++ b/python/perspective/perspective/include/perspective/python/numpy.h
@@ -49,8 +49,6 @@ namespace numpy {
              */
             void init();
 
-            bool has_numeric_dtype() const;
-
             /**
              * Given `inferred_types` from Perspective, use the `m_types` array of numpy array dtypes and 
              * reconcile differences between numeric dtypes by *preferring the dtype of the numpy array* and 
@@ -150,12 +148,6 @@ namespace numpy {
 
             bool m_init;
 
-            /**
-             * A flag to determine whether to reconcile numpy array dtype with perspective inferred types.
-             *
-             * Defaults to false - is true when any array dtype is of int/float/bool.
-             */
-            bool m_has_numeric_dtype;
             py::object m_accessor;
             std::vector<std::string> m_names;
             std::vector<t_dtype> m_types;

--- a/python/perspective/perspective/src/numpy.cpp
+++ b/python/perspective/perspective/src/numpy.cpp
@@ -19,7 +19,6 @@ namespace numpy {
 
     NumpyLoader::NumpyLoader(py::object accessor)
         : m_init(false)
-        , m_has_numeric_dtype(false)
         , m_accessor(accessor) {}
 
     NumpyLoader::~NumpyLoader() {}
@@ -29,12 +28,6 @@ namespace numpy {
         m_names = make_names();
         m_types = make_types();
         m_init = true;
-    }
-
-    bool
-    NumpyLoader::has_numeric_dtype() const {
-        PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-        return m_has_numeric_dtype;
     }
 
     std::vector<t_dtype> 

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -208,6 +208,12 @@ class Table(object):
             [name for name in self._accessor._names if name == "__INDEX__"]
         self._accessor._types = types[:len(columns)]
 
+        if self._accessor._is_numpy:
+            # Try to cast arrays to the Perspective dtype before they end up in
+            # the C++, thus allowing for int/floats to be copied when they are
+            # the same bit width
+            self._accessor.try_cast_numpy_arrays()
+
         if "__INDEX__" in self._accessor._names:
             if self._index != "":
                 index_pos = self._accessor._names.index(self._index)


### PR DESCRIPTION
This PR speeds up `perspective-python`'s numpy loading by adding a code path for a very common requirement - when a column is typed as an integer and updated with a `numpy.float64` array, the array is not trivially copyable into the column's underlying memory, and must be filled iteratively.

This slows down update speeds for dataframes/numpy arrays dramatically, and is an extremely common case given that most numpy arrays are defined as `float64`, and that users may prefer the truncation of unnecessary decimal points. By converting the `float64` array to `int64` before the C++ numpy loader attempts to load the update dataset, the array is made copyable and thus can be loaded with a massive (4-6x) speed increase over iterative fills.

Converting arrays from float to int maintains order and correctness of the values, as well as position of `numpy.nan`s - Perspective constructs a null mask _before_ the array is converted, and the indices of that null mask are used to apply `null` values on top of indices where the float-to-int conversion turns `numpy.nan` into garbage values.