### PR TITLE
`perspective-workspace` CSS fixes

### DIFF
--- a/examples/remote-workspace/src/index.js
+++ b/examples/remote-workspace/src/index.js
@@ -18,7 +18,7 @@ window.addEventListener("load", () => {
     const websocket = perspective.websocket("ws://localhost:8080");
     const worker = perspective.shared_worker();
     const view = websocket.open_view("securities");
-    const table = worker.table(view);
+    const table = worker.table(view, {limit: 10000});
 
     const workspace = document.createElement("perspective-workspace");
     document.body.appendChild(workspace);

--- a/packages/perspective-viewer/src/config/umd.config.js
+++ b/packages/perspective-viewer/src/config/umd.config.js
@@ -33,7 +33,6 @@ module.exports = common({}, config => {
                 for (const theme of THEMES) {
                     try_delete(theme.replace("less", "js"));
                     try_delete(theme.replace("less", "js.map"));
-                    try_delete(theme.replace("less", "css.map"));
                 }
             });
         }

--- a/packages/perspective-viewer/src/less/viewer.less
+++ b/packages/perspective-viewer/src/less/viewer.less
@@ -426,7 +426,11 @@
     }
 
     :hover::-webkit-scrollbar-thumb {
-        background-color: rgba(0, 0, 0, 0.3);
+        background-color: rgba(0,0,0,0.15);
+    }
+    
+    :hover::-webkit-scrollbar-thumb:hover {
+        background-color: rgba(0,0,0,0.3);
     }
 
     ::-webkit-scrollbar-thumb {

--- a/packages/perspective-workspace/src/less/menu.less
+++ b/packages/perspective-workspace/src/less/menu.less
@@ -91,6 +91,10 @@
     background: #e5e5e5;
 }
 
+.p-Menu.workspace-master-menu .p-Menu-item.p-mod-active {
+    background: #555;
+}
+
 .p-MenuBar.p-mod-active .p-MenuBar-item.p-mod-active {
     z-index: 10001;
     background: white;

--- a/packages/perspective-workspace/src/less/tabbar.less
+++ b/packages/perspective-workspace/src/less/tabbar.less
@@ -317,5 +317,9 @@
 
 .perspective-workspace.context-menu * .p-TabBar {
     opacity: 0.2;
+}
+
+.perspective-workspace .p-TabBar {
     transition: opacity 0.2s ease-out;
 }
+

--- a/packages/perspective/src/js/api/server.js
+++ b/packages/perspective/src/js/api/server.js
@@ -154,7 +154,7 @@ export class Server {
                         if (msg.args && msg.args[0]) {
                             if (msg.method === "on_update" && msg.args[0]["mode"] === "row") {
                                 // actual arrow is in the `delta`
-                                this.post(result, ev.delta);
+                                this.post(result, [ev.delta]);
                                 return;
                             }
                         }


### PR DESCRIPTION
* Fixes #1013 
* Lightens scrollbar styling.
* Fixes `perspective-workspace` context menu color when invoked over global filter (e.g. in dark theme).
* Fixes a theme quirk that causes `perspective-workspace` tab bars to flash when the context menu is invoked.
* Fixes node.js `remote-workspace` example.

