### PR TITLE
Fix minor bugs in Perspective datetime + NaN handling

### DIFF
--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -158,12 +158,20 @@ class _PerspectiveDateValidator(object):
 
         timetuple = getattr(obj, to_timetuple)()
 
+        print(timetuple)
+
         is_datetime_min = timetuple.tm_year == 1 and timetuple.tm_mon == 1 \
             and timetuple.tm_mday == 1 and timetuple.tm_hour == 0 \
             and timetuple.tm_min == 0 and timetuple.tm_sec == 0
+
         if is_datetime_min:
-            # Return beginning of epoch for datetime.min
+            # Return beginning of epoch when datetime is datetime.min
             return 0
+
+        if timetuple.tm_year < 1900:
+            # Use calendar.timegm to do conversion between timetuple and
+            # seconds timestamp
+            converter = timegm
 
         # At this point, aware datetime objects are in UTC, and naive datetime
         # objects have not been modified. When the timestamp is serialized
@@ -191,8 +199,6 @@ class _PerspectiveDateValidator(object):
         # match commonly-used date separators
 
         dtype = t_dtype.DTYPE_STR
-
-        print(s, has_separators)
 
         if has_separators:
             try:

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -156,13 +156,21 @@ class _PerspectiveDateValidator(object):
         if isinstance(obj, (int, float)):
             return _normalize_timestamp(obj)
 
+        timetuple = getattr(obj, to_timetuple)()
+
+        is_datetime_min = timetuple.tm_year == 1 and timetuple.tm_mon == 1 \
+            and timetuple.tm_mday == 1 and timetuple.tm_hour == 0 \
+            and timetuple.tm_min == 0 and timetuple.tm_sec == 0
+        if is_datetime_min:
+            # Return beginning of epoch for datetime.min
+            return 0
+
         # At this point, aware datetime objects are in UTC, and naive datetime
         # objects have not been modified. When the timestamp is serialized
         # using `to_format`, it will be in *local time* - Pybind will
         # automatically localize any conversion to `datetime.datetime`
         # from C++ to Python.
-        return int((converter(
-            getattr(obj, to_timetuple)()) + obj.microsecond / 1000000.0) * 1000)
+        return int((converter(timetuple) + obj.microsecond / 1000000.0) * 1000)
 
     def format(self, s):
         '''Return either t_dtype.DTYPE_DATE or t_dtype.DTYPE_TIME depending on
@@ -182,9 +190,12 @@ class _PerspectiveDateValidator(object):
 
         dtype = t_dtype.DTYPE_STR
 
+        print(s, has_separators)
+
         if has_separators:
             try:
                 parsed = parse(s)
+                print(parsed)
                 if (parsed.hour, parsed.minute, parsed.second, parsed.microsecond) == (0, 0, 0, 0):
                     dtype = t_dtype.DTYPE_DATE
                 else:

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -153,7 +153,7 @@ class _PerspectiveDateValidator(object):
             if isinstance(obj, int):
                 return round(obj / 1000000)
 
-        if isinstance(obj, (int, float)):
+        if isinstance(obj, (int, float, numpy.integer, numpy.float)):
             return _normalize_timestamp(obj)
 
         timetuple = getattr(obj, to_timetuple)()
@@ -170,7 +170,9 @@ class _PerspectiveDateValidator(object):
         # using `to_format`, it will be in *local time* - Pybind will
         # automatically localize any conversion to `datetime.datetime`
         # from C++ to Python.
-        return int((converter(timetuple) + obj.microsecond / 1000000.0) * 1000)
+        seconds_timestamp = (converter(timetuple) + obj.microsecond / 1000000.0)
+        ms_timestamp = int(seconds_timestamp * 1000)
+        return ms_timestamp
 
     def format(self, s):
         '''Return either t_dtype.DTYPE_DATE or t_dtype.DTYPE_TIME depending on

--- a/python/perspective/perspective/table/_date_validator.py
+++ b/python/perspective/perspective/table/_date_validator.py
@@ -158,8 +158,6 @@ class _PerspectiveDateValidator(object):
 
         timetuple = getattr(obj, to_timetuple)()
 
-        print(timetuple)
-
         is_datetime_min = timetuple.tm_year == 1 and timetuple.tm_mon == 1 \
             and timetuple.tm_mday == 1 and timetuple.tm_hour == 0 \
             and timetuple.tm_min == 0 and timetuple.tm_sec == 0

--- a/python/perspective/perspective/tests/table/test_table_datetime.py
+++ b/python/perspective/perspective/tests/table/test_table_datetime.py
@@ -158,6 +158,66 @@ if os.name != 'nt':
                 datetime(2019, 11, 3, 7, 10, 20)
             ]
 
+        def test_table_datetime_min(self):
+            data = {
+                "a": [datetime.min]
+            }
+            table = Table(data)
+            assert table.view().to_dict()["a"] == [
+                datetime(1969, 12, 31, 19, 0)
+            ]
+
+        def test_table_datetime_min_df(self):
+            data = pd.DataFrame({
+                "a": [datetime.min]
+            })
+            table = Table(data)
+            assert table.view().to_dict()["a"] == [
+                datetime(1969, 12, 31, 19, 0)
+            ]
+
+        def test_table_datetime_1900(self):
+            data = {
+                "a": [datetime(1900, 1, 1)]
+            }
+            table = Table(data)
+            assert table.view().to_dict()["a"] == [
+                datetime(1900, 1, 1)
+            ]
+
+        def test_table_datetime_1900_df(self):
+            data = pd.DataFrame({
+                "a": [datetime(1900, 1, 1)]
+            })
+            table = Table(data)
+            assert table.view().to_dict()["a"] == [
+                datetime(1899, 12, 31, 19)
+            ]
+
+        def test_table_datetime_min_epoch(self):
+            data = {
+                "a": [0]
+            }
+            table = Table({
+                "a": datetime
+            })
+            table.update(data)
+            assert table.view().to_dict()["a"] == [
+                datetime(1969, 12, 31, 19, 0)
+            ]
+
+        def test_table_datetime_min_epoch_df(self):
+            data = pd.DataFrame({
+                "a": [0]
+            })
+            table = Table({
+                "a": datetime
+            })
+            table.update(data)
+            assert table.view().to_dict()["a"] == [
+                datetime(1969, 12, 31, 19, 0)
+            ]
+
     class TestTableDateTimeUTCToLocal(object):
 
         def teardown_method(self):

--- a/python/perspective/perspective/tests/table/test_table_datetime.py
+++ b/python/perspective/perspective/tests/table/test_table_datetime.py
@@ -194,6 +194,24 @@ if os.name != 'nt':
                 datetime(1899, 12, 31, 19)
             ]
 
+        def test_table_datetime_1899(self):
+            data = {
+                "a": [datetime(1899, 1, 1)]
+            }
+            table = Table(data)
+            assert table.view().to_dict()["a"] == [
+                datetime(1898, 12, 31, 19)
+            ]
+
+        def test_table_datetime_1899_df(self):
+            data = pd.DataFrame({
+                "a": [datetime(1899, 1, 1)]
+            })
+            table = Table(data)
+            assert table.view().to_dict()["a"] == [
+                datetime(1898, 12, 31, 19)
+            ]
+
         def test_table_datetime_min_epoch(self):
             data = {
                 "a": [0]

--- a/python/perspective/perspective/tests/table/test_table_infer.py
+++ b/python/perspective/perspective/tests/table/test_table_infer.py
@@ -6,6 +6,7 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 import six
+from pytest import mark
 from perspective.table import Table
 from datetime import date, datetime
 
@@ -183,5 +184,11 @@ class TestTableInfer(object):
 
     def test_table_datetime_infer_no_false_positive(self):
         data = {"a": [" . - / but clearly not a date"]}
+        tbl = Table(data)
+        assert tbl.schema() == {"a": str}
+
+    @mark.skip
+    def test_table_datetime_infer_from_string_with_time(self):
+        data = {"a": ["11:00 ABCD"]}
         tbl = Table(data)
         assert tbl.schema() == {"a": str}


### PR DESCRIPTION
This PR fixes a few small bugs in `perspective-python`:

- `NaN`, `Infinity`, and `-Infinity` are no longer serialized into JSON by `PerspectiveManager`, and any remote calls into `PerspectiveManager` that returns a result with `NaN` inside will be rejected on the client-side. The server will not raise an Exception, but the exception will be visible inside the client browser console. 

#### A Short Explanation

Perspective's data loading and model treats `None` or `null` as invalid values, and the Javascript value `undefined` as a value for "nothing exists in this cell". To the extent possible, Perspective will strip and treat `NaN`s as `None` (in Python) or `null` (in Javascript). 

A case where `NaN`s cannot be coerced to `None` is in Arrows with columns that contain `NaN` values but do not have the `null_count` or the Arrow array's [validity bitmap](https://arrow.apache.org/docs/format/Columnar.html#validity-bitmaps) correctly set. To take advantage of the speed benefits provided by Arrow, Perspective treats Arrow-formatted data as strongly typed within each column, and where invalid values are indicated through use of the validity bitmap. This allows Perspective to `memcpy` arrays from Arrow into Perspective, i.e. a basically free operation that massively speeds up Arrow loading.

At this time, there are no plans to support a distinction between `NaN` and None in Perspective, especially as the visualization value of `NaN` and `None` are equivalent - both denote invalid values. Thus, using `perspective-python` and attempting to serialize data containing `NaN` values will fail, and this change provides an explicit error message.

Additionally, PyArrow's [default behavior](https://arrow.apache.org/docs/python/data.html#none-values-and-nan-handling) when converting from Pandas is to treat `NaN` values as `None`.

#### Other Changes

- Datetimes before the year 1900 are treated automatically as UTC using `calendar.timegm`, instead of `time.mktime` which raised an error whenever dealing with years before 1900.

- `datetime.min` values passed in to Perspective used to return "2001/1/1" due to a edge case in how timestamps were calculated before being passed into C++. Now, datetime.min values (whenever year, month, and day are `1` and hour, minute, seconds are `0`) return a timestamp of 0, i.e. the Unix epoch.