### PR TITLE
Datetime computed functions use local time

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -369,7 +369,7 @@ jobs:
     - script: npm install -g yarn
       displayName: "Install Yarn"
 
-    - script: yarn
+    - script: yarn --network-timeout 600000
       displayName: 'Install Deps'
 
     - script: yarn build_python --ci $(python_flag)

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -617,18 +617,20 @@ t_tscalar day_bucket<DTYPE_TIME>(t_tscalar x) {
     // Convert the timestamp to a `sys_time` (alias for `time_point`)
     date::sys_time<std::chrono::milliseconds> ts(ms_timestamp);
 
-    // Create a copy of the timestamp with day precision
-    auto days = date::floor<date::days>(ts);
+    // Use localtime so that the day of week is consistent with all output
+    // datetimes, which are in local time
+    std::time_t temp = std::chrono::system_clock::to_time_t(ts);
 
-    // Cast the `time_point` to contain year/month/day
-    auto ymd = date::year_month_day(days);
+    // Convert to a std::tm
+    std::tm* t = std::localtime(&temp);
 
     // Get the year and create a new `t_date`
-    std::int32_t year = static_cast<std::int32_t>(ymd.year());
+    std::int32_t year = static_cast<std::int32_t>(t->tm_year + 1900);
 
     // Month in `t_date` is [0-11]
-    std::int32_t month = static_cast<std::uint32_t>(ymd.month()) - 1;
-    std::uint32_t day = static_cast<std::uint32_t>(ymd.day());
+    std::int32_t month = static_cast<std::uint32_t>(t->tm_mon);
+    std::uint32_t day = static_cast<std::uint32_t>(t->tm_mday);
+
     rval.set(t_date(year, month, day));
     return rval;
 }

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -715,20 +715,18 @@ t_tscalar month_bucket<DTYPE_TIME>(t_tscalar x) {
     if (x.is_none() || !x.is_valid()) return rval;
 
     // Convert the int64 to a milliseconds duration timestamp
-    std::chrono::milliseconds timestamp(x.to_int64());
+    std::chrono::milliseconds ms_timestamp(x.to_int64());
 
     // Convert the timestamp to a `sys_time` (alias for `time_point`)
-    date::sys_time<std::chrono::milliseconds> ts(timestamp);
+    date::sys_time<std::chrono::milliseconds> ts(ms_timestamp);
 
-    // Create a copy of the timestamp with day precision
-    auto days = date::floor<date::days>(ts);
+    // Convert the timestamp to local time
+    std::time_t temp = std::chrono::system_clock::to_time_t(ts);
+    std::tm* t = std::localtime(&temp);
 
-    // Cast the `time_point` to contain year/month/day
-    auto ymd = date::year_month_day(days);
-
-    // Get the year and create a new `t_date`
-    std::int32_t year = static_cast<std::int32_t>(ymd.year());
-    std::int32_t month = static_cast<std::uint32_t>(ymd.month()) - 1;
+    // Use the `tm` to create the `t_date`
+    std::int32_t year = static_cast<std::int32_t>(t->tm_year + 1900);
+    std::int32_t month = static_cast<std::uint32_t>(t->tm_mon);
     rval.set(t_date(year, month, 1));
     return rval;
 }

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -747,19 +747,17 @@ t_tscalar year_bucket<DTYPE_TIME>(t_tscalar x) {
     if (x.is_none() || !x.is_valid()) return rval;
 
     // Convert the int64 to a milliseconds duration timestamp
-    std::chrono::milliseconds timestamp(x.to_int64());
+    std::chrono::milliseconds ms_timestamp(x.to_int64());
 
     // Convert the timestamp to a `sys_time` (alias for `time_point`)
-    date::sys_time<std::chrono::milliseconds> ts(timestamp);
+    date::sys_time<std::chrono::milliseconds> ts(ms_timestamp);
 
-    // Create a copy of the timestamp with day precision
-    auto days = date::floor<date::days>(ts);
+    // Convert the timestamp to local time
+    std::time_t temp = std::chrono::system_clock::to_time_t(ts);
+    std::tm* t = std::localtime(&temp);
 
-    // Cast the `time_point` to contain year/month/day
-    auto ymd = date::year_month_day(days);
-
-    // Get the year and create a new `t_date`
-    std::int32_t year = static_cast<std::int32_t>(ymd.year());
+    // Use the `tm` to create the `t_date`
+    std::int32_t year = static_cast<std::int32_t>(t->tm_year + 1900);
     rval.set(t_date(year, 0, 1));
     return rval;
 }

--- a/packages/perspective/test/js/computed/datetime.js
+++ b/packages/perspective/test/js/computed/datetime.js
@@ -1108,6 +1108,37 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("Bucket (D), datetime at UTC edge", async function() {
+            const table = perspective.table({
+                a: "datetime"
+            });
+
+            const view = table.view({
+                computed_columns: [
+                    {
+                        column: "computed",
+                        computed_function_name: "Bucket (D)",
+                        inputs: ["a"]
+                    }
+                ]
+            });
+
+            const schema = await view.schema();
+            expect(schema).toEqual({
+                a: "datetime",
+                computed: "date"
+            });
+
+            table.update({
+                a: [new Date(2020, 0, 15, 23, 30, 15), null, undefined, new Date(2020, 3, 29, 23, 30, 0), new Date(2020, 4, 30, 23, 30, 15)]
+            });
+
+            let result = await view.to_columns();
+            expect(result.computed.map(x => (x ? new Date(x) : null))).toEqual(result.a.map(x => (x ? common.day_bucket(x) : null)));
+            view.delete();
+            table.delete();
+        });
+
         it("Bucket (W), datetime", async function() {
             const table = perspective.table({
                 a: "datetime"

--- a/python/perspective/perspective/table/_data_formatter.py
+++ b/python/perspective/perspective/table/_data_formatter.py
@@ -104,6 +104,7 @@ def to_format(options, view, output_format):
     if output_format == 'numpy':
         for k, v in data.items():
             # TODO push into C++
+            print(type(v), v)
             data[k] = np.array(v)
 
     return data

--- a/python/perspective/perspective/tests/table/test_table_datetime.py
+++ b/python/perspective/perspective/tests/table/test_table_datetime.py
@@ -1562,6 +1562,63 @@ if os.name != 'nt':
             result = view.to_dict()
             assert result["computed"] == [datetime(2020, 6, 1)]
 
+        def test_table_year_bucket_edge_in_EST(object):
+            """Make sure edge cases are fixed for year_bucket - if a local
+            time converted to UTC is in the next day, the year_bucket
+            computation needs to be in local time."""
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "year_bucket"
+            }]
+  
+            data = {
+                "a": [datetime(2019, 12, 31, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2019, 1, 1)]
+
+        def test_table_year_bucket_edge_in_CST(object):
+            os.environ["TZ"] = "US/Central"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "year_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2019, 12, 31, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2019, 1, 1)]
+
+        def test_table_year_bucket_edge_in_PST(object):
+            os.environ["TZ"] = "US/Pacific"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "year_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2019, 12, 31, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2019, 1, 1)]
+
 
 class TestTableDateTimePivots(object):
 

--- a/python/perspective/perspective/tests/table/test_table_datetime.py
+++ b/python/perspective/perspective/tests/table/test_table_datetime.py
@@ -1276,6 +1276,63 @@ if os.name != 'nt':
             result = view.to_dict()
             assert result["computed"] == ["6 Friday"]
 
+        def test_table_month_of_year_edge_in_EST(object):
+            """Make sure edge cases are fixed for month of year - if a local
+            time converted to UTC is in the next month, the month of year
+            computation needs to be in local time."""
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "month_of_year"
+            }]
+
+            data = {
+                "a": [datetime(2020, 1, 31, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == ["01 January"]
+
+        def test_table_month_of_year_edge_in_CST(object):
+            os.environ["TZ"] = "US/Central"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "month_of_year"
+            }]
+
+            data = {
+                "a": [datetime(2020, 1, 31, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == ["01 January"]
+
+        def test_table_month_of_year_edge_in_PST(object):
+            os.environ["TZ"] = "US/Pacific"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "month_of_year"
+            }]
+
+            data = {
+                "a": [datetime(2020, 1, 31, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == ["01 January"]
+
         def test_table_day_bucket_edge_in_EST(object):
             """Make sure edge cases are fixed for day_bucket - if a local
             time converted to UTC is in the next day, the day_bucket
@@ -1333,62 +1390,177 @@ if os.name != 'nt':
             result = view.to_dict()
             assert result["computed"] == [datetime(2020, 1, 31)]
 
-        def test_table_month_of_year_edge_in_EST(object):
-            """Make sure edge cases are fixed for month of year - if a local
-            time converted to UTC is in the next month, the month of year
+        @mark.skip
+        def test_table_week_bucket_edge_in_EST(object):
+            """Make sure edge cases are fixed for week_bucket - if a local
+            time converted to UTC is in the next day, the week_bucket
             computation needs to be in local time."""
             computed_columns = [{
                 "inputs": ["a"],
                 "column": "computed",
-                "computed_function_name": "month_of_year"
+                "computed_function_name": "week_bucket"
             }]
 
             data = {
-                "a": [datetime(2020, 1, 31, 23, 59)]
+                "a": [datetime(2020, 2, 2, 23, 59)]
             }
 
             table = Table(data)
             view = table.view(computed_columns=computed_columns)
             result = view.to_dict()
-            assert result["computed"] == ["01 January"]
+            assert result["computed"] == [datetime(2020, 1, 27)]
 
-        def test_table_month_of_year_edge_in_CST(object):
+        @mark.skip
+        def test_table_week_bucket_edge_in_CST(object):
             os.environ["TZ"] = "US/Central"
             time.tzset()
 
             computed_columns = [{
                 "inputs": ["a"],
                 "column": "computed",
-                "computed_function_name": "month_of_year"
+                "computed_function_name": "week_bucket"
             }]
 
             data = {
-                "a": [datetime(2020, 1, 31, 23, 59)]
+                "a": [datetime(2020, 2, 2, 23, 59)]
             }
 
             table = Table(data)
             view = table.view(computed_columns=computed_columns)
             result = view.to_dict()
-            assert result["computed"] == ["01 January"]
+            assert result["computed"] == [datetime(2020, 1, 27)]
 
-        def test_table_month_of_year_edge_in_PST(object):
+        @mark.skip
+        def test_table_week_bucket_edge_in_PST(object):
             os.environ["TZ"] = "US/Pacific"
             time.tzset()
 
             computed_columns = [{
                 "inputs": ["a"],
                 "column": "computed",
-                "computed_function_name": "month_of_year"
+                "computed_function_name": "week_bucket"
             }]
 
             data = {
-                "a": [datetime(2020, 1, 31, 23, 59)]
+                "a": [datetime(2020, 2, 2, 23, 59)]
             }
 
             table = Table(data)
             view = table.view(computed_columns=computed_columns)
             result = view.to_dict()
-            assert result["computed"] == ["01 January"]
+            assert result["computed"] == [datetime(2020, 1, 27)]
+
+        def test_table_week_bucket_edge_flip_in_EST(object):
+            """Week bucket should flip backwards to last month."""
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "week_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2020, 3, 1, 12, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2020, 2, 24)]
+
+        def test_table_week_bucket_edge_flip_in_CST(object):
+            os.environ["TZ"] = "US/Central"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "week_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2020, 3, 1, 12, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2020, 2, 24)]
+
+        def test_table_week_bucket_edge_flip_in_PST(object):
+            os.environ["TZ"] = "US/Pacific"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "week_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2020, 3, 1, 12, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2020, 2, 24)]
+
+        def test_table_month_bucket_edge_in_EST(object):
+            """Make sure edge cases are fixed for month_bucket - if a local
+            time converted to UTC is in the next day, the month_bucket
+            computation needs to be in local time."""
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "month_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2020, 6, 30, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2020, 6, 1)]
+
+        def test_table_month_bucket_edge_in_CST(object):
+            os.environ["TZ"] = "US/Central"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "month_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2020, 6, 30, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2020, 6, 1)]
+
+        def test_table_month_bucket_edge_in_PST(object):
+            os.environ["TZ"] = "US/Pacific"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "month_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2020, 6, 30, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2020, 6, 1)]
 
 
 class TestTableDateTimePivots(object):

--- a/python/perspective/perspective/tests/table/test_table_datetime.py
+++ b/python/perspective/perspective/tests/table/test_table_datetime.py
@@ -1390,7 +1390,6 @@ if os.name != 'nt':
             result = view.to_dict()
             assert result["computed"] == [datetime(2020, 1, 31)]
 
-        @mark.skip
         def test_table_week_bucket_edge_in_EST(object):
             """Make sure edge cases are fixed for week_bucket - if a local
             time converted to UTC is in the next day, the week_bucket
@@ -1410,7 +1409,6 @@ if os.name != 'nt':
             result = view.to_dict()
             assert result["computed"] == [datetime(2020, 1, 27)]
 
-        @mark.skip
         def test_table_week_bucket_edge_in_CST(object):
             os.environ["TZ"] = "US/Central"
             time.tzset()
@@ -1430,7 +1428,6 @@ if os.name != 'nt':
             result = view.to_dict()
             assert result["computed"] == [datetime(2020, 1, 27)]
 
-        @mark.skip
         def test_table_week_bucket_edge_in_PST(object):
             os.environ["TZ"] = "US/Pacific"
             time.tzset()
@@ -1571,7 +1568,7 @@ if os.name != 'nt':
                 "column": "computed",
                 "computed_function_name": "year_bucket"
             }]
-  
+
             data = {
                 "a": [datetime(2019, 12, 31, 23, 59)]
             }

--- a/python/perspective/perspective/tests/table/test_table_datetime.py
+++ b/python/perspective/perspective/tests/table/test_table_datetime.py
@@ -1221,7 +1221,7 @@ if os.name != 'nt':
 
         def test_table_day_of_week_edge_in_EST(object):
             """Make sure edge cases are fixed for day of week - if a local
-            time converted to UTC is in the next day, theday of week
+            time converted to UTC is in the next day, the day of week
             computation needs to be in local time."""
             computed_columns = [{
                 "inputs": ["a"],
@@ -1275,6 +1275,63 @@ if os.name != 'nt':
             view = table.view(computed_columns=computed_columns)
             result = view.to_dict()
             assert result["computed"] == ["6 Friday"]
+
+        def test_table_day_bucket_edge_in_EST(object):
+            """Make sure edge cases are fixed for day_bucket - if a local
+            time converted to UTC is in the next day, the day_bucket
+            computation needs to be in local time."""
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "day_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2020, 1, 31, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2020, 1, 31)]
+
+        def test_table_day_bucket_edge_in_CST(object):
+            os.environ["TZ"] = "US/Central"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "day_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2020, 1, 31, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2020, 1, 31)]
+
+        def test_table_day_bucket_edge_in_PST(object):
+            os.environ["TZ"] = "US/Pacific"
+            time.tzset()
+
+            computed_columns = [{
+                "inputs": ["a"],
+                "column": "computed",
+                "computed_function_name": "day_bucket"
+            }]
+
+            data = {
+                "a": [datetime(2020, 1, 31, 23, 59)]
+            }
+
+            table = Table(data)
+            view = table.view(computed_columns=computed_columns)
+            result = view.to_dict()
+            assert result["computed"] == [datetime(2020, 1, 31)]
 
         def test_table_month_of_year_edge_in_EST(object):
             """Make sure edge cases are fixed for month of year - if a local


### PR DESCRIPTION
This PR fixes all datetime computed functions to compute in local time instead of UTC, through the use of `std::localtime`. 

Previously, computed functions that returned strings/ints from datetimes were fixed to return in local time, but I left out the functions that returned datetimes (as I assumed they were correct). This PR fixes that mistake and makes sure that day/week/month/year bucket use local time. The second/minute/hour buckets are unaffected, as timezones do not affect the correctness of their calculation.