### PR TITLE
Enable updates from arrows that have more/less columns than the Table schema

### DIFF
--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -126,11 +126,11 @@ namespace apachearrow {
             auto name = m_names[cidx];
             t_dtype type = m_types[cidx];
 
-            // if (input_schema.has_column(name)) {
-            //     type = input_schema.get_dtype(name);
-            // } else {
-            //     type = m_types[cidx];
-            // }
+            if (!input_schema.has_column(name)) {
+                // Skip columns that are defined in the arrow but not 
+                // in the Table's input schema.
+                continue;
+            }
 
             auto raw_type = fields[cidx]->type()->name();
 
@@ -160,6 +160,12 @@ namespace apachearrow {
                     okey_col->set_nth<std::int32_t>(ridx, (ridx + offset) % limit);
                 }
             } else {
+                if (!input_schema.has_column(index)) {
+                    std::stringstream ss;
+                    ss << "Specified index `" << index << "` is invalid as it does not appear in the Table." << std::endl;
+                    PSP_COMPLAIN_AND_ABORT(ss.str());
+                }
+
                 tbl.clone_column(index, "psp_pkey");
                 tbl.clone_column(index, "psp_okey");
             }

--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -111,15 +111,27 @@ namespace apachearrow {
     }
 
     void
-    ArrowLoader::fill_table(t_data_table& tbl, const std::string& index, std::uint32_t offset,
-        std::uint32_t limit, bool is_update) {
+    ArrowLoader::fill_table(
+        t_data_table& tbl, 
+        const t_schema& input_schema,
+        const std::string& index,
+        std::uint32_t offset,
+        std::uint32_t limit,
+        bool is_update) {
         bool implicit_index = false;
         std::shared_ptr<arrow::Schema> schema = m_table->schema();
         std::vector<std::shared_ptr<arrow::Field>> fields = schema->fields();
 
         for (long unsigned int cidx = 0; cidx < m_names.size(); ++cidx) {
             auto name = m_names[cidx];
-            auto type = m_types[cidx];
+            t_dtype type = m_types[cidx];
+
+            // if (input_schema.has_column(name)) {
+            //     type = input_schema.get_dtype(name);
+            // } else {
+            //     type = m_types[cidx];
+            // }
+
             auto raw_type = fields[cidx]->type()->name();
 
             if (name == "__INDEX__") {
@@ -189,7 +201,8 @@ namespace apachearrow {
                 auto indices = scol->indices();
                 switch (indices->type()->id()) {
                     case arrow::Int8Type::type_id: {
-                        iter_col_copy<::arrow::Int8Array, t_uindex>(dest, indices, offset, len);                    } break;
+                        iter_col_copy<::arrow::Int8Array, t_uindex>(dest, indices, offset, len);                    
+                    } break;
                     case ::arrow::UInt8Type::type_id: {
                         iter_col_copy<::arrow::UInt8Array, t_uindex>(dest, indices, offset, len);
                     } break;

--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -188,6 +188,10 @@ namespace apachearrow {
         const int64_t offset, const int64_t len) {
         switch (src->type()->id()) {
             case arrow::DictionaryType::type_id: {
+                // If there are duplicate values in the dictionary at different
+                // indices, i.e. [0 => a, 1 => b, 2 => a], tables with
+                // explicit indexes on a string column created from a dictionary
+                // array may have duplicate primary keys.
                 auto scol = std::static_pointer_cast<arrow::DictionaryArray>(src);
                 std::shared_ptr<arrow::StringArray> dict
                     = std::static_pointer_cast<arrow::StringArray>(scol->dictionary());
@@ -480,7 +484,7 @@ namespace apachearrow {
                         std::stringstream ss;
                         ss << "Could not fill column `" << name << "` with "
                            << "t_dtype: `" << get_dtype_descr(column_dtype) << "`, "
-                           << "array type: `" << get_dtype_descr(type) << std::endl;
+                           << "array type: `" << get_dtype_descr(type) << "`" << std::endl;
                         PSP_COMPLAIN_AND_ABORT(ss.str());
                     };
                 }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1130,11 +1130,14 @@ namespace binding {
             offset = 0;
         }
 
-        // Create input schema - an input schema contains all columns to be displayed AND index + operation columns
+        // Create input schema - an input schema contains all columns to be
+        // displayed, as well as `__INDEX__` column
         t_schema input_schema(column_names, data_types);
 
         // strip implicit index, if present
-        auto implicit_index_it = std::find(column_names.begin(), column_names.end(), "__INDEX__");
+        auto implicit_index_it = std::find(
+            column_names.begin(), column_names.end(), "__INDEX__");
+
         if (implicit_index_it != column_names.end()) {
             auto idx = std::distance(column_names.begin(), implicit_index_it);
             // position of the column is at the same index in both vectors
@@ -1142,8 +1145,10 @@ namespace binding {
             data_types.erase(data_types.begin() + idx);
         }
 
-        // Create output schema - contains only columns to be displayed to the user
-        t_schema output_schema(column_names, data_types); // names + types might have been mutated at this point after implicit index removal
+        // Create output schema - contains only columns to be displayed to the
+        // user, as names and types may have been mutated after implicit
+        // index removal.
+        t_schema output_schema(column_names, data_types);
 
         std::uint32_t row_count = 0;
         if (is_arrow) {
@@ -1165,9 +1170,6 @@ namespace binding {
         if (is_arrow) {
             free((void *)ptr);
         }
-
-
-        std::cout << "output: " << data_table.get_schema() << std::endl;
 
         // calculate offset, limit, and set the gnode
         tbl->init(data_table, row_count, op, port_id);

--- a/cpp/perspective/src/include/perspective/arrow_loader.h
+++ b/cpp/perspective/src/include/perspective/arrow_loader.h
@@ -31,10 +31,28 @@ namespace apachearrow {
         ArrowLoader();
         ~ArrowLoader();
 
+        /**
+         * @brief Initialize the arrow loader with a pointer to a binary.
+         * 
+         * @param ptr 
+         */
         void initialize(uintptr_t ptr, std::uint32_t);
 
+        /**
+         * @brief Given an arrow binary and a data table, load the arrow into
+         * Perspective. If updating an existing table, use the `input_schema`
+         * of the table and respect it as much as possible.
+         * 
+         * @param tbl
+         * @param input_schema
+         * @param index
+         * @param offset
+         * @param limit
+         * @param is_update 
+         */
         void fill_table(
             t_data_table& tbl,
+            const t_schema& input_schema,
             const std::string& index,
             std::uint32_t offset,
             std::uint32_t limit, 

--- a/packages/perspective-viewer-d3fc/src/js/charts/treemap.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/treemap.js
@@ -48,8 +48,6 @@ function treemap(container, settings) {
         .each(function({split, data}) {
             const treemapSvg = d3.select(this);
 
-            console.log(split, data);
-
             if (!settings.treemaps[split]) settings.treemaps[split] = {};
 
             treemapSeries()

--- a/packages/perspective-viewer/test/js/regressions.spec.js
+++ b/packages/perspective-viewer/test/js/regressions.spec.js
@@ -95,7 +95,6 @@ utils.with_server({}, () => {
                         c: "string"
                     };
                     const arrow = arrows.int_float_str_arrow.slice();
-                    console.log(arrow.byteLength);
                     const byte_length = await page.evaluate(
                         async (viewer, data, schema) => {
                             viewer.load(schema);

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -392,16 +392,37 @@ module.exports = perspective => {
 
         it("schema constructor, then arrow update() with more columns than in the Table", async function() {
             const table = perspective.table({
-                a: "integer",
-                b: "float"
+                a: "integer"
             });
             const view = table.view();
             table.update(arrows.int_float_str_arrow.slice());
             expect(await table.size()).toBe(4);
             const result = await view.to_columns();
             expect(result).toEqual({
+                a: [1, 2, 3, 4]
+            });
+            view.delete();
+            table.delete();
+        });
+
+        it("schema constructor indexed, then arrow update() with more columns than in the Table", async function() {
+            const table = perspective.table(
+                {
+                    a: "integer",
+                    b: "float"
+                },
+                {
+                    index: "a"
+                }
+            );
+            const view = table.view();
+            table.update(arrows.int_float_str_arrow.slice());
+            table.update(arrows.int_float_str_update_arrow.slice());
+            expect(await table.size()).toBe(4);
+            const result = await view.to_columns();
+            expect(result).toEqual({
                 a: [1, 2, 3, 4],
-                b: [1.5, 2.5, 3.5, 4.5]
+                b: [100.5, 2.5, 3.5, 400.5]
             });
             view.delete();
             table.delete();

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -366,6 +366,71 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it.skip("schema constructor, then indexed arrow dictionary `update()`", async function() {
+            const table = perspective.table(
+                {
+                    a: "string",
+                    b: "string"
+                },
+                {index: "a"}
+            );
+            table.update(arrows.dict_arrow.slice());
+            const view = table.view();
+            const size = await table.size();
+            expect(size).toEqual(3);
+            const result = await view.to_columns();
+            expect(result).toEqual({
+                a: [null, "abc", "def"],
+                b: ["hij", "klm", "hij"]
+            });
+            view.delete();
+            table.delete();
+        });
+
+        it.skip("schema constructor, then indexed arrow dictionary `update()` with more columns than in schema", async function() {
+            const table = perspective.table(
+                {
+                    a: "string"
+                },
+                {index: "a"}
+            );
+            table.update(arrows.dict_arrow.slice());
+            const view = table.view();
+            const size = await table.size();
+            console.log(await view.to_columns());
+            expect(size).toEqual(3);
+            const result = await view.to_columns();
+            expect(result).toEqual({
+                a: [null, "abc", "def"]
+            });
+            view.delete();
+            table.delete();
+        });
+
+        it.skip("schema constructor, then indexed arrow dictionary `update()` with less columns than in schema", async function() {
+            const table = perspective.table(
+                {
+                    a: "string",
+                    b: "string",
+                    x: "integer"
+                },
+                {index: "a"}
+            );
+            table.update(arrows.dict_arrow.slice());
+            const view = table.view();
+            const size = await table.size();
+            console.log(await view.to_columns());
+            expect(size).toEqual(3);
+            const result = await view.to_columns();
+            expect(result).toEqual({
+                a: [null, "abc", "def"],
+                b: ["hij", "klm", "hij"],
+                x: [null, null, null]
+            });
+            view.delete();
+            table.delete();
+        });
+
         it("schema constructor, then indexed arrow `update()`", async function() {
             const table = perspective.table(
                 {
@@ -423,6 +488,50 @@ module.exports = perspective => {
             expect(result).toEqual({
                 a: [1, 2, 3, 4],
                 b: [100.5, 2.5, 3.5, 400.5]
+            });
+            view.delete();
+            table.delete();
+        });
+
+        it("schema constructor, then arrow update() with less columns than in the Table", async function() {
+            const table = perspective.table({
+                a: "integer",
+                x: "float",
+                y: "string"
+            });
+            const view = table.view();
+            table.update(arrows.int_float_str_arrow.slice());
+            expect(await table.size()).toBe(4);
+            const result = await view.to_columns();
+            expect(result).toEqual({
+                a: [1, 2, 3, 4],
+                x: [null, null, null, null],
+                y: [null, null, null, null]
+            });
+            view.delete();
+            table.delete();
+        });
+
+        it("schema constructor indexed, then arrow update() with less columns than in the Table", async function() {
+            const table = perspective.table(
+                {
+                    a: "integer",
+                    x: "float",
+                    y: "string"
+                },
+                {
+                    index: "a"
+                }
+            );
+            const view = table.view();
+            table.update(arrows.int_float_str_arrow.slice());
+            table.update(arrows.int_float_str_update_arrow.slice());
+            expect(await table.size()).toBe(4);
+            const result = await view.to_columns();
+            expect(result).toEqual({
+                a: [1, 2, 3, 4],
+                x: [null, null, null, null],
+                y: [null, null, null, null]
             });
             view.delete();
             table.delete();

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -366,7 +366,7 @@ module.exports = perspective => {
             table.delete();
         });
 
-        it.skip("schema constructor, then indexed arrow `update()`", async function() {
+        it("schema constructor, then indexed arrow `update()`", async function() {
             const table = perspective.table(
                 {
                     a: "integer",
@@ -376,14 +376,32 @@ module.exports = perspective => {
                 {index: "a"}
             );
 
+            const view = table.view();
             table.update(arrows.int_float_str_arrow.slice());
             table.update(arrows.int_float_str_update_arrow.slice());
-            const view = table.view();
+            expect(await table.size()).toBe(4);
             const result = await view.to_columns();
             expect(result).toEqual({
                 a: [1, 2, 3, 4],
                 b: [100.5, 2.5, 3.5, 400.5],
                 c: ["x", "b", "c", "y"]
+            });
+            view.delete();
+            table.delete();
+        });
+
+        it("schema constructor, then arrow update() with more columns than in the Table", async function() {
+            const table = perspective.table({
+                a: "integer",
+                b: "float"
+            });
+            const view = table.view();
+            table.update(arrows.int_float_str_arrow.slice());
+            expect(await table.size()).toBe(4);
+            const result = await view.to_columns();
+            expect(result).toEqual({
+                a: [1, 2, 3, 4],
+                b: [1.5, 2.5, 3.5, 4.5]
             });
             view.delete();
             table.delete();

--- a/python/perspective/perspective/src/table.cpp
+++ b/python/perspective/perspective/src/table.cpp
@@ -177,7 +177,7 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor,
         row_count = arrow_loader.row_count();
         data_table.extend(arrow_loader.row_count());
 
-        arrow_loader.fill_table(data_table, index, offset, limit, is_update);
+        arrow_loader.fill_table(data_table, input_schema, index, offset, limit, is_update);
     } else if (is_numpy) {
         row_count = numpy_loader.row_count();
         data_table.extend(row_count);


### PR DESCRIPTION
This PR implements and tests the ability for tables to be updated with arrows that have more/less columns than the table's schema - i.e. the table's schema will always be respected when reading through the arrow binary. If a column exists in the arrow binary but does not in the schema, it will be skipped, and vice versa - if a column exists in the schema and not in the arrow binary, it will not be filled. Additionally, this PR fixes an issue where an integer index column would cause an error when it was updated with an arrow - index columns will not be promoted, and filled through iteration instead.