### PR TITLE
fix(perspective-viewer-d3fc): show formatted dates on treemap and sunburst (1144)

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/data/treeData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/treeData.js
@@ -8,6 +8,7 @@
  */
 
 import * as d3 from "d3";
+import {toValue} from "../tooltip/selectionData";
 
 export function treeData(settings) {
     const sets = {};
@@ -66,9 +67,14 @@ export function treeData(settings) {
                 .map(cross => cross.data.name)
                 .join("|");
             d.key = set[0];
+            d.label = toValue(settings.crossValues[d.depth - 1 < 0 ? 0 : d.depth - 1].type, d.data.name);
         });
 
-        return {split: set[0], data: chartData, extents: getExtents(settings, set)};
+        return {
+            split: set[0],
+            data: chartData,
+            extents: getExtents(settings, set)
+        };
     });
 
     return data;

--- a/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstClick.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstClick.js
@@ -16,7 +16,7 @@ export const clickHandler = (data, g, parent, parentTitle, path, label, radius, 
     if (p.parent) {
         parent.datum(p.parent);
         parent.style("cursor", "pointer");
-        parentTitle.html(`&#8682; ${p.data.name}`);
+        parentTitle.html(`&#8682; ${p.label}`);
     } else {
         parent.datum(data);
         parent.style("cursor", "default");

--- a/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstLabel.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstLabel.js
@@ -20,7 +20,7 @@ export function labelTransform(d, radius) {
 export function cropLabel(d, targetWidth) {
     let actualWidth = this.getBBox().width;
     if (actualWidth > targetWidth) {
-        let labelText = d.data.name;
+        let labelText = d.label;
         const textSelection = select(this);
         while (actualWidth > targetWidth) {
             labelText = labelText.substring(0, labelText.length - 1);

--- a/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstSeries.js
@@ -44,7 +44,7 @@ export function sunburstSeries() {
             .select("text")
             .attr("fill-opacity", d => +labelVisible(d.current))
             .attr("transform", d => labelTransform(d.current, radius))
-            .text(d => d.data.name)
+            .text(d => d.label)
             .each(function(d) {
                 cropLabel.call(this, d, radius);
             });

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapSeries.js
@@ -13,7 +13,11 @@ import {changeLevel, returnToLevel} from "./treemapTransitions";
 import {parentControls} from "./treemapControls";
 import {calculateRootLevelMap, saveLabelMap} from "./treemapLevelCalculation";
 
-export const nodeLevel = {leaf: "leafnode", branch: "branchnode", root: "rootnode"};
+export const nodeLevel = {
+    leaf: "leafnode",
+    branch: "branchnode",
+    root: "rootnode"
+};
 export const calcWidth = d => d.x1 - d.x0;
 export const calcHeight = d => d.y1 - d.y0;
 const isLeafNode = (maxDepth, d) => d.depth === maxDepth;
@@ -59,7 +63,7 @@ export function treemapSeries() {
             .select("text")
             .attr("x", d => d.x0 + calcWidth(d) / 2)
             .attr("y", d => d.y0 + calcHeight(d) / 2)
-            .text(d => d.data.name);
+            .text(d => d.label);
 
         const rootNode = rects.filter(d => d.crossValue === "").datum();
         calculateRootLevelMap(nodesMerge, rootNode);

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapTransitions.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapTransitions.js
@@ -108,7 +108,7 @@ function executeTransition(d, rects, nodesMerge, labels, settings, treemapDiv, t
     if (parent) {
         parentCtrls
             .hide(false)
-            .text(d.data.name)
+            .text(d.label)
             .onClick(() => changeLevel(parent, rects, nodesMerge, labels, settings, treemapDiv, treemapSvg, rootNode, parentCtrls, duration))();
     } else {
         parentCtrls.hide(true)();

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
@@ -6,12 +6,13 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+import {get_type_config} from "@finos/perspective/dist/esm/config";
 
-function toValue(type, value) {
+export function toValue(type, value) {
     switch (type) {
         case "date":
         case "datetime":
-            return value instanceof Date ? value : new Date(parseInt(value));
+            return value instanceof Date ? value : new Date(parseInt(value)).toLocaleString("en-us", get_type_config(type).format);
         case "integer":
             return parseInt(value, 10);
         case "float":
@@ -23,13 +24,19 @@ function toValue(type, value) {
 export function getGroupValues(data, settings) {
     if (settings.crossValues.length === 0) return [];
     const groupValues = (data.crossValue.split ? data.crossValue.split("|") : [data.crossValue]) || [data.key];
-    return groupValues.map((cross, i) => ({name: settings.crossValues[i].name, value: toValue(settings.crossValues[i].type, cross)}));
+    return groupValues.map((cross, i) => ({
+        name: settings.crossValues[i].name,
+        value: toValue(settings.crossValues[i].type, cross)
+    }));
 }
 
 export function getSplitValues(data, settings) {
     if (settings.splitValues.length === 0) return [];
     const splitValues = data.key ? data.key.split("|") : data.mainValue.split ? data.mainValue.split("|") : [data.mainValue];
-    return settings.splitValues.map((split, i) => ({name: split.name, value: toValue(split.type, splitValues[i])}));
+    return settings.splitValues.map((split, i) => ({
+        name: split.name,
+        value: toValue(split.type, splitValues[i])
+    }));
 }
 
 export function getDataValues(data, settings) {
@@ -42,7 +49,10 @@ export function getDataValues(data, settings) {
                 }
             ];
         }
-        return settings.mainValues.map((main, i) => ({name: main.name, value: toValue(main.type, data.mainValues[i])}));
+        return settings.mainValues.map((main, i) => ({
+            name: main.name,
+            value: toValue(main.type, data.mainValues[i])
+        }));
     }
     return [
         {

--- a/packages/perspective-viewer-d3fc/test/js/integration/sunburst.spec.js
+++ b/packages/perspective-viewer-d3fc/test/js/integration/sunburst.spec.js
@@ -20,6 +20,47 @@ utils.with_server({}, () => {
         "sunburst.html",
         () => {
             simple_tests.default("skip");
+
+            test.run("sunburst label shows formatted date", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.evaluate(element => element.setAttribute("row-pivots", '["Ship Date"]'), viewer);
+                await page.evaluate(element => element.setAttribute("columns", '["Sales", "Profit"]'), viewer);
+                await page.evaluate(element => element.setAttribute("filters", '[["Product ID", "==", "FUR-BO-10001798"]]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                const result = await page.waitFor(
+                    element => {
+                        let elem = element.shadowRoot.querySelector("perspective-d3fc-chart").shadowRoot.querySelector(".segment");
+                        if (elem) {
+                            return elem.textContent.includes("11/12");
+                        }
+                    },
+                    {},
+                    viewer
+                );
+                return !!result;
+            });
+
+            test.run("sunburst parent button shows formatted date", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.evaluate(element => element.setAttribute("row-pivots", '["Ship Date", "City"]'), viewer);
+                await page.evaluate(element => element.setAttribute("columns", '["Sales", "Profit"]'), viewer);
+                await page.evaluate(element => element.setAttribute("filters", '[["Product ID", "==", "FUR-BO-10001798"]]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.mouse.click(500, 400);
+                const result = await page.waitFor(
+                    element => {
+                        let elem = element.shadowRoot.querySelector("perspective-d3fc-chart").shadowRoot.querySelector(".parent");
+                        if (elem) {
+                            return elem.textContent.includes("11/12/2013, 12:00:00 AM");
+                        }
+                    },
+                    {},
+                    viewer
+                );
+                return !!result;
+            });
         },
         {reload_page: false, root: path.join(__dirname, "..", "..", "..")}
     );

--- a/packages/perspective-viewer-d3fc/test/js/integration/treemap.spec.js
+++ b/packages/perspective-viewer-d3fc/test/js/integration/treemap.spec.js
@@ -60,6 +60,48 @@ utils.with_server({}, () => {
                 },
                 {preserve_hover: true}
             );
+
+            test.capture(
+                "treemap label shows formatted date",
+                async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.shadow_click("perspective-viewer", "#config_button");
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["Ship Date"]'), viewer);
+                    await page.evaluate(element => element.setAttribute("columns", '["Sales", "Profit"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await page.waitFor(
+                        element => {
+                            let elem = element.shadowRoot.querySelector("perspective-d3fc-chart").shadowRoot.querySelector(".top");
+                            if (elem) {
+                                return elem.textContent === "6/14/2011, 12:00:00 AM";
+                            }
+                        },
+                        {},
+                        viewer
+                    );
+                },
+                {preserve_hover: true}
+            );
+
+            test.run("treemap parent button shows formatted date", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.evaluate(element => element.setAttribute("row-pivots", '["Ship Date", "City"]'), viewer);
+                await page.evaluate(element => element.setAttribute("columns", '["Sales", "Profit"]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.mouse.click(500, 200);
+                const result = await page.waitFor(
+                    element => {
+                        let elem = element.shadowRoot.querySelector("perspective-d3fc-chart").shadowRoot.querySelector("#goto-parent");
+                        if (elem) {
+                            return elem.textContent.includes("9/21/2012, 12:00:00 AM");
+                        }
+                    },
+                    {},
+                    viewer
+                );
+                return !!result;
+            });
         },
         {reload_page: false, root: path.join(__dirname, "..", "..", "..")}
     );

--- a/packages/perspective-viewer-d3fc/test/js/unit/tooltip/generateHTML.spec.js
+++ b/packages/perspective-viewer-d3fc/test/js/unit/tooltip/generateHTML.spec.js
@@ -8,6 +8,7 @@
  */
 import {select} from "d3";
 import {generateHtml} from "../../../../src/js/tooltip/generateHTML";
+import {get_type_config} from "@finos/perspective/dist/esm/config";
 
 describe("tooltip generateHTML should", () => {
     let tooltip = null;
@@ -61,7 +62,7 @@ describe("tooltip generateHTML should", () => {
             mainValue: testDate.getTime()
         };
         generateHtml(tooltip, data, settings);
-        expect(getContent()).toEqual([`main-1: ${testDate.toLocaleString()}`]);
+        expect(getContent()).toEqual([`main-1: ${testDate.toLocaleString("en-us", get_type_config("datetime").format)}`]);
     });
 
     test("format mainValue as integer", () => {

--- a/packages/perspective-viewer-d3fc/test/results/linux.docker.json
+++ b/packages/perspective-viewer-d3fc/test/results/linux.docker.json
@@ -1,7 +1,7 @@
 {
     "candlestick_filter_by_a_single_instrument_": "f988ca6494d7a36bada09928cd1a544e",
     "candlestick_filter_to_date_range_": "8ca4da0a6229d4f9db4a845d5d415c20",
-    "__GIT_COMMIT__": "66c751c99ac69898969049e164e63bb368e877dd",
+    "__GIT_COMMIT__": "199af527de833da4f5865d57570aae55f8a18849",
     "ohlc_filter_by_a_single_instrument_": "0110fac1f2befac1b97a9d33f0022acf",
     "ohlc_filter_to_date_range_": "3ec466996be47e2c8df135a4303bf383",
     "scatter_shows_a_grid_without_any_settings_applied_": "8677946ab48f16a376c421500d59e6c0",
@@ -126,5 +126,7 @@
     "treemap_displays_visible_columns_": "62996aa87b1237b0be568a339a700bdf",
     "treemap_with_column_position_1_set_to_null_": "a2f594ff864fb673cde708e4533d8edc",
     "treemap_tooltip_columns_works": "9b3a44cc1b4b1d11cb8b635c850a0612",
-    "line_Sets_a_category_axis_when_pivoted_by_a_computed_datetime": "eb1c86dc44988ad9a65fdd5a335850b8"
+    "line_Sets_a_category_axis_when_pivoted_by_a_computed_datetime": "eb1c86dc44988ad9a65fdd5a335850b8",
+    "sunburst_sunburst_label_shows_formatted_date": "590f474e076fd49ce10eb5e97bfc66d3",
+    "treemap_treemap_label_shows_formatted_date": "6c39c766e14c64c28316137f5f1ff85b"
 }


### PR DESCRIPTION
# Bugfix

#1144 reports an issue where date labels were not correctly formatted in the d3fc package. Treedata has been modified to add a new attribute `label` which is a properly formatted value. 

## Testing

JS tests added to check dates are displayed with consistent format for Treemap and Sunburst. Additionally a test was updated to check for a consistent format which was used in the highcharts package. 

## Screenshots (if appropriate)

<img width="1556" alt="Screenshot 2020-08-25 at 16 41 38" src="https://user-images.githubusercontent.com/19375110/91196372-f4fdc500-e6f1-11ea-9b4e-0206820175d7.png">

<img width="1673" alt="Screenshot 2020-08-25 at 16 42 02" src="https://user-images.githubusercontent.com/19375110/91196366-f4652e80-e6f1-11ea-94b2-36efdc2a760e.png">

## Checklist

- [X] I have read the [`CONTRIBUTING.md`](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md) and followed its [Guidelines](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md#guidelines)
- [X] I have linted my code locally, following the project's code style
- [X] I have tested my changes locally, and changes pass on the Azure Pipelines CI.