### PR TITLE
Restore firefox support by removing captrue group from regex pattern

### DIFF
--- a/packages/perspective-viewer/src/js/computed_expressions/lexer.js
+++ b/packages/perspective-viewer/src/js/computed_expressions/lexer.js
@@ -32,7 +32,7 @@ const UpperLowerCaseTokenType = createToken({
 });
 
 // Create tokens for column names and computed function names
-const column_name_regex_pattern = /(["'])(?<column_name>.*?[^\\])\1/y;
+const column_name_regex_pattern = /(["'])(.*?[^\\])\1/y;
 
 /**
  * Given a string from which to extract a column name, extract the column name


### PR DESCRIPTION
fixes #1047