### PR TITLE
Add perspective-click event to datagrid

### DIFF
--- a/examples/simple/superstore-custom-grid.html
+++ b/examples/simple/superstore-custom-grid.html
@@ -1,7 +1,7 @@
 <!--
-   
+
    Copyright (c) 2017, the Perspective Authors.
-   
+
    This file is part of the Perspective library, distributed under the terms of
    the Apache License 2.0.  The full license can be found in the LICENSE file.
 
@@ -23,8 +23,9 @@
 </head>
 
 <body>
-    <perspective-viewer 
-        plugin="datagrid" 
+    <perspective-viewer
+        plugin="datagrid"
+        selectable
         columns='["Profit","Sub-Category","State","Sales","Category","Order Date","Quantity"]'>
     </perspective-viewer>
 
@@ -102,7 +103,7 @@
                 }
                 img.setAttribute("crossorigin", "anonymous")
                 img.setAttribute("src", `http://perspective.finos.org/img/flags/${states[clean_name].toLowerCase()}.png`);
-   
+
                 td.textContent = "";
                 span.appendChild(img)
                 td.appendChild(span);

--- a/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
+++ b/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
@@ -102,7 +102,7 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
      * @memberof DatagridVirtualTableViewModel
      */
     _calculate_viewport(nrows, reset_scroll_position) {
-        const id = this._view_cache.config.row_pivots.length > 0;
+        const id = this._view_cache.config.row_pivots.length > 0 || this._render_element.hasAttribute("selectable");
         if (this._virtual_scrolling_disabled) {
             return {id};
         }


### PR DESCRIPTION
* fix row selection for un-pivoted views
* make selection details mirror hypergrid
* update superstore custom grid example's perspective-viewer element to be selectable