### PR TITLE
Update to emsdk 1.39.12 and remove 2gb MAXIMUM_MEMORY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,14 @@ tramp
 package-lock.json
 
 # Intellij/WebStorm IDE
+*.iml
 /.idea
 
 # Visual Studio Code configuration
+*.code-workspace
+.history
 /jsconfig.json
+.vscode
 
 # Org-mode
 .org-id-locations

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -244,7 +244,6 @@ if (PSP_WASM_BUILD)
 		set(OPT_FLAGS " \
 			-O3 \
 			-g0 \
-			-s WASM_OBJECT_FILES=0 \
 			--llvm-lto 3 \
 			--closure 1 \
 			-s AGGRESSIVE_VARIABLE_ELIMINATION=1 \

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -224,6 +224,7 @@ if (PSP_WASM_BUILD)
 		-s MODULARIZE=1 \
 		-s EXPORT_NAME=\"load_perspective\" \
 		-s EXPORT_ES6=1 \
+		-s MAXIMUM_MEMORY=-1 \
 		-s USE_ES6_IMPORT_META=0 \
 		-s EXPORTED_FUNCTIONS=\"['_main']\" \
 		")
@@ -244,7 +245,7 @@ if (PSP_WASM_BUILD)
 		set(OPT_FLAGS " \
 			-O3 \
 			-g0 \
-			--llvm-lto 3 \
+			-flto \
 			--closure 1 \
 			-s AGGRESSIVE_VARIABLE_ELIMINATION=1 \
 			")

--- a/cpp/perspective/src/cpp/config.cpp
+++ b/cpp/perspective/src/cpp/config.cpp
@@ -23,8 +23,8 @@ t_config::t_config(const std::vector<std::string>& row_pivots,
     , m_col_sortspecs(col_sortspecs)
     , m_aggregates(aggregates)
     , m_detail_columns(col_names) // this should be the columns property
-    , m_combiner(combiner)
-    , m_fterms(fterms) {
+    , m_fterms(fterms)
+    , m_combiner(combiner) {
     for (const auto& p : row_pivots) {
         m_row_pivots.push_back(t_pivot(p));
     }
@@ -102,8 +102,8 @@ t_config::t_config(const std::vector<std::string>& row_pivots,
     const t_totals totals, t_filter_op combiner, const std::vector<t_fterm>& fterms)
     : m_aggregates(aggregates)
     , m_totals(totals)
-    , m_combiner(combiner)
     , m_fterms(fterms)
+    , m_combiner(combiner)
     , m_fmode(FMODE_SIMPLE_CLAUSES) {
     for (const auto& p : row_pivots) {
         m_row_pivots.push_back(t_pivot(p));

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -549,7 +549,6 @@ t_ctx0::calc_step_delta(const t_data_table& flattened, const t_data_table& prev,
 
     const t_column* pkey_col = flattened.get_const_column("psp_pkey").get();
 
-    t_uindex ncols = m_config.get_num_columns();
     const auto& column_names = m_config.get_column_names();
 
     for (const auto& name : column_names) {

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -764,10 +764,7 @@ namespace binding {
                 continue;
             }
 
-            std::wstring welem = item.as<std::wstring>();
-            std::wstring_convert<utf16convert_type, wchar_t> converter;
-            std::string elem = converter.to_bytes(welem);
-            col->set_nth(i, elem);
+            col->set_nth(i, item.as<std::string>());
         }
     }
 
@@ -909,11 +906,7 @@ namespace binding {
                 break;
             }
             case DTYPE_STR: {
-                std::wstring welem = value.as<std::wstring>();
-
-                std::wstring_convert<utf16convert_type, wchar_t> converter;
-                std::string elem = converter.to_bytes(welem);
-                col->set_nth(idx, elem, STATUS_VALID);
+                col->set_nth(idx, value.as<std::string>(), STATUS_VALID);
                 break;
             }
             case DTYPE_DATE: {

--- a/cpp/perspective/src/cpp/gnode.cpp
+++ b/cpp/perspective/src/cpp/gnode.cpp
@@ -907,7 +907,6 @@ t_gnode::_add_computed_column(
     const t_computed_column_definition& computed_column,
     std::shared_ptr<t_data_table> tbl) {
     std::string computed_column_name = std::get<0>(computed_column);
-    t_computed_function_name computed_function_name = std::get<1>(computed_column);
     std::vector<std::string> input_column_names = std::get<2>(computed_column);
     t_computation computation = std::get<3>(computed_column);
 
@@ -934,7 +933,6 @@ t_gnode::_compute_column(
     std::vector<std::shared_ptr<t_column>> input_columns;
 
     std::string computed_column_name = std::get<0>(computed_column);
-    t_computed_function_name computed_function_name = std::get<1>(computed_column);
     std::vector<std::string> input_column_names = std::get<2>(computed_column);
     t_computation computation = std::get<3>(computed_column);
     
@@ -976,7 +974,6 @@ t_gnode::_recompute_column(
     std::vector<std::shared_ptr<t_column>> flattened_columns;
 
     std::string computed_column_name = std::get<0>(computed_column);
-    t_computed_function_name computed_function_name = std::get<1>(computed_column);
     std::vector<std::string> input_column_names = std::get<2>(computed_column);
     t_computation computation = std::get<3>(computed_column);
 

--- a/cpp/perspective/src/include/perspective/utils.h
+++ b/cpp/perspective/src/include/perspective/utils.h
@@ -65,12 +65,12 @@ vec_to_set(const std::vector<DATA_T>& v, std::set<DATA_T>& out_s) {
 inline void
 ltrim_inplace(std::string& s) {
     s.erase(s.begin(),
-        std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+        std::find_if(s.begin(), s.end(), [](int c) {return !std::isspace(c);}));
 }
 
 inline void
 rtrim_inplace(std::string& s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace)))
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int c) {return !std::isspace(c);})
                 .base(),
         s.end());
 }

--- a/docker/emsdk/Dockerfile
+++ b/docker/emsdk/Dockerfile
@@ -25,7 +25,7 @@ FROM debian:stretch AS stage_build
 # -------------------------------- STAGE BUILD  --------------------------------
 # ------------------------------------------------------------------------------
 
-ENV EMSCRIPTEN_SDK 1.38.46-upstream
+ENV EMSCRIPTEN_SDK 1.39.12
 ENV EMSDK_CHANGESET master
 
 # ------------------------------------------------------------------------------
@@ -432,8 +432,6 @@ RUN printf '#include <iostream>\n#include <emscripten.h>\n#include <emscripten/b
 
 RUN em++ --std=c++14 -O3 test.cpp -o test.js --closure 1
 RUN node test.js
-
-RUN embuilder.py build libc-extras
 
 RUN cd /
 RUN rm -fr /tmp/emscripten_test

--- a/docker/emsdk/Dockerfile
+++ b/docker/emsdk/Dockerfile
@@ -25,7 +25,7 @@ FROM debian:stretch AS stage_build
 # -------------------------------- STAGE BUILD  --------------------------------
 # ------------------------------------------------------------------------------
 
-ENV EMSCRIPTEN_SDK 1.39.12
+ENV EMSCRIPTEN_SDK 1.39.13
 ENV EMSDK_CHANGESET master
 
 # ------------------------------------------------------------------------------
@@ -398,7 +398,6 @@ libidn11
 
 RUN apt-get -qq update && apt-get install -q -y software-properties-common
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA9EF27F
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y
 RUN apt-get -qq update && apt-get install -qy g++ gcc git wget
 RUN wget --quiet --max-redirect 3 https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
 RUN mkdir -p /usr/include/boost && tar zxf boost_1_71_0.tar.gz -C /usr/include/boost --strip-components=1

--- a/packages/perspective-bench/src/js/bench.js
+++ b/packages/perspective-bench/src/js/bench.js
@@ -59,23 +59,8 @@ async function run_node_version(args, run_test) {
     return await js.run();
 }
 
-function new_host() {
-    return new Promise(
-        resolve =>
-            new perspective.WebSocketServer({
-                assets: ["build"],
-                port: 0,
-                on_start: function() {
-                    resolve(this);
-                }
-            })
-    );
-}
-
 exports.run = async function run(version, benchmark, ...cmdArgs) {
     const options = cmdArgs.splice(cmdArgs.length - 1, 1)[0];
-    const host = await new_host();
-    // const port = host._server.address().port;
 
     let benchmark_name = options.output || "benchmark";
 
@@ -108,7 +93,6 @@ exports.run = async function run(version, benchmark, ...cmdArgs) {
         await browser.close();
 
         console.log(`Benchmark suite has finished running - results are in ${benchmark_name}.html.`);
-        host.close();
     } else {
         bins = await run_node_version(cmdArgs, RUN_TEST);
     }


### PR DESCRIPTION
Rebased & updated version of #958, moved to a branch on this repo, with updated `dockerfile` for new images and a further upgrade to emscripten 1.39.12.  Per this version's release notes, `MAXIMUM_MEMORY` has been set to enable unsigned pointers & 4gb+ heaps for Emscripten.

Alas, this version still does not pass Perspective's test suite, so cannot currently be merged.