### PR TITLE
Fix #1129 and #1130, remove Highcharts and Hypergrid from PerspectiveWidget

### DIFF
--- a/packages/perspective-jupyterlab/src/config/plugin.config.js
+++ b/packages/perspective-jupyterlab/src/config/plugin.config.js
@@ -29,9 +29,20 @@ module.exports = {
     module: {
         rules: [
             {
+                test: /\.less$/,
+                use: [{loader: "style-loader"}, {loader: "css-loader"}, {loader: "less-loader"}]
+            },
+            {
                 test: /\.css$/,
                 exclude: /node_modules/,
                 use: [{loader: "css-loader"}]
+            },
+            {
+                test: /\.(html)$/,
+                use: {
+                    loader: "html-loader",
+                    options: {}
+                }
             },
             {
                 test: /\.ts$/,

--- a/packages/perspective-jupyterlab/src/config/webpack.config.js
+++ b/packages/perspective-jupyterlab/src/config/webpack.config.js
@@ -28,9 +28,20 @@ module.exports = {
     module: {
         rules: [
             {
+                test: /\.less$/,
+                use: [{loader: "style-loader"}, {loader: "css-loader"}, {loader: "less-loader"}]
+            },
+            {
                 test: /\.css$/,
                 exclude: /node_modules/,
                 use: [{loader: "css-loader"}]
+            },
+            {
+                test: /\.(html)$/,
+                use: {
+                    loader: "html-loader",
+                    options: {}
+                }
             },
             {
                 test: /\.ts$/,

--- a/packages/perspective-jupyterlab/src/ts/index.ts
+++ b/packages/perspective-jupyterlab/src/ts/index.ts
@@ -16,8 +16,8 @@ export * from "./widget";
 /* css */
 import "!!style-loader!css-loader!less-loader!../less/index.less";
 
-import "@finos/perspective-viewer-hypergrid";
-import "@finos/perspective-viewer-highcharts";
+import "@finos/perspective-viewer-datagrid";
+import "@finos/perspective-viewer-d3fc";
 
 import {JupyterFrontEndPlugin} from "@jupyterlab/application";
 import {perspectiveRenderers} from "./renderer";

--- a/packages/perspective-viewer-d3fc/src/js/charts/charts.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/charts.js
@@ -19,6 +19,6 @@ import candlestick from "./candlestick";
 import sunburst from "./sunburst";
 import treemap from "./treemap";
 
-const chartClasses = [barChart, columnChart, lineChart, areaChart, yScatter, xyScatter, heatmap, ohlc, candlestick, sunburst, treemap];
+const chartClasses = [barChart, columnChart, lineChart, areaChart, yScatter, xyScatter, ohlc, candlestick, treemap, sunburst, heatmap];
 
 export default chartClasses;

--- a/packages/perspective-viewer-highcharts/src/js/highcharts/highcharts.js
+++ b/packages/perspective-viewer-highcharts/src/js/highcharts/highcharts.js
@@ -90,21 +90,6 @@ const PLUGINS = {
         max_columns: MAX_COLUMN_COUNT["line"]
     },
 
-    y_scatter: {
-        name: "Y Scatter Chart",
-        create: draw("y_scatter", true),
-        update: draw("y_scatter", false),
-        resize: resize,
-        initial: {
-            type: "number",
-            count: 1
-        },
-        selectMode: "select",
-        delete: delete_chart,
-        max_cells: MAX_CELL_COUNT["scatter"],
-        max_columns: MAX_COLUMN_COUNT["scatter"]
-    },
-
     y_area: {
         name: "Y Area Chart",
         create: draw("y_area", true),
@@ -131,6 +116,21 @@ const PLUGINS = {
             names: ["X Axis", "Y Axis", "Tooltip"]
         },
         selectMode: "toggle",
+        delete: delete_chart,
+        max_cells: MAX_CELL_COUNT["scatter"],
+        max_columns: MAX_COLUMN_COUNT["scatter"]
+    },
+
+    y_scatter: {
+        name: "Y Scatter Chart",
+        create: draw("y_scatter", true),
+        update: draw("y_scatter", false),
+        resize: resize,
+        initial: {
+            type: "number",
+            count: 1
+        },
+        selectMode: "select",
         delete: delete_chart,
         max_cells: MAX_CELL_COUNT["scatter"],
         max_columns: MAX_COLUMN_COUNT["scatter"]

--- a/packages/perspective-viewer-highcharts/src/js/highcharts/highcharts.js
+++ b/packages/perspective-viewer-highcharts/src/js/highcharts/highcharts.js
@@ -105,22 +105,6 @@ const PLUGINS = {
         max_columns: MAX_COLUMN_COUNT["area"]
     },
 
-    xy_line: {
-        name: "X/Y Line Chart",
-        create: draw("line", true),
-        update: draw("line", false),
-        resize: resize,
-        initial: {
-            type: "number",
-            count: 2,
-            names: ["X Axis", "Y Axis", "Tooltip"]
-        },
-        selectMode: "toggle",
-        delete: delete_chart,
-        max_cells: MAX_CELL_COUNT["scatter"],
-        max_columns: MAX_COLUMN_COUNT["scatter"]
-    },
-
     y_scatter: {
         name: "Y Scatter Chart",
         create: draw("y_scatter", true),
@@ -146,6 +130,22 @@ const PLUGINS = {
             type: "number",
             count: 2,
             names: ["X Axis", "Y Axis", "Color", "Size", "Tooltip"]
+        },
+        selectMode: "toggle",
+        delete: delete_chart,
+        max_cells: MAX_CELL_COUNT["scatter"],
+        max_columns: MAX_COLUMN_COUNT["scatter"]
+    },
+
+    xy_line: {
+        name: "X/Y Line Chart",
+        create: draw("line", true),
+        update: draw("line", false),
+        resize: resize,
+        initial: {
+            type: "number",
+            count: 2,
+            names: ["X Axis", "Y Axis", "Tooltip"]
         },
         selectMode: "toggle",
         delete: delete_chart,


### PR DESCRIPTION
This PR fixes issues #1129 and #1130 by matching the order of the plugins between Highcharts and d3fc: 

_Highcharts_
![Screen Shot 2020-07-29 at 11 36 03 AM](https://user-images.githubusercontent.com/13220267/88820754-bd056f80-d18f-11ea-974e-2eb9d2ee0e0c.png)

_d3fc_
![Screen Shot 2020-07-29 at 11 03 50 AM](https://user-images.githubusercontent.com/13220267/88817302-58e0ac80-d18b-11ea-95a2-d0b4aaad2d8b.png)

Additionally, this PR removes the use of `perspective-viewer-hypergrid` and `perspective-viewer-highcharts` plugins from `PerspectiveWidget` in JupyterLab, and replaces them with `perspective-viewer-datagrid` and `perspective-viewer-d3fc`.
