### PR TITLE
Adds PR templates for bugfix, documentation, and feature

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/Bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Bugfix.md
@@ -1,0 +1,30 @@
+---
+name: 🐛 Bug Fix
+about: Fixes a bug reported in our issues list 📕
+
+---
+
+# Fix for {GITHUB_ISSUE_NUMBER} - {Describe your fix in a few words}
+
+## Description
+
+<!--- Describe your changes in detail - how does it solve the problem? Do you
+have any questions about your approach/places for future improvement? -->
+
+## Testing
+
+<!--- Describe in detail how your changes have been tested - were tests added
+or changed? -->
+
+## Screenshots (if appropriate)
+
+<!--- If the bug report had a screenshot/could be reproduced visually,
+please include a screenshot showing the fix. -->
+
+## Checklist
+
+<!--- If you have any questions, please reach out! We are here to help. -->
+
+- [ ] I have read the [`CONTRIBUTING.md`](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md) and followed its [Guidelines](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md#guidelines)
+- [ ] I have linted my code locally, following the project's code style
+- [ ] I have tested my changes locally, and changes pass on the Azure Pipelines CI.

--- a/.github/PULL_REQUEST_TEMPLATE/Bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Bugfix.md
@@ -6,9 +6,7 @@ about: Fixes a bug reported in our issues list 📕
 
 # Fix for {GITHUB_ISSUE_NUMBER} - {Describe your fix in a few words}
 
-## Description
-
-<!--- Describe your changes in detail - how does it solve the problem? Do you
+<!--- Describe your changes in detail. How does it fix the issue? Do you
 have any questions about your approach/places for future improvement? -->
 
 ## Testing

--- a/.github/PULL_REQUEST_TEMPLATE/Bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Bugfix.md
@@ -4,7 +4,7 @@ about: Fixes a bug reported in our issues list 📕
 
 ---
 
-# Fix for {GITHUB_ISSUE_NUMBER} - {Describe your fix in a few words}
+# Bugfix
 
 <!--- Describe your changes in detail. How does it fix the issue? Do you
 have any questions about your approach/places for future improvement? -->

--- a/.github/PULL_REQUEST_TEMPLATE/Documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Documentation.md
@@ -4,7 +4,7 @@ about: Improves documentation for the API or on the docs website.
 
 ---
 
-# {Describe your documentation changes in a few words.}
+# Documentation
 
 <!--- Describe your documentation additions/improvements in detail here. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/Documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Documentation.md
@@ -6,9 +6,7 @@ about: Improves documentation for the API or on the docs website.
 
 # {Describe your documentation changes in a few words.}
 
-## Description
-
-<!--- Where was documentation added/improved? -->
+<!--- Describe your documentation additions/improvements in detail here. -->
 
 ## Validation
 

--- a/.github/PULL_REQUEST_TEMPLATE/Documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Documentation.md
@@ -1,0 +1,35 @@
+---
+name: 📄 Documentation
+about: Improves documentation for the API or on the docs website.
+
+---
+
+# {Describe your documentation changes in a few words.}
+
+## Description
+
+<!--- Where was documentation added/improved? -->
+
+## Validation
+
+<!--- Describe how you have validated your documentation additions:
+
+1. Run `yarn docs` from the project root to regenerate the API documentation
+   from source.
+
+2. Inside the `/docs` subdirectory, run `yarn start` to generate the
+   Docusaurus site, and validate that your documentation is formatted
+   and styled correctly.
+
+-->
+
+- [ ] I have linted, spell-checked, and grammar-checked my documentation additions.
+- [ ] I have run `yarn docs` to regenerate the API documentation from source.
+- [ ] Within `/docs`, I have run `yarn start` to regenerate the Docusaurus site, and I have validated the changes
+- [ ] My additions are styled and structured correctly on the Docusaurus site
+
+## Checklist
+
+<!--- If you have any questions, please reach out! We are here to help. -->
+
+- [ ] I have read the [`CONTRIBUTING.md`](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md) and followed its [Guidelines](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md#guidelines)

--- a/.github/PULL_REQUEST_TEMPLATE/Feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Feature.md
@@ -1,0 +1,55 @@
+---
+name: New Feature
+about: Adds a new feature to Perspective 🙂!
+
+---
+
+# {Describe your feature addition in a few words}
+
+## Description
+
+<!--- Check one box below. If you are unsure as to whether your feature changes
+are breaking, tag a core contributor: @texodus, @timkpaine, @sc1f or leave a
+comment. --->
+
+- [ ] Breaking feature
+- [ ] Non-breaking feature
+
+<!--- Describe your feature addition and all changes you've made in detail.
+
+- What was the motivation for the feature change?
+- How were your changes implemented?
+- If necessary, were your changes implemented in both the Javascript and Python bindings?
+- Have you considered any alternative approaches that weren't implemented?
+- Do you have any questions about your approach/places for future improvement?
+
+-->
+
+## Changelog
+
+- {A bullet-pointed changelog that outlines the contents of your PR.}
+
+## Testing
+
+<!--- Describe in detail how your changes have been tested.
+
+- Have tests been added or changed?
+- Have you used the examples folder to test your new feature?
+- If useful, were new examples created for others to check out?
+- If your feature adds new public APIs/changes only one binding (JS _or_ Python),
+  has the equivalent API been implemented and tested in the other binding language?
+
+-->
+
+## Screenshots (if appropriate)
+
+<!--- If your feature is accessible via the UI/can be seen visually, please
+include a screenshot (or a few!). -->
+
+## Checklist
+
+<!--- If you have any questions, please reach out! We are here to help. -->
+
+- [ ] I have read the [`CONTRIBUTING.md`](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md) and followed its [Guidelines](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md#guidelines)
+- [ ] I have linted my code locally, following the project's code style
+- [ ] I have tested my changes locally, and changes pass on the Azure Pipelines CI.

--- a/.github/PULL_REQUEST_TEMPLATE/Feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Feature.md
@@ -4,7 +4,7 @@ about: Adds a new feature to Perspective 🙂!
 
 ---
 
-# {Describe your feature addition in a few words}
+# Feature
 
 <!--- Describe your feature addition and all changes you've made in detail.
 

--- a/.github/PULL_REQUEST_TEMPLATE/Feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Feature.md
@@ -6,15 +6,6 @@ about: Adds a new feature to Perspective 🙂!
 
 # {Describe your feature addition in a few words}
 
-## Description
-
-<!--- Check one box below. If you are unsure as to whether your feature changes
-are breaking, tag a core contributor: @texodus, @timkpaine, @sc1f or leave a
-comment. --->
-
-- [ ] Breaking feature
-- [ ] Non-breaking feature
-
 <!--- Describe your feature addition and all changes you've made in detail.
 
 - What was the motivation for the feature change?
@@ -24,6 +15,14 @@ comment. --->
 - Do you have any questions about your approach/places for future improvement?
 
 -->
+
+<!--- Check one box below. If you are unsure as to whether your feature changes
+are breaking, tag a core contributor: @texodus, @timkpaine, @sc1f or leave a
+comment. --->
+
+- [ ] Breaking feature
+- [ ] Non-breaking feature
+
 
 ## Changelog
 


### PR DESCRIPTION
# Adds new PR templates

I've added new PR templates for three categories:

- Bugfix: fixes towards reported bugs on our Issues page
- Documentation: additions/edits to API or Docusaurus documentation
- Feature: A new feature addition to Perspective

@texodus I've added them in the same form as our issue templates, so we should be able to get the same sort of selector window that happens with issue templates - the GitHub docs are a little unclear about whether PR templates will work in the same way with the nice picker. If it doesn't work, however, happy to coalesce into one template.

## Checklist

- [x] I have read the [`CONTRIBUTING.md`](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md) and followed its [Guidelines](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md#guidelines)
