### PR TITLE
FIx for issue

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,7 @@
             "camelcase": "off",
             "@typescript-eslint/camelcase": "off"
 
-        }    
+        }
     }, {
         "files": ["**/test/**/*.js"],
         "rules": {
@@ -42,7 +42,7 @@
                 "comments": 200,
                 "ignoreTrailingComments": true
             }]
-        }    
+        }
     }, {
         "files": ["**/*.md"],
         "rules": {
@@ -64,6 +64,7 @@
             "ignoreTrailingComments": true
         }],
         "@typescript-eslint/camelcase": "off",
+        "linebreak-style": ["error","unix"],
         "camelcase": "off",
         "no-const-assign": "error",
         "no-this-before-super": "error",

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 docs/* linguist-documentation
 python/perspective/notebooks/* linguist-documentation
 python/perspective/docs/* linguist-documentation
+*.js text eol=lf


### PR DESCRIPTION
I've added a rule to catch the CRLF formatting in the ESlint config. However, according to https://eslint.org/docs/rules/linebreak-style the problem would appear to lie at least partly in the way git automatically converts the formatting on windows machines (although it's possibly coming from the windows based code editors. to quote: 

   If you use git, you may want to add a line to your .gitattributes file to prevent git from converting linebreaks in .js files:
    *.js text eol=lf

So I've added that line to the .gitattributes as well. 

Please note that this pull request doesn't change all the existing files with CLRF end of line sequences, but should help for future changes. If you'd like me to submit an additional pull request for existing files or work it into this one please let me know.