### PR TITLE
Fix segfault and errors on 2-sided sorted views when data window is invalid

### DIFF
--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -389,11 +389,27 @@ View<t_ctx2>::get_data(
         }
 
         cols = column_names(true, depth);
-        column_indices = std::vector<t_uindex>(column_indices.begin() + start_col,
-            column_indices.begin() + std::min(end_col, (t_uindex)column_indices.size()));
+
+        // Filter down column indices by user-provided start/end columns
+        column_indices = std::vector<t_uindex>(
+            column_indices.begin() + start_col,
+            column_indices.begin() + std::min(end_col, (t_uindex)column_indices.size())
+        );
+
+        t_uindex start_col_index = start_col;
+        t_uindex end_col_index = end_col;
+
+        // If start_col == end_col, then column_indices will be an empty
+        // vector. Only try to access the first and last elements if the
+        // vector is not empty. `get_data` correctly handles cases where
+        // start == end and start > end.
+        if (column_indices.size() > 0) {
+            start_col_index = column_indices.front();
+            end_col_index = column_indices.back() + 1;
+        }
 
         std::vector<t_tscalar> slice_with_headers = m_ctx->get_data(
-            start_row, end_row, column_indices.front(), column_indices.back() + 1);
+            start_row, end_row, start_col_index, end_col_index);
 
         auto iter = slice_with_headers.begin();
         while (iter != slice_with_headers.end()) {

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -379,33 +379,38 @@ View<t_ctx2>::get_data(
          * Perspective generates headers for sorted columns, so we have to
          * skip them in the underlying slice.
          */
-        auto depth = m_column_pivots.size();
-        auto col_length = m_ctx->unity_get_column_count();
-        column_indices.push_back(0);
-        for (t_uindex i = 0; i < col_length; ++i) {
-            if (m_ctx->unity_get_column_path(i + 1).size() == depth) {
-                column_indices.push_back(i + 1);
-            }
-        }
-
-        cols = column_names(true, depth);
-
-        // Filter down column indices by user-provided start/end columns
-        column_indices = std::vector<t_uindex>(
-            column_indices.begin() + start_col,
-            column_indices.begin() + std::min(end_col, (t_uindex)column_indices.size())
-        );
-
         t_uindex start_col_index = start_col;
         t_uindex end_col_index = end_col;
 
-        // If start_col == end_col, then column_indices will be an empty
-        // vector. Only try to access the first and last elements if the
-        // vector is not empty. `get_data` correctly handles cases where
-        // start == end and start > end.
-        if (column_indices.size() > 0) {
-            start_col_index = column_indices.front();
-            end_col_index = column_indices.back() + 1;
+        // Only construct column_indices if start_col > end_col - get_data will
+        // handle the incorrect data window properly, which is consistent
+        // with the implementation for when the context is not sorted.
+        if (start_col < end_col) {
+            auto depth = m_column_pivots.size();
+            auto col_length = m_ctx->unity_get_column_count();
+            column_indices.push_back(0);
+            for (t_uindex i = 0; i < col_length; ++i) {
+                if (m_ctx->unity_get_column_path(i + 1).size() == depth) {
+                    column_indices.push_back(i + 1);
+                }
+            }
+
+            cols = column_names(true, depth);
+
+            // Filter down column indices by user-provided start/end columns
+            column_indices = std::vector<t_uindex>(
+                column_indices.begin() + start_col,
+                column_indices.begin() + std::min(end_col, (t_uindex)column_indices.size())
+            );
+
+            // If start_col == end_col, then column_indices will be an empty
+            // vector. Only try to access the first and last elements if the
+            // vector is not empty. `get_data` correctly handles cases where
+            // start == end and start > end.
+            if (column_indices.size() > 0) {
+                start_col_index = column_indices.front();
+                end_col_index = column_indices.back() + 1;
+            }
         }
 
         std::vector<t_tscalar> slice_with_headers = m_ctx->get_data(

--- a/python/perspective/perspective/table/_data_formatter.py
+++ b/python/perspective/perspective/table/_data_formatter.py
@@ -9,7 +9,6 @@
 import numpy as np
 from math import floor, ceil, trunc
 from ._constants import COLUMN_SEPARATOR_STRING
-from ..core.exception import PerspectiveError
 from .libbinding import get_data_slice_zero, get_data_slice_one, get_data_slice_two, \
     get_from_data_slice_zero, get_from_data_slice_one, get_from_data_slice_two, \
     get_pkeys_from_data_slice_zero, get_pkeys_from_data_slice_one, \
@@ -137,24 +136,11 @@ def _to_format_helper(view, options=None):
 def _parse_format_options(view, options):
     '''Given a user-provided options dictionary, extract the useful values.'''
     max_cols = view.num_columns() + (1 if view._sides > 0 else 0)
-    start_row = int(floor(max(options.get("start_row", 0), 0)))
-    end_row = int(ceil(min(options.get("end_row", view.num_rows()), view.num_rows())))
-    start_col = int(floor(max(options.get("start_col", 0), 0)))
-    end_col = int(ceil(min(options.get("end_col", max_cols) * (view._num_hidden_cols() + 1), max_cols)))
-
-    # Catch issues with start/end row and column, and raise a PerspectiveError
-
-    if start_row > end_row or start_col > end_col:
-        raise PerspectiveError("Start row/col cannot be larger than end row/col!")
-    elif start_row == end_row or start_col == end_col:
-        print(start_row, end_row, start_col, end_col)
-        raise PerspectiveError("Start row/col must be different from end row/col!")
-
     return {
-        "start_row": start_row,
-        "end_row": end_row,
-        "start_col": start_col,
-        "end_col": end_col,
+        "start_row": int(floor(max(options.get("start_row", 0), 0))),
+        "end_row": int(ceil(min(options.get("end_row", view.num_rows()), view.num_rows()))),
+        "start_col": int(floor(max(options.get("start_col", 0), 0))),
+        "end_col": int(ceil(min(options.get("end_col", max_cols) * (view._num_hidden_cols() + 1), max_cols))),
         "index": options.get("index", False),
         "leaves_only": options.get("leaves_only", False),
         "has_row_path": view._sides > 0 and (not view._column_only)

--- a/python/perspective/perspective/table/_data_formatter.py
+++ b/python/perspective/perspective/table/_data_formatter.py
@@ -9,6 +9,7 @@
 import numpy as np
 from math import floor, ceil, trunc
 from ._constants import COLUMN_SEPARATOR_STRING
+from ..core.exception import PerspectiveError
 from .libbinding import get_data_slice_zero, get_data_slice_one, get_data_slice_two, \
     get_from_data_slice_zero, get_from_data_slice_one, get_from_data_slice_two, \
     get_pkeys_from_data_slice_zero, get_pkeys_from_data_slice_one, \
@@ -136,11 +137,24 @@ def _to_format_helper(view, options=None):
 def _parse_format_options(view, options):
     '''Given a user-provided options dictionary, extract the useful values.'''
     max_cols = view.num_columns() + (1 if view._sides > 0 else 0)
+    start_row = int(floor(max(options.get("start_row", 0), 0)))
+    end_row = int(ceil(min(options.get("end_row", view.num_rows()), view.num_rows())))
+    start_col = int(floor(max(options.get("start_col", 0), 0)))
+    end_col = int(ceil(min(options.get("end_col", max_cols) * (view._num_hidden_cols() + 1), max_cols)))
+
+    # Catch issues with start/end row and column, and raise a PerspectiveError
+
+    if start_row > end_row or start_col > end_col:
+        raise PerspectiveError("Start row/col cannot be larger than end row/col!")
+    elif start_row == end_row or start_col == end_col:
+        print(start_row, end_row, start_col, end_col)
+        raise PerspectiveError("Start row/col must be different from end row/col!")
+
     return {
-        "start_row": int(floor(max(options.get("start_row", 0), 0))),
-        "end_row": int(ceil(min(options.get("end_row", view.num_rows()), view.num_rows()))),
-        "start_col": int(floor(max(options.get("start_col", 0), 0))),
-        "end_col": int(ceil(min(options.get("end_col", max_cols) * (view._num_hidden_cols() + 1), max_cols))),
+        "start_row": start_row,
+        "end_row": end_row,
+        "start_col": start_col,
+        "end_col": end_col,
         "index": options.get("index", False),
         "leaves_only": options.get("leaves_only", False),
         "has_row_path": view._sides > 0 and (not view._column_only)

--- a/python/perspective/perspective/tests/table/test_to_format.py
+++ b/python/perspective/perspective/tests/table/test_to_format.py
@@ -10,6 +10,7 @@ import os
 import numpy as np
 import pandas as pd
 import pytz
+from pytest import mark
 from io import StringIO
 from datetime import date, datetime
 from perspective.table import Table
@@ -593,6 +594,98 @@ class TestToFormat(object):
             {'2|a': 1, '2|b': 2, '4|a': None, '4|b': None, '__ROW_PATH__': [1]},
             {'2|a': None, '2|b': None, '4|a': 3, '4|b': 4, '__ROW_PATH__': [3]}
         ]
+
+    def test_to_records_two_start_gt_end_col(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            column_pivots=["b"]
+        )
+        records = view.to_records(
+            end_row=12,
+            start_col=5,
+            end_col=4
+        )
+        assert records == [{}, {}, {}]
+
+    @mark.skip
+    def test_to_records_two_sorted_start_gt_end_col(self):
+        """FIXME: behavior of sorted 2-sided view should be the same as
+        unsorted 2-sided view in test above."""
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            column_pivots=["b"],
+            sort=[["a", "desc"]]
+        )
+        records = view.to_records(
+            end_row=12,
+            start_col=5,
+            end_col=4
+        )
+        assert records == [{}, {}, {}]
+
+    def test_to_records_two_sorted_start_gt_end_col_large_overage(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            column_pivots=["b"],
+            sort=[["a", "desc"]]
+        )
+        records = view.to_records(
+            end_row=12,
+            start_col=20,
+            end_col=30
+        )
+        assert records == [{}, {}, {}]
+
+    def test_to_records_two_sorted_start_gt_end_col_overage(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view(
+            columns=[],
+            row_pivots=["a"],
+            column_pivots=["b"],
+            sort=[["a", "desc"]]
+        )
+        records = view.to_records(
+            end_row=12,
+            start_col=1,
+            end_col=3
+        )
+        assert records == [{}, {}, {}]
+
+    def test_to_records_two_sorted_start_end_col(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            column_pivots=["b"],
+            sort=[["a", "desc"]]
+        )
+        records = view.to_records(
+            start_col=1,
+            end_col=2
+        )
+        assert records == [{"__ROW_PATH__": []}, {"__ROW_PATH__": [3]}, {"__ROW_PATH__": [1]}]
+
+    def test_to_records_two_sorted_start_end_col_equiv(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            column_pivots=["b"],
+            sort=[["a", "desc"]]
+        )
+        records = view.to_records(
+            end_row=12,
+            start_col=5,
+            end_col=5
+        )
+        assert records == [{}, {}, {}]
 
     def test_to_records_start_col_end_col(self):
         data = [{"a": 1, "b": 2, "c": 3}, {"a": 3, "b": 4, "c": 5}]

--- a/python/perspective/perspective/tests/table/test_to_format.py
+++ b/python/perspective/perspective/tests/table/test_to_format.py
@@ -10,7 +10,6 @@ import os
 import numpy as np
 import pandas as pd
 import pytz
-from pytest import mark
 from io import StringIO
 from datetime import date, datetime
 from perspective.table import Table
@@ -529,6 +528,26 @@ class TestToFormat(object):
         )
         assert records == data
 
+    def test_to_records_zero_start_gt_end_col(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view()
+        records = view.to_records(
+            start_col=2,
+            end_col=1
+        )
+        assert records == [{}, {}]
+
+    def test_to_records_zero_start_eq_end_col(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view()
+        records = view.to_records(
+            start_col=1,
+            end_col=1
+        )
+        assert records == [{}, {}]
+
     def test_to_records_one_over_max_col(self):
         data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
         tbl = Table(data)
@@ -543,6 +562,42 @@ class TestToFormat(object):
             {'__ROW_PATH__': [1.5], 'a': 1.5, 'b': 2.5},
             {'__ROW_PATH__': [3.5], 'a': 3.5, 'b': 4.5}
         ]
+
+    def test_to_records_one_start_gt_end_col(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"]
+        )
+        records = view.to_records(
+            start_col=2,
+            end_col=1
+        )
+        assert records == [{}, {}, {}]
+
+    def test_to_records_one_start_gt_end_col_large(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"]
+        )
+        records = view.to_records(
+            start_col=20,
+            end_col=19
+        )
+        assert records == [{}, {}, {}]
+
+    def test_to_records_one_start_eq_end_col(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"]
+        )
+        records = view.to_records(
+            start_col=0,
+            end_col=0
+        )
+        assert records == [{}, {}, {}]
 
     def test_to_records_two_over_max_col(self):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
@@ -609,10 +664,36 @@ class TestToFormat(object):
         )
         assert records == [{}, {}, {}]
 
-    @mark.skip
+    def test_to_records_two_start_gt_end_col_large_overage(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            column_pivots=["b"]
+        )
+        records = view.to_records(
+            end_row=12,
+            start_col=50,
+            end_col=49
+        )
+        assert records == [{}, {}, {}]
+
+    def test_to_records_two_start_end_col_equiv(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        view = tbl.view(
+            row_pivots=["a"],
+            column_pivots=["b"]
+        )
+        records = view.to_records(
+            end_row=12,
+            start_col=5,
+            end_col=5
+        )
+        assert records == [{}, {}, {}]
+
+
     def test_to_records_two_sorted_start_gt_end_col(self):
-        """FIXME: behavior of sorted 2-sided view should be the same as
-        unsorted 2-sided view in test above."""
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
         view = tbl.view(
@@ -627,9 +708,7 @@ class TestToFormat(object):
         )
         assert records == [{}, {}, {}]
 
-    @mark.skip
     def test_to_records_two_sorted_start_gt_end_col_large_overage(self):
-        """FIXME: fails with ValueError: vector"""
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
         view = tbl.view(
@@ -673,6 +752,7 @@ class TestToFormat(object):
             end_col=2
         )
         assert records == [{"__ROW_PATH__": []}, {"__ROW_PATH__": [3]}, {"__ROW_PATH__": [1]}]
+        
 
     def test_to_records_two_sorted_start_end_col_equiv(self):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]

--- a/python/perspective/perspective/tests/table/test_to_format.py
+++ b/python/perspective/perspective/tests/table/test_to_format.py
@@ -627,7 +627,9 @@ class TestToFormat(object):
         )
         assert records == [{}, {}, {}]
 
+    @mark.skip
     def test_to_records_two_sorted_start_gt_end_col_large_overage(self):
+        """FIXME: fails with ValueError: vector"""
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
         view = tbl.view(


### PR DESCRIPTION
Retrieving data from a `View` can be controlled via the `start_row`/`end_row` and `start_col`/`end_col` arguments to `to_json`, which are parsed in a similar fashion to Python's `range` - inclusive of `start` and stopping at `end - 1`. 

Invalid data windows - where `start > end` or `start == end` - are handled by returning empty data. However, in the special case of two-sided sorted views, it did not correctly handle invalid data windows while constructing a column indices vector, and would segfault or throw a ValueError.

This does not raise an issue with the viewer/plugins - the data window requested by `perspective-viewer` will be valid, even if the viewport is extremely small. However, this interferes with a Websocket testing suite I'm currently building, which randomly generates data windows with the expectation that they are handled correctly by Perspective.

Because there are many situations where a data window can be _technically_ invalid, such as requesting a `to_json` on a view with 0 rows, or a view with 0 columns (such as the one created when generating autocomplete results for string filtering), I think it's better to have consistent behavior rather than throwing an error.

### Changes

- Fixes segfault and ValueError when data windows are invalid for 2-sided sorted views
- Adds tests for all view contexts to check the behavior for invalid data windows are consistent