### PR TITLE
Updated development.md to show correct Emscripten version.

### DIFF
--- a/docs/md/development.md
+++ b/docs/md/development.md
@@ -82,14 +82,14 @@ Emscripten SDK, then activate and export the latest `emsdk` environment via
 source emsdk/emsdk_env.sh
 ```
 
-We currently use Emscripten version `1.38.47` — deviating from this specific
+We currently use Emscripten version `1.39.13` — deviating from this specific
 version of Emscripten can introduce various errors that are extremely difficult
 to debug.
 
 To install this specific version of Emscripten:
 
 ```bash
-./emsdk install 1.38.47
+./emsdk install 1.39.13
 ```
 
 ### `perspective-python`


### PR DESCRIPTION
Changed the Emscripten version in the developer guide markdown (development.md) from 1.38.47 to 1.39.13.  Updated the version number for reference and the script used to install the Emscripten SDK.  Related to issue #1121 .