### PR TITLE
Adds jsdelivr package.json metadata

### DIFF
--- a/packages/perspective-bench/package.json
+++ b/packages/perspective-bench/package.json
@@ -5,6 +5,7 @@
     "private": true,
     "main": "src/js/bench.js",
     "unpkg": "src/js/browser_runtime.js",
+    "jsdelivr": "src/js/browser_runtime.js",
     "browser": "src/js/browser_runtime.js",
     "module": "src/js/bench.js",
     "files": [

--- a/packages/perspective-viewer-d3fc/package.json
+++ b/packages/perspective-viewer-d3fc/package.json
@@ -17,6 +17,7 @@
         "y-scatter": "./dist/esm/index/y-scatter.js"
     },
     "unpkg": "./dist/umd/perspective-viewer-d3fc.js",
+    "jsdelivr": "./dist/umd/perspective-viewer-d3fc.js",
     "files": [
         "dist/**/*",
         "babel.config.js"

--- a/packages/perspective-viewer-datagrid/package.json
+++ b/packages/perspective-viewer-datagrid/package.json
@@ -6,6 +6,7 @@
     "module": "dist/cjs/perspective-viewer-datagrid.js",
     "browser": "dist/cjs/perspective-viewer-datagrid.js",
     "unpkg": "dist/umd/perspective-viewer-datagrid.js",
+    "jsdelivr": "dist/umd/perspective-viewer-datagrid.js",
     "files": [
         "dist/**/*",
         "babel.config.js"

--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -4,6 +4,7 @@
     "description": "Perspective.js",
     "main": "./dist/cjs/perspective-viewer-highcharts.js",
     "unpkg": "./dist/umd/perspective-viewer-highcharts.js",
+    "jsdelivr": "./dist/umd/perspective-viewer-highcharts.js",
     "browser": {
         "heatmap": "./dist/esm/heatmap.js",
         "sunburst": "./dist/esm/sunburst.js",

--- a/packages/perspective-viewer-hypergrid/package.json
+++ b/packages/perspective-viewer-hypergrid/package.json
@@ -6,6 +6,7 @@
     "module": "dist/cjs/perspective-viewer-hypergrid.js",
     "browser": "dist/cjs/perspective-viewer-hypergrid.js",
     "unpkg": "dist/umd/perspective-viewer-hypergrid.js",
+    "jsdelivr": "dist/umd/perspective-viewer-hypergrid.js",
     "files": [
         "dist/**/*",
         "babel.config.js"

--- a/packages/perspective-viewer/package.json
+++ b/packages/perspective-viewer/package.json
@@ -5,6 +5,7 @@
     "main": "dist/cjs/perspective-viewer.js",
     "module": "dist/cjs/perspective-viewer.js",
     "unpkg": "dist/umd/perspective-viewer.js",
+    "jsdelivr": "dist/umd/perspective-viewer.js",
     "browser": {
         "themes/all-themes.less": "./dist/themes/all-themes.less",
         "themes/all-themes.css": "./dist/umd/all-themes.css",

--- a/packages/perspective-workspace/package.json
+++ b/packages/perspective-workspace/package.json
@@ -10,6 +10,7 @@
         "index.d.ts"
     ],
     "unpkg": "./dist/umd/perspective-workspace.js",
+    "jsdelivr": "./dist/umd/perspective-workspace.js",
     "scripts": {
         "bench": "npm-run-all bench:build bench:run",
         "bench:build": "echo \"No Benchmarks\"",

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -4,6 +4,7 @@
     "description": "Perspective.js",
     "main": "dist/cjs/perspective.node.js",
     "unpkg": "dist/umd/perspective.js",
+    "jsdelivr": "dist/umd/perspective.js",
     "browser": "dist/umd/perspective.inline.js",
     "module": "dist/umd/perspective.inline.js",
     "publishConfig": {


### PR DESCRIPTION
Adds support for [JSDelivr](https://jsdelivr.com) metadata, such that links like [https://cdn.jsdelivr.net/npm/@finos/perspective-viewer](https://cdn.jsdelivr.net/npm/@finos/perspective-viewer) point to the CDN version of Perspective, rather than the CJS version.