### PR TITLE
Datagrid virtual scroll fixes and `-webkit-scrollbar` CSS

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
+++ b/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
@@ -156,11 +156,11 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
         const header_levels = this._view_cache.config.column_pivots.length + 1;
         const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - this._scroll_container.offsetHeight);
         const percent_scroll = this._scroll_container.scrollTop / total_scroll_height;
-        const virtual_panel_row_height = Math.floor(height / row_height);
+        const virtual_panel_row_height = height / row_height;
         const relative_nrows = !reset_scroll_position ? this._nrows || 0 : nrows;
         const scroll_rows = Math.max(0, relative_nrows + (header_levels - virtual_panel_row_height));
-        let start_row = Math.round(scroll_rows * percent_scroll);
-        let end_row = start_row + virtual_panel_row_height;
+        let start_row = Math.ceil(scroll_rows * percent_scroll);
+        let end_row = start_row + virtual_panel_row_height + 1;
         return {start_row, end_row};
     }
 
@@ -258,6 +258,7 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
      * @memberof DatagridVirtualTableViewModel
      */
     _swap_in(args) {
+        this._render_element.dispatchEvent(new CustomEvent("perspective-datagrid-before-update", {bubbles: true, detail: this}));
         if (!this._virtual_scrolling_disabled) {
             if (this._needs_swap(args)) {
                 if (this._sticky_container === this.table_model.table.parentElement) {
@@ -270,7 +271,6 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
                 }
             }
         }
-        this._render_element.dispatchEvent(new CustomEvent("perspective-datagrid-before-update", {bubbles: true, detail: this}));
     }
 
     /**
@@ -318,7 +318,9 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
      */
     _update_virtual_panel_height(nrows) {
         const {row_height = 19} = this._column_sizes;
-        const virtual_panel_px_size = Math.min(BROWSER_MAX_HEIGHT, nrows * row_height);
+        const {height} = this._container_size;
+        const zoom_factor = this._scroll_container.offsetHeight / (height - this.table_model.header.cells.length * row_height);
+        const virtual_panel_px_size = Math.min(BROWSER_MAX_HEIGHT, nrows * row_height * zoom_factor);
         this._virtual_panel.style.height = `${virtual_panel_px_size}px`;
     }
 

--- a/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
+++ b/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
@@ -77,8 +77,8 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
                 ${CONTAINER_STYLE + MATERIAL_STYLE}
             </style>
             <div class="pd-scroll-container">
-                <div class="pd-virtual-panel">${this._virtual_scrolling_disabled && slot}</div>
-                <div class="pd-scroll-table-clip">${this._virtual_scrolling_disabled || slot}</div>
+                <div class="pd-virtual-panel">${this._virtual_scrolling_disabled ? slot : ""}</div>
+                <div class="pd-scroll-table-clip">${this._virtual_scrolling_disabled ? "" : slot}</div>
                 <div style="position: absolute; visibility: hidden;"></div>
             </div>
         `;

--- a/packages/perspective-viewer-datagrid/src/js/table.js
+++ b/packages/perspective-viewer-datagrid/src/js/table.js
@@ -65,7 +65,7 @@ export class DatagridTableViewModel {
         const {view, config, column_paths, schema, table_schema} = view_cache;
         const visible_columns = column_paths.slice(viewport.start_col);
         const columns_data = await view.to_columns(viewport);
-        const {start_row: ridx_offset, start_col: cidx_offset} = viewport;
+        const {start_row: ridx_offset = 0, start_col: cidx_offset = 0} = viewport;
         const depth = config.row_pivots.length;
         const id_column = columns_data["__ID__"];
         const view_state = {viewport_width: 0, selected_id, depth, ridx_offset, cidx_offset, row_height: this._column_sizes.row_height};

--- a/packages/perspective-viewer-datagrid/src/js/tbody.js
+++ b/packages/perspective-viewer-datagrid/src/js/tbody.js
@@ -52,7 +52,7 @@ export class DatagridBodyViewModel extends ViewModel {
         } else if (formatter) {
             formatter.format(td, val, type, val.length === depth, is_open);
             metadata.value = Array.isArray(val) ? val[val.length - 1] : val;
-            metadata.row_path = val;
+            metadata.row_path = id;
             metadata.is_open = is_open;
         } else {
             td.textContent = val;

--- a/packages/perspective-viewer-datagrid/src/less/container.less
+++ b/packages/perspective-viewer-datagrid/src/less/container.less
@@ -13,7 +13,7 @@
     left: 0px;
     right: 0px;
     bottom: 0px;
-    overflow:auto;
+    overflow: overlay;
     -webkit-overflow-scrolling: auto;
 }
 

--- a/packages/perspective-viewer-datagrid/src/less/material.less
+++ b/packages/perspective-viewer-datagrid/src/less/material.less
@@ -20,6 +20,7 @@ perspective-viewer > div {
 
 
 perspective-viewer, :host {
+
     
     th {
         text-align: center;
@@ -195,5 +196,23 @@ perspective-viewer, :host {
         top: 0;
         right: 0;
         cursor: col-resize;
+    }
+
+    ::-webkit-scrollbar {
+        width: 10px;
+        height: 10px;
+    }
+
+    :hover::-webkit-scrollbar-thumb {
+        background-color: rgba(0,0,0,0.3);
+    }
+
+    ::-webkit-scrollbar-thumb {
+        border-radius: 10px;
+        background-color: rgba(0,0,0,0);
+    }
+
+    ::-webkit-scrollbar-corner {
+        background-color: rgba(0,0,0,0);
     }
 }

--- a/packages/perspective-viewer-datagrid/src/less/material.less
+++ b/packages/perspective-viewer-datagrid/src/less/material.less
@@ -199,8 +199,8 @@ perspective-viewer, :host {
     }
 
     ::-webkit-scrollbar {
-        width: 10px;
-        height: 10px;
+        width: 8px;
+        height: 8px;
     }
 
     :hover::-webkit-scrollbar-thumb {
@@ -208,7 +208,7 @@ perspective-viewer, :host {
     }
 
     ::-webkit-scrollbar-thumb {
-        border-radius: 10px;
+        border-radius: 4px;
         background-color: rgba(0,0,0,0);
     }
 

--- a/packages/perspective-viewer/src/less/viewer.less
+++ b/packages/perspective-viewer/src/less/viewer.less
@@ -208,7 +208,7 @@
         padding: 0px;
         width: 100%;
         margin: var(--column-container--margin, 8px 0px 0px 0px);
-        overflow-y: auto;
+        overflow-y: overlay;
         overflow-x: hidden;
         position: relative;
     }
@@ -453,5 +453,23 @@
         bottom: 0;
         width: 8px;
         cursor: col-resize;
+    }
+
+    ::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
+    }
+
+    :hover::-webkit-scrollbar-thumb {
+        background-color: rgba(0,0,0,0.3);
+    }
+
+    ::-webkit-scrollbar-thumb {
+        border-radius: 4px;
+        background-color: rgba(0,0,0,0);
+    }
+
+    ::-webkit-scrollbar-corner {
+        background-color: rgba(0,0,0,0);
     }
 }


### PR DESCRIPTION
Assorted fixes for `@finos/perspective-viewer-datagrid`s scrolling, and adds OSX-style overlay scrollbars to all `<perspective-viewer>` scrollable content, for sad Windows users.

Fixes #602