### PR TITLE
`perspective-viewer-highcharts-lite`

### DIFF
--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -138,11 +138,10 @@ they are compatible with perspective versions < 1.0.0:
   [Hypergrid](https://github.com/fin-hypergrid/core).
 
 - `@finos/perspective-viewer-highcharts`  
-  A `<perspective-viewer>` plugin for
+  [DEPRECATED] A `<perspective-viewer>` plugin for
   [HighCharts](https://github.com/highcharts/highcharts). This plugin has a
-  dependency on Highcharts'
-  [mixed commercial license](https://creativecommons.org/licenses/by-nc/3.0/),
-  and is no longer under active development.
+  `highcharts` as a peerDependency, and requires a
+  [mixed commercial license](https://shop.highsoft.com/).
 
 When imported after `@finos/perspective-viewer`, the plugin modules will
 register themselves automatically, and the renderers they export will be
@@ -906,7 +905,7 @@ Once an update has finished, a `perspective-update-complete` DOM event is fired.
 
 ```javascript
 elem.addEventListener("perspective-update-complete", function(event) {
-  console.log("Update is now complete");
+    console.log("Update is now complete");
 });
 ```
 

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -27,7 +27,7 @@
 <body>
 
     <div id="list">
-        <a href="superstore-arrow.html">Superstore example as an Apache Arrow</a>
+        <a href="superstore.html">Superstore example as an Apache Arrow</a>
         <a href="superstore-hypergrid.html">Editable example</a>
         <a href="superstore-custom-grid.html">Themed example</a>
         <a href="streaming.html">High-frequency streaming random data example</a>

--- a/examples/simple/superstore.html
+++ b/examples/simple/superstore.html
@@ -17,7 +17,7 @@
     <script src="perspective-viewer.js"></script>
     <script src="perspective-viewer-hypergrid.js"></script>
     <script src="perspective-viewer-datagrid.js"></script>
-    <script src="perspective-viewer-d3fc.js"></script>
+    <script src="perspective-viewer-highcharts.js"></script>
 
     <script src="perspective.js"></script>
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "file-loader": "^2.0.0",
         "fs-extra": "^8.1.0",
         "graceful-fs": "https://github.com/mekwall/node-graceful-fs.git#patch-1",
+        "highcharts": "6.1.0",
         "html-loader": "^0.5.1",
         "html-loader-jest": "^0.2.1",
         "inquirer": "^7.0.0",

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -37,8 +37,7 @@
     "dependencies": {
         "@finos/perspective-viewer": "^0.5.1",
         "@finos/perspective-viewer-d3fc": "^0.5.1",
-        "@finos/perspective-viewer-highcharts": "^0.5.1",
-        "@finos/perspective-viewer-hypergrid": "^0.5.1",
+        "@finos/perspective-viewer-datagrid": "^0.5.1",
         "@jupyter-widgets/base": "^3.0.0",
         "@jupyterlab/application": "^2.0.0",
         "@lumino/application": "^1.7.3",

--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -6,16 +6,7 @@
     "unpkg": "./dist/umd/perspective-viewer-highcharts.js",
     "jsdelivr": "./dist/umd/perspective-viewer-highcharts.js",
     "browser": {
-        "heatmap": "./dist/esm/heatmap.js",
-        "sunburst": "./dist/esm/sunburst.js",
-        "treemap": "./dist/esm/treemap.js",
-        "x_bar": "./dist/esm/x_bar.js",
-        "xy_line": "./dist/esm/xy_line.js",
-        "xy_scatter": "./dist/esm/xy_scatter.js",
-        "y_area": "./dist/esm/y_area.js",
-        "y_bar": "./dist/esm/y_bar.js",
-        "y_line": "./dist/esm/y_line.js",
-        "y_scatter": "./dist/esm/y_scatter.js"
+        "lite": "./dist/cjs/perspective-viewer-highcharts-lite.js"
     },
     "module": "./dist/cjs/perspective-viewer-highcharts.js",
     "files": [
@@ -28,7 +19,8 @@
         "bench:run": "echo \"No Benchmarks\"",
         "prebuild": "mkdirp dist/esm",
         "build:babel": "cpx \"src/**/*\" dist && babel src/js --source-maps --out-dir dist/esm",
-        "build:webpack": "npm-run-all build:webpack:cjs build:webpack:umd",
+        "build:webpack": "npm-run-all build:webpack:lite build:webpack:cjs build:webpack:umd",
+        "build:webpack:lite": "webpack --color --config src/config/lite.config.js",
         "build:webpack:cjs": "webpack --color --config src/config/cjs.config.js",
         "build:webpack:umd": "webpack --color --config src/config/umd.config.js",
         "build": "npm-run-all --silent build:babel build:webpack",
@@ -56,12 +48,13 @@
         "core-js": "^3.6.4",
         "detectie": "1.0.0",
         "gradient-parser": "0.1.5",
-        "highcharts": "6.1.0",
-        "highcharts-grouped-categories": "1.1.2",
-        "highcharts-more": "^0.1.2"
+        "highcharts-grouped-categories": "1.1.2"
     },
     "devDependencies": {
         "@finos/perspective-test": "^0.5.1",
         "@finos/perspective-webpack-plugin": "^0.5.0"
+    },
+    "peerDependencies": {
+        "highcharts": "6.1.0"
     }
 }

--- a/packages/perspective-viewer-highcharts/src/config/lite.config.js
+++ b/packages/perspective-viewer-highcharts/src/config/lite.config.js
@@ -1,0 +1,15 @@
+const path = require("path");
+const common = require("@finos/perspective/src/config/common.config.js");
+
+module.exports = common({}, config =>
+    Object.assign(config, {
+        entry: "./dist/esm/lite.js",
+        externals: [/^[a-z0-9@]/],
+        output: {
+            filename: "perspective-viewer-highcharts-lite.js",
+            library: "perspective-viewer-highcharts",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "../../dist/cjs")
+        }
+    })
+);

--- a/packages/perspective-viewer-highcharts/src/js/highcharts/base.js
+++ b/packages/perspective-viewer-highcharts/src/js/highcharts/base.js
@@ -1,0 +1,115 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import Highcharts from "highcharts";
+
+export const COLORS_10 = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"];
+export const COLORS_20 = [
+    "#1f77b4",
+    "#aec7e8",
+    "#ff7f0e",
+    "#ffbb78",
+    "#2ca02c",
+    "#98df8a",
+    "#d62728",
+    "#ff9896",
+    "#9467bd",
+    "#c5b0d5",
+    "#8c564b",
+    "#c49c94",
+    "#e377c2",
+    "#f7b6d2",
+    "#7f7f7f",
+    "#c7c7c7",
+    "#bcbd22",
+    "#dbdb8d",
+    "#17becf",
+    "#9edae5"
+];
+
+Highcharts.setOptions({
+    colors: COLORS_20
+});
+
+(function(H) {
+    H.wrap(H.seriesTypes.scatter.prototype, "translate", function(translate) {
+        translate.apply(this, Array.prototype.slice.call(arguments, 1));
+        if (this.chart.userOptions.chart.type.slice(0, 7) === "colored") {
+            this.translateColors.call(this);
+        }
+    });
+    var seriesTypes = H.seriesTypes,
+        merge = H.merge,
+        extendClass = H.extendClass,
+        defaultOptions = H.getOptions(),
+        plotOptions = defaultOptions.plotOptions;
+    var colorSeriesMixin = {
+        optionalAxis: "colorAxis",
+        colorKey: "colorValue",
+        translateColors: seriesTypes.heatmap && seriesTypes.heatmap.prototype.translateColors
+    };
+    plotOptions.coloredColumn = merge(plotOptions.column, {});
+    seriesTypes.coloredColumn = extendClass(
+        seriesTypes.column,
+        merge(colorSeriesMixin, {
+            type: "coloredColumn",
+            axisTypes: ["xAxis", "yAxis", "colorAxis"]
+        })
+    );
+    plotOptions.coloredScatter = merge(plotOptions.scatter, {});
+    seriesTypes.coloredScatter = extendClass(
+        seriesTypes.scatter,
+        merge(colorSeriesMixin, {
+            type: "coloredScatter",
+            axisTypes: ["xAxis", "yAxis", "colorAxis"]
+        })
+    );
+    plotOptions.coloredBubble = merge(plotOptions.bubble, {});
+    seriesTypes.coloredBubble = extendClass(
+        seriesTypes.bubble,
+        merge(colorSeriesMixin, {
+            type: "coloredBubble",
+            axisTypes: ["xAxis", "yAxis", "colorAxis"]
+        })
+    );
+
+    // draw points and add setting colors
+    H.wrap(H.seriesTypes.sunburst.prototype, "translate", function(p, positions) {
+        p.call(this, positions);
+        this.translateColors();
+    });
+
+    // copy method from heatmap for color mixin
+    H.seriesTypes.sunburst.prototype.translateColors = function() {
+        var series = this,
+            nullColor = this.options.nullColor,
+            colorAxis = this.colorAxis,
+            colorKey = this.colorKey;
+
+        H.each(this.data, function(point) {
+            var value = point[colorKey],
+                color;
+
+            color =
+                point.options.color ||
+                (!point.value // LINE CHANGED
+                    ? nullColor
+                    : colorAxis && value !== undefined
+                    ? colorAxis.toColor(value, point)
+                    : point.color || series.color);
+
+            if (color) {
+                point.color = color;
+            }
+        });
+    };
+
+    // use "colorValue" to calculate color
+    H.seriesTypes.sunburst.prototype.colorKey = "colorValue";
+})(Highcharts);

--- a/packages/perspective-viewer-highcharts/src/js/highcharts/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/highcharts/draw.js
@@ -12,7 +12,7 @@ import Highcharts from "highcharts";
 import style from "../../less/highcharts.less";
 import template from "../../html/highcharts.html";
 
-import {COLORS_10, COLORS_20} from "./externals.js";
+import {COLORS_10, COLORS_20} from "./base.js";
 import {color_axis} from "./color_axis.js";
 import {make_tree_data, make_y_data, make_xy_data, make_xyz_data, make_xy_column_data} from "./series.js";
 import {set_boost, set_category_axis, set_both_axis, default_config, set_tick_size} from "./config.js";

--- a/packages/perspective-viewer-highcharts/src/js/highcharts/externals.js
+++ b/packages/perspective-viewer-highcharts/src/js/highcharts/externals.js
@@ -8,17 +8,15 @@
  */
 
 import highcharts from "highcharts";
-import highchartsMore from "highcharts-more";
+import highchartsMore from "highcharts/highcharts-more";
 import heatmap from "highcharts/modules/heatmap";
 import boost from "highcharts/modules/boost";
 import treemap from "highcharts/modules/treemap";
 import sunburst from "highcharts/modules/sunburst";
 import grouped_categories from "highcharts-grouped-categories";
 
-const Highcharts = highcharts;
-
 // cache prototypes
-let axisProto = Highcharts.Axis.prototype,
+let axisProto = highcharts.Axis.prototype,
     // cache original methods
     protoAxisRender = axisProto.render,
     UNDEFINED = void 0;
@@ -30,202 +28,98 @@ sunburst(highcharts);
 grouped_categories(highcharts);
 boost(highcharts);
 
-export const COLORS_10 = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"];
-export const COLORS_20 = [
-    "#1f77b4",
-    "#aec7e8",
-    "#ff7f0e",
-    "#ffbb78",
-    "#2ca02c",
-    "#98df8a",
-    "#d62728",
-    "#ff9896",
-    "#9467bd",
-    "#c5b0d5",
-    "#8c564b",
-    "#c49c94",
-    "#e377c2",
-    "#f7b6d2",
-    "#7f7f7f",
-    "#c7c7c7",
-    "#bcbd22",
-    "#dbdb8d",
-    "#17becf",
-    "#9edae5"
-];
+// Pushes part of grid to path
+function walk(arr, key, fn) {
+    var l = arr.length,
+        children;
 
-Highcharts.setOptions({
-    colors: COLORS_20
-});
+    while (l--) {
+        children = arr[l][key];
 
-(function(H) {
-    H.wrap(H.seriesTypes.scatter.prototype, "translate", function(translate) {
-        translate.apply(this, Array.prototype.slice.call(arguments, 1));
-        if (this.chart.userOptions.chart.type.slice(0, 7) === "colored") {
-            this.translateColors.call(this);
+        if (children) {
+            walk(children, key, fn);
         }
-    });
-    var seriesTypes = H.seriesTypes,
-        merge = H.merge,
-        extendClass = H.extendClass,
-        defaultOptions = H.getOptions(),
-        plotOptions = defaultOptions.plotOptions;
-    var colorSeriesMixin = {
-        optionalAxis: "colorAxis",
-        colorKey: "colorValue",
-        translateColors: seriesTypes.heatmap && seriesTypes.heatmap.prototype.translateColors
-    };
-    plotOptions.coloredColumn = merge(plotOptions.column, {});
-    seriesTypes.coloredColumn = extendClass(
-        seriesTypes.column,
-        merge(colorSeriesMixin, {
-            type: "coloredColumn",
-            axisTypes: ["xAxis", "yAxis", "colorAxis"]
-        })
-    );
-    plotOptions.coloredScatter = merge(plotOptions.scatter, {});
-    seriesTypes.coloredScatter = extendClass(
-        seriesTypes.scatter,
-        merge(colorSeriesMixin, {
-            type: "coloredScatter",
-            axisTypes: ["xAxis", "yAxis", "colorAxis"]
-        })
-    );
-    plotOptions.coloredBubble = merge(plotOptions.bubble, {});
-    seriesTypes.coloredBubble = extendClass(
-        seriesTypes.bubble,
-        merge(colorSeriesMixin, {
-            type: "coloredBubble",
-            axisTypes: ["xAxis", "yAxis", "colorAxis"]
-        })
-    );
+        fn(arr[l]);
+    }
+}
 
-    // draw points and add setting colors
-    H.wrap(H.seriesTypes.sunburst.prototype, "translate", function(p, positions) {
-        p.call(this, positions);
-        this.translateColors();
-    });
+axisProto.render = function() {
+    // clear grid path
+    if (this.isGrouped) {
+        this.labelsGridPath = [];
+    }
 
-    // copy method from heatmap for color mixin
-    H.seriesTypes.sunburst.prototype.translateColors = function() {
-        var series = this,
-            nullColor = this.options.nullColor,
-            colorAxis = this.colorAxis,
-            colorKey = this.colorKey;
+    // cache original tick length
+    if (this.originalTickLength === UNDEFINED) {
+        this.originalTickLength = this.options.tickLength;
+    }
 
-        H.each(this.data, function(point) {
-            var value = point[colorKey],
-                color;
+    // use default tickLength for not-grouped axis
+    // and generate grid on grouped axes,
+    // use tiny number to force highcharts to hide tick
+    this.options.tickLength = this.isGrouped ? 0.001 : this.originalTickLength;
 
-            color =
-                point.options.color ||
-                (!point.value // LINE CHANGED
-                    ? nullColor
-                    : colorAxis && value !== undefined
-                    ? colorAxis.toColor(value, point)
-                    : point.color || series.color);
+    protoAxisRender.call(this);
 
-            if (color) {
-                point.color = color;
-            }
-        });
-    };
+    if (!this.isGrouped) {
+        if (this.labelsGrid) {
+            this.labelsGrid.attr({
+                visibility: "hidden"
+            });
+        }
+        return false;
+    }
 
-    // use "colorValue" to calculate color
-    H.seriesTypes.sunburst.prototype.colorKey = "colorValue";
+    var axis = this,
+        options = axis.options,
+        visible = axis.hasVisibleSeries || axis.hasData,
+        grid = axis.labelsGrid,
+        d = axis.labelsGridPath,
+        tickWidth = axis.tickWidth;
 
-    // Pushes part of grid to path
-    function walk(arr, key, fn) {
-        var l = arr.length,
-            children;
-
-        while (l--) {
-            children = arr[l][key];
-
-            if (children) {
-                walk(children, key, fn);
-            }
-            fn(arr[l]);
+    // render grid path for the first time
+    if (!grid) {
+        grid = axis.labelsGrid = axis.chart.renderer
+            .path()
+            .attr({
+                // #58: use tickWidth/tickColor instead of
+                // lineWidth/lineColor:
+                strokeWidth: tickWidth, // < 4.0.3
+                "stroke-width": tickWidth, // 4.0.3+ #30
+                stroke: options.tickColor || "" // for styled mode (tickColor === undefined)
+            })
+            .add(axis.axisGroup);
+        // for styled mode - add class
+        if (!options.tickColor) {
+            grid.addClass("highcharts-tick");
         }
     }
-    axisProto.render = function() {
-        // clear grid path
-        if (this.isGrouped) {
-            this.labelsGridPath = [];
-        }
 
-        // cache original tick length
-        if (this.originalTickLength === UNDEFINED) {
-            this.originalTickLength = this.options.tickLength;
-        }
+    // draw grid path
+    grid.attr({
+        d: d,
+        visibility: visible ? "visible" : "hidden"
+    });
 
-        // use default tickLength for not-grouped axis
-        // and generate grid on grouped axes,
-        // use tiny number to force highcharts to hide tick
-        this.options.tickLength = this.isGrouped ? 0.001 : this.originalTickLength;
+    axis.labelGroup.attr({
+        visibility: visible ? "visible" : "hidden"
+    });
 
-        protoAxisRender.call(this);
+    walk(axis.categoriesTree, "categories", function(group) {
+        var tick = group.tick;
 
-        if (!this.isGrouped) {
-            if (this.labelsGrid) {
-                this.labelsGrid.attr({
-                    visibility: "hidden"
-                });
-            }
+        if (!tick) {
             return false;
         }
-
-        var axis = this,
-            options = axis.options,
-            visible = axis.hasVisibleSeries || axis.hasData,
-            grid = axis.labelsGrid,
-            d = axis.labelsGridPath,
-            tickWidth = axis.tickWidth;
-
-        // render grid path for the first time
-        if (!grid) {
-            grid = axis.labelsGrid = axis.chart.renderer
-                .path()
-                .attr({
-                    // #58: use tickWidth/tickColor instead of
-                    // lineWidth/lineColor:
-                    strokeWidth: tickWidth, // < 4.0.3
-                    "stroke-width": tickWidth, // 4.0.3+ #30
-                    stroke: options.tickColor || "" // for styled mode (tickColor === undefined)
-                })
-                .add(axis.axisGroup);
-            // for styled mode - add class
-            if (!options.tickColor) {
-                grid.addClass("highcharts-tick");
-            }
+        if (tick.startAt + tick.leaves - 1 < axis.min || tick.startAt > axis.max) {
+            tick.label.hide();
+            tick.destroyed = 0;
+        } else {
+            tick.label.attr({
+                visibility: visible ? "visible" : "hidden"
+            });
         }
-
-        // draw grid path
-        grid.attr({
-            d: d,
-            visibility: visible ? "visible" : "hidden"
-        });
-
-        axis.labelGroup.attr({
-            visibility: visible ? "visible" : "hidden"
-        });
-
-        walk(axis.categoriesTree, "categories", function(group) {
-            var tick = group.tick;
-
-            if (!tick) {
-                return false;
-            }
-            if (tick.startAt + tick.leaves - 1 < axis.min || tick.startAt > axis.max) {
-                tick.label.hide();
-                tick.destroyed = 0;
-            } else {
-                tick.label.attr({
-                    visibility: visible ? "visible" : "hidden"
-                });
-            }
-            return true;
-        });
         return true;
-    };
-})(Highcharts);
+    });
+    return true;
+};

--- a/packages/perspective-viewer-highcharts/src/js/lite.js
+++ b/packages/perspective-viewer-highcharts/src/js/lite.js
@@ -7,6 +7,5 @@
  *
  */
 
-import "./highcharts/externals.js";
 import register from "./highcharts/highcharts.js";
 register();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7486,11 +7486,6 @@ highcharts-grouped-categories@1.1.2:
   resolved "https://registry.yarnpkg.com/highcharts-grouped-categories/-/highcharts-grouped-categories-1.1.2.tgz#93ba27d31389e46ce6da772be070eab22b7d3903"
   integrity sha1-k7on0xOJ5Gzm2ncr4HDqsit9OQM=
 
-highcharts-more@^0.1.2:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-more/-/highcharts-more-0.1.7.tgz#43cd6274cccba443166c94d4536d904bbabf9c77"
-  integrity sha1-Q81idMzLpEMWbJTUU22QS7q/nHc=
-
 highcharts@6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-6.1.0.tgz#115a6ee10ad36a53d9913f1030c6d46da16c7cb5"


### PR DESCRIPTION
Adds a new entry point, `@finos/perspective-viewer-highcharts/lite`, which allows importing this plugin without invoking module side effects prevalent in Highcharts, allowing this plugin to be embedded easily alongside sloppier implementations which also rely on these modules - explained in detail [here](https://github.com/highcharts/highcharts/issues/7729).  In order to use `@finos/perspective-viewer-highcharts/lite`, these extension module effects will need to be imported and applied, in the correct order:

```javascript
import highcharts from "highcharts";
import highchartsMore from "highcharts/highcharts-more";
import heatmap from "highcharts/modules/heatmap";
import boost from "highcharts/modules/boost";
import treemap from "highcharts/modules/treemap";
import sunburst from "highcharts/modules/sunburst";
import grouped_categories from "highcharts-grouped-categories";

highchartsMore(highcharts);
heatmap(highcharts);
treemap(highcharts);
sunburst(highcharts);
grouped_categories(highcharts);
boost(highcharts);
```

Additionally - `highcharts` modules has been moved to `peerDependencies` to better reflect the licensing requirements, so be sure to add this to your project's `package.json`.

```json
"dependencies": {
    "highcharts": "6.1.0"
}
```