### PR TITLE
Adds `set_threadpool_size()`

### DIFF
--- a/python/perspective/perspective/include/perspective/python.h
+++ b/python/perspective/perspective/include/perspective/python.h
@@ -383,6 +383,7 @@ PYBIND11_MODULE(libbinding, m)
     m.def("get_computed_functions", &get_computed_functions);
     m.def("make_computations", &make_computations);
     m.def("scalar_to_py", &scalar_to_py);
+    m.def("_set_nthreads", &_set_nthreads);
 }
 
 #endif

--- a/python/perspective/perspective/include/perspective/python/utils.h
+++ b/python/perspective/perspective/include/perspective/python/utils.h
@@ -19,6 +19,8 @@
 namespace perspective {
 namespace binding {
 
+void _set_nthreads(int nthreads);
+
 /******************************************************************************
  *
  * Helper functions

--- a/python/perspective/perspective/libpsp.py
+++ b/python/perspective/perspective/libpsp.py
@@ -22,7 +22,15 @@ try:
     from .manager import *  # noqa: F401, F403
     from .tornado_handler import *  # noqa: F401, F403
     from .viewer import *  # noqa: F401, F403
-    from .table.libbinding import make_computations
+    from .table.libbinding import make_computations, _set_nthreads
+
+    def set_threadpool_size(nthreads):
+        """ Sets the size of the global Perspective thread pool, up to the
+        total number of available cores, which can be set explicity by
+        setting `nthreads` to `None`.
+        """
+        _set_nthreads(-1 if nthreads is None else nthreads)
+
     make_computations()
 except ImportError:
     __is_libpsp__ = False

--- a/python/perspective/perspective/src/utils.cpp
+++ b/python/perspective/perspective/src/utils.cpp
@@ -13,10 +13,29 @@
 #include <perspective/python/base.h>
 #include <perspective/python/utils.h>
 
+#ifndef TBB_PREVIEW_GLOBAL_CONTROL
+#define TBB_PREVIEW_GLOBAL_CONTROL 1
+#endif
+
+#include <tbb/global_control.h>
+
 namespace perspective {
 namespace binding {
 
-t_dtype type_string_to_t_dtype(std::string value, std::string name){
+std::shared_ptr<tbb::global_control> control = 
+    std::make_shared<tbb::global_control>(
+        tbb::global_control::max_allowed_parallelism,
+        tbb::task_scheduler_init::default_num_threads()
+    );
+
+void _set_nthreads(int nthreads) {
+	control = std::make_shared<tbb::global_control>(
+        tbb::global_control::max_allowed_parallelism, 
+        nthreads == -1 ? tbb::task_scheduler_init::default_num_threads() : nthreads
+    );
+}
+
+t_dtype type_string_to_t_dtype(std::string value, std::string name) {
     auto type = t_dtype::DTYPE_STR;
 
     // TODO consider refactor

--- a/python/perspective/perspective/tests/core/test_threadpool.py
+++ b/python/perspective/perspective/tests/core/test_threadpool.py
@@ -1,0 +1,41 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+from perspective import Table, set_threadpool_size
+
+def compare_delta(received, expected):
+    """Compare an arrow-serialized row delta by constructing a Table."""
+    tbl = Table(received)
+    assert tbl.view().to_dict() == expected
+
+class TestThreadpool(object):
+    def test_set_threadpool_size(self):
+        set_threadpool_size(1)
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.num_rows() == 2
+        assert view.num_columns() == 2
+        assert view.schema() == {
+            "a": int,
+            "b": int
+        }
+        assert view.to_records() == data
+
+    def test_set_threadpool_size_max(self):
+        set_threadpool_size(None)
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.num_rows() == 2
+        assert view.num_columns() == 2
+        assert view.schema() == {
+            "a": int,
+            "b": int
+        }
+        assert view.to_records() == data


### PR DESCRIPTION
For Python, adds the method `perspective.set_threadpool_size(nthreads)`, which allows overriding the TBB thread pool size up to `tbb::task_scheduler_init::default_num_threads()`, which can be reset by calling this method with `None` or `-1`.  Also adds an ineffectual ("smoke") test to validate that invoking this method does not otherwise crash.  Fixes #1145 