### PR TITLE
Run ESLint on documentation + minor documentation improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "parser": "babel-eslint",
     "plugins": [
+        "markdown",
         "prettier"
     ],
     "env": {
@@ -42,6 +43,14 @@
                 "ignoreTrailingComments": true
             }]
         }    
+    }, {
+        "files": ["**/*.md"],
+        "rules": {
+            "no-undef": "off",
+            "no-unused-vars": "off",
+            "no-console": "off",
+            "padded-blocks": "off"
+        }
     }],
     "rules": {
         "prettier/prettier": ["error", {

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -8,9 +8,6 @@
       "blog/2018-10-01-v0.2.0-release": {
         "title": "0.2.0 Release"
       },
-      "blog/2018-10-08-nyc-citibike-analysis-1": {
-        "title": "NYC Citibike Analytics in Real-Time, Part 1"
-      },
       "blog/2019-06-10-v0.3.0-release": {
         "title": "0.3.0 Release"
       },
@@ -34,6 +31,9 @@
       },
       "md/styles": {
         "title": "CSS Styles"
+      },
+      "node_modules/react/README": {
+        "title": "node_modules/react/README"
       },
       "obj/perspective-python": {
         "title": "perspective-python API"

--- a/docs/md/concepts.md
+++ b/docs/md/concepts.md
@@ -70,7 +70,7 @@ const schema = {
     d: "datetime",
     e: "boolean",
     f: "string"
-}
+};
 ```
 
 Because Perspective is built in multiple languages, data types are
@@ -123,7 +123,7 @@ To create a `Table` with a `limit`, provide the `limit` property with an integer
 indicating the `limit`:
 
 ```javascript
-const table = perspective.table(data, {limit: 1000})
+const table = perspective.table(data, {limit: 1000});
 ```
 
 `limit` cannot be used in conjunction with `index`.
@@ -140,7 +140,7 @@ To create an indexed `Table`, provide the `index` property with a string column
 name to be used as an index:
 
 ```javascript
-const table = perspective.table(data, {index: "a"})
+const table = perspective.table(data, {index: "a"});
 ```
 
 An indexed `Table` allows for in-place _updates_ whenever a new rows shares an
@@ -171,15 +171,18 @@ using the `index` to determine which rows to update:
 
 ```javascript
 // Create an indexed table
-const table = perspective.table({
-    "id": [1, 2, 3, 4],
-    "name": ["a", "b", "c", "d"]
-}, {index: "id"});
+const table = perspective.table(
+    {
+        id: [1, 2, 3, 4],
+        name: ["a", "b", "c", "d"]
+    },
+    {index: "id"}
+);
 
 // Update rows with primary key `1` and `4`
 table.update({
-    "id": [1, 4],
-    "name": ["x", "y"]
+    id: [1, 4],
+    name: ["x", "y"]
 });
 ```
 
@@ -195,10 +198,13 @@ An indexed `Table` can also have rows removed by primary key:
 
 ```javascript
 // Create an indexed table
-const table = perspective.table({
-    "id": [1, 2, 3, 4],
-    "name": ["a", "b", "c", "d"]
-}, {index: "id"});
+const table = perspective.table(
+    {
+        id: [1, 2, 3, 4],
+        name: ["a", "b", "c", "d"]
+    },
+    {index: "id"}
+);
 
 // Remove rows with primary key `1` and `4`
 table.remove([1, 4]);
@@ -240,8 +246,8 @@ instance via the `view()` method with a set of
 
 ```javascript
 const table = perspective.table({
-    "id": [1, 2, 3, 4],
-    "name": ["a", "b", "c", "d"]
+    id: [1, 2, 3, 4],
+    name: ["a", "b", "c", "d"]
 });
 
 // Create a view showing just the `name` column.
@@ -249,8 +255,11 @@ const view = table.view({
     columns: ["name"]
 });
 
-// Now you have a `View`!  Get your data!
-const json = await view.to_json();
+// Now you have a `View`!  Get your data using ES6 async/await:
+const json = async () => await view.to_json();
+
+// or using the Promise API
+view.to_arrow().then(arrow => console.log(arrow));
 
 // Delete the Query!
 view.delete();

--- a/docs/md/development.md
+++ b/docs/md/development.md
@@ -273,7 +273,7 @@ the `build/` directory of every package which supports benchmarks, as well as a
 `results.json` file in the `bench/results/`, which can be checked in to GIT with
 your changes to preserve them for future comparison.
 
-```javascript
+```bash
 yarn bench
 ```
 

--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -42,12 +42,12 @@ Perspective's additional assets, and is easy to set up in your `webpack.config`:
 const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
 
 module.exports = {
-  entry: "./in.js",
-  output: {
-    filename: "out.js",
-    path: "build"
-  },
-  plugins: [new PerspectivePlugin()]
+    entry: "./in.js",
+    output: {
+        filename: "out.js",
+        path: "build"
+    },
+    plugins: [new PerspectivePlugin()]
 };
 ```
 
@@ -74,8 +74,8 @@ Once added to your page, you can access the Javascript API through the
 
 ```javascript
 const worker = perspective.worker();
-const table = worker.table({ A: [1, 2, 3] });
-const view = table.view({ sort: [["A", "desc"]] });
+const table = worker.table({A: [1, 2, 3]});
+const view = table.view({sort: [["A", "desc"]]});
 ```
 
 Or create a `<perspective-viewer>` in HTML:

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -617,7 +617,7 @@ import "@finos/perspective-viewer/themes/material-dense.dark.css";
 import "@finos/perspective-viewer/themes/vaporwave.css";
 ```
 
-**_Note that importing multiple themes may override each other_**
+***Note that importing multiple themes may override each other***
 
 Alternatively, you may use `all-themes.css`, which exposes all available
 themes as CSS classes. This allows you to trivially apply different themes
@@ -635,15 +635,9 @@ _*index.html*_
 
 ```html
 <perspective-viewer class="perspective-viewer-material"></perspective-viewer>
-<perspective-viewer
-  class="perspective-viewer-material-dark"
-></perspective-viewer>
-<perspective-viewer
-  class="perspective-viewer-material-dense"
-></perspective-viewer>
-<perspective-viewer
-  class="perspective-viewer-material-dense-dark"
-></perspective-viewer>
+<perspective-viewer class="perspective-viewer-material-dark"></perspective-viewer>
+<perspective-viewer class="perspective-viewer-material-dense"></perspective-viewer>
+<perspective-viewer class="perspective-viewer-material-dense-dark"></perspective-viewer>
 <perspective-viewer class="perspective-viewer-vaporwave"></perspective-viewer>
 ```
 

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -94,7 +94,8 @@ different visualization on load or transform the dataset, use the viewer's attri
   id="view1"
   plugin="xy_scatter"
   columns='["Sales", "Profits"]'
-  row_pivots='["State", "City"]'>
+  row_pivots='["State", "City"]'
+>
 </perspective-viewer>
 ```
 
@@ -122,14 +123,14 @@ and must be imported individually.
 
 Perspective offers these plugin modules:
 
-- `@finos/perspective-viewer-d3fc`  
+- `@finos/perspective-viewer-datagrid`  
   A custom high-performance data-grid component based on HTML `<table>`.
 
 - `@finos/perspective-viewer-d3fc`  
   A `<perspective-viewer>` plugin for the [d3fc](https://d3fc.io) charting
   library.
 
-Also available are these legacy modules;  though no longer under development,
+Also available are these legacy modules; though no longer under development,
 they are compatible with perspective versions < 1.0.0:
 
 - `@finos/perspective-viewer-hypergrid`  
@@ -157,6 +158,7 @@ modules. Some basic guidelines to help you decide what is most appropriate for
 your project:
 
 - For Perspective as a simple, browser-based data visualization widget, import:
+
   - `@finos/perspective-viewer`, detailed [here](#perspective-viewer-web-component)
   - `@finos/perspective-viewer-datagrid` for data grids
   - `@finos/perspective-viewer-d3fc` for charting
@@ -165,6 +167,7 @@ your project:
 
 - For Perspective's high-performance streaming data engine (in WebAssembly), or
   for a purely Node.js based application, import:
+
   - `@finos/perspective`, as detailed [here](#perspective-library)
 
 - For more complex cases, such as
@@ -192,15 +195,15 @@ It exports Perspective's data interfaces:
 
 `@finos/perspective` also exports process management functions such as
 `worker()` and `websocket()` (in the browser) and `WebSocketServer()`
-(in node.js). See the [API documentation](/obj/perspective.html) for a complete 
+(in node.js). See the [API documentation](/obj/perspective.html) for a complete
 reference on all exported methods.
 
-This module is a dependency of `@finos/perspective-viewer`, and is not needed if 
+This module is a dependency of `@finos/perspective-viewer`, and is not needed if
 you only intend to use `<perspective-viewer>` to visualize simple data.
 
 ### Importing in the browser
 
-`perspective` can be imported as an ES6 module and/or `require` syntax if you're 
+`perspective` can be imported as an ES6 module and/or `require` syntax if you're
 using a bundler such as Webpack (and the `@finos/perspective-webpack-plugin`):
 
 ```javascript
@@ -225,7 +228,7 @@ const perspective = require("@finos/perspective");
 
 Once imported, you'll need to instantiate a `perspective` engine via the
 `worker()` method. This will create a new WebWorker (browser) or
-Process (Node.js), and load the WebAssembly binary; all calculation and data 
+Process (Node.js), and load the WebAssembly binary; all calculation and data
 accumulation will occur in this separate process.
 
 ```javascript
@@ -267,7 +270,7 @@ const table1 = worker.table(data);
 ```
 
 `table()`s are columnar data structures, and each column must have a single
-type. When passing data directly to the `table()` constructor, the type of each 
+type. When passing data directly to the `table()` constructor, the type of each
 column is inferred automatically.
 
 Perspective supports the following types:
@@ -297,7 +300,7 @@ var schema = {
 const table2 = worker.table(schema);
 ```
 
-Once instatiated, a `table()` can be updated with new data via the `update()` 
+Once instatiated, a `table()` can be updated with new data via the `update()`
 method:
 
 ```javascript
@@ -382,7 +385,7 @@ table.update([{x: 3, y: "Just Y"}]);
 
 #### Deleting rows with `remove()`
 
-Rows can be removed entirely from a `table()` with `index` set. Call the 
+Rows can be removed entirely from a `table()` with `index` set. Call the
 `remove()` method with a list of the `index` values to be removed:
 
 ```javascript
@@ -614,7 +617,7 @@ import "@finos/perspective-viewer/themes/material-dense.dark.css";
 import "@finos/perspective-viewer/themes/vaporwave.css";
 ```
 
-***Note that importing multiple themes may override each other***
+**_Note that importing multiple themes may override each other_**
 
 Alternatively, you may use `all-themes.css`, which exposes all available
 themes as CSS classes. This allows you to trivially apply different themes
@@ -631,11 +634,17 @@ import "@finos/perspective-viewer/themes/all-themes.css";
 _*index.html*_
 
 ```html
-<perspective-viewer class='perspective-viewer-material'></perspective-viewer>
-<perspective-viewer class='perspective-viewer-material-dark'></perspective-viewer>
-<perspective-viewer class='perspective-viewer-material-dense'></perspective-viewer>
-<perspective-viewer class='perspective-viewer-material-dense-dark'></perspective-viewer>
-<perspective-viewer class='perspective-viewer-vaporwave'></perspective-viewer>
+<perspective-viewer class="perspective-viewer-material"></perspective-viewer>
+<perspective-viewer
+  class="perspective-viewer-material-dark"
+></perspective-viewer>
+<perspective-viewer
+  class="perspective-viewer-material-dense"
+></perspective-viewer>
+<perspective-viewer
+  class="perspective-viewer-material-dense-dark"
+></perspective-viewer>
+<perspective-viewer class="perspective-viewer-vaporwave"></perspective-viewer>
 ```
 
 If you choose not to bundle the themes yourself, they are available through
@@ -644,7 +653,10 @@ the [unpkg.com](https://unpkg.com/@finos/perspective-viewer/dist/umd/).
 These can be directly linked in your HTML:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@finos/perspective-viewer/dist/umd/material.css"/>
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@finos/perspective-viewer/dist/umd/material.css"
+/>
 ```
 
 ### Loading data into `<perspective-viewer>`
@@ -813,22 +825,22 @@ _*index.html*_
 <perspective-viewer id="viewer" editable></perspective-viewer>
 
 <script>
-    window.addEventListener('WebComponentsReady', async function() {
-        // Create a client that expects a Perspective server
-        // to accept connections at the specified URL.
-        const websocket = perspective.websocket("ws://localhost:8888/websocket");
+  window.addEventListener("WebComponentsReady", async function () {
+    // Create a client that expects a Perspective server
+    // to accept connections at the specified URL.
+    const websocket = perspective.websocket("ws://localhost:8888/websocket");
 
-        /* `table` is a proxy for the `Table` we created on the server.
+    /* `table` is a proxy for the `Table` we created on the server.
 
         All operations that are possible through the Javascript API are possible
         on the Python API as well, thus calling `view()`, `schema()`, `update()`
         etc. on `const table` will pass those operations to the Python `Table`,
         execute the commands, and return the result back to Javascript.*/
-        const table = websocket.open_table('data_source_one');
+    const table = websocket.open_table("data_source_one");
 
-        // Load this in the `<perspective-viewer>`.
-        document.getElementById('viewer').load(table);
-    });
+    // Load this in the `<perspective-viewer>`.
+    document.getElementById("viewer").load(table);
+  });
 </script>
 ```
 

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -17,6 +17,9 @@ This document offers an overview of the Javascript library, providing:
 For understanding Perspective's core concepts and vocabulary, see the
 [Conceptual Overview](/docs/md/concepts.html).
 
+For example code, see the [examples directory](https://github.com/finos/perspective/tree/master/examples)
+on GitHub.
+
 ## Quick Start
 
 First, make sure that Perspective [is installed](/docs/md/installation.html),

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -79,8 +79,8 @@ handle everything for you:
 ```javascript
 // Assume that new ticks are delivered via websocket
 websocket.onmessage = function(event) {
-  viewer.update(event.data);
-}
+    viewer.update(event.data);
+};
 ```
 
 ### Configuring `perspective-viewer`
@@ -257,10 +257,10 @@ to the table via its `update()` method.
 ```javascript
 // With data (also works with strings in CSV format)
 var data = [
-  { x: 1, y: "a", z: true },
-  { x: 2, y: "b", z: false },
-  { x: 3, y: "c", z: true },
-  { x: 4, y: "d", z: false }
+    {x: 1, y: "a", z: true},
+    {x: 2, y: "b", z: false},
+    {x: 3, y: "c", z: true},
+    {x: 4, y: "d", z: false}
 ];
 
 const table1 = worker.table(data);
@@ -289,9 +289,9 @@ In these cases, create a `table()` with a _schema_:
 ```javascript
 // With a schema
 var schema = {
-  x: "integer",
-  y: "string",
-  z: "boolean"
+    x: "integer",
+    y: "string",
+    z: "boolean"
 };
 
 const table2 = worker.table(schema);
@@ -302,8 +302,8 @@ method:
 
 ```javascript
 // Add a new row to each table
-table1.update([{ x: 5, y: "e", z: true }]);
-table2.update([{ x: 5, y: "e", z: true }]);
+table1.update([{x: 5, y: "e", z: true}]);
+table2.update([{x: 5, y: "e", z: true}]);
 ```
 
 New data is appended by default. In-place updates can be enabled through the
@@ -317,10 +317,13 @@ table:
 
 ```javascript
 // Use the 'x' column as a primary key
-const table3 = worker.table({
-  x: [1, 2, 3, 4],
-  y: ["a", "b", "c", "d"]
-}, { index: "x" });
+const table3 = worker.table(
+    {
+        x: [1, 2, 3, 4],
+        y: ["a", "b", "c", "d"]
+    },
+    {index: "x"}
+);
 ```
 
 If an index is set, the `update()` method uses the index to _replace_ or
@@ -329,15 +332,15 @@ _append_ rows:
 ```javascript
 // Replace the values at index 1 and 4
 table3.update({
-  x: [1, 4],
-  y: ["new1", "new2"]
+    x: [1, 4],
+    y: ["new1", "new2"]
 });
 
 // append these rows, as the value in `x` is not an existing primary key
 table3.update({
-  x: [5, 6],
-  y: ["e", "f"]
-})
+    x: [5, 6],
+    y: ["e", "f"]
+});
 ```
 
 #### Row limits via `limit`
@@ -348,7 +351,7 @@ rows.
 
 ```javascript
 // Keep only the most recent 1000 rows
-const table3 = worker.table(data, { limit: 1000 });
+const table3 = worker.table(data, {limit: 1000});
 ```
 
 Appended rows that exceed the `limit` overwrite old rows starting at position 0.
@@ -363,7 +366,7 @@ on a `table()` with `index` applied:
 
 ```javascript
 // Unsets the 'y' column for row 3
-table.update([{ x: 3, y: null }]);
+table.update([{x: 3, y: null}]);
 ```
 
 #### Partial row updates via `undefined`
@@ -374,7 +377,7 @@ Missing keys, or keys with values set to `undefined`, will be omitted from
 
 ```javascript
 // Only updates the 'y' column for row 3, leaving the 'z' column alone
-table.update([{ x: 3, y: "Just Y" }]);
+table.update([{x: 3, y: "Just Y"}]);
 ```
 
 #### Deleting rows with `remove()`
@@ -398,10 +401,10 @@ configuration object:
 const table = worker.table(data);
 
 const view = table.view({
-  columns: ["Sales"],
-  aggregates: { Sales: "sum" },
-  row_pivot: ["Region", "Country"],
-  filter: [["Category", "in", ["Furniture", "Technology"]]]
+    columns: ["Sales"],
+    aggregates: {Sales: "sum"},
+    row_pivot: ["Region", "Country"],
+    filter: [["Category", "in", ["Furniture", "Technology"]]]
 });
 ```
 
@@ -426,10 +429,12 @@ view.to_csv().then(csv => console.log(csv));
 view.to_arrow().then(arrow => console.log(arrow));
 
 // Via ES6 await/async
-console.log(await view.to_json());
-console.log(await view.to_columns());
-console.log(await view.to_csv());
-console.log(await view.to_arrow());
+async function print_data() {
+    console.log(await view.to_json());
+    console.log(await view.to_columns());
+    console.log(await view.to_csv());
+    console.log(await view.to_arrow());
+}
 ```
 
 ### Deleting a `table()` or `view()`
@@ -464,17 +469,17 @@ const worker2 = perspective.worker();
 
 // Create a `table and `view` on `worker1`.
 const table = worker1.table(data);
-const view = table.view({ filter: [["State", "==", "Texas"]] });
+const view = table.view({filter: [["State", "==", "Texas"]]});
 
 // Create a table from `view` in `worker2`
 const table2 = worker2.table(view);
-const view2 = table2.view({ filter: [["City", "==", "Austin"]] });
+const view2 = table2.view({filter: [["City", "==", "Austin"]]});
 
 //  Both `view1` and `view2` are updated.
-table.update([{ State: "Texas", City: "Austin" }]);
+table.update([{State: "Texas", City: "Austin"}]);
 
 //  Only `view1` is updated.
-table.update([{ State: "Texas", City: "San Antonio" }]);
+table.update([{State: "Texas", City: "San Antonio"}]);
 ```
 
 This is especially useful for piping together `perspective` data from
@@ -500,18 +505,18 @@ configuration object to the `worker()` constructor on initialization.
 
 ```javascript
 module.exports = {
-  types: {
-    string: {
-      aggregate: "dominant"
-    },
-    float: {
-      format: {
-        style: "decimal",
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      }
+    types: {
+        string: {
+            aggregate: "dominant"
+        },
+        float: {
+            format: {
+                style: "decimal",
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            }
+        }
     }
-  }
 };
 ```
 
@@ -523,9 +528,9 @@ First, add a new type and declare its base in your `perspective.config.js`:
 
 ```javascript
 module.exports = {
-  types: {
-    price: { type: "float" }
-  }
+    types: {
+        price: {type: "float"}
+    }
 };
 ```
 
@@ -533,8 +538,8 @@ Perspective will not infer these types for you, so you'll need to create your
 table [from a schema](#loading-data-with-table) to use them:
 
 ```javascript
-const table = worker.table({ volume: "integer", price: "price" });
-table.update([{ volume: 10, price: 100.75 }]);
+const table = worker.table({volume: "integer", price: "price"});
+table.update([{volume: 10, price: 100.75}]);
 ```
 
 #### Formatting data types
@@ -544,17 +549,17 @@ Default and user-created types can be styled using the `format` key in
 
 ```javascript
 module.exports = {
-  types: {
-    price: {
-      type: float,
-      format: {
-        style: "decimal",
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      }
+    types: {
+        price: {
+            type: float,
+            format: {
+                style: "decimal",
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            }
+        }
     }
-  }
-}
+};
 ```
 
 ## `perspective-viewer` web component
@@ -655,18 +660,18 @@ has loaded:
 
 ```javascript
 document.addEventListener("WebComponentsReady", function() {
-  var data = [
-    { x: 1, y: "a", z: true },
-    { x: 2, y: "b", z: false },
-    { x: 3, y: "c", z: true },
-    { x: 4, y: "d", z: false }
-  ];
+    var data = [
+        {x: 1, y: "a", z: true},
+        {x: 2, y: "b", z: false},
+        {x: 3, y: "c", z: true},
+        {x: 4, y: "d", z: false}
+    ];
 
-  var viewer = document.getElementById("view1");
-  viewer.load(data);
+    var viewer = document.getElementById("view1");
+    viewer.load(data);
 
-  // Add new row
-  viewer.update([{ x: 5, y: "e", z: true }]);
+    // Add new row
+    viewer.update([{x: 5, y: "e", z: true}]);
 });
 ```
 
@@ -709,7 +714,7 @@ view1.load(table);
 view2.load(table);
 
 // Both `view1` and `view2` will reflect this update
-table.update([{ x: 5, y: "e", z: true }]);
+table.update([{x: 5, y: "e", z: true}]);
 ```
 
 ### Remote Perspective via `WebSocketServer()` and Node.js
@@ -723,13 +728,13 @@ footprint.
 In Node.js:
 
 ```javascript
-const { WebSocketServer, table } = require("@finos/perspective");
+const {WebSocketServer, table} = require("@finos/perspective");
 const fs = require("fs");
 
 // Start a WS/HTTP host on port 8080.  The `assets` property allows
 // the `WebSocketServer()` to also serves the file structure rooted in this
 // module's directory.
-const host = new WebSocketServer({ assets: [__dirname], port: 8080 });
+const host = new WebSocketServer({assets: [__dirname], port: 8080});
 
 // Read an arrow file from the file system and load it as a named table.
 const arr = fs.readFileSync(__dirname + "/superstore.arrow");
@@ -737,7 +742,7 @@ const tbl = table(arr);
 host.host_table("table_one", tbl);
 
 // Or host a view
-const view = tbl.view({ filter: [["State", "==", "Texas"]] });
+const view = tbl.view({filter: [["State", "==", "Texas"]]});
 host.host_view("view_one", view);
 ```
 
@@ -747,9 +752,7 @@ In the browser:
 const elem = document.getElementsByTagName("perspective-viewer")[0];
 
 // Bind to the server's worker instead of instantiating a Web Worker.
-const websocket = perspective.websocket(
-  window.location.origin.replace("http", "ws")
-);
+const websocket = perspective.websocket(window.location.origin.replace("http", "ws"));
 
 // Bind the viewer to the preloaded data source.  `table` and `view` objects
 // live on the server.
@@ -888,8 +891,8 @@ through user interaction will fire a `perspective-config-update` event:
 
 ```javascript
 elem.addEventListener("perspective-config-update", function() {
-  var config = elem.save();
-  console.log("The view() config has changed to " + JSON.stringify(config));
+    var config = elem.save();
+    console.log("The view() config has changed to " + JSON.stringify(config));
 });
 ```
 
@@ -908,7 +911,7 @@ property returns the associated row data.
 
 ```javascript
 elem.addEventListener("perspective-click", function(event) {
-  var config = event.detail.config;
-  elem.restore(config);
+    var config = event.detail.config;
+    elem.restore(config);
 });
 ```

--- a/docs/md/python.md
+++ b/docs/md/python.md
@@ -31,8 +31,10 @@ The `perspective` module exports several tools:
 - `Table`, the table constructor for Perspective, which implements the `table`
   and `view` API in the same manner as the Javascript library.
 - `PerspectiveWidget` the JupyterLab widget for interactive visualization.
-- `PerspectiveManager` the session manager for shared server deployment, with a
-  reference implementation in [Tornado](https://www.tornadoweb.org/).
+- `PerspectiveTornadoHandler`, an integration with [Tornado](https://www.tornadoweb.org/)
+that interfaces seamlessly with `<perspective-viewer>` in Javascript.
+- `PerspectiveManager` the session manager for a shared server deployment of
+`perspective-python`.
 
 This user's guide provides an overview of the most common ways to use
 Perspective in Python: the `Table` API, the JupyterLab widget, and the Tornado
@@ -41,6 +43,9 @@ handler.
 For an understanding of Perspective's core concepts, see the
 [Conceptual Overview](/docs/md/concepts.html). For API documentation, see the
 [Python API](/docs/obj/perspective-python.html).
+
+For example code, see the [Python examples directory](https://github.com/finos/perspective/tree/master/python/perspective/examples)
+on GitHub.
 
 ## `Table`
 
@@ -95,7 +100,9 @@ objects. Because Perspective is designed for applying its own transformations on
 top of a flat dataset, dataframes that are passed in will be flattened and have
 its `index` treated as another column (through the
 [`reset_index()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.reset_index.html)
-method). If the dataframe does not have an index set, an integer-typed column
+method).
+
+If the dataframe does not have an index set, an integer-typed column
 named `"index"` is created. If you want to preserve the indexing behavior of the
 dataframe passed into Perspective, simply create the `Table` with
 `index="index"` as a keyword argument. This tells Perspective to once again
@@ -138,30 +145,41 @@ actual Python `type` of the data that it receives.
 
 Type inference can also leverage python converters, e.g. `__int__`, `__float__`, etc.
 
-Additionally, when loading a custom object into perspective, there are several options:
+#### Loading Custom Objects
 
-- Perspective will default to `str` column type and call the objects' `__repr__` method
-- You can customize how perspective extracts data from your objects by implementing
-  - `_psp_repr_`: Since `__repr__` can only return strings, this lets you return other values
-  - `_psp_dtype_`: perpspective will look at this to determine how to cast your objects' repr
-  - if you use `object` in schema, or have `_psp_dtype_` return `object`, we will store a reference
-  to your object as an unsigned 64 bit integer (e.g. a pointer)
+Custom objects can also be loaded into Perspective by using `object` in the schema, or
+implementing `_psp_repr_` to return `object`. Perspective stores a reference
+to your object as an unsigned 64-bit integer (e.g. a pointer), and uses  `__repr__`
+(or `_psp_repr` if implemented) to represent the object.
+
+You can customize how perspective extracts data from your objects by implementing these
+two methods into your object:
+
+- `_psp_repr_`: Since `__repr__` can only return strings, this lets you return other values
+- `_psp_dtype_`: perpspective will look at this to determine how to cast your objects' repr.
 
 #### Time Zone Handling
 
 When passing in `datetime` objects, Perspective checks the `tzinfo` attribute
-to see if a time zone is set. Objects with an unset `tzinfo` attribute are
-treated as local time, and do not undergo any time zone conversion. Objects with
-the `tzinfo` attribute set will be _converted into UTC_ before being stored in
+to see if a time zone is set. For more details, see this in-depth [explanation](https://github.com/finos/perspective/pull/867)
+of `perspective-python` semantics around time zone handling.
+
+##### Naive Datetimes
+
+Objects with an unset `tzinfo` attribute (naive datetimes) are treated as _local time_, and do not undergo any time zone conversion.
+
+##### Aware Datetimes
+
+Objects with the `tzinfo` attribute set (aware datetimes) will be _converted into UTC_ before being stored in
 Perspective, and they will be _serialized as local time_.
+
+##### Pandas Timestamps
 
 `pandas.Timestamp` objects stored in a `pandas.DataFrame` are _always_ treated
 as UTC times, and will be converted to local time when serialized to the user.
+
 To treat a `Timestamp` in a `DataFrame` as local time, use `tz_localize` or
 `tz_convert` to provide the `Timestamp` with a time zone.
-
-For more details, see this in-depth [explanation](https://github.com/finos/perspective/pull/867)
-of Perspective's semantics around time zone handling.
 
 ### Callbacks and Events
 
@@ -170,19 +188,32 @@ set—simply call `on_update` or `on_delete` with a reference to a function or a
 lambda without any parameters:
 
 ```python
-def callback():
+def update_callback():
     print("Updated!")
-view.on_update(callback)
-view.on_delete(lambda: print("Updated again!"))
+
+# set the update callback
+view.on_update(update_callback)
+
+
+def delete_callback():
+    print("Deleted!")
+
+# set the delete callback
+view.on_delete(delete_callback)
+
+# set a lambda as a callback
+view.on_delete(lambda: print("Deleted x2!"))
 ```
 
 If the callback is a named reference to a function, it can be removed with
-`remove_update` or `remove_delete`. Callbacks defined with a lambda function
-cannot be removed, as lambda functions have no identifier.
+`remove_update` or `remove_delete`:
 
 ```python
-view.remove_update(callback)
+view.remove_update(update_callback)
+view.remove_delete(delete_callback)
 ```
+
+Callbacks defined with a lambda function cannot be removed, as lambda functions have no identifier.
 
 ## `PerspectiveManager`
 
@@ -199,13 +230,13 @@ using a websocket API.
 
 `PerspectiveManager` has the ability to "host" `perspective.Table` and
 `perspective.View` instances. Hosted tables/views can have their methods
-called from other sources than the user, i.e. by a `perspective-viewer` running
-in Javascript over the network, interfacing with `perspective-python` through
+called from other sources than the Python server, i.e. by a `perspective-viewer` running
+in a Javascript client over the network, interfacing with `perspective-python` through
 the websocket API.
 
-The user has full control of all hosted `Table` and `View` instances, and can
-call any API method on hosted instances. This makes it extremely easy to
-stream data to a hosted `Table` using `.update()`:
+The server has full control of all hosted `Table` and `View`
+instances, and can call any public API method on hosted instances. This makes
+it extremely easy to stream data to a hosted `Table` using `.update()`:
 
 ```python
 manager = PerspectiveManager()
@@ -215,6 +246,18 @@ manager.host_table("data_source", table)
 for i in range(10):
     # updates continue to propagate automatically
     table.update(new_data)
+```
+
+In situations where clients should only be able to view the table and
+not modify it through `update`, `delete`, etc., initialize the `PerspectiveManager`
+with `lock=True`, or call the `lock()` method on a manager instance:
+
+```python
+# lock prevents clients from calling methods that may mutate the state
+# of the table.
+manager = PerspectiveManager(lock=True)
+table = Table(data)
+manager.host_table("data_source", table)
 ```
 
 A `PerspectiveManager` instance can host as many `Table`s and `View`s as

--- a/docs/md/python.md
+++ b/docs/md/python.md
@@ -56,7 +56,6 @@ commonly used when processing data:
 
 - `pandas.DataFrame`
 - `numpy.ndarray`
-- `numpy.ndarray`
 - `bytes` (encoding an Apache Arrow)
 - `objects` (either extracting a repr or via reference)
 
@@ -95,7 +94,7 @@ arrays, make sure that your dataset contains only NumPy arrays, and not a
 mixture of arrays and Python lists — this will raise an exception. Numpy
 structured/record arrays are parsed according to their field name and dtype.
 
-`Table` can aslo be constructed from `pandas.DataFrame` and `pandas.Series`
+`Table` can also be constructed from `pandas.DataFrame` and `pandas.Series`
 objects. Because Perspective is designed for applying its own transformations on
 top of a flat dataset, dataframes that are passed in will be flattened and have
 its `index` treated as another column (through the
@@ -333,22 +332,22 @@ _*index.html*_
 <perspective-viewer id="viewer" editable></perspective-viewer>
 
 <script>
-    window.addEventListener('WebComponentsReady', async function() {
-        // Create a client that expects a Perspective server
-        // to accept connections at the specified URL.
-        const websocket = perspective.websocket("ws://localhost:8888/websocket");
+  window.addEventListener("WebComponentsReady", async function () {
+    // Create a client that expects a Perspective server
+    // to accept connections at the specified URL.
+    const websocket = perspective.websocket("ws://localhost:8888/websocket");
 
-        /* `table` is a proxy for the `Table` we created on the server.
+    /* `table` is a proxy for the `Table` we created on the server.
 
         All operations that are possible through the Javascript API are possible
         on the Python API as well, thus calling `view()`, `schema()`, `update()`
         etc. on `const table` will pass those operations to the Python `Table`,
         execute the commands, and return the result back to Javascript.*/
-        const table = websocket.open_table('data_source_one');
+    const table = websocket.open_table("data_source_one");
 
-        // Load this in the `<perspective-viewer>`.
-        document.getElementById('viewer').load(table);
-    });
+    // Load this in the `<perspective-viewer>`.
+    document.getElementById("viewer").load(table);
+  });
 </script>
 ```
 
@@ -377,7 +376,7 @@ MANAGER.host_view("view_one", VIEW)
 # Continue with Tornado setup
 ```
 
-Changes to the client code are also minimal. Use `open_view` instead of 
+Changes to the client code are also minimal. Use `open_view` instead of
 `open_table`:
 
 ```javascript

--- a/docs/static/css/material.dark.css
+++ b/docs/static/css/material.dark.css
@@ -20,6 +20,7 @@
 perspective-viewer,
 .perspective-viewer-material {
   font-family: "Open Sans";
+  --interface--font-family: "Open Sans";
   --interface-monospace--font-family: "Roboto Mono";
   --inactive-column-selector--content: "\E835";
   --active-column-selector--content: "\E834";
@@ -60,6 +61,8 @@ perspective-viewer,
   --column-container--margin: 24px 0px 0px 0px;
   --column-add--font-family: "Material Icons";
   --column-add--before: "add";
+  --column-close--font-family: "Material Icons";
+  --column-close--before: "close";
   --column_type--padding: 0px 0px 0px 0px;
   --column_type--width: 25px;
   --column-selector--font-family: "Material Icons";
@@ -103,6 +106,7 @@ perspective-viewer,
 .homeContainer .perspective-viewer-material-dense-dark,
 #get_started .perspective-viewer-material-dense-dark {
   font-family: "Open Sans";
+  --interface--font-family: "Open Sans";
   --interface-monospace--font-family: "Roboto Mono";
   --inactive-column-selector--content: "\E835";
   --active-column-selector--content: "\E834";
@@ -143,6 +147,8 @@ perspective-viewer,
   --column-container--margin: 24px 0px 0px 0px;
   --column-add--font-family: "Material Icons";
   --column-add--before: "add";
+  --column-close--font-family: "Material Icons";
+  --column-close--before: "close";
   --column_type--padding: 0px 0px 0px 0px;
   --column_type--width: 25px;
   --column-selector--font-family: "Material Icons";
@@ -165,6 +171,8 @@ perspective-viewer,
   --d3fc-treedata-axis--lines: none;
   background-color: #2a2c2f;
   color: #cfd8dc;
+  --background-color: #2a2c2f;
+  --color: #cfd8dc;
   --plugin--background: #2f3136;
   --select--background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIwLjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0LjkgMTAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDQuOSAxMDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiM0NDQ0NDQ7fQo8L3N0eWxlPgo8dGl0bGU+YXJyb3dzPC90aXRsZT4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIxLjQsNC43IDIuNSwzLjIgMy41LDQuNyAiLz4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIzLjUsNS4zIDIuNSw2LjggMS40LDUuMyAiLz4KPC9zdmc+Cg==) no-repeat 95% 50%;
   --inactive--color: #666;
@@ -182,6 +190,9 @@ perspective-viewer,
   --hypergrid-selection--background: rgba(255, 255, 255, 0.25);
   --hypergrid-positive--color: #22a0ce;
   --hypergrid-negative--color: #ff8888;
+  --expression--operator-color: #cfd8dc;
+  --expression--function-color: #22a0ce;
+  --expression--error-color: #ff8888;
   --hypergrid-row-hover--background: #555;
   --hypergrid-row-hover--color: #eee;
   --hypergrid-cell-hover--background: #444;
@@ -215,6 +226,8 @@ perspective-viewer,
   --highcharts-positive--gradient: linear-gradient(#222222 0%, #1a237e 35%, #42b3d5 70%, #dcedc8 100%);
   --highcharts-negative--gradient: linear-gradient(#feeb65 0%, #e4521b 35%, #4d342f 70%, #222222 100%);
   --warning--color: #333;
+  --autocomplete-select-background: #555;
+  --autocomplete-hover-background: #444;
   --hypergrid--padding: 12px 12px 12px 12px;
   --hypergrid-row--height: 20px;
   --side_panel--padding: 12px 12px 12px 10px;

--- a/examples/simple/superstore.html
+++ b/examples/simple/superstore.html
@@ -15,6 +15,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
 
     <script src="perspective-viewer.js"></script>
+    <script src="perspective-viewer-hypergrid.js"></script>
     <script src="perspective-viewer-datagrid.js"></script>
     <script src="perspective-viewer-d3fc.js"></script>
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "dotenv": "^8.1.0",
         "eslint": "^6.6.0",
         "eslint-config-prettier": "^3.0.1",
+        "eslint-plugin-markdown": "^1.0.2",
         "eslint-plugin-prettier": "^2.6.2",
         "file-loader": "^2.0.0",
         "fs-extra": "^8.1.0",

--- a/packages/perspective-viewer/README.md
+++ b/packages/perspective-viewer/README.md
@@ -1,22 +1,32 @@
 <a name="module_perspective-viewer"></a>
 
 ## perspective-viewer
-Module for the `<perspective-viewer>` custom element.This module has no exports, but importing it has a sideeffect: the [module:perspective_viewer~PerspectiveViewer](module:perspective_viewer~PerspectiveViewer) class isregistered as a custom element, after which it can be used as a standard DOMelement.The documentation in this module defines the instance structure of a`<perspective-viewer>` DOM object instantiated typically, through HTML or anyrelevent DOM method e.g. `document.createElement("perspective-viewer")` or`document.getElementsByTagName("perspective-viewer")`.
+Module for the `<perspective-viewer>` custom element.
+
+This module has no exports, but importing it has a side
+effect: the [module:perspective_viewer~PerspectiveViewer](module:perspective_viewer~PerspectiveViewer) class is
+registered as a custom element, after which it can be used as a standard DOM
+element.
+
+The documentation in this module defines the instance structure of a
+`<perspective-viewer>` DOM object instantiated typically, through HTML or any
+relevent DOM method e.g. `document.createElement("perspective-viewer")` or
+`document.getElementsByTagName("perspective-viewer")`.
 
 
 * [perspective-viewer](#module_perspective-viewer)
     * [~PerspectiveViewer](#module_perspective-viewer..PerspectiveViewer) ⇐ <code>HTMLElement</code>
         * [new PerspectiveViewer()](#new_module_perspective-viewer..PerspectiveViewer_new)
-        * [.sort](#module_perspective-viewer..PerspectiveViewer+sort) : <code>[ &#x27;array&#x27; ].&lt;string&gt;</code>
-        * [.columns](#module_perspective-viewer..PerspectiveViewer+columns)
-        * [.computed-columns](#module_perspective-viewer..PerspectiveViewer+computed-columns)
-        * [.aggregates](#module_perspective-viewer..PerspectiveViewer+aggregates)
-        * [.filters](#module_perspective-viewer..PerspectiveViewer+filters) : <code>array</code>
-        * [.plugin](#module_perspective-viewer..PerspectiveViewer+plugin) : <code>string</code>
+        * [.sort](#module_perspective-viewer..PerspectiveViewer+sort) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
+        * [.columns](#module_perspective-viewer..PerspectiveViewer+columns) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
+        * [.computed-columns](#module_perspective-viewer..PerspectiveViewer+computed-columns) : <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code>
+        * [.aggregates](#module_perspective-viewer..PerspectiveViewer+aggregates) : <code>Object</code>
+        * [.filters](#module_perspective-viewer..PerspectiveViewer+filters) : <code>[ &#x27;Array&#x27; ].&lt;Array&gt;</code>
+        * [.plugin](#module_perspective-viewer..PerspectiveViewer+plugin) : <code>String</code>
         * [.column-pivots](#module_perspective-viewer..PerspectiveViewer+column-pivots) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
-        * [.row-pivots](#module_perspective-viewer..PerspectiveViewer+row-pivots) : <code>[ &#x27;array&#x27; ].&lt;string&gt;</code>
-        * [.editable](#module_perspective-viewer..PerspectiveViewer+editable) : <code>boolean</code>
-        * [.throttle](#module_perspective-viewer..PerspectiveViewer+throttle) : <code>integer</code> \| <code>string</code>
+        * [.row-pivots](#module_perspective-viewer..PerspectiveViewer+row-pivots) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
+        * [.editable](#module_perspective-viewer..PerspectiveViewer+editable) : <code>Boolean</code>
+        * [.throttle](#module_perspective-viewer..PerspectiveViewer+throttle) : <code>Number</code> \| <code>String</code>
         * [.worker](#module_perspective-viewer..PerspectiveViewer+worker)
         * [.table](#module_perspective-viewer..PerspectiveViewer+table)
         * [.view](#module_perspective-viewer..PerspectiveViewer+view)
@@ -24,7 +34,7 @@ Module for the `<perspective-viewer>` custom element.This module has no export
         * [.update(data)](#module_perspective-viewer..PerspectiveViewer+update)
         * [.notifyResize()](#module_perspective-viewer..PerspectiveViewer+notifyResize)
         * [.clone(widget)](#module_perspective-viewer..PerspectiveViewer+clone)
-        * [.delete(delete_table)](#module_perspective-viewer..PerspectiveViewer+delete) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;boolean&gt;</code>
+        * [.delete(delete_table)](#module_perspective-viewer..PerspectiveViewer+delete) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Boolean&gt;</code>
         * [.restyleElement()](#module_perspective-viewer..PerspectiveViewer+restyleElement)
         * [.save()](#module_perspective-viewer..PerspectiveViewer+save) ⇒ <code>object</code>
         * [.restore(config)](#module_perspective-viewer..PerspectiveViewer+restore) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
@@ -34,6 +44,7 @@ Module for the `<perspective-viewer>` custom element.This module has no export
         * [.reset()](#module_perspective-viewer..PerspectiveViewer+reset)
         * [.copy()](#module_perspective-viewer..PerspectiveViewer+copy)
         * [.toggleConfig()](#module_perspective-viewer..PerspectiveViewer+toggleConfig)
+        * [.getEditPort()](#module_perspective-viewer..PerspectiveViewer+getEditPort)
 
 
 * * *
@@ -46,16 +57,16 @@ Module for the `<perspective-viewer>` custom element.This module has no export
 
 * [~PerspectiveViewer](#module_perspective-viewer..PerspectiveViewer) ⇐ <code>HTMLElement</code>
     * [new PerspectiveViewer()](#new_module_perspective-viewer..PerspectiveViewer_new)
-    * [.sort](#module_perspective-viewer..PerspectiveViewer+sort) : <code>[ &#x27;array&#x27; ].&lt;string&gt;</code>
-    * [.columns](#module_perspective-viewer..PerspectiveViewer+columns)
-    * [.computed-columns](#module_perspective-viewer..PerspectiveViewer+computed-columns)
-    * [.aggregates](#module_perspective-viewer..PerspectiveViewer+aggregates)
-    * [.filters](#module_perspective-viewer..PerspectiveViewer+filters) : <code>array</code>
-    * [.plugin](#module_perspective-viewer..PerspectiveViewer+plugin) : <code>string</code>
+    * [.sort](#module_perspective-viewer..PerspectiveViewer+sort) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
+    * [.columns](#module_perspective-viewer..PerspectiveViewer+columns) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
+    * [.computed-columns](#module_perspective-viewer..PerspectiveViewer+computed-columns) : <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code>
+    * [.aggregates](#module_perspective-viewer..PerspectiveViewer+aggregates) : <code>Object</code>
+    * [.filters](#module_perspective-viewer..PerspectiveViewer+filters) : <code>[ &#x27;Array&#x27; ].&lt;Array&gt;</code>
+    * [.plugin](#module_perspective-viewer..PerspectiveViewer+plugin) : <code>String</code>
     * [.column-pivots](#module_perspective-viewer..PerspectiveViewer+column-pivots) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
-    * [.row-pivots](#module_perspective-viewer..PerspectiveViewer+row-pivots) : <code>[ &#x27;array&#x27; ].&lt;string&gt;</code>
-    * [.editable](#module_perspective-viewer..PerspectiveViewer+editable) : <code>boolean</code>
-    * [.throttle](#module_perspective-viewer..PerspectiveViewer+throttle) : <code>integer</code> \| <code>string</code>
+    * [.row-pivots](#module_perspective-viewer..PerspectiveViewer+row-pivots) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
+    * [.editable](#module_perspective-viewer..PerspectiveViewer+editable) : <code>Boolean</code>
+    * [.throttle](#module_perspective-viewer..PerspectiveViewer+throttle) : <code>Number</code> \| <code>String</code>
     * [.worker](#module_perspective-viewer..PerspectiveViewer+worker)
     * [.table](#module_perspective-viewer..PerspectiveViewer+table)
     * [.view](#module_perspective-viewer..PerspectiveViewer+view)
@@ -63,7 +74,7 @@ Module for the `<perspective-viewer>` custom element.This module has no export
     * [.update(data)](#module_perspective-viewer..PerspectiveViewer+update)
     * [.notifyResize()](#module_perspective-viewer..PerspectiveViewer+notifyResize)
     * [.clone(widget)](#module_perspective-viewer..PerspectiveViewer+clone)
-    * [.delete(delete_table)](#module_perspective-viewer..PerspectiveViewer+delete) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;boolean&gt;</code>
+    * [.delete(delete_table)](#module_perspective-viewer..PerspectiveViewer+delete) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Boolean&gt;</code>
     * [.restyleElement()](#module_perspective-viewer..PerspectiveViewer+restyleElement)
     * [.save()](#module_perspective-viewer..PerspectiveViewer+save) ⇒ <code>object</code>
     * [.restore(config)](#module_perspective-viewer..PerspectiveViewer+restore) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
@@ -73,6 +84,7 @@ Module for the `<perspective-viewer>` custom element.This module has no export
     * [.reset()](#module_perspective-viewer..PerspectiveViewer+reset)
     * [.copy()](#module_perspective-viewer..PerspectiveViewer+copy)
     * [.toggleConfig()](#module_perspective-viewer..PerspectiveViewer+toggleConfig)
+    * [.getEditPort()](#module_perspective-viewer..PerspectiveViewer+getEditPort)
 
 
 * * *
@@ -80,19 +92,32 @@ Module for the `<perspective-viewer>` custom element.This module has no export
 <a name="new_module_perspective-viewer..PerspectiveViewer_new"></a>
 
 #### new PerspectiveViewer()
-The HTMLElement class for `<perspective-viewer>` custom element.This class is not exported, so this constructor cannot be invoked in thetypical manner; instead, instances of the class are created through theCustom Elements DOM API.Properties of an instance of this class, such as[module:perspective_viewer~PerspectiveViewer#columns](module:perspective_viewer~PerspectiveViewer#columns), are reflected onthe DOM element as Attributes, and should be accessed as such - e.g.`instance.setAttribute("columns", JSON.stringify(["a", "b"]))`.
+The HTMLElement class for `<perspective-viewer>` custom element.
+
+This class is not exported, so this constructor cannot be invoked in the
+typical manner; instead, instances of the class are created through the
+Custom Elements DOM API.
+
+Properties of an instance of this class, such as
+[module:perspective_viewer~PerspectiveViewer#columns](module:perspective_viewer~PerspectiveViewer#columns), are reflected on
+the DOM element as Attributes, and should be accessed as such - e.g.
+`instance.setAttribute("columns", JSON.stringify(["a", "b"]))`.
 
 **Example**  
 ```js
-// Create a new `<perspective-viewer>`const elem = document.createElement("perspective-viewer");elem.setAttribute("columns", JSON.stringify(["a", "b"]));document.body.appendChild(elem);
+// Create a new `<perspective-viewer>`
+const elem = document.createElement("perspective-viewer");
+elem.setAttribute("columns", JSON.stringify(["a", "b"]));
+document.body.appendChild(elem);
 ```
 
 * * *
 
 <a name="module_perspective-viewer..PerspectiveViewer+sort"></a>
 
-#### perspectiveViewer.sort : <code>[ &#x27;array&#x27; ].&lt;string&gt;</code>
-Sets this `perspective.table.view`'s `sort` property, an array of columnnames.
+#### perspectiveViewer.sort : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
+Sets this `perspective.table.view`'s `sort` property, an Array of column
+names.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Emits**: <code>PerspectiveViewer#event:perspective-config-update</code>  
@@ -110,14 +135,14 @@ elem.setAttribute('sort', JSON.stringify([["x","desc"]));
 
 <a name="module_perspective-viewer..PerspectiveViewer+columns"></a>
 
-#### perspectiveViewer.columns
+#### perspectiveViewer.columns : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
 The set of visible columns.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Emits**: <code>PerspectiveViewer#event:perspective-config-update</code>  
 **Params**
 
-- columns <code>array</code> - An array of strings, the names of visible columns.
+- columns <code>Array</code> - An Array of strings, the names of visible columns.
 
 **Example** *(via Javascript DOM)*  
 ```js
@@ -133,37 +158,45 @@ elem.setAttribute('columns', JSON.stringify(["x", "y'"]));
 
 <a name="module_perspective-viewer..PerspectiveViewer+computed-columns"></a>
 
-#### perspectiveViewer.computed-columns
-The set of visible columns.
+#### perspectiveViewer.computed-columns : <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code>
+Sets new computed columns for the viewer.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Emits**: <code>PerspectiveViewer#event:perspective-config-update</code>  
 **Params**
 
-- computed-columns <code>array</code> - An array of computed column objects
+- computed-columns <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code> - An Array of computed column objects,
+which have three properties: `name`, a column name for the new column,
+`computed_function_name`, a String representing the computed function to
+apply, and `inputs`, an Array of String column names to be used as
+inputs to the computation.
 
 **Example** *(via Javascript DOM)*  
 ```js
 let elem = document.getElementById('my_viewer');
-elem.setAttribute('computed-columns', JSON.stringify([{name: "x+y", func: "add", inputs: ["x", "y"]}]));
+elem.setAttribute('computed-columns', JSON.stringify([{name: "x+y", computed_function_name: "+", inputs: ["x", "y"]}]));
 ```
 **Example** *(via HTML)*  
 ```js
-<perspective-viewer computed-columns="[{name:'x+y',func:'add',inputs:['x','y']}]""></perspective-viewer>
+<perspective-viewer computed-columns="[{name:'x+y',computed_function_name:'+',inputs:['x','y']}]""></perspective-viewer>
 ```
 
 * * *
 
 <a name="module_perspective-viewer..PerspectiveViewer+aggregates"></a>
 
-#### perspectiveViewer.aggregates
+#### perspectiveViewer.aggregates : <code>Object</code>
 The set of column aggregate configurations.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Emits**: <code>PerspectiveViewer#event:perspective-config-update</code>  
 **Params**
 
-- aggregates <code>object</code> - A dictionary whose keys are column names, andvalues are valid aggregations. The `aggregates` attribute works as anoverride; in lieu of a key for a column supplied by the developers, adefault will be selected and reflected to the attribute based on thecolumn's type.  See [perspective/src/js/defaults.js](perspective/src/js/defaults.js)
+- aggregates <code>Object</code> - A dictionary whose keys are column names, and
+values are valid aggregations. The `aggregates` attribute works as an
+override; in lieu of a key for a column supplied by the developers, a
+default will be selected and reflected to the attribute based on the
+column's type.  See [perspective/src/js/defaults.js](perspective/src/js/defaults.js)
 
 **Example** *(via Javascript DOM)*  
 ```js
@@ -180,7 +213,7 @@ elem.setAttribute('aggregates', JSON.stringify({x: "distinct count"}));
 
 <a name="module_perspective-viewer..PerspectiveViewer+filters"></a>
 
-#### perspectiveViewer.filters : <code>array</code>
+#### perspectiveViewer.filters : <code>[ &#x27;Array&#x27; ].&lt;Array&gt;</code>
 The set of column filter configurations.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
@@ -204,8 +237,9 @@ elem.setAttribute('filters', JSON.stringify(filters));
 
 <a name="module_perspective-viewer..PerspectiveViewer+plugin"></a>
 
-#### perspectiveViewer.plugin : <code>string</code>
-Sets the currently selected plugin, via its `name` field.
+#### perspectiveViewer.plugin : <code>String</code>
+Sets the currently selected plugin, via its `name` field, and removes
+any children the previous plugin may have left behind in the light DOM.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Emits**: <code>PerspectiveViewer#event:perspective-config-update</code>  
@@ -224,7 +258,7 @@ Sets this `perspective.table.view`'s `column_pivots` property.
 
 <a name="module_perspective-viewer..PerspectiveViewer+row-pivots"></a>
 
-#### perspectiveViewer.row-pivots : <code>[ &#x27;array&#x27; ].&lt;string&gt;</code>
+#### perspectiveViewer.row-pivots : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
 Sets this `perspective.table.view`'s `row_pivots` property.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
@@ -234,8 +268,9 @@ Sets this `perspective.table.view`'s `row_pivots` property.
 
 <a name="module_perspective-viewer..PerspectiveViewer+editable"></a>
 
-#### perspectiveViewer.editable : <code>boolean</code>
-Determines whether this viewer is editable or not (though it isultimately up to the plugin as to whether editing is implemented).
+#### perspectiveViewer.editable : <code>Boolean</code>
+Determines whether this viewer is editable or not (though it is
+ultimately up to the plugin as to whether editing is implemented).
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Emits**: <code>PerspectiveViewer#event:perspective-config-update</code>  
@@ -244,13 +279,17 @@ Determines whether this viewer is editable or not (though it isultimately up to
 
 <a name="module_perspective-viewer..PerspectiveViewer+throttle"></a>
 
-#### perspectiveViewer.throttle : <code>integer</code> \| <code>string</code>
-Determines the render throttling behavior. Can be an integer, formillisecond window to throttle render event; or, if `undefined`,will try to determine the optimal throttle time from this component'srender framerate.
+#### perspectiveViewer.throttle : <code>Number</code> \| <code>String</code>
+Determines the render throttling behavior. Can be an integer, for
+millisecond window to throttle render event; or, if `undefined`,
+will try to determine the optimal throttle time from this component's
+render framerate.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Example**  
 ```js
-<!-- Only draws at most 1 frame/sec. --><perspective-viewer throttle="1000"></perspective-viewer>
+<!-- Only draws at most 1 frame/sec. -->
+<perspective-viewer throttle="1000"></perspective-viewer>
 ```
 
 * * *
@@ -258,13 +297,18 @@ Determines the render throttling behavior. Can be an integer, formillisecond wi
 <a name="module_perspective-viewer..PerspectiveViewer+worker"></a>
 
 #### perspectiveViewer.worker
-This element's `perspective` worker instance. This property is notreflected as an HTML attribute, and is readonly; it can be effectivelyset however by calling the `load() method with a `perspective.table`instance from the preferred worker.
+This element's `perspective` worker instance. This property is not
+reflected as an HTML attribute, and is readonly; it can be effectively
+set however by calling the `load() method with a `perspective.table`
+instance from the preferred worker.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Read only**: true  
 **Example**  
 ```js
-let elem = document.getElementById('my_viewer');let table = elem.worker.table([{x:1, y:2}]);elem.load(table);
+let elem = document.getElementById('my_viewer');
+let table = elem.worker.table([{x:1, y:2}]);
+elem.load(table);
 ```
 
 * * *
@@ -282,7 +326,9 @@ This element's `perspective.table` instance.
 <a name="module_perspective-viewer..PerspectiveViewer+view"></a>
 
 #### perspectiveViewer.view
-This element's `perspective.table.view` instance. The instance itselfwill change after every `PerspectiveViewer#perspective-config-update`event.
+This element's `perspective.table.view` instance. The instance itself
+will change after every `PerspectiveViewer#perspective-config-update`
+event.
 
 **Kind**: instance property of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Read only**: true  
@@ -292,14 +338,19 @@ This element's `perspective.table.view` instance. The instance itselfwill chang
 <a name="module_perspective-viewer..PerspectiveViewer+load"></a>
 
 #### perspectiveViewer.load(data) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
-Load data. If `load` or `update` have already been called on thiselement, its internal `perspective.table` will also be deleted.
+Load data. If `load` or `update` have already been called on this
+element, its internal `perspective.table` will also be deleted.
 
 **Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code> - A promise which resolves once the data is loadedand a `perspective.view` has been created.  
-**Emits**: <code>module:perspective\_viewer~PerspectiveViewer#perspective-clickPerspectiveViewer#perspective-view-update]);event:</code>  
+**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code> - A promise which resolves once the data is loaded
+and a `perspective.view` has been created.  
+**Emits**: <code>module:perspective\_viewer~PerspectiveViewer#perspective-click
+PerspectiveViewer#perspective-view-update
+]);event:</code>  
 **Params**
 
-- data <code>any</code> - The data to load.  Works with the same input typessupported by `perspective.table`.
+- data <code>any</code> - The data to load.  Works with the same input types
+supported by `perspective.table`.
 
 **Example** *(Load CSV)*  
 ```js
@@ -330,11 +381,16 @@ Updates this element's `perspective.table` with new data.
 **Emits**: <code>PerspectiveViewer#event:perspective-view-update</code>  
 **Params**
 
-- data <code>any</code> - The data to load.  Works with the same input typessupported by `perspective.table.update`.
+- data <code>any</code> - The data to load.  Works with the same input types
+supported by `perspective.table.update`.
 
 **Example**  
 ```js
-const my_viewer = document.getElementById('#my_viewer');my_viewer.update([    {x: 1, y: 'a'},    {x: 2, y: 'b'}]);
+const my_viewer = document.getElementById('#my_viewer');
+my_viewer.update([
+    {x: 1, y: 'a'},
+    {x: 2, y: 'b'}
+]);
 ```
 
 * * *
@@ -351,7 +407,9 @@ Determine whether to reflow the viewer and redraw.
 <a name="module_perspective-viewer..PerspectiveViewer+clone"></a>
 
 #### perspectiveViewer.clone(widget)
-Duplicate an existing `<perspective-element>`, including data and viewsettings.  The underlying `perspective.table` will be shared between bothelements
+Duplicate an existing `<perspective-element>`, including data and view
+settings.  The underlying `perspective.table` will be shared between both
+elements
 
 **Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 **Params**
@@ -363,14 +421,18 @@ Duplicate an existing `<perspective-element>`, including data and viewsettings.
 
 <a name="module_perspective-viewer..PerspectiveViewer+delete"></a>
 
-#### perspectiveViewer.delete(delete_table) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;boolean&gt;</code>
-Deletes this element's data and clears it's internal state (but not itsuser state).  This (or the underlying `perspective.table`'s equivalentmethod) must be called in order for its memory to be reclaimed.
+#### perspectiveViewer.delete(delete_table) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Boolean&gt;</code>
+Deletes this element's data and clears it's internal state (but not its
+user state).  This (or the underlying `perspective.table`'s equivalent
+method) must be called in order for its memory to be reclaimed.
 
 **Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;boolean&gt;</code> - Whether or not this call resulted in theunderlying `perspective.table` actually being deleted.  
+**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Boolean&gt;</code> - Whether or not this call resulted in the
+underlying `perspective.table` actually being deleted.  
 **Params**
 
-- delete_table <code>boolean</code> <code> = true</code> - Should a delete call also be made to theunderlying `table()`.
+- delete_table <code>Boolean</code> <code> = true</code> - Should a delete call also be made to the
+underlying `table()`.
 
 
 * * *
@@ -397,13 +459,15 @@ Serialize this element's attribute/interaction state.
 <a name="module_perspective-viewer..PerspectiveViewer+restore"></a>
 
 #### perspectiveViewer.restore(config) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code>
-Restore this element to a state as generated by a reciprocal call to`save` or `serialize`.
+Restore this element to a state as generated by a reciprocal call to
+`save` or `serialize`.
 
 **Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code> - A promise which resolves when the changes havebeen applied.  
+**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code> - A promise which resolves when the changes have
+been applied.  
 **Params**
 
-- config <code>object</code> | <code>string</code> - returned by `save` or `serialize`.
+- config <code>Object</code> | <code>String</code> - returned by `save` or `serialize`.
 
 
 * * *
@@ -414,7 +478,8 @@ Restore this element to a state as generated by a reciprocal call to`save` or `
 Flush any pending attribute modifications to this element.
 
 **Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code> - A promise which resolves when the currentattribute state has been applied.  
+**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;void&gt;</code> - A promise which resolves when the current
+attribute state has been applied.  
 
 * * *
 
@@ -439,7 +504,9 @@ Replaces all rows in the current [table](table).
 <a name="module_perspective-viewer..PerspectiveViewer+reset"></a>
 
 #### perspectiveViewer.reset()
-Reset's this element's view state and attributes to default.  Does notdelete this element's `perspective.table` or otherwise modify the datastate.
+Reset's this element's view state and attributes to default.  Does not
+delete this element's `perspective.table` or otherwise modify the data
+state.
 
 **Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 
@@ -448,7 +515,10 @@ Reset's this element's view state and attributes to default.  Does notdelete th
 <a name="module_perspective-viewer..PerspectiveViewer+copy"></a>
 
 #### perspectiveViewer.copy()
-Copies this element's view data (as a CSV) to the clipboard.  This methodmust be called from an event handler, subject to the browser'srestrictions on clipboard access.  See[https://www.w3.org/TR/clipboard-apis/#allow-read-clipboard](https://www.w3.org/TR/clipboard-apis/#allow-read-clipboard).
+Copies this element's view data (as a CSV) to the clipboard.  This method
+must be called from an event handler, subject to the browser's
+restrictions on clipboard access.  See
+[https://www.w3.org/TR/clipboard-apis/#allow-read-clipboard](https://www.w3.org/TR/clipboard-apis/#allow-read-clipboard).
 
 **Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 
@@ -458,6 +528,16 @@ Copies this element's view data (as a CSV) to the clipboard.  This methodmust b
 
 #### perspectiveViewer.toggleConfig()
 Opens/closes the element's config menu.
+
+**Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
+
+* * *
+
+<a name="module_perspective-viewer..PerspectiveViewer+getEditPort"></a>
+
+#### perspectiveViewer.getEditPort()
+Returns a promise that resolves to the element's edit port ID, used
+internally when edits are made using Hypergrid or DataGrid.
 
 **Kind**: instance method of [<code>PerspectiveViewer</code>](#module_perspective-viewer..PerspectiveViewer)  
 

--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -95,11 +95,11 @@ class PerspectiveViewer extends ActionElement {
     }
 
     /**
-     * Sets this `perspective.table.view`'s `sort` property, an array of column
+     * Sets this `perspective.table.view`'s `sort` property, an Array of column
      * names.
      *
      * @kind member
-     * @type {array<string>} Array of arrays tuples of column name and
+     * @type {Array<String>} Array of arrays tuples of column name and
      * direction, where the possible values are "asc", "desc", "asc abs", "desc
      * abs" and "none".
      * @fires PerspectiveViewer#perspective-config-update
@@ -148,7 +148,8 @@ class PerspectiveViewer extends ActionElement {
      * The set of visible columns.
      *
      * @kind member
-     * @param {array} columns An array of strings, the names of visible columns.
+     * @type {Array<String>}
+     * @param {Array} columns An Array of strings, the names of visible columns.
      * @fires PerspectiveViewer#perspective-config-update
      * @example <caption>via Javascript DOM</caption>
      * let elem = document.getElementById('my_viewer');
@@ -176,10 +177,15 @@ class PerspectiveViewer extends ActionElement {
     /* eslint-disable max-len */
 
     /**
-     * The set of visible columns.
+     * Sets new computed columns for the viewer.
      *
      * @kind member
-     * @param {array} computed-columns An array of computed column objects
+     * @type {Array<Object>}
+     * @param {Array<Object>} computed-columns An Array of computed column objects,
+     * which have three properties: `name`, a column name for the new column,
+     * `computed_function_name`, a String representing the computed function to
+     * apply, and `inputs`, an Array of String column names to be used as
+     * inputs to the computation.
      * @fires PerspectiveViewer#perspective-config-update
      * @example <caption>via Javascript DOM</caption>
      * let elem = document.getElementById('my_viewer');
@@ -270,7 +276,8 @@ class PerspectiveViewer extends ActionElement {
      * The set of column aggregate configurations.
      *
      * @kind member
-     * @param {object} aggregates A dictionary whose keys are column names, and
+     * @type {Object}
+     * @param {Object} aggregates A dictionary whose keys are column names, and
      * values are valid aggregations. The `aggregates` attribute works as an
      * override; in lieu of a key for a column supplied by the developers, a
      * default will be selected and reflected to the attribute based on the
@@ -307,11 +314,11 @@ class PerspectiveViewer extends ActionElement {
      * The set of column filter configurations.
      *
      * @kind member
-     * @type {array} filters An array of filter config objects. A filter config
-     * object is an array of three elements: * The column name. * The filter
-     * operation as a string. See
+     * @type {Array<Array>} filters An Array of filter configs. A filter
+     * config is an Array of three elements: * The column name. * The filter
+     * operation as a String. See
      * {@link perspective/src/js/config/constants.js} * The filter argument, as
-     * a string, float or Array<string> as the filter operation demands.
+     * a String, float or Array<String> as the filter operation demands.
      * @fires PerspectiveViewer#perspective-config-update
      * @example <caption>via Javascript DOM</caption>
      * let filters = [
@@ -366,7 +373,7 @@ class PerspectiveViewer extends ActionElement {
      * Sets the currently selected plugin, via its `name` field, and removes
      * any children the previous plugin may have left behind in the light DOM.
      *
-     * @type {string}
+     * @type {String}
      * @fires PerspectiveViewer#perspective-config-update
      */
     set plugin(v) {
@@ -433,7 +440,7 @@ class PerspectiveViewer extends ActionElement {
      * Sets this `perspective.table.view`'s `row_pivots` property.
      *
      * @kind member
-     * @type {array<string>} Array of column names
+     * @type {Array<String>} Array of column names
      * @fires PerspectiveViewer#perspective-config-update
      */
     @array_attribute
@@ -462,7 +469,7 @@ class PerspectiveViewer extends ActionElement {
      * ultimately up to the plugin as to whether editing is implemented).
      *
      * @kind member
-     * @type {boolean} Is this viewer editable?
+     * @type {Boolean} Is this viewer editable?
      * @fires PerspectiveViewer#perspective-config-update
      */
     set editable(x) {
@@ -484,7 +491,7 @@ class PerspectiveViewer extends ActionElement {
      * render framerate.
      *
      * @kind member
-     * @type {integer|string} The throttle rate - milliseconds (integer), or the
+     * @type {Number|String} The throttle rate - milliseconds (integer), or the
      * enum "adaptive" for a dynamic throttle based on render time.
      * @example
      * <!-- Only draws at most 1 frame/sec. -->
@@ -506,7 +513,7 @@ class PerspectiveViewer extends ActionElement {
      * ultimately up to the plugin as to whether selectable is implemented).
      *
      * @kind member
-     * @type {boolean} Is this viewer editable?
+     * @type {Boolean} Is this viewer editable?
      * @fires PerspectiveViewer#perspective-config-update
      */
     set selectable(x) {
@@ -657,9 +664,9 @@ class PerspectiveViewer extends ActionElement {
      * user state).  This (or the underlying `perspective.table`'s equivalent
      * method) must be called in order for its memory to be reclaimed.
      *
-     * @param {boolean} delete_table Should a delete call also be made to the
+     * @param {Boolean} delete_table Should a delete call also be made to the
      * underlying `table()`.
-     * @returns {Promise<boolean>} Whether or not this call resulted in the
+     * @returns {Promise<Boolean>} Whether or not this call resulted in the
      * underlying `perspective.table` actually being deleted.
      */
     delete(delete_table = true) {
@@ -713,7 +720,7 @@ class PerspectiveViewer extends ActionElement {
      * Restore this element to a state as generated by a reciprocal call to
      * `save` or `serialize`.
      *
-     * @param {object|string} config returned by `save` or `serialize`.
+     * @param {Object|String} config returned by `save` or `serialize`.
      * @returns {Promise<void>} A promise which resolves when the changes have
      * been applied.
      */
@@ -793,7 +800,7 @@ class PerspectiveViewer extends ActionElement {
     /**
      * Download this element's data as a CSV file.
      *
-     * @param {boolean} [flat=false] Whether to use the element's current view
+     * @param {Boolean} [flat=false] Whether to use the element's current view
      * config, or to use a default "flat" view.
      * @memberof PerspectiveViewer
      */
@@ -876,11 +883,11 @@ class PerspectiveViewer extends ActionElement {
  *
  * @event module:perspective_viewer~PerspectiveViewer#perspective-click
  * @type {object}
- * @property {array} column_names - Includes a list of column names.
+ * @property {Array} column_names - Includes a list of column names.
  * @property {object} config - Contains a property `filters` that can be applied
  * to a `<perspective-viewer>` through the use of `restore()` updating it to
  * show the filtered subset of data..
- * @property {array} row - Includes the data row.
+ * @property {Array} row - Includes the data row.
  */
 
 /**
@@ -888,7 +895,7 @@ class PerspectiveViewer extends ActionElement {
  * been modified, by the user or otherwise.
  *
  * @event module:perspective_viewer~PerspectiveViewer#perspective-config-update
- * @type {string}
+ * @type {String}
  */
 
 /**
@@ -896,5 +903,5 @@ class PerspectiveViewer extends ActionElement {
  * updated, including every invocation of `load` and `update`.
  *
  * @event module:perspective_viewer~PerspectiveViewer#perspective-view-update
- * @type {string}
+ * @type {String}
  */

--- a/packages/perspective/README.md
+++ b/packages/perspective/README.md
@@ -13,7 +13,8 @@ For more information, see the
         * [.get_config()](#module_perspective..view+get_config) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;object&gt;</code>
         * [.delete()](#module_perspective..view+delete)
         * [.schema()](#module_perspective..view+schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-        * [.column_paths()](#module_perspective..view+column_paths)
+        * [.computed_schema()](#module_perspective..view+computed_schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+        * [.column_paths()](#module_perspective..view+column_paths) ⇒ <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
         * [.to_columns([options])](#module_perspective..view+to_columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
         * [.to_json([options])](#module_perspective..view+to_json) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
         * [.to_csv([options])](#module_perspective..view+to_csv) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;string&gt;</code>
@@ -37,14 +38,13 @@ For more information, see the
         * [.remove_delete(callback)](#module_perspective..table+remove_delete)
         * [.size()](#module_perspective..table+size) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
         * [.schema(computed)](#module_perspective..table+schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-        * [.computed_schema()](#module_perspective..table+computed_schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+        * [.computed_schema(computed_columns)](#module_perspective..table+computed_schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
         * [.is_valid_filter([filter])](#module_perspective..table+is_valid_filter)
         * [.view([config])](#module_perspective..table+view) ⇒ <code>view</code>
         * [.update(data)](#module_perspective..table+update)
         * [.remove(data)](#module_perspective..table+remove)
-        * [.add_computed(computed)](#module_perspective..table+add_computed)
+        * [.get_computed_functions()](#module_perspective..table+get_computed_functions)
         * [.columns(computed)](#module_perspective..table+columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array.&lt;string&gt;&gt;</code>
-    * [~name_to_computation(name)](#module_perspective..name_to_computation)
 
 
 * * *
@@ -59,7 +59,8 @@ For more information, see the
     * [.get_config()](#module_perspective..view+get_config) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;object&gt;</code>
     * [.delete()](#module_perspective..view+delete)
     * [.schema()](#module_perspective..view+schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-    * [.column_paths()](#module_perspective..view+column_paths)
+    * [.computed_schema()](#module_perspective..view+computed_schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+    * [.column_paths()](#module_perspective..view+column_paths) ⇒ <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
     * [.to_columns([options])](#module_perspective..view+to_columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
     * [.to_json([options])](#module_perspective..view+to_json) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array&gt;</code>
     * [.to_csv([options])](#module_perspective..view+to_csv) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;string&gt;</code>
@@ -128,22 +129,61 @@ method to reclaim these.
 <a name="module_perspective..view+schema"></a>
 
 #### view.schema() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-The schema of this [view](#module_perspective..view). A schema is an
-Object, the keys of which are the columns of this
+The schema of this [view](#module_perspective..view).
+
+A schema is an Object, the keys of which are the columns of this
 [view](#module_perspective..view), and the values are their string type
 names. If this [view](#module_perspective..view) is aggregated, theses will
 be the aggregated types; otherwise these types will be the same as the
-columns in the underlying [table](#module_perspective..table)
+columns in the underlying [table](#module_perspective..table).
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
 **Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code> - A Promise of this
 [view](#module_perspective..view)'s schema.  
+**Example**  
+```js
+// Create a view
+const view = table.view({
+     columns: ["a", "b"]
+});
+const schema = await view.schema(); // {a: "float", b: "string"}
+```
+
+* * *
+
+<a name="module_perspective..view+computed_schema"></a>
+
+#### view.computed\_schema() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+The computed column schema of this [view](#module_perspective..view),
+containing only user-created computed columns.
+
+A schema is an Object, the keys of which are the columns of this
+[view](#module_perspective..view), and the values are their string type
+names. If this [view](#module_perspective..view) is aggregated, these will
+be the aggregated types; otherwise these types will be the same as the
+columns in the underlying [table](#module_perspective..table).
+
+**Kind**: instance method of [<code>view</code>](#module_perspective..view)  
+**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code> - A Promise of this
+[view](#module_perspective..view)'s computed column schema.  
+**Example**  
+```js
+// Create a view with computed columns
+const view = table.view({
+     computed_columns: [{
+         name: "x + y",
+         computed_function_name: "+",
+         inputs: ["x", "y"]
+     }]
+});
+const computed_schema = await view.computed_schema(); // {x: "float"}
+```
 
 * * *
 
 <a name="module_perspective..view+column_paths"></a>
 
-#### view.column\_paths()
+#### view.column\_paths() ⇒ <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
 Returns an array of strings containing the column paths of the View
 without any of the source columns.
 
@@ -151,6 +191,7 @@ A column path shows the columns that a given cell belongs to after pivots
 are applied.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code> - an Array of Strings containing the column paths.  
 
 * * *
 
@@ -363,20 +404,34 @@ Set expansion `depth` of the pivot tree.
 <a name="module_perspective..view+on_update"></a>
 
 #### view.on\_update(callback)
-Register a callback with this [view](#module_perspective..view).  Whenever
+Register a callback with this [view](#module_perspective..view). Whenever
 the [view](#module_perspective..view)'s underlying table emits an update,
-this callback will be invoked with the aggregated row deltas.
+this callback will be invoked with an object containing `port_id`,
+indicating which port the update fired on, and optionally `delta`, which
+is the new data that was updated for each cell or each row.
 
 **Kind**: instance method of [<code>view</code>](#module_perspective..view)  
 **Params**
 
-- callback <code>function</code> - A callback function invoked on update.  The
-parameter to this callback is dependent on the `mode` parameter:
-    - "none" (default): The callback is invoked without an argument.
-    - "cell": The callback is invoked with the new data for each updated
-          cell, serialized to JSON format.
-    - "row": The callback is invoked with an Arrow of the updated rows.
+- callback <code>function</code> - A callback function invoked on update, which
+receives an object with two keys: `port_id`, indicating which port the
+update was triggered on, and `delta`, whose value is dependent on the
+`mode` parameter:
+    - "none" (default): `delta` is `undefined`.
+    - "cell": `delta` is the new data for each updated cell, serialized
+         to JSON format.
+    - "row": `delta` is an Arrow of the updated rows.
 
+**Example**  
+```js
+// Attach an `on_update` callback
+view.on_update(updated => console.log(updated.port_id));
+```
+**Example**  
+```js
+// `on_update` with row deltas
+view.on_update(updated => console.log(updated.delta), {mode: "row"});
+```
 
 * * *
 
@@ -423,12 +478,12 @@ Unregister a previously registered delete callback with this
     * [.remove_delete(callback)](#module_perspective..table+remove_delete)
     * [.size()](#module_perspective..table+size) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;number&gt;</code>
     * [.schema(computed)](#module_perspective..table+schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-    * [.computed_schema()](#module_perspective..table+computed_schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+    * [.computed_schema(computed_columns)](#module_perspective..table+computed_schema) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
     * [.is_valid_filter([filter])](#module_perspective..table+is_valid_filter)
     * [.view([config])](#module_perspective..table+view) ⇒ <code>view</code>
     * [.update(data)](#module_perspective..table+update)
     * [.remove(data)](#module_perspective..table+remove)
-    * [.add_computed(computed)](#module_perspective..table+add_computed)
+    * [.get_computed_functions()](#module_perspective..table+get_computed_functions)
     * [.columns(computed)](#module_perspective..table+columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Array.&lt;string&gt;&gt;</code>
 
 
@@ -545,15 +600,19 @@ false)
 
 <a name="module_perspective..table+computed_schema"></a>
 
-#### table.computed\_schema() ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
-The computed schema of this [table](#module_perspective..table). Returns a
-schema of only computed columns added by the user, the keys of which are
-computed columns and the values an Object containing the associated
-column_name, column_type, and computation.
+#### table.computed\_schema(computed_columns) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code>
+Given an array of computed column definitions, perform type lookups to
+create a schema for the computed column without calculating or
+constructing any new columns.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code> - A Promise of this
-[table](#module_perspective..table)'s computed schema.  
+**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Object&gt;</code> - A Promise that resolves to a computed schema
+based on the computed column definitions provided.  
+**Params**
+
+- computed_columns <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code> - an array of computed column
+definitions.
+
 
 * * *
 
@@ -653,17 +712,25 @@ pushed down to any derived [view](#module_perspective..view) objects.
 
 * * *
 
-<a name="module_perspective..table+add_computed"></a>
+<a name="module_perspective..table+get_computed_functions"></a>
 
-#### table.add\_computed(computed)
-Create a new table with the addition of new computed columns (defined as
-javascript functions)
+#### table.get\_computed\_functions()
+Return an Object containing computed function metadata. Keys are strings,
+and each value is an Object containing the following metadata:
+
+- name
+- label
+- pattern
+- computed_function_name: the name of the computed function
+- input_type: the type of its input columns (all input columns are of
+the same type)
+- return_type: the return type of its output column
+- group: a category for the function
+- num_params: the number of input parameters
+- format_function: an anonymous function used for naming new columns
+- help: a help string that can be displayed in the UI.
 
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
-**Params**
-
-- computed <code>Computation</code> - A computation specification object
-
 
 * * *
 
@@ -679,20 +746,6 @@ table.
 
 - computed <code>boolean</code> - Should computed columns be included? (default
 false)
-
-
-* * *
-
-<a name="module_perspective..name_to_computation"></a>
-
-### perspective~name\_to\_computation(name)
-Map a string name of a computation function to a value in the
-`t_computed_function_name` enum.
-
-**Kind**: inner method of [<code>perspective</code>](#module_perspective)  
-**Params**
-
-- name <code>String</code> - The name of a computation function.
 
 
 * * *

--- a/python/perspective/docs/perspective.core.rst
+++ b/python/perspective/docs/perspective.core.rst
@@ -24,6 +24,16 @@ PerspectiveWidget
    :show-inheritance:
    :exclude-members: random
 
+PerspectiveTornadoHandler
+=========================
+
+``PerspectiveTornadoHandler`` is a ready-made Perspective server that interfaces seamlessly with
+``@finos/perspective-viewer`` in Javascript.
+
+.. automodule:: perspective.tornado_handler.tornado_handler
+   :members:
+   :show-inheritance:
+
 PerspectiveManager
 ==================
 

--- a/python/perspective/perspective/manager/manager.py
+++ b/python/perspective/perspective/manager/manager.py
@@ -69,17 +69,18 @@ class PerspectiveManager(object):
         self._lock = lock
 
     def lock(self):
-        """Block messages that can mutate the state of `Table`s and `View`s
-        under management.
+        """Block messages that can mutate the state of :obj:`~perspective.Table`
+         and :obj:`~perspective.View` objects under management.
 
-        All `PerspectiveManager`s exposed over the internet should be locked to
-        prevent content from being mutated by clients.
+        All ``PerspectiveManager`` objects exposed over the internet should be
+        locked to prevent content from being mutated by clients.
         """
         self._lock = True
 
     def unlock(self):
-        """Unblock messages that can mutate the state of `Table`s and `View`s
-        under management."""
+        """Unblock messages that can mutate the state of
+        :obj:`~perspective.Table` and :obj:`~perspective.View` objects under
+        management."""
         self._lock = False
 
     def host(self, item, name=None):
@@ -93,7 +94,7 @@ class PerspectiveManager(object):
 
         Keyword Args:
             name (:obj:`str`) : an optional name to allow retrieval through
-                `get_table` or `get_view`. A name will be generated if not
+                ``get_table`` or ``get_view``. A name will be generated if not
                 provided.
         """
         name = name or gen_name()
@@ -111,7 +112,8 @@ class PerspectiveManager(object):
 
         If a function for `queue_process` is defined (i.e., by
         :obj:`~perspective.PerspectiveTornadoHandler`), bind the function to
-        `Table` and have it call the manager's version of `queue_process`.
+        :obj:`~perspective.Table` and have it call the manager's version of
+        `queue_process`.
         '''
         if self._queue_process_callback is not None:
             # always bind the callback to the table's state manager
@@ -138,11 +140,11 @@ class PerspectiveManager(object):
         return PerspectiveSession(self)
 
     def _set_queue_process(self, func):
-        """For each table under management, bind `func` to the table's state
-        manager and to run whenever `queue_process` is called.
+        """For each table under management, bind :obj:`func` to the table's state
+        manager and to run whenever ``queue_process`` is called.
 
         After this method is called, future Tables hosted on this manager
-        instance will call the same `queue_process` callback.
+        instance will call the same ``queue_process`` callback.
         """
         self._queue_process_callback = func
         for table in self._tables.values():

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -108,16 +108,18 @@ class Table(object):
     def get_computed_functions(self):
         """Returns a dict of computed function metadata, where each value is a
         dict that contains the following metadata:
-            - name
-            - label
-            - pattern
-            - computed_function_name: the name of the computed function
-            - input_type: the data type of input columns ("float"/"integer" and
-            "date"/"datetime" are interchangable)
-            - return_type: the return type of its output column
-            - group: a category for the function
-            - num_params: the number of input parameters
-            - format_function: an anonymous function used for naming new columns
+
+        - name
+        - label
+        - pattern
+        - computed_function_name: the name of the computed function
+        - input_type: the data type of input columns ("float"/"integer" and
+        "date"/"datetime" are interchangable)
+        - return_type: the return type of its output column
+        - group: a category for the function
+        - num_params: the number of input parameters
+        - format_function: an anonymous function used for naming new columns
+
         """
         computed_functions = get_computed_functions()
         for value in computed_functions.values():

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -192,7 +192,7 @@ class View(object):
         Multiple callbacks can be set through calling ``on_update`` multiple
         times, and will be called in the order they are set. Callback must be a
         callable function that takes exactly 1 or 2 parameters, depending on
-        whether `on_update` is called with `mode="rows"`. The first parameter is
+        whether `on_update` is called with `mode="row"`. The first parameter is
         always `port_id`, an :obj:`int` that indicates which input port the
         update comes from. A `RuntimeError` will be thrown if the callback
         has mis-configured parameters.
@@ -200,7 +200,7 @@ class View(object):
         Args:
             callback (:obj:`callable`): a callable function reference that will
                 be called when :func:`perspective.Table.update()` is called.
-            mode (:obj:`str`): if set to "rows", the callback will be passed
+            mode (:obj:`str`): if set to "row", the callback will be passed
                 an Arrow-serialized dataset of the rows that were updated.
                 Defaults to "none".
 

--- a/python/perspective/perspective/tornado_handler/tornado_handler.py
+++ b/python/perspective/perspective/tornado_handler/tornado_handler.py
@@ -27,6 +27,9 @@ class PerspectiveTornadoHandler(tornado.websocket.WebSocketHandler):
     with `IOLoop.current()` in order to defer expensive operations until the
     next free iteration of the event loop.
 
+    To keep the websocket connection alive, set your Tornado application's
+    ``websocket_ping_interval`` configuration variable.
+
     Examples:
         >>> MANAGER = PerspectiveManager()
         >>> MANAGER.host_table("data_source_one", Table(
@@ -69,13 +72,20 @@ class PerspectiveTornadoHandler(tornado.websocket.WebSocketHandler):
     def check_origin(self, origin):
         '''Returns whether the handler allows requests from origins outside
         of the host URL.
+
+        Args:
+            origin (:obj"`bool`): a boolean that indicates whether requests
+                outside of the host URL should be accepted. If :obj:`True`, request
+                URLs will not be validated and all requests will be allowed.
+                Defaults to :obj:`False`.
         '''
         return self._check_origin
 
     def on_message(self, message):
-        '''When the websocket receives a message, send it to the `process`
-        method of the `PerspectiveManager` with a reference to the `post`
-        callback.
+        '''When the websocket receives a message, send it to the :obj:`process`
+        method of the `PerspectiveManager` with a reference to the :obj:`post`
+        callback. Contains special logic to handle passing :obj:`ArrayBuffer`
+        objects over the wire from JS to Python, and vice-versa.
         '''
         if message == "heartbeat":
             return
@@ -116,7 +126,7 @@ class PerspectiveTornadoHandler(tornado.websocket.WebSocketHandler):
         JSON and send it to the client.
 
         Args:
-            message (str): a JSON-serialized string containing a message to the
+            message (:obj:`str`): a JSON-serialized string containing a message to the
                 front-end `perspective-viewer`.
         '''
         self.write_message(message, binary)

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -69,10 +69,11 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
                 each dict containing ``column``, a new computed column name,
                 ``computed_function_name``, a string computed function name,
                 and ``inputs``, a list of input column names.
-            plugin (`str`/`perspective.Plugin`): Which plugin to select by
+            plugin (:obj:`str`/:obj:`perspective.Plugin`): Which plugin to select by
                 default.
-            plugin_config (`dict`): Custom config for all plugins by name.
-            dark (`bool`): Whether to invert the colors.
+            plugin_config (:obj:`dict`): Custom config for all plugins by name.
+            editable (:obj:`bool`): Whether to allow editability using the grid.
+            dark (:obj:`bool`): Whether to invert the colors.
 
         Examples:
             >>> viewer = PerspectiveViewer(
@@ -110,38 +111,38 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
 
     @property
     def table(self):
-        '''Returns the `perspective.Table` under management by the viewer.'''
+        '''Returns the ``perspective.Table`` under management by the viewer.'''
         return self.manager.get_table(self.table_name)
 
     @property
     def view(self):
-        '''Returns the `perspective.View` currently shown by the viewer.
+        '''Returns the ``perspective.View`` currently shown by the viewer.
 
         This property changes every time the viewer configuration changes.'''
         return self.manager.get_view(self.view_name)
 
     def load(self, table_or_data, **options):
-        '''Given a `perspective.Table` or data that can be handled by
-        `perspective.Table`, pass it to the viewer.
+        '''Given a ``perspective.Table`` or data that can be handled by
+        ``perspective.Table``, pass it to the viewer.
 
-        `load()` resets the state of the viewer.  If a `perspective.Table`
-        is passed into `table_or_data`, `**options` is ignored as the options
-        already set on the `Table` take precedence.  If data is passed in, a
-        `perspective.Table` is automatically created by this function, and the
-        options passed to `**config` are extended to the new Table.
+        ``load()`` resets the state of the viewer.  If a ``perspective.Table``
+        is passed into ``table_or_data``, ``**options`` is ignored as the options
+        already set on the ``Table`` take precedence.  If data is passed in, a
+        ``perspective.Table`` is automatically created by this function, and the
+        options passed to ``**config`` are extended to the new Table.
 
         Args:
-            table_or_data (`Table`|`dict`|`list`|`pandas.DataFrame`): a
+            table_or_data (:obj:`Table`|:obj:`dict`|:obj:`list`|`pandas.DataFrame`): a
                 `perspective.Table` instance or a dataset to be displayed
                 in the viewer.
 
         Keyword Arguments:
-            name (`str`): An optional name to reference the table by so it can
+            name (:obj:`str`): An optional name to reference the table by so it can
                 be accessed from the front-end. If not provided, a name will
                 be generated.
-            index (`str`): A column name to be used as the primary key.
+            index (:obj:`str`): A column name to be used as the primary key.
                 Ignored if a `Table` is supplied.
-            limit (`int`): A upper limit on the number of rows in the Table.
+            limit (:obj:`int`): A upper limit on the number of rows in the Table.
                 Cannot be set at the same time as `index`, ignored if a `Table`
                 is passed in.
 
@@ -178,13 +179,13 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         affected by whether an index is set on the underlying table.
 
         Args:
-            data (`dict`|`list`|`pandas.DataFrame`): the update data for the
+            data (:obj:`dict`|:obj:`list`|:obj:`pandas.DataFrame`): the update data for the
                 table.
         '''
         self.table.update(data)
 
     def clear(self):
-        '''Clears the rows of this viewer's `Table`.'''
+        '''Clears the rows of this viewer's ``Table``.'''
         if self.table is not None:
             self.table.clear()
 
@@ -192,7 +193,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         '''Replaces the rows of this viewer's `Table` with new data.
 
         Args:
-            data (`dict`|`list`|`pandas.DataFrame`): new data to set into the
+            data (:obj:`dict`|:obj:`list`|:obj:`pandas.DataFrame`): new data to set into the
                 table - must conform to the table's schema.
         '''
         if self.table is not None:
@@ -234,11 +235,11 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
 
     def delete(self, delete_table=True):
         '''Delete the Viewer's data and clears its internal state. If
-        `delete_table` is True, the underlying `perspective.Table` and all
-        associated `View`s will be deleted.
+        ``delete_table`` is True, the underlying `perspective.Table` and all
+        associated ``View`` objects will be deleted.
 
         Args:
-            delete_table (bool) : whether the underlying `Table` will be
+            delete_table (:obj:`bool`) : whether the underlying `Table` will be
                 deleted. Defaults to True.
         '''
         if self.view:
@@ -258,7 +259,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
     def _new_view(self):
         '''Create a new View, and assign its name to the viewer.  Do not call
         this function - it will be called automatically when the state of the
-        viewer changes.  There should only be one View associated with the
+        viewer changes. There should only be one View associated with the
         Viewer at any given time - when a new View is created, the old one
         is destroyed.
         '''

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,6 +1073,109 @@
     "@d3fc/d3fc-rebind" "^5.0.10"
     d3-array "^1.0.0"
 
+"@finos/perspective-viewer-d3fc@^0.4.4", "@finos/perspective-viewer-d3fc@^0.4.7":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@finos/perspective-viewer-d3fc/-/perspective-viewer-d3fc-0.4.8.tgz#e99bc37365ccce489e2649c5b3fa34b111ba294d"
+  integrity sha512-DydKfEy5V2pfR1vJwfSKRf/xDQM3FG+f99Dl2HhTC5T6PQEe2CaIYEILE/fhAzGvDkWcS/66bkPY52OoPCiktQ==
+  dependencies:
+    "@finos/perspective" "^0.4.8"
+    "@finos/perspective-viewer" "^0.4.8"
+    babel-runtime "^6.26.0"
+    chroma-js "^1.3.4"
+    core-js "^3.6.4"
+    d3 "^5.7.0"
+    d3-svg-legend "^2.25.6"
+    d3fc "14.0.40"
+    gradient-parser "0.1.5"
+
+"@finos/perspective-viewer-datagrid@^0.4.7":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@finos/perspective-viewer-datagrid/-/perspective-viewer-datagrid-0.4.8.tgz#b37476a8ea6aa6369d3d6391bbacf6370328e72f"
+  integrity sha512-ntWwhzcNdLpL9iqserpQOzL8+Hkk6tD7qTeWFnQGKzmHeyfNMvQvvBa7OLI5CNLG2LM1yTsZ8nQ9UgPEVWZ9rg==
+  dependencies:
+    "@finos/perspective" "^0.4.8"
+    "@finos/perspective-viewer" "^0.4.8"
+    core-js "^3.6.4"
+    superscript-number "^1.0.0"
+
+"@finos/perspective-viewer-hypergrid@^0.4.4":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@finos/perspective-viewer-hypergrid/-/perspective-viewer-hypergrid-0.4.8.tgz#cc74bc9fed30b84375f5110e0d91855b19c29abe"
+  integrity sha512-+K5F/esh5h6de0mQE4gYq3b/SgQ3KP/9f98y4qFGg1NC9+jgHT5A9ION/mJRp9jQ+j3Epju+V5x5TslF0Ee+6Q==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@finos/perspective" "^0.4.8"
+    "@finos/perspective-viewer" "^0.4.8"
+    core-js "^3.6.4"
+    datasaur-local "3.0.0"
+    faux-hypergrid "3.2.5"
+    fin-hypergrid-grouped-header-plugin "^1.2.4"
+    lodash "^4.17.4"
+    rectangular "1.0.1"
+    superscript-number "^1.0.0"
+
+"@finos/perspective-viewer@^0.4.4", "@finos/perspective-viewer@^0.4.7", "@finos/perspective-viewer@^0.4.8":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@finos/perspective-viewer/-/perspective-viewer-0.4.8.tgz#79fb644662ce8b990819eea7528f67faa9a803e0"
+  integrity sha512-jYAe6y7UJ63QaDauGbWlirWcWoAd3s23ec+0FsqMbx+8AxZD4tQWk7lNxzQIwvXRuYonKaziQ6pofvAnPhWOBQ==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@finos/perspective" "^0.4.8"
+    "@types/react" "^16.9.17"
+    "@webcomponents/shadycss" "^1.5.2"
+    "@webcomponents/webcomponentsjs" "~2.0.4"
+    awesomplete "^1.1.2"
+    core-js "^3.6.4"
+    d3-array "^1.2.1"
+    detectie "1.0.0"
+    lit-html "^1.1.2"
+    lodash "^4.17.4"
+    mobile-drag-drop "^2.3.0-rc.2"
+
+"@finos/perspective-webpack-plugin@^0.4.4", "@finos/perspective-webpack-plugin@^0.4.6":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@finos/perspective-webpack-plugin/-/perspective-webpack-plugin-0.4.8.tgz#754a49677c3566d0657a3420fd898d62511a8de1"
+  integrity sha512-YVB1HTeUJK1qwqRSLEuXbiEFPAhxHvHfLbzFFbscNpJR33971Yx99hSapKBKa+FHCkxfwPuEMm8CCh9lX8FaLA==
+  dependencies:
+    "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
+    acorn "^6.1.1"
+    source-map-loader "^0.2.4"
+    string-replace-loader "^2.1.1"
+    tslib "^1.9.3"
+    worker-loader "^2.0.0"
+
+"@finos/perspective-workspace@^0.4.4", "@finos/perspective-workspace@^0.4.7":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@finos/perspective-workspace/-/perspective-workspace-0.4.8.tgz#baf54d457d047ebf6906f6c95e220a4abbd7706d"
+  integrity sha512-IusjNk8EOpfjisNW76X2F/v8PdZMOYUzHsFsZkh4OtdNTNk5DGSqXKDN+0D7GujjL6wljKPHtiAvvc2nu1TPoQ==
+  dependencies:
+    "@finos/perspective-viewer" "^0.4.8"
+    "@lumino/algorithm" "^1.2.0"
+    "@lumino/commands" "^1.7.2"
+    "@lumino/domutils" "^1.1.4"
+    "@lumino/messaging" "^1.3.0"
+    "@lumino/virtualdom" "^1.2.0"
+    "@lumino/widgets" "^1.9.3"
+    core-js "^3.6.4"
+    lodash "^4.17.4"
+
+"@finos/perspective@^0.4.4", "@finos/perspective@^0.4.7", "@finos/perspective@^0.4.8":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@finos/perspective/-/perspective-0.4.8.tgz#a6fde87c4e0c0e06a6701f6fcf910e166a708f81"
+  integrity sha512-pxHxbhTEEw0JHIPTlBf2bl9WDLC4LPjRUkQnj9lENvajUnFy4QjhlO+fJ/uWR9wRixHMq4YeuWzIZMzxXbrNfQ==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    core-js "^3.6.4"
+    d3-array "^1.2.1"
+    detectie "1.0.0"
+    flatbuffers "^1.10.2"
+    lodash "^4.17.4"
+    moment "^2.19.1"
+    papaparse "^4.3.6"
+    text-encoding-utf-8 "^1.0.2"
+    tslib "^1.9.3"
+    ws "^6.1.2"
+
 "@fortawesome/fontawesome-free@^5.12.0":
   version "5.12.1"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.1.tgz#2a98fea9fbb8a606ddc79a4680034e9d5591c550"
@@ -2852,6 +2955,11 @@ backbone@1.2.3:
   dependencies:
     underscore ">=1.7.0"
 
+bail@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
+  integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
+
 balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
@@ -3488,6 +3596,21 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
@@ -3784,6 +3907,11 @@ coffee-script@^1.12.4:
   version "1.12.7"
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
   integrity sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==
+
+collapse-white-space@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
+  integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
 
 collect-all@^1.0.3:
   version "1.0.3"
@@ -5920,6 +6048,15 @@ eslint-config-prettier@^3.0.1:
   dependencies:
     get-stdin "^6.0.0"
 
+eslint-plugin-markdown@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.2.tgz#79274bf17ce3ead48e4a55cbcb6d7ce735754280"
+  integrity sha512-BfvXKsO0K+zvdarNc801jsE/NTLmig4oKhZ1U3aSUgTf2dB/US5+CrfGxMsCK2Ki1vS1R3HPok+uYpufFndhzw==
+  dependencies:
+    object-assign "^4.0.1"
+    remark-parse "^5.0.0"
+    unified "^6.1.2"
+
 eslint-plugin-prettier@^2.6.2:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz#b4312dcf2c1d965379d7f9d5b5f8aaadc6a45904"
@@ -6291,7 +6428,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -7881,7 +8018,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -8048,6 +8185,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arguments@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
@@ -8070,7 +8220,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -8124,6 +8274,11 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -8238,6 +8393,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-jpg@^2.0.0:
   version "2.0.0"
@@ -8419,10 +8579,20 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
+is-whitespace-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz#0858edd94a95594c7c9dd0b5c174ec6e45ee4aa7"
+  integrity sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-word-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.4.tgz#ce0e73216f98599060592f62ff31354ddbeb0230"
+  integrity sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -9808,6 +9978,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-escapes@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
+  integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
+
 markdown-link@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/markdown-link/-/markdown-link-0.1.1.tgz#32c5c65199a6457316322d1e4229d13407c8c7cf"
@@ -10971,6 +11146,11 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
+papaparse@^4.3.6:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.6.3.tgz#742e5eaaa97fa6c7e1358d2934d8f18f44aee781"
+  integrity sha512-LRq7BrHC2kHPBYSD50aKuw/B/dGcg29omyJbKWY3KsYUZU69RKwaBHu13jGmCYBtOc4odsLCrFyk6imfyNubJQ==
+
 papaparse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/papaparse/-/papaparse-5.2.0.tgz#97976a1b135c46612773029153dc64995caa3b7b"
@@ -11010,6 +11190,18 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 parse-github-repo-url@^1.3.0:
   version "1.4.1"
@@ -12594,6 +12786,27 @@ relateurl@0.2.x:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remarkable@^1.7.1:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-1.7.4.tgz#19073cb960398c87a7d6546eaa5e50d2022fcd00"
@@ -12631,7 +12844,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.5.2, repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -12643,7 +12856,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-replace-ext@^1.0.0:
+replace-ext@1.0.0, replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
@@ -13557,6 +13770,11 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
+state-toggle@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.3.tgz#e123b16a88e143139b09c6852221bc9815917dfe"
+  integrity sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -14376,6 +14594,21 @@ trim-repeated@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz#7f0739881ff76657b7776e10874128004b625a94"
+  integrity sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
+trough@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
+  integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
+
 truncate-html@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/truncate-html/-/truncate-html-1.0.3.tgz#0166dfc7890626130c2e4174c6b73d4d63993e5f"
@@ -14568,6 +14801,14 @@ underscore@~1.8.3:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
   integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
 
+unherit@^1.0.4:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"
+  integrity sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==
+  dependencies:
+    inherits "^2.0.0"
+    xtend "^4.0.0"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -14590,6 +14831,18 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
+
+unified@^6.1.2:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -14631,6 +14884,37 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
+  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
+unist-util-visit@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -14819,6 +15103,28 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
+  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
+
+vfile-message@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
+  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
@@ -15235,6 +15541,11 @@ ws@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
   integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
+
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
 
 xml-js@^1.6.11:
   version "1.6.11"


### PR DESCRIPTION
This PR adds `eslint-plugin-markdown` and applies auto-formatting fixes to Javascript code blocks in our markdown documentation.

Additionally it fixes some formatting issues with the Python documentation, adds `PerspectiveTornadoHandler` to the Python documentation, as well as fixes typos, makes improvements & adds examples to both JS and Python docs.