### PR TITLE
Fixes #1159 - deltas are now generated on first update for 0-sided contexts

### DIFF
--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -381,20 +381,12 @@ t_ctx0::sidedness() const {
     return 0;
 }
 
-/**
- * @brief Handle additions and new data, calculating deltas along the way.
- *
- * @param flattened
- * @param delta
- * @param prev
- * @param curr
- * @param transitions
- * @param existed
- */
 void
 t_ctx0::notify(const t_data_table& flattened, const t_data_table& delta,
     const t_data_table& prev, const t_data_table& curr, const t_data_table& transitions,
     const t_data_table& existed) {
+    // Notify the context with new data when the `t_gstate` master table is
+    // not empty, and being updated with new data.
     psp_log_time(repr() + " notify.enter");
     t_uindex nrecs = flattened.size();
     std::shared_ptr<const t_column> pkey_sptr = flattened.get_const_column("psp_pkey");
@@ -406,6 +398,7 @@ t_ctx0::notify(const t_data_table& flattened, const t_data_table& delta,
     const t_column* existed_col = existed_sptr.get();
 
     bool delete_encountered = false;
+
     if (m_config.has_filters()) {
         t_mask msk_prev = filter_table_for_config(prev, m_config);
         t_mask msk_curr = filter_table_for_config(curr, m_config);
@@ -441,7 +434,7 @@ t_ctx0::notify(const t_data_table& flattened, const t_data_table& delta,
                 default: { PSP_COMPLAIN_AND_ABORT("Unexpected OP"); } break;
             }
 
-            // add the pkey for updated rows
+            // add the pkey for row delta
             add_delta_pkey(pkey);
         }
         psp_log_time(repr() + " notify.has_filter_path.updated_traversal");
@@ -455,6 +448,7 @@ t_ctx0::notify(const t_data_table& flattened, const t_data_table& delta,
         return;
     }
 
+    // Context does not have filters applied
     for (t_uindex idx = 0; idx < nrecs; ++idx) {
         t_tscalar pkey = m_symtable.get_interned_tscalar(pkey_col->get_scalar(idx));
         std::uint8_t op_ = *(op_col->get_nth<std::uint8_t>(idx));
@@ -476,7 +470,7 @@ t_ctx0::notify(const t_data_table& flattened, const t_data_table& delta,
             default: { PSP_COMPLAIN_AND_ABORT("Unexpected OP"); } break;
         }
 
-        // add the pkey for updated rows
+        // add the pkey for row delta
         add_delta_pkey(pkey);
     }
 
@@ -489,13 +483,10 @@ t_ctx0::notify(const t_data_table& flattened, const t_data_table& delta,
     psp_log_time(repr() + " notify.no_filter_path.exit");
 }
 
-/**
- * @brief Handle the addition of new data.
- *
- * @param flattened
- */
 void
 t_ctx0::notify(const t_data_table& flattened) {
+    // Notify the context with new data after the `t_gstate`'s master table
+    // has been updated for the first time with data.
     t_uindex nrecs = flattened.size();
     std::shared_ptr<const t_column> pkey_sptr = flattened.get_const_column("psp_pkey");
     std::shared_ptr<const t_column> op_sptr = flattened.get_const_column("psp_op");
@@ -518,10 +509,11 @@ t_ctx0::notify(const t_data_table& flattened) {
                         m_traversal->add_row(m_gstate, m_config, pkey);
                     }
                 } break;
-                default: {
-                    // pass
-                } break;
+                default: break;
             }
+
+            // Add primary key to track row delta
+            add_delta_pkey(pkey);
         }
         return;
     }
@@ -535,13 +527,19 @@ t_ctx0::notify(const t_data_table& flattened) {
             case OP_INSERT: {
                 m_traversal->add_row(m_gstate, m_config, pkey);
             } break;
-            default: { } break; }
+            default: break; 
+        }
+
+        // Add primary key to track row delta
+        add_delta_pkey(pkey);
     }
 }
 
 void
 t_ctx0::calc_step_delta(const t_data_table& flattened, const t_data_table& prev,
     const t_data_table& curr, const t_data_table& transitions) {
+    // Calculate step deltas when the `t_gstate` master table already has
+    // data, so we can take transitions into account.
     t_uindex nrows = flattened.size();
 
     PSP_VERBOSE_ASSERT(prev.size() == nrows, "Shape violation detected");
@@ -579,6 +577,13 @@ t_ctx0::calc_step_delta(const t_data_table& flattened, const t_data_table& prev,
         }
     }
 }
+
+void
+t_ctx0::calc_step_delta(const t_data_table& flattened) {
+    // Calculate step deltas when the `t_gstate` master table is updated with
+    // data for the first time, so every single row is a new delta.
+}
+
 
 /**
  * @brief Mark a primary key as updated by adding it to the tracking set.

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -443,6 +443,7 @@ t_ctx0::notify(const t_data_table& flattened, const t_data_table& delta,
         if (get_deltas_enabled()) {
             calc_step_delta(flattened, prev, curr, transitions);
         }
+
         m_has_delta = m_deltas->size() > 0 || m_delta_pkeys.size() > 0 || delete_encountered;
 
         psp_log_time(repr() + " notify.has_filter_path.exit");
@@ -519,6 +520,13 @@ t_ctx0::notify(const t_data_table& flattened) {
             // Add primary key to track row delta
             add_delta_pkey(pkey);
         }
+
+        // Calculate the step delta, if enabled in the context through an on_update
+        // callback with the "cell" or "row" mode set.
+        if (get_deltas_enabled()) {
+            calc_step_delta(flattened);
+        }
+
         return;
     }
 

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -575,21 +575,11 @@ View<CTX_T>::_get_deltas_enabled() const {
     return m_ctx->get_deltas_enabled();
 }
 
-template <>
-bool
-View<t_ctx0>::_get_deltas_enabled() const {
-    return true;
-}
-
 template <typename CTX_T>
 void
 View<CTX_T>::_set_deltas_enabled(bool enabled_state) {
     m_ctx->set_deltas_enabled(enabled_state);
 }
-
-template <>
-void
-View<t_ctx0>::_set_deltas_enabled(bool enabled_state) {}
 
 // Pivot table operations
 template <typename CTX_T>

--- a/cpp/perspective/src/include/perspective/context_zero.h
+++ b/cpp/perspective/src/include/perspective/context_zero.h
@@ -47,10 +47,28 @@ protected:
     std::vector<t_tscalar> get_all_pkeys(
         const std::vector<std::pair<t_uindex, t_uindex>>& cells) const;
 
+    /**
+     * @brief During a call to `notify` when the master table has data,
+     * calculate the deltas - both changed and added cells, and write them
+     * to `m_deltas`.
+     * 
+     * @param flattened 
+     * @param prev 
+     * @param curr 
+     * @param transitions 
+     */
     void calc_step_delta(const t_data_table& flattened, const t_data_table& prev,
         const t_data_table& curr, const t_data_table& transitions);
 
-    void calc_row_delta(const t_data_table& flattened, const t_data_table& transitions);
+    /**
+     * @brief During a call to `notify` when the master table is being updated
+     * with data for the first time (prev, curr, and transitions tables are
+     * empty), take all added rows in the traversal and store them in
+     * `m_deltas`.
+     * 
+     * @param flattened 
+     */
+    void calc_step_delta(const t_data_table& flattened);
 
     void add_delta_pkey(t_tscalar pkey);
 

--- a/cpp/perspective/src/include/perspective/context_zero.h
+++ b/cpp/perspective/src/include/perspective/context_zero.h
@@ -48,6 +48,16 @@ protected:
         const std::vector<std::pair<t_uindex, t_uindex>>& cells) const;
 
     /**
+     * @brief During a call to `notify` when the master table is being updated
+     * with data for the first time (prev, curr, and transitions tables are
+     * empty), take all added rows in the traversal and store them in
+     * `m_deltas`.
+     * 
+     * @param flattened 
+     */
+    void calc_step_delta(const t_data_table& flattened);
+
+    /**
      * @brief During a call to `notify` when the master table has data,
      * calculate the deltas - both changed and added cells, and write them
      * to `m_deltas`.
@@ -59,16 +69,6 @@ protected:
      */
     void calc_step_delta(const t_data_table& flattened, const t_data_table& prev,
         const t_data_table& curr, const t_data_table& transitions);
-
-    /**
-     * @brief During a call to `notify` when the master table is being updated
-     * with data for the first time (prev, curr, and transitions tables are
-     * empty), take all added rows in the traversal and store them in
-     * `m_deltas`.
-     * 
-     * @param flattened 
-     */
-    void calc_step_delta(const t_data_table& flattened);
 
     void add_delta_pkey(t_tscalar pkey);
 

--- a/packages/perspective-bench/bench/perspective.benchmark.js
+++ b/packages/perspective-bench/bench/perspective.benchmark.js
@@ -114,6 +114,124 @@ describe("Update", async () => {
     }
 });
 
+describe("Deltas", async () => {
+    // Generate update data from Perspective
+    const static_table = worker.table(data.arrow.slice());
+    const static_view = static_table.view();
+
+    let table, view;
+
+    afterEach(async () => {
+        await view.delete();
+        await table.delete();
+    });
+
+    describe("mixed", async () => {
+        describe("ctx0", async () => {
+            table = worker.table(data.arrow.slice());
+            view = table.view();
+            view.on_update(() => {}, {mode: "cell"});
+            const test_data = await static_view.to_arrow({end_row: 500});
+            benchmark("cell delta", async () => {
+                for (let i = 0; i < 3; i++) {
+                    table.update(test_data.slice());
+                    await table.size();
+                }
+            });
+        });
+
+        describe("ctx0", async () => {
+            table = worker.table(data.arrow.slice());
+            view = table.view();
+            view.on_update(() => {}, {mode: "row"});
+            const test_data = await static_view.to_arrow({end_row: 500});
+            benchmark("row delta", async () => {
+                for (let i = 0; i < 3; i++) {
+                    table.update(test_data.slice ? test_data.slice() : test_data);
+                    await table.size();
+                }
+            });
+        });
+
+        describe("ctx1", async () => {
+            table = worker.table(data.arrow.slice());
+            view = table.view({
+                row_pivots: ["State"]
+            });
+            view.on_update(() => {}, {mode: "row"});
+            const test_data = await static_view.to_arrow({end_row: 500});
+            benchmark("row delta", async () => {
+                for (let i = 0; i < 3; i++) {
+                    table.update(test_data.slice());
+                    await table.size();
+                }
+            });
+        });
+
+        describe("ctx1 deep", async () => {
+            table = worker.table(data.arrow.slice());
+            view = table.view({
+                row_pivots: ["State", "City"]
+            });
+            view.on_update(() => {}, {mode: "row"});
+            const test_data = await static_view.to_arrow({end_row: 500});
+            benchmark("row delta", async () => {
+                for (let i = 0; i < 3; i++) {
+                    table.update(test_data.slice());
+                    await table.size();
+                }
+            });
+        });
+
+        describe("ctx2", async () => {
+            table = worker.table(data.arrow.slice());
+            view = table.view({
+                row_pivots: ["State"],
+                column_pivots: ["Sub-Category"]
+            });
+            view.on_update(() => {}, {mode: "row"});
+            const test_data = await static_view.to_arrow({end_row: 500});
+            benchmark("row delta", async () => {
+                for (let i = 0; i < 3; i++) {
+                    table.update(test_data.slice());
+                    await table.size();
+                }
+            });
+        });
+
+        describe("ctx2 deep", async () => {
+            table = worker.table(data.arrow.slice());
+            view = table.view({
+                row_pivots: ["State", "City"],
+                column_pivots: ["Sub-Category"]
+            });
+            view.on_update(() => {}, {mode: "row"});
+            const test_data = await static_view.to_arrow({end_row: 500});
+            benchmark("row delta", async () => {
+                for (let i = 0; i < 3; i++) {
+                    table.update(test_data.slice());
+                    await table.size();
+                }
+            });
+        });
+
+        describe("ctx1.5", async () => {
+            table = worker.table(data.arrow.slice());
+            view = table.view({
+                column_pivots: ["Sub-Category"]
+            });
+            view.on_update(() => {}, {mode: "row"});
+            const test_data = await static_view.to_arrow({end_row: 500});
+            benchmark("row delta", async () => {
+                for (let i = 0; i < 3; i++) {
+                    table.update(test_data.slice());
+                    await table.size();
+                }
+            });
+        });
+    });
+});
+
 describe("View", async () => {
     let table;
 

--- a/packages/perspective-bench/bench/perspective.benchmark.js
+++ b/packages/perspective-bench/bench/perspective.benchmark.js
@@ -92,16 +92,108 @@ describe("Update", async () => {
     const static_table = worker.table(data.arrow.slice());
     const static_view = static_table.view();
 
-    let table;
+    let table, view;
 
     afterEach(async () => {
+        if (view) {
+            await view.delete();
+        }
         await table.delete();
     });
 
     for (const name of Object.keys(data)) {
         describe("mixed", async () => {
-            describe("update", async () => {
+            // Benchmark how long it takes the table to update without any
+            // linked contexts to notify.
+            describe("table_only", async () => {
                 table = worker.table(data.arrow.slice());
+
+                let test_data = await static_view[`to_${name}`]({end_row: 500});
+                benchmark(name, async () => {
+                    for (let i = 0; i < 5; i++) {
+                        table.update(test_data.slice ? test_data.slice() : test_data);
+                        await table.size();
+                    }
+                });
+            });
+
+            describe("ctx0", async () => {
+                table = worker.table(data.arrow.slice());
+                view = table.view();
+
+                let test_data = await static_view[`to_${name}`]({end_row: 500});
+                benchmark(name, async () => {
+                    for (let i = 0; i < 5; i++) {
+                        table.update(test_data.slice ? test_data.slice() : test_data);
+                        await table.size();
+                    }
+                });
+            });
+
+            describe("ctx1", async () => {
+                table = worker.table(data.arrow.slice());
+                view = table.view({
+                    row_pivots: ["State"]
+                });
+
+                let test_data = await static_view[`to_${name}`]({end_row: 500});
+                benchmark(name, async () => {
+                    for (let i = 0; i < 5; i++) {
+                        table.update(test_data.slice ? test_data.slice() : test_data);
+                        await table.size();
+                    }
+                });
+            });
+
+            describe("ctx1 deep", async () => {
+                table = worker.table(data.arrow.slice());
+                view = table.view({
+                    row_pivots: ["State", "City"]
+                });
+                let test_data = await static_view[`to_${name}`]({end_row: 500});
+                benchmark(name, async () => {
+                    for (let i = 0; i < 5; i++) {
+                        table.update(test_data.slice ? test_data.slice() : test_data);
+                        await table.size();
+                    }
+                });
+            });
+
+            describe("ctx2", async () => {
+                table = worker.table(data.arrow.slice());
+                view = table.view({
+                    row_pivots: ["State"],
+                    column_pivots: ["Sub-Category"]
+                });
+                let test_data = await static_view[`to_${name}`]({end_row: 500});
+                benchmark(name, async () => {
+                    for (let i = 0; i < 5; i++) {
+                        table.update(test_data.slice ? test_data.slice() : test_data);
+                        await table.size();
+                    }
+                });
+            });
+
+            describe("ctx2 deep", async () => {
+                table = worker.table(data.arrow.slice());
+                view = table.view({
+                    row_pivots: ["State", "City"],
+                    column_pivots: ["Sub-Category"]
+                });
+                let test_data = await static_view[`to_${name}`]({end_row: 500});
+                benchmark(name, async () => {
+                    for (let i = 0; i < 5; i++) {
+                        table.update(test_data.slice ? test_data.slice() : test_data);
+                        await table.size();
+                    }
+                });
+            });
+
+            describe("ctx1.5", async () => {
+                table = worker.table(data.arrow.slice());
+                view = table.view({
+                    column_pivots: ["Sub-Category"]
+                });
                 let test_data = await static_view[`to_${name}`]({end_row: 500});
                 benchmark(name, async () => {
                     for (let i = 0; i < 5; i++) {

--- a/packages/perspective-bench/bench/versions.js
+++ b/packages/perspective-bench/bench/versions.js
@@ -34,7 +34,7 @@ const JPMC_VERSIONS = [
 
 const FINOS_VERSIONS = ["0.3.1", "0.3.0", "0.3.0-rc.3", "0.3.0-rc.2", "0.3.0-rc.1"];
 
-const UMD_VERSIONS = ["0.4.8", "0.4.7", "0.4.6", "0.4.5", "0.4.4", "0.4.2", "0.4.1", "0.4.0", "0.3.9", "0.3.8", "0.3.7", "0.3.6"];
+const UMD_VERSIONS = ["0.5.2", "0.5.1", "0.5.0", "0.4.8", "0.4.7", "0.4.6", "0.4.5", "0.4.4", "0.4.2", "0.4.1", "0.4.0", "0.3.9", "0.3.8", "0.3.7", "0.3.6"];
 
 async function run() {
     await PerspectiveBench.run("master", "bench/perspective.benchmark.js", `http://${process.env.PSP_DOCKER_PUPPETEER ? `localhost` : `host.docker.internal`}:8080/perspective.js`, {

--- a/packages/perspective-bench/src/js/browser_runtime.js
+++ b/packages/perspective-bench/src/js/browser_runtime.js
@@ -133,7 +133,7 @@ class Benchmark {
         this._table_printer(
             ...(OUTPUT_MODE === "tree" ? path : []),
             `{${color} ${completed}}{whiteBright /${total}}`,
-            `({${color} ${(100 * completed_per).toFixed(2)}}{whiteBright %)}`,
+            `{${color} ${(100 * completed_per).toFixed(2)}}{whiteBright %)}`,
             `{whiteBright ${time.toFixed(3)}}s`,
             `{whiteBright ${time_per.toFixed(2)}}secs/op`,
             `{${stddev_color} ${(100 * stddev).toFixed(2)}}{whiteBright %} σ/mean`,

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -819,15 +819,18 @@ export default function(Module) {
      */
     view.prototype.on_update = function(callback, {mode = "none"} = {}) {
         _call_process(this.table.get_id());
+
         if (["none", "cell", "row"].indexOf(mode) === -1) {
             throw new Error(`Invalid update mode "${mode}" - valid modes are "none", "cell" and "row".`);
         }
+
         if (mode === "cell" || mode === "row") {
             // Enable deltas only if needed by callback
             if (!this._View._get_deltas_enabled()) {
                 this._View._set_deltas_enabled(true);
             }
         }
+
         this.callbacks.push({
             view: this,
             orig_callback: callback,

--- a/packages/perspective/test/js/computed/deltas.js
+++ b/packages/perspective/test/js/computed/deltas.js
@@ -55,7 +55,7 @@ module.exports = perspective => {
                 table.update({x: [1, 3], y: ["HELLO", "WORLD"]});
             });
 
-            it("Returns appended rows for normal and computed columns froms schema", async function(done) {
+            it("Returns appended rows for normal and computed columns from schema", async function(done) {
                 const table = perspective.table({
                     x: "integer",
                     y: "string"
@@ -88,7 +88,7 @@ module.exports = perspective => {
 
                 table.update({
                     x: [1, 2, 3, 4],
-                    y: ["A", "B", "C", "D"]
+                    y: ["a", "b", "c", "d"]
                 });
             });
 

--- a/packages/perspective/test/js/computed/deltas.js
+++ b/packages/perspective/test/js/computed/deltas.js
@@ -55,6 +55,43 @@ module.exports = perspective => {
                 table.update({x: [1, 3], y: ["HELLO", "WORLD"]});
             });
 
+            it("Returns appended rows for normal and computed columns froms schema", async function(done) {
+                const table = perspective.table({
+                    x: "integer",
+                    y: "string"
+                });
+                const view = table.view({
+                    computed_columns: [
+                        {
+                            column: "uppercase",
+                            computed_function_name: "Uppercase",
+                            inputs: ["y"]
+                        }
+                    ]
+                });
+
+                view.on_update(
+                    async function(updated) {
+                        const expected = [
+                            {x: 1, y: "a", uppercase: "A"},
+                            {x: 2, y: "b", uppercase: "B"},
+                            {x: 3, y: "c", uppercase: "C"},
+                            {x: 4, y: "d", uppercase: "D"}
+                        ];
+                        await match_delta(perspective, updated.delta, expected);
+                        await view.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update({
+                    x: [1, 2, 3, 4],
+                    y: ["A", "B", "C", "D"]
+                });
+            });
+
             it("Returns partially updated step delta for normal and computed columns", async function(done) {
                 let table = perspective.table(
                     [

--- a/packages/perspective/test/js/delta.js
+++ b/packages/perspective/test/js/delta.js
@@ -101,6 +101,33 @@ module.exports = perspective => {
             table.update(data);
         });
 
+        it("Should calculate step delta for added rows in 0-sided filtered contexts from schema", async function(done) {
+            let table = perspective.table({
+                x: "integer",
+                y: "string",
+                z: "boolean"
+            });
+            let view = table.view({
+                filter: [["x", ">", 3]]
+            });
+            view.on_update(
+                function(updated) {
+                    expect(updated.delta).toEqual([
+                        {
+                            x: 4,
+                            y: "d",
+                            z: false
+                        }
+                    ]);
+                    view.delete();
+                    table.delete();
+                    done();
+                },
+                {mode: "cell"}
+            );
+            table.update(data);
+        });
+
         it("Should calculate step delta for added rows with partial nones in 0-sided contexts from schema", async function(done) {
             let table = perspective.table({
                 x: "integer",

--- a/packages/perspective/test/js/delta.js
+++ b/packages/perspective/test/js/delta.js
@@ -60,6 +60,72 @@ module.exports = perspective => {
             table.update(partial_change_y);
         });
 
+        it("Should calculate step delta for 0-sided contexts from schema", async function(done) {
+            let table = perspective.table(
+                {
+                    x: "integer",
+                    y: "string",
+                    z: "boolean"
+                },
+                {index: "x"}
+            );
+            let view = table.view();
+            view.on_update(
+                function(updated) {
+                    expect(updated.delta).toEqual(data);
+                    view.delete();
+                    table.delete();
+                    done();
+                },
+                {mode: "cell"}
+            );
+            table.update(data);
+        });
+
+        it("Should calculate step delta for added rows in 0-sided contexts from schema", async function(done) {
+            let table = perspective.table({
+                x: "integer",
+                y: "string",
+                z: "boolean"
+            });
+            let view = table.view();
+            view.on_update(
+                function(updated) {
+                    expect(updated.delta).toEqual(data);
+                    view.delete();
+                    table.delete();
+                    done();
+                },
+                {mode: "cell"}
+            );
+            table.update(data);
+        });
+
+        it("Should calculate step delta for added rows with partial nones in 0-sided contexts from schema", async function(done) {
+            let table = perspective.table({
+                x: "integer",
+                y: "string",
+                z: "boolean"
+            });
+            let view = table.view();
+            view.on_update(
+                function(updated) {
+                    expect(updated.delta).toEqual([
+                        {x: 1, y: "a", z: true},
+                        {x: 2, y: "b", z: null}
+                    ]);
+                    view.delete();
+                    table.delete();
+                    done();
+                },
+                {mode: "cell"}
+            );
+            table.update([
+                {x: 1, y: "a", z: true},
+                {x: 2, y: "b"}
+            ]);
+        });
+
         it.skip("Should calculate step delta for 0-sided contexts during non-sequential updates", async function(done) {
             let table = perspective.table(data, {index: "x"});
             let view = table.view();

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -842,6 +842,85 @@ class TestView(object):
         view.on_update(cb1, mode="row")
         tbl.update(update_data)
 
+    def test_view_row_delta_zero_from_schema(self, util):
+        update_data = {
+            "a": [5],
+            "b": [6]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, update_data)
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        })
+        view = tbl.view()
+        view.on_update(cb1, mode="row")
+        tbl.update(update_data)
+
+    def test_view_row_delta_zero_from_schema_filtered(self, util):
+        update_data = {
+            "a": [8, 9, 10, 11],
+            "b": [1, 2, 3, 4]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": [11],
+                "b": [4]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        })
+        view = tbl.view(filter=[["a", ">", 10]])
+        view.on_update(cb1, mode="row")
+        tbl.update(update_data)
+
+    def test_view_row_delta_zero_from_schema_indexed(self, util):
+        update_data = {
+            "a": ["a", "b", "a"],
+            "b": [1, 2, 3]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": ["a", "b"],
+                "b": [3, 2]
+            })
+
+        tbl = Table({
+            "a": str,
+            "b": int
+        }, index="a")
+
+        view = tbl.view()
+        view.on_update(cb1, mode="row")
+
+        tbl.update(update_data)
+
+    def test_view_row_delta_zero_from_schema_indexed_filtered(self, util):
+        update_data = {
+            "a": [8, 9, 10, 11, 11],
+            "b": [1, 2, 3, 4, 5]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": [11],
+                "b": [5]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        }, index="a")
+        view = tbl.view(filter=[["a", ">", 10]])
+        view.on_update(cb1, mode="row")
+        tbl.update(update_data)
+
     def test_view_row_delta_one(self, util):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         update_data = {
@@ -863,6 +942,155 @@ class TestView(object):
             "b": [6, 2, 4]
         }
         view.on_update(cb1, mode="row")
+        tbl.update(update_data)
+
+    def test_view_row_delta_one_from_schema(self, util):
+        update_data = {
+            "a": [1, 2, 3, 4, 5],
+            "b": [6, 7, 8, 9, 10]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": [15, 1, 2, 3, 4, 5],
+                "b": [40, 6, 7, 8, 9, 10]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        })
+        view = tbl.view(row_pivots=["a"])
+        view.on_update(cb1, mode="row")
+        tbl.update(update_data)
+
+    def test_view_row_delta_one_from_schema_sorted(self, util):
+        update_data = {
+            "a": [1, 2, 3, 4, 5],
+            "b": [6, 7, 8, 9, 10]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": [15, 5, 4, 3, 2, 1],
+                "b": [40, 10, 9, 8, 7, 6]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        })
+        view = tbl.view(row_pivots=["a"], sort=[["a", "desc"]])
+        view.on_update(cb1, mode="row")
+        tbl.update(update_data)
+
+    def test_view_row_delta_one_from_schema_filtered(self, util):
+        update_data = {
+            "a": [1, 2, 3, 4, 5],
+            "b": [6, 7, 8, 9, 10]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": [9, 4, 5],
+                "b": [19, 9, 10]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        })
+        view = tbl.view(row_pivots=["a"], filter=[["a", ">", 3]])
+        view.on_update(cb1, mode="row")
+        tbl.update(update_data)
+
+    def test_view_row_delta_one_from_schema_sorted_filtered(self, util):
+        update_data = {
+            "a": [1, 2, 3, 4, 5],
+            "b": [6, 7, 8, 9, 10]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": [9, 5, 4],
+                "b": [19, 10, 9]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        })
+        view = tbl.view(
+            row_pivots=["a"],
+            sort=[["a", "desc"]],
+            filter=[["a", ">", 3]])
+        view.on_update(cb1, mode="row")
+        tbl.update(update_data)
+
+    def test_view_row_delta_one_from_schema_indexed(self, util):
+        update_data = {
+            "a": [1, 2, 3, 4, 5, 5, 4],
+            "b": [6, 7, 8, 9, 10, 11, 12]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": [15, 1, 2, 3, 4, 5],
+                "b": [44, 6, 7, 8, 12, 11]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        }, index="a")
+
+        view = tbl.view(row_pivots=["a"])
+        view.on_update(cb1, mode="row")
+
+        tbl.update(update_data)
+
+    def test_view_row_delta_one_from_schema_sorted_indexed(self, util):
+        update_data = {
+            "a": [1, 2, 3, 4, 5, 5, 4],
+            "b": [6, 7, 8, 9, 10, 11, 12]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": [15, 4, 5, 3, 2, 1],
+                "b": [44, 12, 11, 8, 7, 6]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        }, index="a")
+
+        view = tbl.view(row_pivots=["a"], sort=[["b", "desc"]])
+        view.on_update(cb1, mode="row")
+
+        tbl.update(update_data)
+
+    def test_view_row_delta_one_from_schema_filtered_indexed(self, util):
+        update_data = {
+            "a": [1, 2, 3, 4, 5, 5, 4],
+            "b": [6, 7, 8, 9, 10, 11, 12]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "a": [9, 4, 5],
+                "b": [23, 12, 11]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        }, index="a")
+
+        view = tbl.view(row_pivots=["a"], filter=[["a", ">", 3]])
+        view.on_update(cb1, mode="row")
+
         tbl.update(update_data)
 
     def test_view_row_delta_two(self, util):
@@ -894,6 +1122,44 @@ class TestView(object):
         view.on_update(cb1, mode="row")
         tbl.update(update_data)
 
+    def test_view_row_delta_two_from_schema(self, util):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "2|a": [1, 1, None],
+                "2|b": [2, 2, None],
+                "4|a": [3, None, 3],
+                "4|b": [4, None, 4]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        })
+        view = tbl.view(row_pivots=["a"], column_pivots=["b"])
+        view.on_update(cb1, mode="row")
+        tbl.update(data)
+
+    def test_view_row_delta_two_from_schema_indexed(self, util):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 3, "b": 5}]
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "2|a": [1, 1, None],
+                "2|b": [2, 2, None],
+                "5|a": [3, None, 3],
+                "5|b": [5, None, 5]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        }, index="a")
+        view = tbl.view(row_pivots=["a"], column_pivots=["b"])
+        view.on_update(cb1, mode="row")
+        tbl.update(data)
+
     def test_view_row_delta_two_column_only(self, util):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         update_data = {
@@ -922,7 +1188,73 @@ class TestView(object):
         view.on_update(cb1, mode="row")
         tbl.update(update_data)
 
-    # hidden rows
+    def test_view_row_delta_two_column_only_indexed(self, util):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 3, "b": 5}]
+        update_data = {
+            "a": [5],
+            "b": [6]
+        }
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "2|a": [1, None],
+                "2|b": [2, None],
+                "5|a": [3, None],
+                "5|b": [5, None],
+                "6|a": [5, 5],
+                "6|b": [6, 6]
+            })
+
+        tbl = Table(data, index="a")
+        view = tbl.view(column_pivots=["b"])
+        assert view.to_dict() == {
+            "2|a": [1, None],
+            "2|b": [2, None],
+            "5|a": [None, 3],
+            "5|b": [None, 5],
+        }
+        view.on_update(cb1, mode="row")
+        tbl.update(update_data)
+
+    def test_view_row_delta_two_column_only_from_schema(self, util):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "2|a": [1, 1, None],
+                "2|b": [2, 2, None],
+                "4|a": [3, None, 3],
+                "4|b": [4, None, 4]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        })
+        view = tbl.view(column_pivots=["b"])
+        view.on_update(cb1, mode="row")
+        tbl.update(data)
+
+    def test_view_row_delta_two_column_only_from_schema_indexed(self, util):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 3, "b": 5}]
+
+        def cb1(port_id, delta):
+            compare_delta(delta, {
+                "2|a": [1, 1, None],
+                "2|b": [2, 2, None],
+                "5|a": [3, None, 3],
+                "5|b": [5, None, 5]
+            })
+
+        tbl = Table({
+            "a": int,
+            "b": int
+        }, index="a")
+        view = tbl.view(column_pivots=["b"])
+        view.on_update(cb1, mode="row")
+        tbl.update(data)
+
+    # hidden cols
 
     def test_view_num_hidden_cols(self):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]


### PR DESCRIPTION
# Bugfix

#1159 reported an issue where row deltas were empty in tables after their first update from schema. This was due to the `notify` calls for first and subsequent updates being on different code paths (with different invocations of `notify`), and the line that added the primary key to be tracked as a changed row was missing. This PR fixes the issue, and adds a litany of tests in Javascript and Python.

Additionally, this PR fixes a previously overlooked issue - though we enable delta calculation based on whether they are used in on_update or not, 0-sided contexts would always calculate step and row deltas regardless of whether they were enabled or not. This seemed to be a default - `get_deltas_enabled` would always return `true`, and `set_deltas_enabled` would be a no-op for zero sided contexts.

Because there is no public API to get a delta without going through `on_update` and enabling deltas, and considering that row deltas are used far more widely than cell deltas (and cell deltas aren't even implemented in Python), it seems to make sense for 0-sided contexts to have the same behavior as 1/2 sided contexts, which respect `get_deltas_enabled`.

A next step might be differentiating cell/row delta enablement inside the context, which means that a callback that requests a row delta would not also enable cell delta calculation. This would be an internal API, as the cell/row delta methods are, and might bring some performance improvements.

This PR also adds benchmarking for deltas across different contexts, which means we can use it to test out actual performance over different versions.

## Testing

Tests added for JS and Python, for multiple context types, computed columns, indexed, etc.

## Screenshots (if appropriate)

![Screen Shot 2020-08-24 at 3 22 18 PM](https://user-images.githubusercontent.com/13220267/91086948-a54dc980-e61d-11ea-95c4-d8b890c0b5c5.png)

## Checklist

<!--- If you have any questions, please reach out! We are here to help. -->

- [x] I have read the [`CONTRIBUTING.md`](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md) and followed its [Guidelines](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md#guidelines)
- [x] I have linted my code locally, following the project's code style
- [x] I have tested my changes locally, and changes pass on the Azure Pipelines CI.