### PR TITLE
Fix regression in regex for Firefox

### DIFF
--- a/packages/perspective-viewer/src/js/computed_expressions/lexer.js
+++ b/packages/perspective-viewer/src/js/computed_expressions/lexer.js
@@ -37,7 +37,7 @@ export const UpperLowerCaseTokenType = createToken({
 });
 
 // Create tokens for column names and computed function names
-const column_name_regex_pattern = /(["'])(.*?[^\\])\1/y;
+export const COLUMN_NAME_REGEX_PATTERN = /(["'])(.*?[^\\])\1/y;
 
 /**
  * Given a string from which to extract a column name, extract the column name
@@ -48,8 +48,8 @@ const column_name_regex_pattern = /(["'])(.*?[^\\])\1/y;
  * @param {Number} start_offset
  */
 const match_column_name = function(string, start_offset) {
-    column_name_regex_pattern.lastIndex = start_offset;
-    const result = column_name_regex_pattern.exec(string);
+    COLUMN_NAME_REGEX_PATTERN.lastIndex = start_offset;
+    const result = COLUMN_NAME_REGEX_PATTERN.exec(string);
 
     if (result !== null && result.length === 3) {
         result.payload = result[2]; // 2nd capture group is in-between quotes

--- a/packages/perspective-viewer/src/js/computed_expressions/widget.js
+++ b/packages/perspective-viewer/src/js/computed_expressions/widget.js
@@ -15,7 +15,7 @@ import template from "../../html/computed_expression_widget.html";
 
 import style from "../../less/computed_expression_widget.less";
 
-import {ColumnNameTokenType, FunctionTokenType, OperatorTokenType, clean_tokens} from "./lexer";
+import {ColumnNameTokenType, FunctionTokenType, OperatorTokenType, clean_tokens, COLUMN_NAME_REGEX_PATTERN} from "./lexer";
 import {ComputedExpressionAutocompleteSuggestion} from "./computed_expression_parser";
 import {tokenMatcher} from "chevrotain";
 
@@ -407,7 +407,7 @@ class ComputedExpressionWidget extends HTMLElement {
             // FIXME: clean up this affront against all things good
             const last_word = old_value.substring(old_value.lastIndexOf(" ")).trim();
             const last_word_is_column_name = /["'].*[^'"]/.test(last_word) || last_word === '"' || last_word === "'";
-            const new_is_column_name = /(["'])(?<column_name>.*?[^\\])\1/y.test(new_value);
+            const new_is_column_name = COLUMN_NAME_REGEX_PATTERN.test(new_value);
 
             if (last_word_is_column_name && new_is_column_name) {
                 let last_word_idx = old_value.lastIndexOf(last_word);


### PR DESCRIPTION
This PR fixes a regression in a regular expression pattern that used a named capturing group. It was previously fixed by @telamonian, but I accidentally re-introduced it by using the old broken regex expression in a different place while building the autocomplete.