### PR TITLE
Fix issue where contexts were being notified before gnode state was updated

### DIFF
--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -464,17 +464,6 @@ t_gnode::update_context_from_state(
     if (flattened->size() == 0)
         return;
 
-    // Flattened won't have the computed columns if it didn't pass through the
-    // main body of `process_table`, i.e. creating a 1/2 sided context, so
-    // compute again here.
-    auto computed_columns = m_computed_column_map.m_computed_columns;
-
-    if (computed_columns.size() > 0) {
-        for (const auto& computed : computed_columns) {
-            _compute_column(computed.second, flattened);
-        }
-    }
-
     // Need to cast shared ptr to a const reference before passing to notify,
     // reference is valid as `notify` is not async
     const t_data_table& const_flattened = 

--- a/packages/perspective/test/js/computed.js
+++ b/packages/perspective/test/js/computed.js
@@ -20,7 +20,7 @@ module.exports = perspective => {
     numeric(perspective);
     string(perspective);
     datetime(perspective);
-    updates(perspective);
-    deltas(perspective);
-    invariant(perspective);
+    // updates(perspective);
+    // deltas(perspective);
+    // invariant(perspective);
 };

--- a/packages/perspective/test/js/computed.js
+++ b/packages/perspective/test/js/computed.js
@@ -20,7 +20,7 @@ module.exports = perspective => {
     numeric(perspective);
     string(perspective);
     datetime(perspective);
-    // updates(perspective);
-    // deltas(perspective);
-    // invariant(perspective);
+    updates(perspective);
+    deltas(perspective);
+    invariant(perspective);
 };

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -95,6 +95,33 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("['z'], weighted mean on a table created from schema should return valid values after update", async function() {
+            const table = perspective.table({
+                x: "integer",
+                y: "integer",
+                z: "boolean"
+            });
+
+            const view = table.view({
+                row_pivots: ["z"],
+                columns: ["x"],
+                aggregates: {x: ["weighted mean", "y"]}
+            });
+
+            const answer = [
+                {__ROW_PATH__: [], x: 2.8333333333333335},
+                {__ROW_PATH__: [false], x: 3.3333333333333335},
+                {__ROW_PATH__: [true], x: 2.3333333333333335}
+            ];
+
+            table.update(data2);
+
+            let result = await view.to_json();
+            expect(result).toEqual(answer);
+            view.delete();
+            table.delete();
+        });
+
         it("['z'], mean", async function() {
             var table = perspective.table(data);
             var view = table.view({
@@ -107,6 +134,31 @@ module.exports = perspective => {
                 {__ROW_PATH__: [false], x: 3},
                 {__ROW_PATH__: [true], x: 2}
             ];
+            let result = await view.to_json();
+            expect(result).toEqual(answer);
+            view.delete();
+            table.delete();
+        });
+
+        it("['z'], mean on a table created from schema should return valid values after update", async function() {
+            const table = perspective.table({
+                x: "integer",
+                y: "string",
+                z: "boolean"
+            });
+            const view = table.view({
+                row_pivots: ["z"],
+                columns: ["x"],
+                aggregates: {x: "mean"}
+            });
+            const answer = [
+                {__ROW_PATH__: [], x: 2.5},
+                {__ROW_PATH__: [false], x: 3},
+                {__ROW_PATH__: [true], x: 2}
+            ];
+
+            table.update(data);
+
             let result = await view.to_json();
             expect(result).toEqual(answer);
             view.delete();

--- a/python/perspective/perspective/tests/core/test_aggregates.py
+++ b/python/perspective/perspective/tests/core/test_aggregates.py
@@ -22,6 +22,15 @@ class TestAggregates:
         widget = PerspectiveWidget(data, aggregates=aggs)
         assert widget.aggregates == aggs
 
+    def test_aggregates_widget_load_weighted_mean(self):
+        aggs = {
+            "a": Aggregate.AVG,
+            "b": ["weighted mean", "a"]
+        }
+        data = {"a": [1, 2, 3], "b": ["a", "b", "c"]}
+        widget = PerspectiveWidget(data, aggregates=aggs)
+        assert widget.aggregates == aggs
+
     def test_aggregates_widget_setattr(self):
         data = {"a": [1, 2, 3], "b": ["a", "b", "c"]}
         widget = PerspectiveWidget(data)

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -432,7 +432,24 @@ class TestView(object):
             {"__ROW_PATH__": [datetime(2019, 1, 1, 5, 5, 5)], "a": 1}
         ]
 
-    def test_view_aggregate_multiple_columns(self):
+    def test_view_aggregate_mean(self):
+        data = [
+            {"a": "a", "x": 1, "y": 200},
+            {"a": "a", "x": 2, "y": 100},
+            {"a": "a", "x": 3, "y": None}
+        ]
+        tbl = Table(data)
+        view = tbl.view(
+            aggregates={"y": "mean"},
+            row_pivots=["a"],
+            columns=['y']
+        )
+        assert view.to_records() == [
+            {"__ROW_PATH__": [], "y": 300 / 2},
+            {"__ROW_PATH__": ["a"], "y": 300 / 2}
+        ]
+
+    def test_view_aggregate_weighted_mean(self):
         data = [
             {"a": "a", "x": 1, "y": 200},
             {"a": "a", "x": 2, "y": 100},
@@ -449,7 +466,7 @@ class TestView(object):
             {"__ROW_PATH__": ["a"], "y": (1.0 * 200 + 2 * 100) / (1.0 + 2)}
         ]
 
-    def test_view_aggregate_multiple_columns_with_negative_weights(self):
+    def test_view_aggregate_weighted_mean_with_negative_weights(self):
         data = [
             {"a": "a", "x": 1, "y": 200},
             {"a": "a", "x": -2, "y": 100},

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -449,6 +449,28 @@ class TestView(object):
             {"__ROW_PATH__": ["a"], "y": 300 / 2}
         ]
 
+    def test_view_aggregate_mean_from_schema(self):
+        data = [
+            {"a": "a", "x": 1, "y": 200},
+            {"a": "a", "x": 2, "y": 100},
+            {"a": "a", "x": 3, "y": None}
+        ]
+        tbl = Table({
+            "a": str,
+            "x": int,
+            "y": float
+        })
+        view = tbl.view(
+            aggregates={"y": "mean"},
+            row_pivots=["a"],
+            columns=['y']
+        )
+        tbl.update(data)
+        assert view.to_records() == [
+            {"__ROW_PATH__": [], "y": 300 / 2},
+            {"__ROW_PATH__": ["a"], "y": 300 / 2}
+        ]
+
     def test_view_aggregate_weighted_mean(self):
         data = [
             {"a": "a", "x": 1, "y": 200},

--- a/python/perspective/perspective/viewer/validate.py
+++ b/python/perspective/perspective/viewer/validate.py
@@ -68,7 +68,7 @@ def validate_aggregates(aggregates):
                 # Parse weighted mean aggregate in ["weighted mean", "COLUMN"]
                 if len(v) == 2 and v[0] == "weighted mean":
                     continue
-                raise PerspectiveError("Unrecognized aggregate in incorrect syntax for weighted mean: %s \Syntax should be: ['weighted mean', 'COLUMN']", v) 
+                raise PerspectiveError("Unrecognized aggregate in incorrect syntax for weighted mean: %s - Syntax should be: ['weighted mean', 'COLUMN']", v)
             else:
                 raise PerspectiveError('Cannot parse aggregation of type %s', str(type(v)))
         return aggregates

--- a/python/perspective/perspective/viewer/validate.py
+++ b/python/perspective/perspective/viewer/validate.py
@@ -64,6 +64,11 @@ def validate_aggregates(aggregates):
             elif isinstance(v, string_types):
                 if v not in Aggregate.options():
                     raise PerspectiveError('Unrecognized aggregate: %s', v)
+            elif isinstance(v, list):
+                # Parse weighted mean aggregate in ["weighted mean", "COLUMN"]
+                if len(v) == 2 and v[0] == "weighted mean":
+                    continue
+                raise PerspectiveError("Unrecognized aggregate in incorrect syntax for weighted mean: %s \Syntax should be: ['weighted mean', 'COLUMN']", v) 
             else:
                 raise PerspectiveError('Cannot parse aggregation of type %s', str(type(v)))
         return aggregates

--- a/python/perspective/perspective/viewer/viewer_traitlets.py
+++ b/python/perspective/perspective/viewer/viewer_traitlets.py
@@ -31,7 +31,7 @@ class PerspectiveTraitlets(HasTraits):
     columns = List(default_value=[]).tag(sync=True)
     row_pivots = List(trait=Unicode(), default_value=[]).tag(sync=True, o=True)
     column_pivots = List(trait=Unicode(), default_value=[]).tag(sync=True)
-    aggregates = Dict(trait=Unicode(), default_value={}).tag(sync=True)
+    aggregates = Dict(default_value={}).tag(sync=True)
     sort = List(default_value=[]).tag(sync=True)
     filters = List(default_value=[]).tag(sync=True)
     computed_columns = List(default_value=[]).tag(sync=True)


### PR DESCRIPTION
This PR fixes a regression in gnode `_process_table`, which would notify contexts with a new update dataset before updating the master table maintained by the gnode state. This caused a problem with certain aggregates such as mean and avg, which read from gnode state.

The problem emanates from a specific code path - a table is created with a schema, and a pivoted view with a mean/avg/etc. aggregate is created, and _then_ update is called. If the table is not updated again/a new context is not created, the aggregate values return null as they have been notified with a stale version of the gnode state. In the viewer, it was easy to miss this bug - making any UI changes would create a fresh context, which would make the issue disappear as the contexts were re-synchronized to the latest gnode state.

- Fixes regression and added tests
- Fixed traitlets in PerspectiveWidget to allow `weighted mean` aggregates