### PR TITLE
Changed font for chart tooltips

### DIFF
--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -441,6 +441,7 @@
         position: absolute;
         text-align: left;
         font-size: 10pt;
+        font-family: "Inconsolata", monospace;
         white-space: nowrap;
         padding: 0.5em;
         background: var(--d3fc-tooltip--background, #ffffff);

--- a/packages/perspective-viewer/src/less/fonts.less
+++ b/packages/perspective-viewer/src/less/fonts.less
@@ -1,3 +1,4 @@
 @import (css) url("https://fonts.googleapis.com/css?family=Material+Icons");
 @import (css) url("https://fonts.googleapis.com/css?family=Open+Sans");// ~typeface-open-sans/index.css");
 @import (css) url("https://fonts.googleapis.com/css?family=Roboto+Mono"); // ~typeface-roboto-mono/index.css");
+@import (css) url("https://fonts.googleapis.com/css?family=Inconsolata");


### PR DESCRIPTION
fixes #1006 

Tool tips now use the Google font, [Inconsolata](https://fonts.google.com/specimen/Inconsolata)
I left the values bolded so there is still a "clear differentiation/highlight on the number"
Here is an example of a tooltip with Inconsolata font
![image](https://user-images.githubusercontent.com/42980188/82598239-f27a5500-9b6f-11ea-859c-ed2bb26d129d.png)

Note: Put as draft pr since I am still waiting on a ICLA