### PR TITLE
Styleable scroll-area for `@finos/perspective-viewer-datagrid`

### DIFF
--- a/packages/perspective-test/src/js/index.js
+++ b/packages/perspective-test/src/js/index.js
@@ -369,7 +369,17 @@ test.capture = function capture(name, body, {timeout = 60000, viewport = null, w
 
                 // Move the mouse offscreen so prev tests dont get hover effects
                 await page.mouse.move(10000, 10000);
-                await body(page);
+                try {
+                    await body(page);
+                } catch (e) {
+                    if (process.env.PSP_PAUSE_ON_FAILURE) {
+                        if (!process.env.WRITE_TESTS) {
+                            private_console.error(`Failed ${name}, pausing`);
+                            await prompt(`Failed ${name}, pausing.  Press enter to continue ..`);
+                        }
+                    }
+                    throw e;
+                }
                 if (!preserve_hover) {
                     await page.mouse.move(10000, 10000);
                 }

--- a/packages/perspective-viewer-datagrid/src/js/datagrid.js
+++ b/packages/perspective-viewer-datagrid/src/js/datagrid.js
@@ -61,13 +61,6 @@ export class DatagridViewModel extends DatagridViewEventModel {
      */
     clear() {
         this._sticky_container.innerHTML = "<table></table>";
-        if (this._render_element) {
-            if (this._render_element !== this.table_model.table.parentElement) {
-                this._render_element.appendChild(this._sticky_container);
-            }
-        } else {
-            this.appendChild(this.table_model.table);
-        }
     }
 
     reset_viewport() {
@@ -78,19 +71,19 @@ export class DatagridViewModel extends DatagridViewEventModel {
     }
 
     reset_size() {
-        this._container_size = undefined;
+        this._invalid_schema = true;
     }
 
     reset_scroll() {
         this._column_sizes.indices = [];
-        this._scroll_container.scrollTop = 0;
-        this._scroll_container.scrollLeft = 0;
+        this.scrollTop = 0;
+        this.scrollLeft = 0;
         this.reset_viewport();
     }
 
-    async set_view(view) {
+    async set_view(table, view) {
         const config = await view.get_config();
-        const table_schema = await this._render_element.table.schema();
+        const table_schema = await table.schema();
         const schema = await view.schema();
         const column_paths = await view.column_paths();
         this._invalid_schema = true;
@@ -99,21 +92,14 @@ export class DatagridViewModel extends DatagridViewEventModel {
         return options;
     }
 
-    set_element(_render_element) {
-        if (_render_element) {
-            this._render_element = _render_element;
-        }
-        this._virtual_scrolling_disabled = _render_element.hasAttribute("disable-virtual-datagrid");
+    set_element(virtual_scrolling_disabled = false) {
+        this._virtual_scrolling_disabled = virtual_scrolling_disabled;
         this.create_shadow_dom();
         this._column_sizes = {auto: {}, override: {}, indices: []};
         this.table_model = new DatagridTableViewModel(this._table_clip, this._column_sizes, this._sticky_container);
         if (!this.table_model) return;
-        if (this._render_element) {
-            if (this._render_element !== this.table_model.table.parentElement) {
-                this._render_element.appendChild(this._sticky_container);
-            }
-        } else {
-            this.appendChild(this.table_model.table);
+        if (this !== this._sticky_container.parentElement) {
+            this.appendChild(this._sticky_container);
         }
     }
 

--- a/packages/perspective-viewer-datagrid/src/js/datagrid.js
+++ b/packages/perspective-viewer-datagrid/src/js/datagrid.js
@@ -70,10 +70,6 @@ export class DatagridViewModel extends DatagridViewEventModel {
         this._end_col = undefined;
     }
 
-    reset_size() {
-        this._invalid_schema = true;
-    }
-
     reset_scroll() {
         this._column_sizes.indices = [];
         this.scrollTop = 0;

--- a/packages/perspective-viewer-datagrid/src/js/index.js
+++ b/packages/perspective-viewer-datagrid/src/js/index.js
@@ -25,20 +25,20 @@ function get_or_create_datagrid(element, div) {
     let datagrid;
     if (!VIEWER_MAP.has(div)) {
         datagrid = document.createElement("perspective-datagrid");
-        datagrid.appendChild(document.createElement("slot"));
-        datagrid.set_element(element);
+        datagrid.set_element(element.hasAttribute("disable-virtual-datagrid"));
         datagrid.register_listeners();
         div.innerHTML = "";
-        div.appendChild(datagrid);
+        div.appendChild(document.createElement("slot"));
+        element.appendChild(datagrid);
         VIEWER_MAP.set(div, datagrid);
     } else {
         datagrid = VIEWER_MAP.get(div);
-    }
-
-    if (!datagrid.isConnected) {
-        datagrid.clear();
-        div.innerHTML = "";
-        div.appendChild(datagrid);
+        if (!datagrid.isConnected) {
+            datagrid.clear();
+            div.innerHTML = "";
+            div.appendChild(document.createElement("slot"));
+            element.appendChild(datagrid);
+        }
     }
 
     return datagrid;
@@ -65,7 +65,7 @@ class DatagridPlugin {
 
     static async create(div, view) {
         const datagrid = get_or_create_datagrid(this, div);
-        const options = await datagrid.set_view(view);
+        const options = await datagrid.set_view(this.table, view);
         if (this._plugin_config) {
             datagrid.restore(this._plugin_config);
             delete this._plugin_config;

--- a/packages/perspective-viewer-datagrid/src/js/index.js
+++ b/packages/perspective-viewer-datagrid/src/js/index.js
@@ -76,7 +76,6 @@ class DatagridPlugin {
     static async resize() {
         if (this.view && VIEWER_MAP.has(this._datavis)) {
             const datagrid = VIEWER_MAP.get(this._datavis);
-            datagrid.reset_size();
             await datagrid.draw({invalid_viewport: true});
         }
     }

--- a/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
+++ b/packages/perspective-viewer-datagrid/src/js/scroll_panel.js
@@ -388,7 +388,7 @@ export class DatagridVirtualTableViewModel extends HTMLElement {
         if (this._virtual_scrolling_disabled) {
             this._container_size = {width: Infinity, height: Infinity};
         } else {
-            this._container_size = (!this._invalid_schema && this._container_size) || {
+            this._container_size = (!this._invalid_schema && !invalid_viewport && this._container_size) || {
                 width: this._table_clip.offsetWidth,
                 height: this._table_clip.offsetHeight
             };

--- a/packages/perspective-viewer-datagrid/src/js/table.js
+++ b/packages/perspective-viewer-datagrid/src/js/table.js
@@ -72,15 +72,16 @@ export class DatagridTableViewModel {
 
         let cont_body,
             cidx = 0,
-            last_cells = [];
+            last_cells = [],
+            first_col = true;
         if (column_paths[0] === "__ROW_PATH__") {
             const column_name = config.row_pivots.join(",");
             const type = config.row_pivots.map(x => table_schema[x]);
             const column_data = columns_data["__ROW_PATH__"];
-            const column_state = {column_name, cidx: 0, column_data, id_column, type};
+            const column_state = {column_name, cidx: 0, column_data, id_column, type, first_col};
             const cont_head = this.header.draw(config, column_name, "", type, 0);
             cont_body = this.body.draw(container_height, column_state, {...view_state, cidx_offset: 0});
-            view_state.selected_id = false;
+            first_col = false;
             view_state.viewport_width += this._column_sizes.indices[0] || cont_body.td?.offsetWidth || cont_head.th.offsetWidth;
             view_state.row_height = view_state.row_height || cont_body.row_height;
             cidx++;
@@ -106,10 +107,10 @@ export class DatagridTableViewModel {
 
                 const type = column_path_2_type(schema, column_name);
                 const column_data = columns_data[column_name];
-                const column_state = {column_name, cidx, column_data, id_column, type};
+                const column_state = {column_name, cidx, column_data, id_column, type, first_col};
                 const cont_head = this.header.draw(config, undefined, column_name, type, cidx + cidx_offset);
                 cont_body = this.body.draw(container_height, column_state, view_state);
-                view_state.selected_id = false;
+                first_col = false;
                 view_state.viewport_width += this._column_sizes.indices[cidx + cidx_offset] || cont_body.td?.offsetWidth || cont_head.th.offsetWidth;
                 view_state.row_height = view_state.row_height || cont_body.row_height;
                 cidx++;

--- a/packages/perspective-viewer-datagrid/src/js/tbody.js
+++ b/packages/perspective-viewer-datagrid/src/js/tbody.js
@@ -16,15 +16,18 @@ import {ViewModel} from "./view_model";
  * @class DatagridBodyViewModel
  */
 export class DatagridBodyViewModel extends ViewModel {
-    _draw_td(ridx, val, id, is_open, {cidx, column_name, type}, {selected_id, depth, ridx_offset, cidx_offset}) {
+    _draw_td(ridx, val, id, is_open, {cidx, column_name, type, first_col}, {selected_id, depth, ridx_offset, cidx_offset}) {
         const {tr, row_container} = this._get_row(ridx);
-        if (selected_id !== false) {
+
+        const td = this._get_cell("td", row_container, cidx, tr);
+        td.className = `pd-${type}`;
+        if (first_col && selected_id !== undefined) {
             const is_selected = isEqual(id, selected_id);
             const is_sub_selected = !is_selected && isEqual(id?.slice(0, selected_id?.length), selected_id);
             tr.classList.toggle("pd-selected", !!id && is_selected);
             tr.classList.toggle("pd-sub-selected", !!id && is_sub_selected);
         }
-        const td = this._get_cell("td", row_container, cidx, tr);
+
         const metadata = this._get_or_create_metadata(td);
         metadata.id = id;
         metadata.cidx = cidx + cidx_offset;
@@ -32,7 +35,6 @@ export class DatagridBodyViewModel extends ViewModel {
         metadata.column = column_name;
         metadata.size_key = `${column_name}|${type}`;
         metadata.ridx = ridx + ridx_offset;
-        td.className = `pd-${type}`;
         const override_width = this._column_sizes.override[metadata.size_key];
         if (override_width) {
             const auto_width = this._column_sizes.auto[metadata.size_key];

--- a/packages/perspective-viewer-datagrid/src/js/thead.js
+++ b/packages/perspective-viewer-datagrid/src/js/thead.js
@@ -131,7 +131,8 @@ export class DatagridHeaderViewModel extends ViewModel {
                 th = this._draw_group_th(this._offset_cache, d, column_name, sort_dir);
 
                 // Update the group header's metadata such that each group
-                // header has the same metadata coordinates of its rightmost column.
+                // header has the same metadata coordinates of its rightmost
+                // column.
                 const metadata = this._draw_th(alias || column_path, column_name, type, th);
                 metadata.vcidx = vcidx;
                 metadata.cidx = cidx;

--- a/packages/perspective-viewer-datagrid/src/less/container.less
+++ b/packages/perspective-viewer-datagrid/src/less/container.less
@@ -7,7 +7,7 @@
  *
  */
 
- div.pd-scroll-container {
+ :host {
     position:absolute;
     top: 0px;
     left: 0px;

--- a/packages/perspective-viewer-datagrid/src/less/material.less
+++ b/packages/perspective-viewer-datagrid/src/less/material.less
@@ -9,19 +9,17 @@
 
 @row-height: 19px;
 
-perspective-viewer > div {
-    position: absolute;
-    overflow: hidden;
-    top: 12px;
-    left: 12px;
-    right: 12px;
-    bottom: 12px;
+perspective-viewer > perspective-datagrid {
+    padding: 12px;
 }
 
 
-perspective-viewer, :host {
+perspective-datagrid, :host {
 
-    
+    div[tabindex] {
+        outline: none;
+    }
+
     th {
         text-align: center;
     }
@@ -85,10 +83,8 @@ perspective-viewer, :host {
         border-bottom: 1px solid #ddd;
     }
 
-
-
     th {
-    position: relative;
+        position: relative;
     }
 
     tr td span.pd-tree-group {
@@ -198,21 +194,21 @@ perspective-viewer, :host {
         cursor: col-resize;
     }
 
-    ::-webkit-scrollbar {
+    &::-webkit-scrollbar {
         width: 8px;
         height: 8px;
     }
 
-    :hover::-webkit-scrollbar-thumb {
+    &:hover::-webkit-scrollbar-thumb {
         background-color: rgba(0,0,0,0.3);
     }
 
-    ::-webkit-scrollbar-thumb {
+    &::-webkit-scrollbar-thumb {
         border-radius: 4px;
         background-color: rgba(0,0,0,0);
     }
 
-    ::-webkit-scrollbar-corner {
+    &::-webkit-scrollbar-corner {
         background-color: rgba(0,0,0,0);
     }
 }

--- a/packages/perspective-viewer-datagrid/test/js/scrolling.spec.js
+++ b/packages/perspective-viewer-datagrid/test/js/scrolling.spec.js
@@ -1,0 +1,107 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const utils = require("@finos/perspective-test");
+const path = require("path");
+
+utils.with_server({}, () => {
+    describe.page(
+        "superstore.html",
+        () => {
+            test.capture("scrolls vertically", async page => {
+                const datagrid = await page.$("perspective-datagrid");
+                await page.evaluate(element => {
+                    element.scrollTop = 0;
+                    element.scrollLeft = 0;
+                }, datagrid);
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.waitFor("perspective-viewer[settings]");
+                await page.evaluate(element => {
+                    element.scrollTop = 300;
+                }, datagrid);
+                await page.evaluate(() => new Promise(window.requestIdleCallback));
+            });
+
+            test.capture("scrolls horizontally", async page => {
+                const datagrid = await page.$("perspective-datagrid");
+                await page.evaluate(element => {
+                    element.scrollTop = 0;
+                    element.scrollLeft = 0;
+                }, datagrid);
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.waitFor("perspective-viewer[settings]");
+                await page.evaluate(element => {
+                    element.scrollLeft = 300;
+                }, datagrid);
+                await page.evaluate(() => new Promise(window.requestIdleCallback));
+            });
+
+            test.capture("scrolls both", async page => {
+                const datagrid = await page.$("perspective-datagrid");
+                await page.evaluate(element => {
+                    element.scrollTop = 0;
+                    element.scrollLeft = 0;
+                }, datagrid);
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.waitFor("perspective-viewer[settings]");
+                await page.evaluate(element => {
+                    element.scrollTop = 300;
+                    element.scrollLeft = 300;
+                }, datagrid);
+                await page.evaluate(() => new Promise(window.requestIdleCallback));
+            });
+
+            test.capture("scroll past horizontal max", async page => {
+                const datagrid = await page.$("perspective-datagrid");
+                await page.evaluate(element => {
+                    element.scrollTop = 0;
+                    element.scrollLeft = 0;
+                }, datagrid);
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.waitFor("perspective-viewer[settings]");
+                await page.evaluate(element => {
+                    element.scrollLeft = element.scrollWidth;
+                }, datagrid);
+                await page.evaluate(() => new Promise(window.requestIdleCallback));
+            });
+
+            test.capture("scroll past vertical max", async page => {
+                const datagrid = await page.$("perspective-datagrid");
+                await page.evaluate(element => {
+                    element.scrollTop = 0;
+                    element.scrollLeft = 0;
+                }, datagrid);
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.waitFor("perspective-viewer[settings]");
+                await page.evaluate(element => {
+                    element.scrollTop = element.scrollHeight;
+                }, datagrid);
+                await page.evaluate(() => new Promise(window.requestIdleCallback));
+            });
+
+            test.capture("resets scroll position when resized and scrolled to max corner", async page => {
+                const datagrid = await page.$("perspective-datagrid");
+                await page.evaluate(element => {
+                    element.scrollTop = 0;
+                    element.scrollLeft = 0;
+                }, datagrid);
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.waitFor("perspective-viewer[settings]");
+                await page.evaluate(element => {
+                    element.scrollTop = element.scrollHeight;
+                    element.scrollLeft = element.scrollWidth;
+                }, datagrid);
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.waitFor("perspective-viewer:not([settings])");
+                await page.evaluate(() => new Promise(window.requestIdleCallback));
+            });
+        },
+        {reload_page: false, root: path.join(__dirname, "..", "..")}
+    );
+});

--- a/packages/perspective-viewer-datagrid/test/results/linux.docker.json
+++ b/packages/perspective-viewer-datagrid/test/results/linux.docker.json
@@ -1,10 +1,9 @@
 {
     "superstore_replaces_all_rows_": "7f95361aa2a268a8ee842c4632513578",
-    "__GIT_COMMIT__": "de9b20ab4e3651612156b5bdd54c745e34e1a798",
+    "__GIT_COMMIT__": "d819788dd6f1d470e3b7a03ac3d5c21d8aa874b0",
     "empty_empty_grids_do_not_explode": "deb15d155a84145e67da078c803e3eec",
     "regressions_Updates_should_not_render_an_extra_row_for_column_only_views": "676bcaac0bc0d63a2bfa3bd254443b0c",
     "regressions_Updates_regular_updates": "86561ee0ebe91f656f56941e7ff1cf35",
-    "regressions_Updates_saving_a_computed_expression_column_does_not_interrupt_update_rendering": "6c05b485e3c1079338e20ad82afe54ea",
     "superstore_shows_a_grid_without_any_settings_applied_": "4fb387275da7c37f5aaf25af52d9e8d5",
     "superstore_pivots_by_a_row_": "4e0997491754ffd9d4886154be4a8638",
     "superstore_pivots_by_two_rows_": "5d4895fb6286057cd676f17284c31ba7",
@@ -19,5 +18,12 @@
     "superstore_sorts_by_an_alpha_column_": "bc2c035e1c21eab541ae2e1119289913",
     "superstore_displays_visible_columns_": "f7ab6c498375d5b98b47ef582105ea25",
     "superstore_resets_viewable_area_when_the_logical_size_expands_": "e2eafa3c5eedb70bc538e759234d5122",
-    "superstore_resets_viewable_area_when_the_physical_size_expands_": "4fb387275da7c37f5aaf25af52d9e8d5"
+    "superstore_resets_viewable_area_when_the_physical_size_expands_": "4fb387275da7c37f5aaf25af52d9e8d5",
+    "superstore_scrolls_vertically": "51e601b650c136fc0c7f01bbaf794b4f",
+    "superstore_scrolls_horizontally": "5f2e30ff7e0ee21b4a76aee696a3a155",
+    "superstore_scrolls_both": "094e79de075933020db0a7dcc8261c3b",
+    "superstore_scroll_past_horizontal_max": "bc5fd5dd95f0d1849e376712284c172b",
+    "superstore_scroll_past_vertical_max": "34a3f1f5b90ef8b950357ae606967514",
+    "superstore_resets_scroll_position_when_resized_and_scrolled_to_max_corner": "5fa5b44c9ad04efe0973bc35370b9079",
+    "regressions_Updates_saving_a_computed_expression_column_does_not_interrupt_update_rendering": "6c05b485e3c1079338e20ad82afe54ea"
 }

--- a/packages/perspective-viewer/src/html/viewer.html
+++ b/packages/perspective-viewer/src/html/viewer.html
@@ -87,8 +87,6 @@
 
             </div>
         </div>
-
-        <slot></slot>
     </div>
 
 </template>

--- a/packages/perspective-webpack-plugin/README.md
+++ b/packages/perspective-webpack-plugin/README.md
@@ -1,13 +1,19 @@
 # Perspective Webpack Plugin
 
-In order to use Perspective via webpack, you'll need this plugin.  The plugin
-takes care of:
+For use with [Webpack](https://webpack.js.org/), this plugin allows smaller
+& faster loading assets.  The plugin takes care of:
 
 * Copying the Web Worker engine assets to your output directory.
 * Handling cross-origin loading of the Web Worker assets.
 * Packaging the LESS and HTML assets for the `perspective-viewer` webpack plugin.
 
-Example:
+Without this plugin or a manual equivalent of these steps, the WebAssembly
+binary we be inlined as a `base64` string in the resulting `.js` asset, which
+impacts total asset size and load time.  It will not in any way affect actual
+runtime performance - the `inline` and `plugin` compilations modes are
+otherwise identical.
+
+## Example
 
 ```javascript
 const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
@@ -21,4 +27,9 @@ module.exports = {
     plugins: [new PerspectivePlugin()]
 };
 ```
+
+## `0.4.4` and below
+
+These versions pre-date In order to use Perspective via webpack, so this
+plugin is a requirement.
 

--- a/packages/perspective-workspace/src/js/workspace/workspace.js
+++ b/packages/perspective-workspace/src/js/workspace/workspace.js
@@ -481,7 +481,8 @@ export class PerspectiveWorkspace extends DiscreteSplitPanel {
         widget.title.className += " linked";
         if (this._linkedViewers.indexOf(widget.viewer) === -1) {
             this._linkedViewers.push(widget.viewer);
-            // if this is the first linked viewer, make viewers with row-pivots selectable
+            // if this is the first linked viewer, make viewers with
+            // row-pivots selectable
             if (this._linkedViewers.length === 1) {
                 this.getAllWidgets().forEach(widget => {
                     const config = widget.viewer.save();


### PR DESCRIPTION
Reorganizes `<perspective-datagrid>` DOM structure thusly:

```html
<perspective-viewer>
    <perspective-datagrid>
        <table></table>
    </perspective-datagrid>
</perspective-viewer>
```

.. with `perspective-datagrid` element itself acting as the scroll container.  This means you should:

* Listen to `scroll` events from this element
* Call its `scrollTop` to move.
* Use it to access methods like `get_tds()`.
