### PR TITLE
Fix `perspective-viewer-datagrid` sorting

### DIFF
--- a/packages/perspective-viewer-datagrid/package.json
+++ b/packages/perspective-viewer-datagrid/package.json
@@ -41,7 +41,7 @@
     "dependencies": {
         "@finos/perspective": "^0.5.2",
         "@finos/perspective-viewer": "^0.5.2",
-        "regular-table": "=0.1.0"
+        "regular-table": "=0.1.2"
     },
     "devDependencies": {
         "@finos/perspective-test": "^0.5.2",

--- a/packages/perspective-viewer-datagrid/src/js/sorting.js
+++ b/packages/perspective-viewer-datagrid/src/js/sorting.js
@@ -1,0 +1,15 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+export async function configureSortable(table, viewer) {
+    table.addEventListener("regular-table-psp-sort", event => {
+        this._preserve_focus_state = true;
+        viewer.setAttribute("sort", JSON.stringify(event.detail.sort));
+    });
+}

--- a/packages/perspective-viewer-datagrid/src/less/regular_table.less
+++ b/packages/perspective-viewer-datagrid/src/less/regular_table.less
@@ -4,7 +4,7 @@
 // Row Selection
 
 .psp-row-selected, :hover .psp-row-selected, :hover th.psp-tree-leaf.psp-row-selected, :hover th.psp-tree-label.psp-row-selected {
-    color: black;
+    color: black !important;
     background-color: #EA7319;
 }
 

--- a/packages/perspective-viewer-datagrid/test/results/linux.docker.json
+++ b/packages/perspective-viewer-datagrid/test/results/linux.docker.json
@@ -2,9 +2,9 @@
     "superstore_shows_a_grid_without_any_settings_applied_": "7e269a544b300a204b82806f32bef31b",
     "superstore_pivots_by_a_row_": "45732744b55570c0d6ae259995314993",
     "superstore_pivots_by_two_rows_": "9299f948162b52456632c15e5557f0ad",
-    "superstore_pivots_by_a_column_": "8f064a78e0b77f505632df053317a806",
-    "superstore_pivots_by_a_row_and_a_column_": "c3cd66b434ae463f556fd3ab429d4f2a",
-    "superstore_pivots_by_two_rows_and_two_columns_": "e41f9e68ffb485b8fc873d044609f074",
+    "superstore_pivots_by_a_column_": "16428aad191cd57d298dd16792acecd8",
+    "superstore_pivots_by_a_row_and_a_column_": "0f83cf1e9aaf52e844cca53dca916aca",
+    "superstore_pivots_by_two_rows_and_two_columns_": "c3bd79f2b0226a859528fdc12f3ca7f2",
     "superstore_sorts_by_a_hidden_column_": "db8f68509cf1bcf0c10e95b1a08471e0",
     "superstore_sorts_by_a_numeric_column_": "880ea680df9bc48415450553735c2a6c",
     "superstore_filters_by_a_numeric_column_": "45d824114c57a56b990fe637f5514330",
@@ -12,7 +12,7 @@
     "superstore_highlights_invalid_filter_": "452e3d6d1fb9fcb18bfc6a3b6ef021ff",
     "superstore_sorts_by_an_alpha_column_": "7d4a5cde8d795e020eec5e27763eacbd",
     "superstore_displays_visible_columns_": "99025a1343a80e95a75f01b3d45b5a31",
-    "superstore_resets_viewable_area_when_the_logical_size_expands_": "e0dcc4db517a7ff5471f27301aaceb29",
+    "superstore_resets_viewable_area_when_the_logical_size_expands_": "8ee16c0af95c89d7cbd3987d454a3dfd",
     "superstore_resets_viewable_area_when_the_physical_size_expands_": "7e269a544b300a204b82806f32bef31b",
-    "__GIT_COMMIT__": "a2058151a6a015cab55cad18a4990d96603dbe9a"
+    "__GIT_COMMIT__": "149e29ceb2f1542785b1328248048b2d1de298cb"
 }

--- a/packages/perspective-workspace/test/results/linux.docker.json
+++ b/packages/perspective-workspace/test/results/linux.docker.json
@@ -2,7 +2,7 @@
     "index_restore_workspace_with_detail_only": "b4707075b304f6aae823e30fc39a46d8",
     "index_restore_workspace_with_master_only": "9542d628f04cd89eabb1de2f346b4dd9",
     "index_restore_workspace_with_master_and_detail": "dfb034e51fe36b06e00bc90da140600a",
-    "__GIT_COMMIT__": "8235d1a96e737d73d580eccc18a7138b591ca138",
+    "__GIT_COMMIT__": "149e29ceb2f1542785b1328248048b2d1de298cb",
     "index_HTML_Create_One": "ef6c0b0cee3186584b17e3a86a5bdcf4",
     "index_HTML_Create_Multiple": "403c96829b89027a913430c699a27e51",
     "index_HTML_Create_multiple_with_names": "92d37a6fb3e606bd3ffad77f1fc2d801",
@@ -12,7 +12,7 @@
     "index_appendChild_With_name": "b4707075b304f6aae823e30fc39a46d8",
     "index_appendChild_Without_slot": "ef6c0b0cee3186584b17e3a86a5bdcf4",
     "index_restore_workspace_with_viewers_with_generated_slotids": "01600335e464a4080e2215fb2f56beae",
-    "index_restore_workspace_in_linked_mode": "ffba0d7e5b2dc3961207339d63f05e62",
+    "index_restore_workspace_in_linked_mode": "591a61cc194e66b71e5dfaef62325094",
     "index_selection_is_disabled_if_no_linked_viewers": "e0851bc64139c5c3dd8cb424e74baf9d",
     "index_selection_is_disabled_if_grid_has_no_row-pivots": "0a91a427603a348101cc932c52127b03"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12632,10 +12632,10 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-regular-table@=0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.1.0.tgz#47044a10707a7549cbd4cfa50389baf4f2e727b5"
-  integrity sha512-GNQizd1tPoijJ7vWu+yBafTzskDv981MMOJ96zpuXZEuVc5hSM0XPrn7mD0dIAlcU/6HhLFoFOtdsBLTJ26NZQ==
+regular-table@=0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.1.2.tgz#75c56bc8c0eaea39a07becd168f5fc1e35fd6653"
+  integrity sha512-+P2veAk6TmDkY1d6ssBDm+K9XZna9KHrlq8r6ZxEV1+tZ2Xy7nWq8ySTOu++tyKEWMOyR0e2HfmKbSPFxdHPBw==
 
 relateurl@0.2.x:
   version "0.2.7"


### PR DESCRIPTION
This PR fixes the click-to-sort feature of `@finos/perspective-viewer-datagrid` to use the API of the `<perspective-viewer>` element in which it is embedded to create a new `View()`, rather than invoking one directly, using coordinated `regular-table` fix from version `0.1.1`.