### PR TITLE
Distribute labextension, enable classic notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ darwin.interactive.json
 junit.xml
 python/perspective/python_junit.xml
 python/perspective/coverage.xml
+python/perspective/perspective/labextension
+python/perspective/perspective/nbextension

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,11 +95,14 @@ jobs:
 
     - bash: yarn _js_for_dist
       displayName: 'Copy JS dependencies into python package'
+      env:
+        PERSPECTIVE_CI_SKIPJS: 1
 
     - bash: yarn build_python  --ci $(python_flag) $(manylinux_flag)
       displayName: 'build'
       env:
         PSP_DOCKER: 1
+        PERSPECTIVE_CI_SKIPJS: 1
 
     - task: PublishTestResults@2
       condition: succeededOrFailed()
@@ -191,6 +194,8 @@ jobs:
 
     - bash: yarn _js_for_dist
       displayName: 'Copy JS dependencies into python package'
+      env:
+        PERSPECTIVE_CI_SKIPJS: 1
 
     - script: yarn build_python  --ci $(python_flag)
       displayName: 'build'
@@ -200,6 +205,7 @@ jobs:
         BOOST_ROOT: "C:/hostedtoolcache/windows/Boost/1.69.0/"
         BOOST_INCLUDEDIR: "C:/hostedtoolcache/windows/Boost/1.69.0/include"
         BOOST_LIBRARYDIR: "C:/hostedtoolcache/windows/Boost/1.69.0/libs"
+        PERSPECTIVE_CI_SKIPJS: 1
 
 
 - job: 'Mac'
@@ -248,9 +254,13 @@ jobs:
 
     - bash: yarn _js_for_dist
       displayName: 'Copy JS dependencies into python package'
+      env:
+        PERSPECTIVE_CI_SKIPJS: 1
 
     - script: yarn build_python --ci $(python_flag)
       displayName: 'build'
+      env:
+        PERSPECTIVE_CI_SKIPJS: 1
 
     - task: PublishTestResults@2
       condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,6 +121,7 @@ jobs:
       displayName: 'Build wheel'
       env:
         PSP_DOCKER: 1
+        PERSPECTIVE_CI_SKIPJS: 1
 
     # Start a new virtual environment for the Perspective wheel, so as to
     # isolate it from previously installed dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,6 +93,9 @@ jobs:
     - bash: yarn
       displayName: 'Install Deps'
 
+    - bash: yarn _js_for_dist
+      displayName: 'Copy JS dependencies into python package'
+
     - bash: yarn build_python  --ci $(python_flag) $(manylinux_flag)
       displayName: 'build'
       env:
@@ -186,6 +189,9 @@ jobs:
     - script: yarn
       displayName: 'Install Deps'
 
+    - bash: yarn _js_for_dist
+      displayName: 'Copy JS dependencies into python package'
+
     - script: yarn build_python  --ci $(python_flag)
       displayName: 'build'
       env:
@@ -239,6 +245,9 @@ jobs:
 
     - script: yarn
       displayName: 'Install Deps'
+
+    - bash: yarn _js_for_dist
+      displayName: 'Copy JS dependencies into python package'
 
     - script: yarn build_python --ci $(python_flag)
       displayName: 'build'

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
         "bench": "node scripts/bench.js",
         "bench_python": "python3 python/perspective/bench/perspective_benchmark.py",
         "_wheel_python": "node scripts/_wheel_python.js",
+        "_js_for_dist": "node scripts/_js_for_dist.js",
         "setup": "node scripts/setup.js",
         "docs": "node scripts/docs.js",
         "test": "node scripts/test.js",

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -31,11 +31,12 @@
         "build": "npm-run-all -p build:*",
         "build:jupyterlab": "webpack --color --config src/config/plugin.config.js",
         "build:lumino": "webpack --color --config src/config/webpack.config.js",
-        "build:labdist": "npm-run-all build:jupyterlab clean:labdist && mkdirp ../../python/perspective/perspective/labdist && cd ../../python/perspective/perspective/labdist && npm pack ../../../packages/perspective-jupyterlab/",
+        "build:nbextension": "npm-run-all build:jupyterlab clean:labextension && mkdirp ../../python/perspective/perspective/nbextension/static && cpx \"dist/*.js\" \"../../python/perspective/perspective/nbextension/static/\"",
+        "build:labextension": "npm-run-all build:jupyterlab clean:labextension && mkdirp ../../python/perspective/perspective/labextension && cd ../../python/perspective/perspective/labextension && npm pack ../../../../packages/perspective-jupyterlab/",
         "clean": "npm-run-all -p clean:*",
-        "clean:build": "rimraf dist",
-        "clean:labdist": "rimraf ../../python/perspective/perspective/labdist",
-        "clean:nbextension": "../../python/perspective/perspective/nbextension/static/",
+        "clean:build": "rimraf \"dist\"",
+        "clean:labextension": "rimraf \"../../python/perspective/perspective/labextension\"",
+        "clean:nbextension": "rimrar \"../../python/perspective/perspective/nbextension/static/\"",
         "version": "yarn build"
     },
     "dependencies": {
@@ -58,6 +59,7 @@
         "isomorphic-fetch": "^2.2.1",
         "jest-transform-css": "^2.0.0",
         "source-map-support": "^0.5.9",
+        "tar": "^6.0.2",
         "ts-jest": "^24.1.0",
         "typescript": "^3.7.4"
     },

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -43,8 +43,6 @@
         "@finos/perspective-viewer": "^0.4.8",
         "@finos/perspective-viewer-d3fc": "^0.4.8",
         "@finos/perspective-viewer-datagrid": "^0.4.8",
-        "@finos/perspective-viewer-highcharts": "^0.4.8",
-        "@finos/perspective-viewer-hypergrid": "^0.4.8",
         "@jupyter-widgets/base": "^3.0.0",
         "@jupyterlab/application": "^2.0.0",
         "@lumino/application": "^1.7.3",

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -43,6 +43,8 @@
         "@finos/perspective-viewer": "^0.4.8",
         "@finos/perspective-viewer-d3fc": "^0.4.8",
         "@finos/perspective-viewer-datagrid": "^0.4.8",
+        "@finos/perspective-viewer-highcharts": "^0.4.8",
+        "@finos/perspective-viewer-hypergrid": "^0.4.8",
         "@jupyter-widgets/base": "^3.0.0",
         "@jupyterlab/application": "^2.0.0",
         "@lumino/application": "^1.7.3",

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -31,7 +31,11 @@
         "build": "npm-run-all -p build:*",
         "build:jupyterlab": "webpack --color --config src/config/plugin.config.js",
         "build:lumino": "webpack --color --config src/config/webpack.config.js",
-        "clean": "rimraf dist",
+        "build:labdist": "npm-run-all build:jupyterlab clean:labdist && mkdirp ../../python/perspective/perspective/labdist && cd ../../python/perspective/perspective/labdist && npm pack ../../../packages/perspective-jupyterlab/",
+        "clean": "npm-run-all -p clean:*",
+        "clean:build": "rimraf dist",
+        "clean:labdist": "rimraf ../../python/perspective/perspective/labdist",
+        "clean:nbextension": "../../python/perspective/perspective/nbextension/static/",
         "version": "yarn build"
     },
     "dependencies": {
@@ -58,6 +62,6 @@
         "typescript": "^3.7.4"
     },
     "jupyterlab": {
-        "extension": "dist/index.js"
+        "extension": "dist/labextension.js"
     }
 }

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -42,6 +42,7 @@
     "dependencies": {
         "@finos/perspective-viewer": "^0.4.8",
         "@finos/perspective-viewer-d3fc": "^0.4.8",
+        "@finos/perspective-viewer-datagrid": "^0.4.8",
         "@finos/perspective-viewer-highcharts": "^0.4.8",
         "@finos/perspective-viewer-hypergrid": "^0.4.8",
         "@jupyter-widgets/base": "^3.0.0",

--- a/packages/perspective-jupyterlab/src/config/plugin.config.js
+++ b/packages/perspective-jupyterlab/src/config/plugin.config.js
@@ -63,7 +63,7 @@ module.exports = [
             maxEntrypointSize: 512000,
             maxAssetSize: 512000
         },
-        externals: /\@jupyterlab|\@lumino|\@jupyter-widgets/,
+        externals: ["@jupyter-widgets/base"],
         stats: {modules: false, hash: false, version: false, builtAt: false, entrypoints: false},
         plugins: [new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /(en|es|fr)$/)],
         module: {
@@ -96,7 +96,7 @@ module.exports = [
             maxEntrypointSize: 512000,
             maxAssetSize: 512000
         },
-        externals: /\@jupyterlab|\@lumino|\@jupyter-widgets/,
+        externals: ["@jupyter-widgets/base"],
         stats: {modules: false, hash: false, version: false, builtAt: false, entrypoints: false},
         plugins: [new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /(en|es|fr)$/)],
         module: {

--- a/packages/perspective-jupyterlab/src/config/plugin.config.js
+++ b/packages/perspective-jupyterlab/src/config/plugin.config.js
@@ -71,7 +71,7 @@ module.exports = [
         },
         output: {
             filename: "extension.js",
-            path: path.resolve(__dirname, "..", "..", "python", "perspective", "perspective", "static"),
+            path: path.resolve(__dirname, "../../dist"),
             libraryTarget: "amd"
         }
     },
@@ -104,7 +104,7 @@ module.exports = [
         },
         output: {
             filename: "index.js",
-            path: path.resolve(__dirname, "dist"),
+            path: path.resolve(__dirname, "../../dist"),
             libraryTarget: "amd",
             library: "@finos/perspective-jupyterlab",
             publicPath: "https://unpkg.com/@finos/perspective-jupyterlab@" + packagejson.version + "/dist/"

--- a/packages/perspective-jupyterlab/src/config/plugin.config.js
+++ b/packages/perspective-jupyterlab/src/config/plugin.config.js
@@ -28,9 +28,7 @@ module.exports = [
     {
         // bundle for the jupyterlab
         mode: process.env.PSP_NO_MINIFY || process.env.PSP_DEBUG ? "development" : process.env.NODE_ENV || "production",
-        entry: {
-            index: "./src/ts/labextension.ts"
-        },
+        entry: "./src/ts/labextension.ts",
         resolve: {
             extensions: [".ts", ".js"]
         },

--- a/packages/perspective-jupyterlab/src/config/plugin.config.js
+++ b/packages/perspective-jupyterlab/src/config/plugin.config.js
@@ -9,40 +9,105 @@
 
 const path = require("path");
 const webpack = require("webpack");
+const packagejson = require("../../package.json");
 
-module.exports = {
-    mode: process.env.PSP_NO_MINIFY || process.env.PSP_DEBUG ? "development" : process.env.NODE_ENV || "production",
-    entry: {
-        index: "./src/ts/index.ts"
+const rules = [
+    {
+        test: /\.css$/,
+        exclude: /node_modules/,
+        use: [{loader: "css-loader"}]
     },
-    resolve: {
-        extensions: [".ts", ".js"]
-    },
-    performance: {
-        hints: false,
-        maxEntrypointSize: 512000,
-        maxAssetSize: 512000
-    },
-    externals: /\@jupyterlab|\@lumino|\@jupyter-widgets/,
-    stats: {modules: false, hash: false, version: false, builtAt: false, entrypoints: false},
-    plugins: [new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /(en|es|fr)$/)],
-    module: {
-        rules: [
-            {
-                test: /\.css$/,
-                exclude: /node_modules/,
-                use: [{loader: "css-loader"}]
-            },
-            {
-                test: /\.ts$/,
-                exclude: /node_modules/,
-                loader: "ts-loader"
-            }
-        ]
-    },
-    output: {
-        filename: "[name].js",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../dist")
+    {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        loader: "ts-loader"
     }
-};
+];
+
+module.exports = [
+    {
+        // bundle for the jupyterlab
+        mode: process.env.PSP_NO_MINIFY || process.env.PSP_DEBUG ? "development" : process.env.NODE_ENV || "production",
+        entry: {
+            index: "./src/ts/labextension.ts"
+        },
+        resolve: {
+            extensions: [".ts", ".js"]
+        },
+        performance: {
+            hints: false,
+            maxEntrypointSize: 512000,
+            maxAssetSize: 512000
+        },
+        externals: /\@jupyterlab|\@lumino|\@jupyter-widgets/,
+        stats: {modules: false, hash: false, version: false, builtAt: false, entrypoints: false},
+        plugins: [new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /(en|es|fr)$/)],
+        module: {
+            rules: rules
+        },
+        output: {
+            filename: "labextension.js",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist")
+        }
+    },
+    {
+        // bundle for the classic notebook
+        mode: process.env.PSP_NO_MINIFY || process.env.PSP_DEBUG ? "development" : process.env.NODE_ENV || "production",
+        entry: "./src/ts/extension.ts",
+        resolve: {
+            extensions: [".ts", ".js"]
+        },
+        performance: {
+            hints: false,
+            maxEntrypointSize: 512000,
+            maxAssetSize: 512000
+        },
+        externals: /\@jupyterlab|\@lumino|\@jupyter-widgets/,
+        stats: {modules: false, hash: false, version: false, builtAt: false, entrypoints: false},
+        plugins: [new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /(en|es|fr)$/)],
+        module: {
+            rules: rules
+        },
+        output: {
+            filename: "extension.js",
+            path: path.resolve(__dirname, "..", "..", "python", "perspective", "perspective", "static"),
+            libraryTarget: "amd"
+        }
+    },
+    /**
+     * Embeddable bundle
+     *
+     * This bundle is almost identical to the notebook extension bundle. The only
+     * difference is in the configuration of the webpack public path for the
+     * static assets.
+     *
+     * The target bundle is always `dist/index.js`, which is the path required by
+     * the custom widget embedder.
+     */
+    {
+        mode: process.env.PSP_NO_MINIFY || process.env.PSP_DEBUG ? "development" : process.env.NODE_ENV || "production",
+        entry: "./src/ts/index.ts",
+        resolve: {
+            extensions: [".ts", ".js"]
+        },
+        performance: {
+            hints: false,
+            maxEntrypointSize: 512000,
+            maxAssetSize: 512000
+        },
+        externals: /\@jupyterlab|\@lumino|\@jupyter-widgets/,
+        stats: {modules: false, hash: false, version: false, builtAt: false, entrypoints: false},
+        plugins: [new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /(en|es|fr)$/)],
+        module: {
+            rules: rules
+        },
+        output: {
+            filename: "index.js",
+            path: path.resolve(__dirname, "dist"),
+            libraryTarget: "amd",
+            library: "@finos/perspective-jupyterlab",
+            publicPath: "https://unpkg.com/@finos/perspective-jupyterlab@" + packagejson.version + "/dist/"
+        }
+    }
+];

--- a/packages/perspective-jupyterlab/src/ts/extension.ts
+++ b/packages/perspective-jupyterlab/src/ts/extension.ts
@@ -15,6 +15,6 @@
 // url for the notebook is not known at build time and is therefore computed
 // dynamically.
 // eslint-disable-next-line @typescript-eslint/camelcase
-(window as any).__webpack_public_path__ = document.querySelector("body")!.getAttribute("data-base-url") + "nbextensions/@finos/perspective-jupyterlab";
+(window as any).__webpack_public_path__ = document.querySelector("body")!.getAttribute("data-base-url") + "nbextensions/finos-perspective-jupyterlab";
 
 export * from "./index";

--- a/packages/perspective-jupyterlab/src/ts/extension.ts
+++ b/packages/perspective-jupyterlab/src/ts/extension.ts
@@ -1,0 +1,20 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2020, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+// Entry point for the notebook bundle containing custom model definitions.
+//
+// Setup notebook base URL
+//
+// Some static assets may be required by the custom widget javascript. The base
+// url for the notebook is not known at build time and is therefore computed
+// dynamically.
+// eslint-disable-next-line @typescript-eslint/camelcase
+(window as any).__webpack_public_path__ = document.querySelector("body")!.getAttribute("data-base-url") + "nbextensions/@finos/perspective-jupyterlab";
+
+export * from "./index";

--- a/packages/perspective-jupyterlab/src/ts/index.ts
+++ b/packages/perspective-jupyterlab/src/ts/index.ts
@@ -17,4 +17,5 @@ export * from "./widget";
 import "!!style-loader!css-loader!less-loader!../less/index.less";
 
 import "@finos/perspective-viewer-hypergrid";
+import "@finos/perspective-viewer-datagrid";
 import "@finos/perspective-viewer-highcharts";

--- a/packages/perspective-jupyterlab/src/ts/index.ts
+++ b/packages/perspective-jupyterlab/src/ts/index.ts
@@ -18,13 +18,3 @@ import "!!style-loader!css-loader!less-loader!../less/index.less";
 
 import "@finos/perspective-viewer-hypergrid";
 import "@finos/perspective-viewer-highcharts";
-
-import {JupyterFrontEndPlugin} from "@jupyterlab/application";
-import {perspectiveRenderers} from "./renderer";
-import {PerspectiveJupyterPlugin} from "./plugin";
-
-/**
- * Export the renderer as default.
- */
-const plugins: JupyterFrontEndPlugin<any>[] = [PerspectiveJupyterPlugin, perspectiveRenderers];
-export default plugins;

--- a/packages/perspective-jupyterlab/src/ts/index.ts
+++ b/packages/perspective-jupyterlab/src/ts/index.ts
@@ -16,6 +16,5 @@ export * from "./widget";
 /* css */
 import "!!style-loader!css-loader!less-loader!../less/index.less";
 
-import "@finos/perspective-viewer-hypergrid";
 import "@finos/perspective-viewer-datagrid";
-import "@finos/perspective-viewer-highcharts";
+import "@finos/perspective-viewer-d3fc";

--- a/packages/perspective-jupyterlab/src/ts/labextension.ts
+++ b/packages/perspective-jupyterlab/src/ts/labextension.ts
@@ -15,8 +15,8 @@ export * from "./widget";
 /* css */
 import "!!style-loader!css-loader!less-loader!../less/index.less";
 
-import "@finos/perspective-viewer-hypergrid";
-import "@finos/perspective-viewer-highcharts";
+import "@finos/perspective-viewer-d3fc";
+import "@finos/perspective-viewer-datagrid";
 
 import {JupyterFrontEndPlugin} from "@jupyterlab/application";
 import {perspectiveRenderers} from "./renderer";

--- a/packages/perspective-jupyterlab/src/ts/labextension.ts
+++ b/packages/perspective-jupyterlab/src/ts/labextension.ts
@@ -17,6 +17,8 @@ import "!!style-loader!css-loader!less-loader!../less/index.less";
 
 import "@finos/perspective-viewer-d3fc";
 import "@finos/perspective-viewer-datagrid";
+import "@finos/perspective-viewer-highcharts";
+import "@finos/perspective-viewer-hypergrid";
 
 import {JupyterFrontEndPlugin} from "@jupyterlab/application";
 import {perspectiveRenderers} from "./renderer";

--- a/packages/perspective-jupyterlab/src/ts/labextension.ts
+++ b/packages/perspective-jupyterlab/src/ts/labextension.ts
@@ -6,6 +6,17 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+export * from "./client";
+export * from "./model";
+export * from "./version";
+export * from "./view";
+export * from "./widget";
+
+/* css */
+import "!!style-loader!css-loader!less-loader!../less/index.less";
+
+import "@finos/perspective-viewer-hypergrid";
+import "@finos/perspective-viewer-highcharts";
 
 import {JupyterFrontEndPlugin} from "@jupyterlab/application";
 import {perspectiveRenderers} from "./renderer";

--- a/packages/perspective-jupyterlab/src/ts/labextension.ts
+++ b/packages/perspective-jupyterlab/src/ts/labextension.ts
@@ -1,0 +1,18 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2020, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import {JupyterFrontEndPlugin} from "@jupyterlab/application";
+import {perspectiveRenderers} from "./renderer";
+import {PerspectiveJupyterPlugin} from "./plugin";
+
+/**
+ * Export the renderer as default.
+ */
+const plugins: JupyterFrontEndPlugin<any>[] = [PerspectiveJupyterPlugin, perspectiveRenderers];
+export default plugins;

--- a/packages/perspective-jupyterlab/src/ts/model.ts
+++ b/packages/perspective-jupyterlab/src/ts/model.ts
@@ -7,6 +7,8 @@
  *
  */
 
+/* eslint-disable @typescript-eslint/camelcase */
+
 import {DOMWidgetModel, ISerializers} from "@jupyter-widgets/base";
 import {PERSPECTIVE_VERSION} from "./version";
 

--- a/packages/perspective-jupyterlab/src/ts/renderer.ts
+++ b/packages/perspective-jupyterlab/src/ts/renderer.ts
@@ -109,17 +109,6 @@ export class PerspectiveJSONFactory extends ABCWidgetFactory<IDocumentWidget<Per
 }
 
 /**
- * The perspective extension for files
- */
-export const perspectiveRenderers: JupyterFrontEndPlugin<void> = {
-    activate: activate,
-    id: "@finos/perspective-jupyterlab:renderers",
-    requires: [],
-    optional: [ILayoutRestorer, IThemeManager],
-    autoStart: true
-};
-
-/**
  * Activate cssviewer extension for CSV files
  */
 function activate(app: JupyterFrontEnd, restorer: ILayoutRestorer | null, themeManager: IThemeManager | null): void {
@@ -209,3 +198,14 @@ function activate(app: JupyterFrontEnd, restorer: ILayoutRestorer | null, themeM
         themeManager.themeChanged.connect(updateThemes);
     }
 }
+
+/**
+ * The perspective extension for files
+ */
+export const perspectiveRenderers: JupyterFrontEndPlugin<void> = {
+    activate: activate,
+    id: "@finos/perspective-jupyterlab:renderers",
+    requires: [],
+    optional: [ILayoutRestorer, IThemeManager],
+    autoStart: true
+};

--- a/packages/perspective-jupyterlab/src/ts/version.ts
+++ b/packages/perspective-jupyterlab/src/ts/version.ts
@@ -6,6 +6,10 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/camelcase */
+
 const pkg_json = require("../../package.json");
 
 export const PERSPECTIVE_VERSION = pkg_json.version;

--- a/packages/perspective-jupyterlab/src/ts/view.ts
+++ b/packages/perspective-jupyterlab/src/ts/view.ts
@@ -6,6 +6,9 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+
+/* eslint-disable @typescript-eslint/camelcase */
+
 import {isEqual} from "underscore";
 import {DOMWidgetView} from "@jupyter-widgets/base";
 
@@ -20,6 +23,7 @@ export class PerspectiveView extends DOMWidgetView {
     pWidget: PerspectiveJupyterWidget; // this should be pWidget, but temporarily calling it pWidget for widgets incompatibilities
     perspective_client: PerspectiveJupyterClient;
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
     _createElement(tagName: string) {
         this.pWidget = new PerspectiveJupyterWidget(undefined, {
             plugin: this.model.get("plugin"),

--- a/python/perspective/finos-perspective-jupyterlab.json
+++ b/python/perspective/finos-perspective-jupyterlab.json
@@ -1,0 +1,5 @@
+{
+  "load_extensions": {
+    "finos-perspective-jupyterlab/extension": true
+  }
+}

--- a/python/perspective/perspective/core/plugin.py
+++ b/python/perspective/perspective/core/plugin.py
@@ -17,7 +17,7 @@ class Plugin(Enum):
         >>> widget = PerspectiveWidget(data, plugin=Plugin.TREEMAP)
     '''
     HYPERGRID = 'hypergrid'  # hypergrid
-    GRID = 'hypergrid'  # hypergrid
+    GRID = 'datagrid'  # datagrid
 
     YBAR = 'y_bar'  # highcharts
     XBAR = 'x_bar'  # highcharts

--- a/python/perspective/perspective/tests/viewer/test_viewer.py
+++ b/python/perspective/perspective/tests/viewer/test_viewer.py
@@ -221,7 +221,7 @@ class TestViewer:
         viewer.load(table)
         assert viewer.filters == [["a", "==", 2]]
         viewer.reset()
-        assert viewer.plugin == "hypergrid"
+        assert viewer.plugin == "datagrid"
         assert viewer.filters == []
 
     # delete
@@ -259,7 +259,7 @@ class TestViewer:
 
         # reset configuration
         viewer.reset()
-        assert viewer.plugin == "hypergrid"
+        assert viewer.plugin == "datagrid"
         assert viewer.filters == []
 
         # restore configuration

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -33,7 +33,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
     }
 
     def __init__(self,
-                 plugin='hypergrid',
+                 plugin='datagrid',
                  columns=None,
                  row_pivots=None,
                  column_pivots=None,
@@ -230,7 +230,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         self.computed_columns = []
         self.aggregates = {}
         self.columns = []
-        self.plugin = "hypergrid"
+        self.plugin = "datagrid"
 
     def delete(self, delete_table=True):
         '''Delete the Viewer's data and clears its internal state. If

--- a/python/perspective/pyproject.toml
+++ b/python/perspective/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "jupyter_packaging", "backports.shutil_which"]

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -217,14 +217,19 @@ data_files_spec = [
 ]
 
 # Create a command class to ensure js files are installed
-cmdclass = create_cmdclass('ensure_js', package_data_spec=package_data_spec, data_files_spec=data_files_spec)
-cmdclass['ensure_js'] = combine_commands(
-    ensure_targets([
-        os.path.join(here, 'perspective', 'nbextension', 'static', 'index.js'),
-        os.path.join(here, 'perspective', 'nbextension', 'static', 'labextension.js'),
-        os.path.join(here, 'perspective', 'nbextension', 'static', 'extension.js'),
-    ]),
-)
+if not os.environ.get('PERSPECTIVE_CI_SKIPJS'):
+    cmdclass = create_cmdclass('ensure_js', package_data_spec=package_data_spec, data_files_spec=data_files_spec)
+    cmdclass['ensure_js'] = combine_commands(
+        ensure_targets([
+            os.path.join(here, 'perspective', 'nbextension', 'static', 'index.js'),
+            os.path.join(here, 'perspective', 'nbextension', 'static', 'labextension.js'),
+            os.path.join(here, 'perspective', 'nbextension', 'static', 'extension.js'),
+        ]),
+    )
+else:
+    # these files might be missing or rearranged during CI, so ignore
+    cmdclass = {}
+
 cmdclass['build_ext'] = PSPBuild
 cmdclass['sdist'] = PSPCheckSDist
 

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -199,7 +199,7 @@ class PSPCheckBDist(bdist_wheel):
 
 # Files for lab/notebook extension
 package_data_spec = {
-    "finos-perspective-jupyterlab": [
+    "perspective": [
         'nbextension/static/*.*js*',
         'labextension/*.tgz'
     ]

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -221,15 +221,15 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
-
-    keywords='analytics tools plotting',
+    platforms="Linux, Mac OS X, Windows",
+    keywords=['Jupyter', 'Jupyterlab', 'Widgets', 'IPython', 'Streaming', 'Data', 'Analytics', 'Plotting'],
     packages=find_packages(),
     include_package_data=True,
     data_files=[
         ('share/jupyter/nbextensions/finos-perspective-jupyterlab', [
             'finos-perspective-jupyterlab/nbextension/static/extension.js',
             'finos-perspective-jupyterlab/nbextension/static/index.js',
-            'ipydafinos-perspective-jupyterlabgred3/nbextension/static/index.js.map',
+            'finos-perspective-jupyterlabgred3/nbextension/static/index.js.map',
         ]),
         ('etc/jupyter/nbconfig/notebook.d', ['finos-perspective-jupyterlab.json'])
     ],

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -252,7 +252,7 @@ setup(
         ('share/jupyter/nbextensions/finos-perspective-jupyterlab', [
             'perspective/nbextension/static/extension.js',
             'perspective/nbextension/static/index.js',
-            'perspective/nbextension/static/index.js.map',
+            'perspective/nbextension/static/labextension.js',
         ]),
         ('etc/jupyter/nbconfig/notebook.d', ['finos-perspective-jupyterlab.json'])
     ],

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -170,6 +170,10 @@ def _check_cpp_files():
 
 
 def _check_js_files():
+    if os.environ.get('PERSPECTIVE_CI_SKIPJS'):
+        print('skipping js file check in ci')
+        return
+
     if not os.path.exists(os.path.join(here, 'perspective', 'labextension', 'finos-perspective-jupyterlab-{}.tgz'.format(version))):
         raise Exception("JupyterLab extension pack is missing!\nMust run `yarn build` or `yarn _js_for_dist` before building sdist so js files are installed")
 
@@ -207,7 +211,7 @@ package_data_spec = {
 
 # Files for lab/notebook extension
 data_files_spec = [
-    ('share/jupyter/nbextensions/',os.path.join(here, "perspective", 'nbextension', 'static'), '*.js*'),
+    ('share/jupyter/nbextensions/finos-perspective-jupyterlab',os.path.join(here, "perspective", 'nbextension', 'static'), '*.js*'),
     ('share/jupyter/lab/extensions', os.path.join(here, "perspective", 'labextension'), '*.tgz'),
     ('etc/jupyter/nbconfig/notebook.d' , here, 'finos-perspective-python.json')
 ]

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -250,9 +250,9 @@ setup(
     include_package_data=True,
     data_files=[
         ('share/jupyter/nbextensions/finos-perspective-jupyterlab', [
-            'finos-perspective-jupyterlab/nbextension/static/extension.js',
-            'finos-perspective-jupyterlab/nbextension/static/index.js',
-            'finos-perspective-jupyterlabgred3/nbextension/static/index.js.map',
+            'perspective/nbextension/static/extension.js',
+            'perspective/nbextension/static/index.js',
+            'perspective/nbextension/static/index.js.map',
         ]),
         ('etc/jupyter/nbconfig/notebook.d', ['finos-perspective-jupyterlab.json'])
     ],

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -201,23 +201,32 @@ class PSPCheckBDist(bdist_wheel):
         _check_js_files()
 
 
-# Files for lab/notebook extension
-package_data_spec = {
-    "perspective": [
-        'nbextension/static/*.*js*',
-        'labextension/*.tgz'
-    ]
-}
-
-# Files for lab/notebook extension
-data_files_spec = [
-    ('share/jupyter/nbextensions/finos-perspective-jupyterlab',os.path.join(here, "perspective", 'nbextension', 'static'), '*.js*'),
-    ('share/jupyter/lab/extensions', os.path.join(here, "perspective", 'labextension'), '*.tgz'),
-    ('etc/jupyter/nbconfig/notebook.d' , here, 'finos-perspective-python.json')
-]
-
 # Create a command class to ensure js files are installed
 if not os.environ.get('PERSPECTIVE_CI_SKIPJS'):
+    # Files for lab/notebook extension
+    package_data_spec = {
+        "perspective": [
+            'nbextension/static/*.*js*',
+            'labextension/*.tgz'
+        ]
+    }
+
+    # Files for lab/notebook extension
+    data_files_spec = [
+        ('share/jupyter/nbextensions/finos-perspective-jupyterlab',os.path.join(here, "perspective", 'nbextension', 'static'), '*.js*'),
+        ('share/jupyter/lab/extensions', os.path.join(here, "perspective", 'labextension'), '*.tgz'),
+        ('etc/jupyter/nbconfig/notebook.d' , here, 'finos-perspective-python.json')
+    ]
+
+    data_files = [
+            ('share/jupyter/nbextensions/finos-perspective-jupyterlab', [
+                'perspective/nbextension/static/extension.js',
+                'perspective/nbextension/static/index.js',
+                'perspective/nbextension/static/labextension.js',
+            ]),
+            ('etc/jupyter/nbconfig/notebook.d', ['finos-perspective-jupyterlab.json'])
+        ]
+
     cmdclass = create_cmdclass('ensure_js', package_data_spec=package_data_spec, data_files_spec=data_files_spec)
     cmdclass['ensure_js'] = combine_commands(
         ensure_targets([
@@ -229,9 +238,11 @@ if not os.environ.get('PERSPECTIVE_CI_SKIPJS'):
 else:
     # these files might be missing or rearranged during CI, so ignore
     cmdclass = {}
+    data_files = []
 
 cmdclass['build_ext'] = PSPBuild
 cmdclass['sdist'] = PSPCheckSDist
+cmdclass['bdist_wheel'] = PSPCheckBDist
 
 
 setup(
@@ -257,14 +268,7 @@ setup(
     keywords=['Jupyter', 'Jupyterlab', 'Widgets', 'IPython', 'Streaming', 'Data', 'Analytics', 'Plotting'],
     packages=find_packages(),
     include_package_data=True,
-    data_files=[
-        ('share/jupyter/nbextensions/finos-perspective-jupyterlab', [
-            'perspective/nbextension/static/extension.js',
-            'perspective/nbextension/static/index.js',
-            'perspective/nbextension/static/labextension.js',
-        ]),
-        ('etc/jupyter/nbconfig/notebook.d', ['finos-perspective-jupyterlab.json'])
-    ],
+    data_files=data_files,
     zip_safe=False,
     install_requires=requires,
     extras_require={

--- a/scripts/_js_for_dist.js
+++ b/scripts/_js_for_dist.js
@@ -55,7 +55,7 @@ try {
     rimraf.sync("package");
 } catch (e) {
     console.error(e.message);
-    if (process.env.PERSPECTIVE_JS_SKIPJS) {
+    if (process.env.PERSPECTIVE_CI_SKIPJS) {
         console.log("Allowing JS bundling to fail in CI (files might have changed)");
         process.exit(0);
     } else {

--- a/scripts/_js_for_dist.js
+++ b/scripts/_js_for_dist.js
@@ -1,0 +1,59 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const lernajson = require("../lerna.json");
+const {execute, resolve, bash} = require("./script_utils.js");
+const fs = require("fs-extra");
+const tar = require("tar");
+const rimraf = require("rimraf");
+
+/**
+ * Using Perspective's docker images, create a wheel built for the image
+ * architecture and output it to the local filesystem.
+ */
+try {
+    console.log("Downloading assets");
+
+    const labextension_folder = resolve`${__dirname}/../python/perspective/perspective/labextension`;
+    const nbextension_folder = resolve`${__dirname}/../python/perspective/perspective/nbextension/static`;
+
+    const package_name = `@finos/perspective-jupyterlab@${lernajson.version}`;
+    const tarball_name = `finos-perspective-jupyterlab-${lernajson.version}.tgz`;
+
+    console.log(`Removing ${labextension_folder} for labextension...`);
+    rimraf.sync(labextension_folder);
+    console.log(`Removing ${nbextension_folder} for nbextension...`);
+    rimraf.sync(nbextension_folder);
+
+    console.log(`Creating ${labextension_folder} for labextension...`);
+    fs.mkdirpSync(labextension_folder);
+    console.log(`Creating ${nbextension_folder} for nbextension...`);
+    fs.mkdirpSync(nbextension_folder);
+
+    console.log(`Fetching ${package_name} for labextension...`);
+    execute(bash`npm pack ${package_name}`);
+
+    console.log(`Unpacking ${package_name} for nbextension...`);
+    tar.extract({
+        file: tarball_name,
+        sync: true
+    });
+
+    console.log(`Moving tarball to labextension...`);
+    fs.moveSync(`${tarball_name}`, resolve`${labextension_folder}/${tarball_name}`);
+
+    console.log(`Moving files to nbextension...`);
+    fs.moveSync(`package/dist/index.js`, resolve`${nbextension_folder}/index.js`);
+    fs.moveSync(`package/dist/extension.js`, resolve`${nbextension_folder}/extension.js`);
+    fs.moveSync(`package/dist/labextension.js`, resolve`${nbextension_folder}/labextension.js`);
+    rimraf.sync("package");
+} catch (e) {
+    console.error(e.message);
+    process.exit(1);
+}

--- a/scripts/_js_for_dist.js
+++ b/scripts/_js_for_dist.js
@@ -55,5 +55,10 @@ try {
     rimraf.sync("package");
 } catch (e) {
     console.error(e.message);
-    process.exit(1);
+    if (process.env.PERSPECTIVE_JS_SKIPJS) {
+        console.log("Allowing JS bundling to fail in CI (files might have changed)");
+        process.exit(0);
+    } else {
+        process.exit(1);
+    }
 }

--- a/scripts/_wheel_python.js
+++ b/scripts/_wheel_python.js
@@ -37,7 +37,7 @@ try {
 
     if (IS_PY2) {
         // shutil_which is required in setup.py
-        cmd = bash`${PYTHON} -m pip install backports.shutil_which &&`;
+        cmd = bash`${PYTHON} -m pip install -U setuptools wheel jupyter_packaging backports.shutil_which &&`;
     } else {
         cmd = bash``;
     }

--- a/scripts/build_python.js
+++ b/scripts/build_python.js
@@ -37,8 +37,8 @@ try {
     if (IS_CI) {
         if (IS_PY2)
             // shutil_which is required in setup.py
-            cmd = bash`${PYTHON} -m pip install backports.shutil_which &&`;
-        else cmd = bash``;
+            cmd = bash`${PYTHON} -m pip install -U setuptools wheel jupyter_packaging backports.shutil_which &&`;
+        else cmd = bash`${PYTHON} -m pip install -U setuptools wheel jupyter_packaging &&`;
 
         cmd =
             cmd +

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -30,7 +30,15 @@ try {
         clean`cpp/perspective/obj`;
     }
     if (process.env.PSP_PROJECT === "python") {
-        clean("cpp/perspective/obj", "cpp/perspective/cppbuild", "python/perspective/dist", "python/perspective/build", "python/perspective/perspective_python.egg-info");
+        clean(
+            "cpp/perspective/obj",
+            "cpp/perspective/cppbuild",
+            "python/perspective/dist",
+            "python/perspective/build",
+            "python/perspective/perspective_python.egg-info",
+            "python/perspective/perspective/labextension",
+            "python/perspective/perspective/nbextension"
+        );
         return;
     }
     if (!IS_SCREENSHOTS && (!process.env.PACKAGE || minimatch("perspective", process.env.PACKAGE))) {

--- a/scripts/script_utils.js
+++ b/scripts/script_utils.js
@@ -231,6 +231,10 @@ exports.docker = function docker(image = "puppeteer") {
         env_vars += bash` -ePSP_MANYLINUX=1 `;
     }
 
+    if (IS_CI) {
+        env_vars += bash` -ePERSPECTIVE_CI_SKIPJS=1 `;
+    }
+
     let ret = bash`docker run \
         ${flags} \
         ${env_vars} \

--- a/yarn.lock
+++ b/yarn.lock
@@ -3567,6 +3567,11 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
   integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 chroma-js@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-1.4.1.tgz#eb2d9c4d1ff24616be84b35119f4d26f8205f134"
@@ -6819,6 +6824,13 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.6.0"
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
@@ -8404,7 +8416,7 @@ is-text-path@^1.0.0:
   dependencies:
     text-extensions "^1.0.0"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -10133,12 +10145,27 @@ minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
+  dependencies:
+    yallist "^4.0.0"
+
 minizlib@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
   integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   dependencies:
     minipass "^2.9.0"
+
+minizlib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.0.tgz#fd52c645301ef09a63a2c209697c294c6ce02cf3"
+  integrity sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -10175,6 +10202,11 @@ mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mobile-drag-drop@^2.3.0-rc.2:
   version "2.3.0-rc.2"
@@ -12219,7 +12251,7 @@ react-dev-utils@^9.1.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dom@16.8.6, react-dom@^16.8.4, react-dom@~16.9.0:
+react-dom@16.8.6, react-dom@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
   integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
@@ -12228,6 +12260,16 @@ react-dom@16.8.6, react-dom@^16.8.4, react-dom@~16.9.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
+
+react-dom@~16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
+  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.15.0"
 
 react-error-overlay@^6.0.3:
   version "6.0.4"
@@ -12267,7 +12309,7 @@ react-transition-group@^2.9.0:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@16.8.6, react@^16.12.0, react@^16.8.4, react@~16.9.0:
+react@16.8.6, react@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
@@ -12276,6 +12318,24 @@ react@16.8.6, react@^16.12.0, react@^16.8.4, react@~16.9.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
+
+react@^16.12.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@~16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
+  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-cmd-shim@^1.0.1:
   version "1.0.5"
@@ -12975,6 +13035,14 @@ scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
   integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -14015,6 +14083,18 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
+tar@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.2.tgz#5df17813468a6264ff14f766886c622b84ae2f39"
+  integrity sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.0"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 tcp-port-used@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.1.tgz#46061078e2d38c73979a2c2c12b5a674e6689d70"
@@ -14495,6 +14575,13 @@ typed-styles@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -15174,7 +15261,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^3.0.0:
+write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
   integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
@@ -15182,6 +15269,16 @@ write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, wri
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-file-atomic@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
 
 write-json-file@^2.2.0:
   version "2.3.0"
@@ -15302,6 +15399,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yamljs@^0.2.1:
   version "0.2.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8416,7 +8416,7 @@ is-text-path@^1.0.0:
   dependencies:
     text-extensions "^1.0.0"
 
-is-typedarray@^1.0.0, is-typedarray@~1.0.0:
+is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -12251,7 +12251,7 @@ react-dev-utils@^9.1.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dom@16.8.6, react-dom@^16.8.4:
+react-dom@16.8.6, react-dom@^16.8.4, react-dom@~16.9.0:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
   integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
@@ -12260,16 +12260,6 @@ react-dom@16.8.6, react-dom@^16.8.4:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
-
-react-dom@~16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
-  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.15.0"
 
 react-error-overlay@^6.0.3:
   version "6.0.4"
@@ -12309,7 +12299,7 @@ react-transition-group@^2.9.0:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@16.8.6, react@^16.8.4:
+react@16.8.6, react@^16.12.0, react@^16.8.4, react@~16.9.0:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
@@ -12318,24 +12308,6 @@ react@16.8.6, react@^16.8.4:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
-
-react@^16.12.0:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@~16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
-  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-cmd-shim@^1.0.1:
   version "1.0.5"
@@ -13035,14 +13007,6 @@ scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
   integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
-  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -14576,13 +14540,6 @@ typed-styles@^0.0.7:
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
 
-typedarray-to-buffer@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
-  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
-  dependencies:
-    is-typedarray "^1.0.0"
-
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -15261,7 +15218,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
+write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^3.0.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
   integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
@@ -15269,16 +15226,6 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
-
-write-file-atomic@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
-  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
-  dependencies:
-    imurmurhash "^0.1.4"
-    is-typedarray "^1.0.0"
-    signal-exit "^3.0.2"
-    typedarray-to-buffer "^3.1.5"
 
 write-json-file@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
This PR does a few things:

- distribute the labextension inside the python package, which removes the need for a separate `jupyter labextension install @finos/perspective-jupyterlab` step
- enable the classic notebook extension, and distribute the assets as well
- ensure the presence of the JS assets during sdist/bdist
