### PR TITLE
Fixed typo on documentation page

### DIFF
--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -119,7 +119,7 @@ and must be imported individually.
 
 Perspective offers these plugin modules:
 
-- `@finos/perspective-viewer-d3fc`  
+- `@finos/perspective-viewer-datagrid`  
   A custom high-performance data-grid component based on HTML `<table>`.
 
 - `@finos/perspective-viewer-d3fc`  


### PR DESCRIPTION
On the documentation page:
It says:
Perspective offers these plugin modules: @finos/perspective-viewer-d3fc A custom high-performance data-grid component based on HTML <table>.

Expected Result:
Perspective offers these plugin modules: @finos/perspective-viewer-datagrid A custom high-performance data-grid component based on HTML <table>.

Resolves #1056