### PR TITLE
Add client/server editing example, fix hypergrid to allow editing in workspace

### DIFF
--- a/examples/workspace-editing/README.md
+++ b/examples/workspace-editing/README.md
@@ -1,0 +1,12 @@
+# `perspective-workspace` client-server editing example
+
+For this example to work, you'll need a `perspective-python` server running
+over a websocket at an accessible URL. This example is preconfigured to use
+`client_server_edits.py` in `python/perspective/examples`. Make sure you
+have `perspective-python` installed, and then run:
+
+```bash
+python3 python/perspective/examples/client_server.py
+```
+
+Then, run `yarn start webpack` from this example to run the local test server.

--- a/examples/workspace-editing/package.json
+++ b/examples/workspace-editing/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "workspace-editing",
+    "private": true,
+    "version": "0.5.1",
+    "description": "An example app demonstrating client/server editing, built using `@finos/perspective-workspace` and `perspective-python`.",
+    "scripts": {
+        "start": "webpack-dev-server --open",
+        "webpack": "webpack --colour"
+    },
+    "keywords": [],
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@finos/perspective": "^0.5.1",
+        "@finos/perspective-viewer": "^0.5.1",
+        "@finos/perspective-viewer-d3fc": "^0.5.1",
+        "@finos/perspective-viewer-hypergrid": "^0.5.1",
+        "@finos/perspective-viewer-datagrid": "^0.5.1",
+        "@finos/perspective-workspace": "^0.5.1"
+    },
+    "devDependencies": {
+        "@finos/perspective-webpack-plugin": "^0.5.0",
+        "css-loader": "^0.28.7",
+        "file-loader": "^4.2.0",
+        "html-webpack-plugin": "^3.2.0",
+        "http-server": "^0.11.1",
+        "less-loader": "^4.0.5",
+        "npm-run-all": "^4.1.3",
+        "rimraf": "^2.5.2",
+        "style-loader": "^0.18.2",
+        "webpack-cli": "^3.3.7",
+        "webpack-dev-server": "^3.8.0"
+    }
+}

--- a/examples/workspace-editing/src/index.html
+++ b/examples/workspace-editing/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Client/Server Editing Workspace</title>
+  </head>
+  <body>
+    <div id="progress" class="slider">
+      <div class="line"></div>
+    <div class="subline inc"></div>
+    <div class="subline dec"></div>
+    </div>
+    <perspective-workspace id="workspace"></perspective-workspace>
+</body>
+</html>

--- a/examples/workspace-editing/src/index.js
+++ b/examples/workspace-editing/src/index.js
@@ -1,0 +1,177 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import perspective from "@finos/perspective";
+import "@finos/perspective-viewer-hypergrid";
+import "@finos/perspective-viewer-datagrid";
+import "@finos/perspective-viewer-d3fc";
+import "@finos/perspective-workspace";
+
+import "./index.less";
+
+const URL = "ws://localhost:8888/websocket";
+
+const websocket = perspective.websocket(URL);
+const worker = perspective.shared_worker();
+
+const server_table = websocket.open_table("data_source_one");
+const server_view = websocket.open_view("view_one");
+
+// All viewers are based on the same table, which then feed edits back to a
+// table on the server.
+let table;
+
+// Keep track of an array of ports. Each new viewer instance creates a new
+// port. For code simplicity, we do not track ports by viewer name, although
+// it is trivial to do so, and the performance benefits of doing so would be
+// negligible, as the `n` in the O(n) search would be number of new viewers
+// created in one session.
+const PORTS = [];
+
+/**
+ * Load and return a table, created from a view hosted on the remote server.
+ *
+ * By calling `to_arrow` ourselves, we bypass some special logic set up when a
+ * table is created from a view, and so we can set up `on_update` callbacks in a
+ * custom way.
+ */
+const datasource = async function() {
+    const load_start = performance.now();
+    const arrow = await server_view.to_arrow();
+    const table = worker.table(arrow, {index: "Row ID"});
+    console.log(`Finished load in: ${performance.now() - load_start}`);
+    const progress_bar = document.getElementById("progress");
+    progress_bar.remove();
+    return table;
+};
+
+const setup_handlers = async () => {
+    // Set up ports based on the viewer configuration - each viewer needs a
+    // unique port.
+    const viewers = window.workspace.querySelectorAll("perspective-viewer");
+    const client_table = viewers[0].table;
+    const client_view = client_table.view();
+
+    for (const viewer of viewers) {
+        PORTS.push(await viewer.getEditPort());
+    }
+
+    // Each client instance (i.e. each workspace) needs to get its own unique
+    // port from the server. This allows workspaces to differentiate between
+    // updates it sends `to` the server, and updates sent `from` the server.
+    const server_edit_port = await server_table.make_port();
+
+    // When the client updates, decide whether it is an edit or an update.
+    // Edits come through any of the edit ports defined in `PORTS`, so allow
+    // those to propagate to the server. Updates back from the server, however,
+    // should not be sent `back` to the server (as it would create an infinite
+    // loop of updates).
+    client_view.on_update(
+        updated => {
+            const client_ports = Object.keys(PORTS).map(viewer => PORTS[viewer]);
+
+            if (client_ports.includes(updated.port_id)) {
+                server_table.update(updated.delta, {
+                    // Call update using the server port we were given, so that
+                    // other workspaces can receive our update.
+                    port_id: server_edit_port
+                });
+            }
+        },
+        {mode: "row"}
+    );
+
+    // If the server updates, decide whether to apply it to the client table.
+    // Use the `server_edit_port` we created earlier - if an update comes
+    // through that port, we know that this workspace created it and there is
+    // no need to double apply.
+    server_view.on_update(
+        updated => {
+            if (updated.port_id !== server_edit_port) {
+                // Update on port 0, as that will never trigger a send back to
+                // the server.
+                client_table.update(updated.delta);
+            }
+        },
+        {mode: "row"}
+    );
+};
+
+/**
+ * If new viewers are added, add them to the `PORTS` array. If we chose to track
+ * viewers by name, we can also handle viewer deletion. However, this requires
+ * viewers to have UNIQUE names, otherwise ports will collide.
+ */
+const refresh_ports = async () => {
+    const viewers = window.workspace.querySelectorAll("perspective-viewer");
+
+    for (const viewer of viewers) {
+        const port = await viewer.getEditPort();
+
+        // add new ports
+        if (!PORTS.includes(port)) {
+            PORTS.push(port);
+        }
+    }
+};
+
+window.addEventListener("load", async () => {
+    table = await datasource();
+
+    // On the first layout draw, when all the viewers are ready, initialize
+    // our custom on_update handlers.
+    let setup_done = false;
+
+    window.workspace.addEventListener("workspace-layout-update", async () => {
+        if (!setup_done) {
+            await setup_handlers();
+            setup_done = true;
+        } else {
+            refresh_ports();
+        }
+    });
+
+    window.workspace.tables.set("datasource", table);
+
+    await window.workspace.restore({
+        detail: {
+            main: {
+                type: "split-area",
+                orientation: "horizontal",
+                children: [
+                    {
+                        type: "tab-area",
+                        currentIndex: 0,
+                        widgets: ["main_widget"]
+                    },
+                    {
+                        type: "tab-area",
+                        currentIndex: 0,
+                        widgets: ["second_widget"]
+                    }
+                ],
+                sizes: [0.5, 0.5]
+            }
+        },
+        viewers: {
+            main_widget: {
+                table: "datasource",
+                name: "Superstore",
+                plugin: "hypergrid",
+                editable: true
+            },
+            second_widget: {
+                table: "datasource",
+                name: "Superstore 2",
+                plugin: "hypergrid",
+                editable: true
+            }
+        }
+    });
+});

--- a/examples/workspace-editing/src/index.less
+++ b/examples/workspace-editing/src/index.less
@@ -1,0 +1,81 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2018, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+@import "~@finos/perspective-workspace/dist/theme/material.less";
+ 
+body {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.slider {
+  position: absolute;
+  width: 250px;
+  height: 10px;
+  overflow-x: hidden;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-left: -125px;
+  margin-top: -5px;
+}
+
+.line {
+  position: absolute;
+  opacity: 0.4;
+  background: rgb(175, 175, 175);
+  width: 150%;
+  height: 5px;
+}
+
+.subline {
+  position: absolute;
+  background: rgb(153, 153, 153);
+  height: 5px;
+}
+
+.inc {
+  animation: increase 2s infinite;
+}
+
+.dec {
+  animation: decrease 2s 0.5s infinite;
+}
+
+@keyframes increase {
+  from {
+    left: -5%;
+    width: 5%;
+  }
+
+  to {
+    left: 130%;
+    width: 100%;
+  }
+}
+
+@keyframes decrease {
+  from {
+    left: -80%;
+    width: 80%;
+  }
+
+  to {
+    left: 110%;
+    width: 10%;
+  }
+}

--- a/examples/workspace-editing/webpack.config.js
+++ b/examples/workspace-editing/webpack.config.js
@@ -1,0 +1,47 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
+const HtmlWebPackPlugin = require("html-webpack-plugin");
+const path = require("path");
+
+module.exports = {
+    mode: process.env.NODE_ENV || "development",
+    entry: "./src/index.js",
+    output: {
+        filename: "index.js"
+    },
+    plugins: [
+        new HtmlWebPackPlugin({
+            title: "Workspace Example",
+            template: "./src/index.html"
+        }),
+        new PerspectivePlugin({})
+    ],
+    module: {
+        rules: [
+            {
+                test: /\.less$/,
+                use: [{loader: "style-loader"}, {loader: "css-loader"}, {loader: "less-loader"}]
+            },
+            {
+                test: /\.(png|jpe?g|gif)$/i,
+                use: [
+                    {
+                        loader: "file-loader"
+                    }
+                ]
+            }
+        ]
+    },
+    devServer: {
+        contentBase: [path.join(__dirname, "dist"), path.join(__dirname, "../simple")]
+    },
+    devtool: "source-map"
+};

--- a/packages/perspective-viewer-hypergrid/src/js/editors.js
+++ b/packages/perspective-viewer-hypergrid/src/js/editors.js
@@ -98,8 +98,9 @@ function getEditorValueText(updated) {
         const index = old.__INDEX__;
         delete old["__INDEX__"];
         const colname = Object.keys(old)[0];
-        const port_id = this.grid.behavior.dataModel._viewer._edit_port || 0;
-        this._table.update([{__INDEX__: index, [colname]: updated}], {port_id: port_id});
+        this.grid.behavior.dataModel._viewer.getEditPort().then(port_id => {
+            this._table.update([{__INDEX__: index, [colname]: updated}], {port_id: port_id});
+        });
     });
     return this.localizer.format(updated);
 }
@@ -109,8 +110,9 @@ function getEditorValueNumber(updated) {
         const index = old.__INDEX__;
         delete old["__INDEX__"];
         const colname = Object.keys(old)[0];
-        const port_id = this.grid.behavior.dataModel._viewer._edit_port || 0;
-        this._table.update([{__INDEX__: index, [colname]: Number(updated.replace(/,/g, ""))}], {port_id: port_id});
+        this.grid.behavior.dataModel._viewer.getEditPort().then(port_id => {
+            this._table.update([{__INDEX__: index, [colname]: Number(updated.replace(/,/g, ""))}], {port_id: port_id});
+        });
     });
     return this.localizer.format(updated);
 }
@@ -121,8 +123,9 @@ function getEditorValueDate(updated) {
         const index = old.__INDEX__;
         delete old["__INDEX__"];
         const colname = Object.keys(old)[0];
-        const port_id = this.grid.behavior.dataModel._viewer._edit_port || 0;
-        this._table.update([{__INDEX__: index, [colname]: updated}], {port_id: port_id});
+        this.grid.behavior.dataModel._viewer.getEditPort().then(port_id => {
+            this._table.update([{__INDEX__: index, [colname]: updated}], {port_id: port_id});
+        });
     });
     return this.localizer.format(updated);
 }

--- a/python/perspective/examples/client_server_edits.py
+++ b/python/perspective/examples/client_server_edits.py
@@ -1,13 +1,11 @@
 import os
 import os.path
-import random
 import sys
 import logging
 import tornado.websocket
 import tornado.web
 import tornado.ioloop
 import pandas as pd
-from datetime import datetime
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
 from perspective import Table, PerspectiveManager, PerspectiveTornadoHandler


### PR DESCRIPTION
This PR adds `examples/workspace-editing`, which implements the `client_server_editing` example from `perspective-python` in a `perspective-workspace`. It is designed to be run in parallel with `client_server_editing.py` in the Python examples folder, and provides a simple, self-contained and annotated demonstration of Perspective's client/server editing capabilities.

This PR also fixes an issue in the Hypergrid plugin that was preventing edits from being tracked when using a remote server and in `perspective-workspace`.