### PR TITLE
Remove duplicate `psp_okey` column from arrow updates

### DIFF
--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -413,7 +413,10 @@ t_data_table::append(const t_data_table& other) {
 
     std::set<std::string> incoming;
 
-    for (const auto& cname : other.m_schema.m_columns) {
+    std::cout << "existing schema: " << m_schema << std::endl;
+    std::cout << "schema to append: " << other.m_schema << std::endl;
+
+    for (const auto& cname : m_schema.m_columns) {
         t_dtype col_dtype = get_column(cname)->get_dtype();
         t_dtype other_col_dtype = other.get_const_column(cname)->get_dtype();
         if (col_dtype != other_col_dtype) {

--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -413,10 +413,7 @@ t_data_table::append(const t_data_table& other) {
 
     std::set<std::string> incoming;
 
-    std::cout << "existing schema: " << m_schema << std::endl;
-    std::cout << "schema to append: " << other.m_schema << std::endl;
-
-    for (const auto& cname : m_schema.m_columns) {
+    for (const auto& cname : other.m_schema.m_columns) {
         t_dtype col_dtype = get_column(cname)->get_dtype();
         t_dtype other_col_dtype = other.get_const_column(cname)->get_dtype();
         if (col_dtype != other_col_dtype) {

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1064,7 +1064,8 @@ namespace binding {
             
             // Always use the `Table` column names and data types on up
             if (table_initialized && is_update) {
-                auto schema = gnode->get_output_schema();
+                auto gnode_output_schema = gnode->get_output_schema();
+                auto schema = gnode_output_schema.drop({"psp_okey"});
                 column_names = schema.columns();
                 data_types = schema.types();
 
@@ -1099,7 +1100,7 @@ namespace binding {
                     }
 
                     // Updated data types need to reflect in new data table
-                    auto new_schema = gnode->get_output_schema();
+                    auto new_schema = gnode->get_output_schema().drop({"psp_okey"});
                     data_types = new_schema.types();
                 }
             } else {

--- a/python/perspective/perspective/src/table.cpp
+++ b/python/perspective/perspective/src/table.cpp
@@ -62,7 +62,8 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor,
 
         // Always use the `Table` column names and data types on update.
         if (table_initialized && is_update) {
-            auto schema = gnode->get_output_schema();
+            auto gnode_output_schema = gnode->get_output_schema();
+            auto schema = gnode_output_schema.drop({"psp_okey"});
             column_names = schema.columns();
             data_types = schema.types();
 
@@ -97,7 +98,7 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor,
                 }
             }
             // Make sure promoted types are used to construct data table
-            auto new_schema = gnode->get_output_schema();
+            auto new_schema = gnode->get_output_schema().drop({"psp_okey"});
             data_types = new_schema.types();
         } else {
             column_names = arrow_loader.names();

--- a/python/perspective/perspective/tests/table/test_update_arrow.py
+++ b/python/perspective/perspective/tests/table/test_update_arrow.py
@@ -512,7 +512,6 @@ class TestUpdateArrow(object):
 
         assert tbl.size() == 3
 
-    @mark.skip
     def test_update_arrow_thread_safe_str_index(self, util):
         data = [["a", "b", "c"] for i in range(11)]
         names = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "uid"]


### PR DESCRIPTION
This PR reproduces and fixes a segmentation fault with arrow updates and string reallocation - previously, the `psp_okey` column was being duplicated incorrectly on an Arrow update, and this turned out to be the cause of a few different segfaults that became trivially reproducible (and has been reproduced and tested in the Python tests).

Removing the incorrect duplication fixes the tests and seems to (for now) prevented any further segfaults related to this issue.