### PR TITLE
Server mode for Jupyterlab `PerspectiveWidget`

### DIFF
--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -25,7 +25,7 @@
         "bench:run": "echo \"No Benchmarks\"",
         "clean:screenshots": "rimraf \"screenshots/**/*.@(failed|diff).png\"",
         "test:build": "cpx \"test/html/*\" dist/umd && cpx \"test/csv/*\" dist/umd && cpx \"test/css/*\" dist/umd && webpack --color --config src/config/webpack.config.js",
-        "test:run": "jest --rootDir=. --config=../perspective-test/jest.config.js --color --verbose",
+        "test:run": "jest --rootDir=. --config=test/config/jest.config.js --color --verbose",
         "test": "npm-run-all test:build test:run",
         "build": "webpack --color --config src/config/plugin.config.js",
         "clean": "rimraf dist",
@@ -43,6 +43,7 @@
     "devDependencies": {
         "@finos/perspective-test": "^0.5.3",
         "@finos/perspective-webpack-plugin": "^0.5.3",
+        "@jupyter-widgets/base-manager": "^1.0.0-alpha.0",
         "@types/jest": "^23.3.9",
         "@types/node": "^11.11.0",
         "file-loader": "^0.11.1",
@@ -50,7 +51,7 @@
         "isomorphic-fetch": "^2.2.1",
         "jest-transform-css": "^2.0.0",
         "source-map-support": "^0.5.9",
-        "ts-jest": "^24.1.0",
+        "ts-jest": "^25.1.0",
         "typescript": "^3.7.4"
     },
     "jupyterlab": {

--- a/packages/perspective-jupyterlab/src/less/index.less
+++ b/packages/perspective-jupyterlab/src/less/index.less
@@ -1,6 +1,6 @@
 @import "~@finos/perspective-viewer/src/less/fonts.less";
-@import (reference) "~@finos/perspective-viewer/src/themes/material.less";
-@import (reference) "~@finos/perspective-viewer/src/themes/material.dark.less";
+@import (reference) "~@finos/perspective-viewer/src/themes/material-dense.less";
+@import (reference) "~@finos/perspective-viewer/src/themes/material-dense.dark.less";
 
 div.PSPContainer,
 div.PSPContainer-dark {
@@ -14,15 +14,17 @@ div.PSPContainer-dark {
 
 .jp-NotebookPanel-notebook div.PSPContainer,
 .jp-NotebookPanel-notebook div.PSPContainer-dark {
-    height: 500px;
+    height: 520px;
 }
 
 div.PSPContainer perspective-viewer {
-    .perspective-viewer-material();
+    .perspective-viewer-material-dense();
+    --plugin--border: 1px solid #e0e0e0;
 }
 
 div.PSPContainer-dark perspective-viewer {
-    .perspective-viewer-material-dark();
+    .perspective-viewer-material-dense-dark();
+    --plugin--border: 1px solid #333333;
 }
 
 div.PSPContainer perspective-viewer,

--- a/packages/perspective-jupyterlab/src/less/index.less
+++ b/packages/perspective-jupyterlab/src/less/index.less
@@ -8,8 +8,13 @@ div.PSPContainer-dark {
     resize: both;
     padding-right: 5px;
     padding-bottom: 5px;
-    height: 500px;
+    height: 100%;
     flex: 1;
+}
+
+.jp-NotebookPanel-notebook div.PSPContainer,
+.jp-NotebookPanel-notebook div.PSPContainer-dark {
+    height: 500px;
 }
 
 div.PSPContainer perspective-viewer {

--- a/packages/perspective-jupyterlab/src/ts/model.ts
+++ b/packages/perspective-jupyterlab/src/ts/model.ts
@@ -14,6 +14,7 @@ import {PERSPECTIVE_VERSION} from "./version";
  * TODO: document
  */
 export class PerspectiveModel extends DOMWidgetModel {
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     defaults() {
         return {
             ...super.defaults(),
@@ -35,6 +36,7 @@ export class PerspectiveModel extends DOMWidgetModel {
             plugin_config: {},
             dark: false,
             editable: false,
+            server: false,
             client: false
         };
     }

--- a/packages/perspective-jupyterlab/test/config/jest.config.js
+++ b/packages/perspective-jupyterlab/test/config/jest.config.js
@@ -1,0 +1,18 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+const main_config = require("../../../perspective-test/jest.config.js");
+
+// Define a custom Jest config that properly transforms Typescript source files
+// and works with the main `perspective-test` Jest config.
+module.exports = Object.assign(main_config, {
+    transform: Object.assign(main_config.transform, {
+        "^.+\\.ts?$": "ts-jest"
+    }),
+    transformIgnorePatterns: ["/node_modules/(?!(lit-html|@jupyter-widgets)/).+\\.js"]
+});

--- a/packages/perspective-jupyterlab/test/js/mocks/manager.js
+++ b/packages/perspective-jupyterlab/test/js/mocks/manager.js
@@ -1,0 +1,175 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+import {PerspectiveModel} from "../../../src/ts/model";
+import {PerspectiveView} from "../../../src/ts/view";
+import {PerspectiveJupyterWidget} from "../../../src/ts/widget";
+import {ManagerBase} from "@jupyter-widgets/base-manager";
+import {uuid} from "@jupyter-widgets/base";
+
+jest.mock("../../../src/ts/widget");
+
+let numComms = 0;
+
+// Duplicated from `@jupyter-widgets`
+export class MockComm {
+    comm_id = undefined;
+    target_name = undefined;
+    _on_msg = undefined;
+    _on_open = undefined;
+    _on_close = undefined;
+
+    constructor() {
+        this.comm_id = `mock-comm-id-${numComms}`;
+        numComms += 1;
+    }
+
+    on_open(fn) {
+        this._on_open = fn;
+    }
+
+    on_close(fn) {
+        this._on_close = fn;
+    }
+
+    on_msg(fn) {
+        this._on_msg = fn;
+    }
+
+    _process_msg(msg) {
+        if (this._on_msg) {
+            return this._on_msg(msg);
+        } else {
+            return Promise.resolve();
+        }
+    }
+
+    open() {
+        if (this._on_open) {
+            this._on_open();
+        }
+        return "";
+    }
+
+    close() {
+        if (this._on_close) {
+            this._on_close();
+        }
+        return "";
+    }
+
+    send() {
+        return "";
+    }
+}
+
+export class MockManager extends ManagerBase {
+    constructor() {
+        super();
+        this.el = window.document.createElement("div");
+    }
+
+    create_view(model) {
+        const id = uuid();
+        const view_promise = async () => {
+            const view = new PerspectiveView({
+                model: model
+            });
+            view.listenTo(model, "destroy", view.remove);
+            view.once("remove", () => {
+                delete model.views[id];
+            });
+
+            return view;
+        };
+        model.views[id] = view_promise;
+        return view_promise;
+    }
+
+    loadClass(className, moduleName, moduleVersion) {
+        return new Promise(function(resolve) {
+            if (moduleName === "@finos/perspective-jupyterlab") {
+                resolve(PerspectiveJupyterWidget);
+            }
+        }).then(function(module) {
+            if (module[className]) {
+                return module[className];
+            } else {
+                return Promise.reject(`Class ${className} not found in module ${moduleName}@${moduleVersion}`);
+            }
+        });
+    }
+
+    get_model(model_id) {
+        return this._models[model_id];
+    }
+
+    register_model(model_id, modelPromise) {
+        this._models[model_id] = modelPromise;
+        modelPromise.then(model => {
+            model.once("comm:close", () => {
+                delete this._models[model_id];
+            });
+        });
+    }
+
+    /**
+     * Create and return a promise for a new widget model
+     *
+     * @param options - the options for creating the model.
+     * @param serialized_state - attribute values for the model.
+     *
+     * @example
+     * widget_manager.new_model({
+     *      model_name: 'IntSlider',
+     *      model_module: '@jupyter-widgets/controls',
+     *      model_module_version: '1.0.0',
+     *      model_id: 'u-u-i-d'
+     * }).then((model) => { console.log('Create success!', model); },
+     *  (err) => {console.error(err)});
+     *
+     */
+    async new_model(options, serialized_state) {
+        let model_id;
+        if (options.model_id) {
+            model_id = options.model_id;
+        } else if (options.comm) {
+            model_id = options.model_id = options.comm.comm_id;
+        } else {
+            throw new Error("Neither comm nor model_id provided in options object. At least one must exist.");
+        }
+
+        const modelPromise = this._make_model(options, serialized_state);
+        // this call needs to happen before the first `await`, see note in `set_state`:
+        this.register_model(model_id, modelPromise);
+        return await modelPromise;
+    }
+
+    async _make_model(options, serialized_state) {
+        const model_id = options.model_id;
+        const model_type = await Promise.resolve(PerspectiveModel);
+        const attributes = await model_type._deserialize_state(serialized_state, this);
+        const model_options = {
+            widget_manager: this,
+            model_id: model_id,
+            comm: options.comm
+        };
+        const widget_model = new model_type(attributes, model_options);
+        widget_model.name = options.model_name;
+        widget_model.module = options.model_module;
+        return widget_model;
+    }
+
+    _get_comm_info() {
+        return Promise.resolve({});
+    }
+
+    _create_comm() {
+        return Promise.resolve(new MockComm());
+    }
+}

--- a/packages/perspective-jupyterlab/test/js/unit/client.spec.js
+++ b/packages/perspective-jupyterlab/test/js/unit/client.spec.js
@@ -1,0 +1,53 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+import {PerspectiveJupyterClient} from "../../../src/ts/client";
+import * as widget_base from "@jupyter-widgets/base";
+
+/**
+ * Decouple the client's view from PerspectiveView, and allow the client
+ * to assert message correctness.
+ */
+export class MockWidgetView extends widget_base.WidgetView {
+    constructor(expected_message) {
+        super({});
+        this.expected_message = expected_message;
+    }
+    send(msg) {
+        expect(msg).toEqual(this.expected_message);
+    }
+}
+
+describe("PerspectiveJupyterClient", () => {
+    /**
+     * Make sure the message schema between the widget and kernel can't be
+     * arbitarily changed without a test failure.
+     *
+     * FIXME: fails because `super()` in `client.ts:41:9` is not correctly
+     * transpiled.
+     */
+    it.skip("Should serialize a message into the correct specification", () => {
+        const msg = {
+            id: 1,
+            cmd: "table_method",
+            name: "table",
+            method: "schema",
+            args: [],
+            subscribe: false
+        };
+
+        const mock_view = new MockWidgetView({
+            id: 1,
+            type: "cmd",
+            data: JSON.stringify(msg)
+        });
+
+        const client = new PerspectiveJupyterClient(mock_view);
+        client.send(msg);
+    });
+});

--- a/packages/perspective-jupyterlab/test/js/unit/view.spec.js
+++ b/packages/perspective-jupyterlab/test/js/unit/view.spec.js
@@ -1,0 +1,466 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+import {MockManager} from "../mocks/manager";
+import {PerspectiveJupyterClient} from "../../../src/ts/client";
+import {PerspectiveJupyterWidget} from "../../../src/ts/widget";
+import {uuid} from "@jupyter-widgets/base";
+
+// Mock the client so we can see what send() was called with.
+jest.mock("../../../src/ts/client");
+
+// Mock the widget so we can track its state changes on the view.
+jest.mock("../../../src/ts/widget");
+
+describe("PerspectiveView", function() {
+    describe("_handle_message", function() {
+        let manager, model, view;
+
+        beforeEach(async function() {
+            PerspectiveJupyterClient.mockClear();
+            PerspectiveJupyterWidget.mockClear();
+            manager = new MockManager();
+            model = await manager.new_model({
+                model_name: "PerspectiveModel",
+                model_module: "@finos/perspective-jupyterlab",
+                model_module_version: "",
+                view_name: "PerspectiveView",
+                view_module: "@finos/perspective-jupyterlab",
+                view_module_version: "",
+                model_id: "test_widget"
+            });
+        });
+
+        /**
+         * Assert that the message schema in the widget translates properly
+         * to the client, and that the client is able to process the messages.
+         */
+        it("Should handle a well-formed data message from the kernel", async function() {
+            view = await manager.create_view(model)();
+            view._handle_message({
+                id: 1,
+                type: "cmd",
+                data: {
+                    a: "integer",
+                    b: "string",
+                    c: "datetime",
+                    d: "date",
+                    e: "float"
+                }
+            });
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+            const handle_arg = mock_client._handle.mock.calls[0][0];
+            expect(handle_arg).toEqual({
+                id: 1,
+                data: {
+                    a: "integer",
+                    b: "string",
+                    c: "datetime",
+                    d: "date",
+                    e: "float"
+                }
+            });
+        });
+
+        /**
+         * Assert that the message for loading a remote table or view work
+         * properly.
+         */
+        it("Should handle a well-formed table message from the kernel in server mode", async function() {
+            const table_name = uuid();
+            view = await manager.create_view(model)();
+            view.pWidget.server = true;
+            view._handle_message({
+                id: -2,
+                type: "table",
+                data: {
+                    table_name: table_name
+                }
+            });
+
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+
+            // `open_table` should be called correctly
+            const open_table_arg = mock_client.open_table.mock.calls[0][0];
+            expect(open_table_arg).toEqual(table_name);
+
+            const send_arg = mock_client.send.mock.calls[0][0];
+            expect(send_arg).toEqual({
+                id: -1,
+                cmd: "init"
+            });
+        });
+
+        it("Should handle a well-formed table/view message from the kernel", async function() {
+            const table_name = uuid();
+            const view_name = uuid();
+            view = await manager.create_view(model)();
+            view._handle_message({
+                id: -2,
+                type: "table",
+                data: {
+                    table_name: table_name,
+                    view_name: view_name
+                }
+            });
+
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+
+            // `open_view` should be called correctly
+            const open_view_arg = mock_client.open_view.mock.calls[0][0];
+            expect(open_view_arg).toEqual(view_name);
+
+            const send_arg = mock_client.send.mock.calls[0][0];
+            expect(send_arg).toEqual({
+                id: -1,
+                cmd: "init"
+            });
+        });
+
+        it("Should handle a well-formed table/view message with index from the kernel", async function() {
+            const table_name = uuid();
+            const view_name = uuid();
+            view = await manager.create_view(model)();
+            view._handle_message({
+                id: -2,
+                type: "table",
+                data: {
+                    table_name: table_name,
+                    view_name: view_name,
+                    options: {
+                        index: "a"
+                    }
+                }
+            });
+
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+
+            // `open_view` should be called correctly
+            const open_view_arg = mock_client.open_view.mock.calls[0][0];
+            expect(open_view_arg).toEqual(view_name);
+
+            const send_arg = mock_client.send.mock.calls[0][0];
+            expect(send_arg).toEqual({
+                id: -1,
+                cmd: "init"
+            });
+        });
+
+        it("Should handle a well-formed view message with limit from the kernel", async function() {
+            const table_name = uuid();
+            const view_name = uuid();
+            view = await manager.create_view(model)();
+            view._handle_message({
+                id: -2,
+                type: "table",
+                data: {
+                    table_name: table_name,
+                    view_name: view_name,
+                    options: {
+                        limit: 1000
+                    }
+                }
+            });
+
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+
+            // `open_view` should be called correctly
+            const open_view_arg = mock_client.open_view.mock.calls[0][0];
+            expect(open_view_arg).toEqual(view_name);
+
+            const send_arg = mock_client.send.mock.calls[0][0];
+            expect(send_arg).toEqual({
+                id: -1,
+                cmd: "init"
+            });
+        });
+
+        it("Should handle a message containing an Arrow from the kernel", async function() {
+            const arrow = new ArrayBuffer(24);
+            const to_arrow_pre_msg = {
+                id: 1,
+                cmd: "view_method",
+                is_transferable: true,
+                method: "to_arrow",
+                name: "view",
+                subscribe: false
+            };
+
+            view = await manager.create_view(model)();
+
+            // Two messages are sent by the server: the first being the
+            // original message with `is_transferable` set to true,
+            // and the second the binary itself with the message as `null`.
+            view._handle_message({
+                id: 1,
+                type: "cmd",
+                data: to_arrow_pre_msg
+            });
+
+            expect(view._pending_arrow).toEqual(1);
+
+            view._handle_message(null, [new DataView(arrow)]);
+
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+
+            // _handle should only be called once with the binary result
+            expect(mock_client._handle.mock.calls.length).toEqual(1);
+
+            const handle_arg = mock_client._handle.mock.calls[0][0];
+            expect(handle_arg).toEqual({
+                id: 1,
+                data: {
+                    id: 1,
+                    data: arrow
+                }
+            });
+
+            // Arrow should not be transferred/dereferenced by the widget.
+            expect(arrow.byteLength).toEqual(24);
+        });
+
+        it("Should handle a message containing an Arrow from `on_update` from the kernel", async function() {
+            const arrow = new ArrayBuffer(1024);
+            const on_update_pre_msg = {
+                id: 1,
+                cmd: "view_method",
+                is_transferable: true,
+                data: {
+                    port_id: 123
+                }
+            };
+
+            view = await manager.create_view(model)();
+
+            // Two messages are sent by the server: the first being the
+            // original message with `is_transferable` set to true,
+            // and the second the binary itself with the message as `null`.
+            view._handle_message({
+                id: 1,
+                type: "cmd",
+                data: on_update_pre_msg
+            });
+
+            expect(view._pending_arrow).toEqual(1);
+            expect(view._pending_port_id).toEqual(123);
+
+            view._handle_message(null, [new DataView(arrow)]);
+
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+
+            // _handle should only be called once with the binary result
+            expect(mock_client._handle.mock.calls.length).toEqual(1);
+
+            const handle_arg = mock_client._handle.mock.calls[0][0];
+            expect(handle_arg).toEqual({
+                id: 1,
+                data: {
+                    id: 1,
+                    data: {
+                        port_id: 123,
+                        delta: arrow
+                    }
+                }
+            });
+
+            // Arrow should not be transferred/dereferenced by the widget.
+            expect(arrow.byteLength).toEqual(1024);
+        });
+
+        it("Should correctly delete", async function() {
+            view = await manager.create_view(model)();
+
+            const msg = {
+                id: 1,
+                type: "cmd",
+                data: {
+                    cmd: "delete"
+                }
+            };
+
+            view._handle_message(msg);
+
+            const widget_mock = PerspectiveJupyterWidget.mock.instances[0];
+            expect(widget_mock.delete.mock.calls.length).toEqual(1);
+        });
+
+        describe("Client mode", function() {
+            let manager, client_model, client_view;
+
+            beforeEach(async function() {
+                PerspectiveJupyterClient.mockClear();
+                PerspectiveJupyterWidget.mockClear();
+                manager = new MockManager();
+                client_model = await manager.new_model({
+                    model_name: "PerspectiveModel",
+                    model_module: "@finos/perspective-jupyterlab",
+                    model_module_version: "",
+                    view_name: "PerspectiveView",
+                    view_module: "@finos/perspective-jupyterlab",
+                    view_module_version: "",
+                    model_id: "test_widget"
+                });
+                client_model.set("client", true);
+            });
+
+            it("Should correctly load a dataset", async function() {
+                client_view = await manager.create_view(client_model)();
+
+                // manually set client to true - it is derived from the widget
+                // init state with the model, and we just care about view
+                // behavior here.
+                client_view.pWidget.client = true;
+
+                // Data is automatically serialized to JSON in the kernel and
+                // un-serialized to an object in JS.
+                const data = {
+                    a: [1, 2, 3, 4],
+                    b: [new Date(), new Date(), new Date(), new Date()],
+                    c: ["a", "b", "c", "d"]
+                };
+
+                const msg = {
+                    id: -2,
+                    type: "table",
+                    data: {
+                        data: data
+                    }
+                };
+
+                client_view._handle_message(msg);
+
+                const widget_mock = PerspectiveJupyterWidget.mock.instances[0];
+                const load_args = widget_mock.load.mock.calls[0][0];
+
+                expect(load_args).toEqual(data);
+            });
+
+            it("Should correctly load a dataset with options", async function() {
+                client_view = await manager.create_view(client_model)();
+                client_view.pWidget.client = true;
+                const data = {
+                    a: [1, 2, 3, 4],
+                    b: [new Date(), new Date(), new Date(), new Date()],
+                    c: ["a", "b", "c", "d"]
+                };
+                const options = {
+                    index: "a"
+                };
+                const msg = {
+                    id: -2,
+                    type: "table",
+                    data: {
+                        data: data,
+                        options: options
+                    }
+                };
+
+                client_view._handle_message(msg);
+
+                const widget_mock = PerspectiveJupyterWidget.mock.instances[0];
+                const load_args = widget_mock.load.mock.calls[0];
+
+                expect(load_args[0]).toEqual(data);
+                expect(load_args[1]).toEqual(options);
+            });
+
+            it("Should correctly update a dataset", async function() {
+                client_view = await manager.create_view(client_model)();
+                client_view.pWidget.client = true;
+
+                const data = {
+                    a: [1, 2, 3, 4],
+                    b: [new Date(), new Date(), new Date(), new Date()],
+                    c: ["a", "b", "c", "d"]
+                };
+
+                const msg = {
+                    id: null,
+                    type: "cmd",
+                    data: {
+                        cmd: "update",
+                        data: data
+                    }
+                };
+
+                client_view._handle_message(msg);
+
+                const widget_mock = PerspectiveJupyterWidget.mock.instances[0];
+                const update_args = widget_mock._update.mock.calls[0];
+
+                expect(update_args[0]).toEqual(data);
+            });
+
+            it("Should correctly replace a dataset", async function() {
+                client_view = await manager.create_view(client_model)();
+                client_view.pWidget.client = true;
+
+                const data = {
+                    a: [1, 2, 3, 4],
+                    b: [new Date(), new Date(), new Date(), new Date()],
+                    c: ["a", "b", "c", "d"]
+                };
+
+                const msg = {
+                    id: null,
+                    type: "cmd",
+                    data: {
+                        id: null,
+                        cmd: "replace",
+                        data: data
+                    }
+                };
+
+                client_view._handle_message(msg);
+
+                const widget_mock = PerspectiveJupyterWidget.mock.instances[0];
+                const replace_args = widget_mock.replace.mock.calls[0];
+
+                expect(replace_args[0]).toEqual(data);
+            });
+
+            it("Should correctly clear", async function() {
+                client_view = await manager.create_view(client_model)();
+                client_view.pWidget.client = true;
+
+                const msg = {
+                    id: null,
+                    type: "cmd",
+                    data: {
+                        id: null,
+                        cmd: "clear"
+                    }
+                };
+
+                client_view._handle_message(msg);
+
+                const widget_mock = PerspectiveJupyterWidget.mock.instances[0];
+                expect(widget_mock.clear.mock.calls.length).toEqual(1);
+            });
+
+            it("Should correctly delete", async function() {
+                client_view = await manager.create_view(client_model)();
+                client_view.pWidget.client = true;
+
+                const msg = {
+                    id: null,
+                    type: "cmd",
+                    data: {
+                        id: null,
+                        cmd: "delete"
+                    }
+                };
+
+                client_view._handle_message(msg);
+
+                const widget_mock = PerspectiveJupyterWidget.mock.instances[0];
+                expect(widget_mock.delete.mock.calls.length).toEqual(1);
+            });
+        });
+    });
+});

--- a/packages/perspective-test/jest.all.config.js
+++ b/packages/perspective-test/jest.all.config.js
@@ -11,13 +11,17 @@ module.exports = {
     testURL: "http://localhost/",
     transform: {
         ".js$": "@finos/perspective-test/src/js/transform.js",
-        ".html$": "html-loader-jest"
+        ".html$": "html-loader-jest",
+        // Transform typescript for perspective-jupyterlab
+        ".ts": "ts-jest"
     },
     collectCoverage: true,
     collectCoverageFrom: ["packages/perspective/dist/cjs/**"],
     coverageProvider: "v8",
     coverageReporters: ["cobertura", "text"],
-    transformIgnorePatterns: ["/node_modules/(?!lit-html).+$"],
+    // perspective-jupyterlab tests mock `@jupyter-widgets`, which is in
+    // Typescript.
+    transformIgnorePatterns: ["/node_modules/(?!(lit-html|@jupyter-widgets)/).+$"],
     automock: false,
     setupFiles: ["@finos/perspective-test/src/js/beforeEachSpec.js"],
     reporters: ["default", "@finos/perspective-test/src/js/reporter.js", "jest-junit"],

--- a/packages/perspective-test/jest.config.js
+++ b/packages/perspective-test/jest.config.js
@@ -1,3 +1,11 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
 module.exports = {
     // rootDir: "../",
     roots: ["test/js/"],

--- a/packages/perspective-viewer-datagrid/package.json
+++ b/packages/perspective-viewer-datagrid/package.json
@@ -41,7 +41,7 @@
     "dependencies": {
         "@finos/perspective": "^0.5.3",
         "@finos/perspective-viewer": "^0.5.3",
-        "regular-table": "=0.1.3"
+        "regular-table": "=0.1.4"
     },
     "devDependencies": {
         "@finos/perspective-test": "^0.5.3",

--- a/packages/perspective-viewer/index.d.ts
+++ b/packages/perspective-viewer/index.d.ts
@@ -11,7 +11,7 @@ import React from "react";
 import {Table, TableData, TableOptions, Schema} from "@finos/perspective";
 
 export interface HTMLPerspectiveViewerElement extends PerspectiveViewerOptions, HTMLElement {
-    load(data: TableData | Table, options?: TableOptions): void;
+    load(data: TableData | Table | View, options?: TableOptions): void;
     load(schema: Schema, options?: TableOptions): void;
     update(data: TableData): void;
     notifyResize(): void;
@@ -19,6 +19,7 @@ export interface HTMLPerspectiveViewerElement extends PerspectiveViewerOptions, 
     clear(): void;
     replace(data: TableData): void;
     flush(): Promise<void>;
+    getEditPort(): Promise<number>;
     toggleConfig(): void;
     save(): PerspectiveViewerOptions;
     reset(): void;

--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -90,7 +90,7 @@ declare module "@finos/perspective" {
         num_columns(): Promise<number>;
         num_rows(): Promise<number>;
         on_delete(callback: Function): void;
-        on_update(callback: UpdateCallback): void;
+        on_update(callback: UpdateCallback, options?: {mode?: string}): void;
         schema(): Promise<Schema>;
         computed_schema(): Promise<Schema>;
         to_arrow(options?: SerializeConfig & {data_slice: any}): Promise<ArrayBuffer>;
@@ -100,9 +100,9 @@ declare module "@finos/perspective" {
     };
 
     /**** Table ****/
-    export type UpdateCallback = (data: Array<object>) => void;
+    export type UpdateCallback = (updated: {port_id: number; delta: Array<object> | ArrayBuffer}) => void;
 
-    export type TableData = string | Array<object> | {[key: string]: Array<object>} | {[key: string]: string};
+    export type TableData = string | Array<object> | {[key: string]: Array<object>} | {[key: string]: string} | ArrayBuffer;
 
     export type TableOptions = {
         index?: string;
@@ -130,8 +130,9 @@ declare module "@finos/perspective" {
         computed_schema(): Promise<Schema>;
         schema(): Promise<Schema>;
         size(): Promise<number>;
-        update(data: TableData): void;
+        update(data: TableData, options?: {port_id?: number}): void;
         view(config?: ViewConfig): View;
+        make_port(): number;
     };
 
     /**** perspective ****/
@@ -140,7 +141,7 @@ declare module "@finos/perspective" {
     }
 
     export type PerspectiveWorker = {
-        table(data: TableData, options?: TableOptions): Table;
+        table(data: TableData | View, options?: TableOptions): Table;
     };
 
     export class WebSocketClient {

--- a/python/perspective/perspective/core/plugin.py
+++ b/python/perspective/perspective/core/plugin.py
@@ -30,6 +30,16 @@ class Plugin(Enum):
     SUNBURST = "sunburst"
     HEATMAP = "heatmap"
 
+    YBAR_D3 = "d3_y_bar"
+    XBAR_D3 = "d3_x_bar"
+    YLINE_D3 = "d3_y_line"
+    YAREA_D3 = "d3_y_area"
+    YSCATTER_D3 = "d3_y_scatter"
+    XYSCATTER_D3 = "d3_xy_scatter"
+    TREEMAP_D3 = "d3_treemap"
+    SUNBURST_D3 = "d3_sunburst"
+    HEATMAP_D3 = "d3_heatmap"
+
     CANDLESTICK = "d3_candlestick"
     OHLC = "d3_ohlc"
 

--- a/python/perspective/perspective/table/__init__.py
+++ b/python/perspective/perspective/table/__init__.py
@@ -7,6 +7,7 @@
 #
 
 from .table import Table
+from .view import View
 from .libbinding import PerspectiveCppError
 
-__all__ = ["Table", "PerspectiveCppError"]
+__all__ = ["Table", "View", "PerspectiveCppError"]

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -89,7 +89,9 @@ def _type_to_format(data_or_schema):
         ):
             # if pandas not installed or is not a dataframe or series
             raise NotImplementedError(
-                "Data must be dataframe, dict, list, numpy.recarray, or a numpy structured array."
+                "Invalid data format `{}` - Data must be dataframe, dict, list, numpy.recarray, or a numpy structured array.".format(
+                    type(data_or_schema)
+                )
             )
         else:
             # flatten column/index multiindex

--- a/python/perspective/perspective/table/_data_formatter.py
+++ b/python/perspective/perspective/table/_data_formatter.py
@@ -172,6 +172,7 @@ def _to_format_helper(view, options=None):
 def _parse_format_options(view, options):
     """Given a user-provided options dictionary, extract the useful values."""
     max_cols = view.num_columns() + (1 if view._sides > 0 else 0)
+    column_only_offset = 1 if view._sides > 0 or view._column_only else 0
     return {
         "start_row": int(floor(max(options.get("start_row", 0), 0))),
         "end_row": int(
@@ -181,7 +182,8 @@ def _parse_format_options(view, options):
         "end_col": int(
             ceil(
                 min(
-                    options.get("end_col", max_cols) * (view._num_hidden_cols() + 1),
+                    (options.get("end_col", max_cols) + column_only_offset)
+                    * (view._num_hidden_cols() + 1),
                     max_cols,
                 )
             )

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -407,6 +407,8 @@ class View(object):
             start_col (:obj:`int`): (Defaults to 0).
             end_col (:obj:`int`): (Defaults to
                 :func:`perspective.View.num_columns()`).
+            id (:obj:`bool`): Whether to return a logical row ID for each
+                row (Defaults to ``False``).
             index (:obj:`bool`): Whether to return an implicit pkey for each
                 row (Defaults to ``False``).
             leaves_only (:obj:`bool`): Whether to return only the data at the
@@ -433,6 +435,8 @@ class View(object):
             start_col (:obj:`int`): (Defaults to 0).
             end_col (:obj:`int`): (Defaults to
                 :func:`perspective.View.num_columns()`).
+            id (:obj:`bool`): Whether to return a logical row ID for each
+                row (Defaults to ``False``).
             index (:obj:`bool`): Whether to return an implicit pkey for each
                 row (Defaults to ``False``).
             leaves_only (:obj:`bool`): Whether to return only the data at the
@@ -456,6 +460,8 @@ class View(object):
             start_col (:obj:`int`): (Defaults to 0).
             end_col (:obj:`int`): (Defaults to
                 :func:`perspective.View.num_columns()`).
+            id (:obj:`bool`): Whether to return a logical row ID for each
+                row (Defaults to ``False``).
             index (:obj:`bool`): Whether to return an implicit pkey for each
                 row (Defaults to ``False``).
             leaves_only (:obj:`bool`): Whether to return only the data at the
@@ -480,6 +486,8 @@ class View(object):
             start_col (:obj:`int`): (Defaults to 0).
             end_col (:obj:`int`): (Defaults to
                 :func:`perspective.View.num_columns()`).
+            id (:obj:`bool`): Whether to return a logical row ID for each
+                row (Defaults to ``False``).
             index (:obj:`bool`): Whether to return an implicit pkey for each
                 row (Defaults to ``False``).
             leaves_only (:obj:`bool`): Whether to return only the data at the
@@ -503,6 +511,8 @@ class View(object):
             start_col (:obj:`int`): (Defaults to 0).
             end_col (:obj:`int`): (Defaults to
                 :func:`perspective.View.num_columns()`).
+            id (:obj:`bool`): Whether to return a logical row ID for each
+                row (Defaults to ``False``).
             index (:obj:`bool`): Whether to return an implicit pkey for each
                 row (Defaults to False).
             leaves_only (:obj:`bool`): Whether to return only the data at the

--- a/python/perspective/perspective/tests/core/test_plugin.py
+++ b/python/perspective/perspective/tests/core/test_plugin.py
@@ -13,6 +13,11 @@ from perspective import PerspectiveError, PerspectiveViewer,\
 
 class TestPlugin:
 
+    def test_plugin_widget_load_grid(self):
+        data = {"a": [1, 2, 3], "b": ["a", "b", "c"]}
+        widget = PerspectiveWidget(data, plugin=Plugin.GRID)
+        assert widget.plugin == "datagrid"
+
     def test_plugin_widget_load(self):
         data = {"a": [1, 2, 3], "b": ["a", "b", "c"]}
         widget = PerspectiveWidget(data, plugin=Plugin.XBAR)

--- a/python/perspective/perspective/tests/table/test_table.py
+++ b/python/perspective/perspective/tests/table/test_table.py
@@ -486,6 +486,18 @@ class TestTable(object):
             {"a": 1, "b": 4}
         ]
 
+    def test_table_index_from_schema(self):
+        data = [{"a": 1, "b": 2}, {"a": 1, "b": 4}]
+        tbl = Table({
+            "a": int,
+            "b": int
+        }, index="a")
+        assert tbl.size() == 0
+        tbl.update(data)
+        assert tbl.view().to_records() == [
+            {"a": 1, "b": 4}
+        ]
+
     # index with None in column
 
     def test_table_index_int_with_none(self):

--- a/python/perspective/perspective/tests/table/test_to_format.py
+++ b/python/perspective/perspective/tests/table/test_to_format.py
@@ -1120,6 +1120,25 @@ class TestToFormat(object):
             "b": [2.5, 4.5]
         }
 
+    def test_to_format_implicit_id_records(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_records(id=True) == [
+            {"__ID__": [0], "a": 1.5, "b": 2.5},
+            {"__ID__": [1], "a": 3.5, "b": 4.5}
+        ]
+
+    def test_to_format_implicit_id_dict(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view()
+        assert view.to_dict(id=True) == {
+            "__ID__": [[0], [1]],
+            "a": [1.5, 3.5],
+            "b": [2.5, 4.5]
+        }
+
     def test_to_format_implicit_index_two_dict(self):
         data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
         tbl = Table(data)
@@ -1130,6 +1149,19 @@ class TestToFormat(object):
             '4.5|a': [3.5, None, 3.5],
             '4.5|b': [4.5, None, 4.5],
             '__INDEX__': [[], [], []],  # index needs to be the same length as each column
+            '__ROW_PATH__': [[], [1.5], [3.5]]
+        }
+
+    def test_to_format_implicit_index_two_dict(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view(row_pivots=["a"], column_pivots=["b"])
+        assert view.to_dict(id=True) == {
+            '2.5|a': [1.5, 1.5, None],
+            '2.5|b': [2.5, 2.5, None],
+            '4.5|a': [3.5, None, 3.5],
+            '4.5|b': [4.5, None, 4.5],
+            '__ID__': [[], [1.5], [3.5]],  # index needs to be the same length as each column
             '__ROW_PATH__': [[], [1.5], [3.5]]
         }
 

--- a/python/perspective/perspective/tests/table/test_to_format.py
+++ b/python/perspective/perspective/tests/table/test_to_format.py
@@ -597,7 +597,7 @@ class TestToFormat(object):
             start_col=0,
             end_col=0
         )
-        assert records == [{}, {}, {}]
+        assert records == [{'__ROW_PATH__': []}, {'__ROW_PATH__': [1.5]}, {'__ROW_PATH__': [3.5]}]
 
     def test_to_records_two_over_max_col(self):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
@@ -751,8 +751,11 @@ class TestToFormat(object):
             start_col=1,
             end_col=2
         )
-        assert records == [{"__ROW_PATH__": []}, {"__ROW_PATH__": [3]}, {"__ROW_PATH__": [1]}]
-        
+        assert records == [
+            {'2|b': 2, '__ROW_PATH__': []},
+            {'2|b': None, '__ROW_PATH__': [3]},
+            {'2|b': 2, '__ROW_PATH__': [1]}
+        ]
 
     def test_to_records_two_sorted_start_end_col_equiv(self):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]

--- a/python/perspective/perspective/tests/table/test_update.py
+++ b/python/perspective/perspective/tests/table/test_update.py
@@ -38,6 +38,11 @@ class TestUpdate(object):
         tbl.update([{"a": "abc", "b": 456}])
         assert tbl.view().to_records() == [{"a": "abc", "b": 456}]
 
+    def test_update_partial_cols_not_in_schema(self):
+        tbl = Table([{"a": "abc", "b": 123}], index="a")
+        tbl.update([{"a": "abc", "b": 456, "c": 789}])
+        assert tbl.view().to_records() == [{"a": "abc", "b": 456}]
+
     def test_update_columnar_append(self):
         tbl = Table({"a": ["abc"], "b": [123]})
         tbl.update({"a": ["def"], "b": [456]})

--- a/python/perspective/perspective/tests/viewer/test_validate.py
+++ b/python/perspective/perspective/tests/viewer/test_validate.py
@@ -17,12 +17,19 @@ class TestValidate:
     def test_validate_plugin_valid_instance(self):
         assert validate.validate_plugin(Plugin.XBAR) == "x_bar"
 
+    def test_validate_plugin_valid_instance_datagrid(self):
+        assert validate.validate_plugin(Plugin.GRID) == "datagrid"
+
     def test_validate_plugin_valid_string(self):
         assert validate.validate_plugin("x_bar") == "x_bar"
 
     def test_validate_plugin_invalid_string(self):
         with raises(PerspectiveError):
             validate.validate_plugin("invalid")
+
+    def test_validate_plugin_invalid_string_hypergrid(self):
+        with raises(PerspectiveError):
+            validate.validate_plugin("hypergrid")
 
     def test_validate_filters_valid(self):
         filters = [["a", ">", 1], ["b", "==", "abc"]]

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -23,7 +23,7 @@ from .viewer_traitlets import PerspectiveTraitlets
 from ..libpsp import is_libpsp
 
 if is_libpsp():
-    from ..libpsp import Table, PerspectiveManager
+    from ..libpsp import Table, View, PerspectiveManager
 
 
 class PerspectiveViewer(PerspectiveTraitlets, object):
@@ -38,6 +38,20 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         "aggregates": validate_aggregates,
         "sort": validate_sort,
     }
+
+    # Viewer attributes that should be saved in `save()` and restored using
+    # `restore()`. Symmetric to `PERSISTENT_ATTRIBUTES` in `perspective-viewer`.
+    PERSISTENT_ATTRIBUTES = (
+        "row_pivots",
+        "column_pivots",
+        "filters",
+        "sort",
+        "aggregates",
+        "columns",
+        "computed_columns",
+        "plugin",
+        "editable",
+    )
 
     def __init__(
         self,
@@ -78,11 +92,11 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
                 each dict containing ``column``, a new computed column name,
                 ``computed_function_name``, a string computed function name,
                 and ``inputs``, a list of input column names.
-            plugin (:obj:`str`/:obj:`perspective.Plugin`): Which plugin to select by
-                default.
+            plugin (:obj:`str`/:obj:`perspective.Plugin`): Which plugin to
+                select by default.
             plugin_config (:obj:`dict`): Custom config for all plugins by name.
+            dark (:obj:`bool`): Whether to invert the color theme.
             editable (:obj:`bool`): Whether to allow editability using the grid.
-            dark (:obj:`bool`): Whether to invert the colors.
 
         Examples:
             >>> viewer = PerspectiveViewer(
@@ -102,8 +116,15 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         # from the `PerspectiveJupyterClient` on the front-end.
         if is_libpsp():
             self.manager = PerspectiveManager()
-        self.table_name = None  # not a traitlet - only used in python
-        self.view_name = None
+
+        # The string name of the Table under management by this viewer and its
+        # attached PerspectiveManager
+        self.table_name = None
+
+        # If `is_libpsp()` and the viewer has a Table, an internal view will be
+        # created to allow remote clients to host their own table that listens
+        # to updates from this table.
+        self._perspective_view_name = None
 
         # Viewer configuration
         self.plugin = validate_plugin(plugin)
@@ -124,36 +145,43 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         return self.manager.get_table(self.table_name)
 
     @property
-    def view(self):
-        """Returns the ``perspective.View`` currently shown by the viewer.
+    def _view(self):
+        """Returns the internal ``perspective.View`` under management by the
+        viewer, which has no bearing to the view that is displayed in the
+        widget."""
+        return self.manager.get_view(self._perspective_view_name)
 
-        This property changes every time the viewer configuration changes."""
-        return self.manager.get_view(self.view_name)
+    def load(self, data, **options):
+        """Given a ``perspective.Table``, a ``perspective.View``,
+        or data that can be handled by ``perspective.Table``, pass it to the
+        viewer.
 
-    def load(self, table_or_data, **options):
-        """Given a ``perspective.Table`` or data that can be handled by
-        ``perspective.Table``, pass it to the viewer.
+        ``load()`` resets the state of the viewer:
 
-        ``load()`` resets the state of the viewer.  If a ``perspective.Table``
-        is passed into ``table_or_data``, ``**options`` is ignored as the options
-        already set on the ``Table`` take precedence.  If data is passed in, a
-        ``perspective.Table`` is automatically created by this function, and the
-        options passed to ``**config`` are extended to the new Table.
+        If a ``perspective.Table`` is loaded, ``**options`` is ignored as the
+        options already set on the ``Table`` take precedence.
+
+        If a ``perspective.View`` is loaded, the options on the
+        ``perspective.Table`` linked to the view take precedence.
+
+        If data is passed in, a ``perspective.Table`` is automatically created
+        by this method, and the options passed to ``**config`` are extended to
+        the new Table.
 
         Args:
-            table_or_data (:obj:`Table`|:obj:`dict`|:obj:`list`|`pandas.DataFrame`): a
-                `perspective.Table` instance or a dataset to be displayed
-                in the viewer.
+            data (:obj:`Table`|:obj:`View`|:obj:`dict`|:obj:`list`|:obj:`pandas.DataFrame`|:obj:`bytes`|:obj:`str`): a
+                `perspective.Table` instance, a `perspective.View` instance, or
+                a dataset to be loaded in the viewer.
 
         Keyword Arguments:
             name (:obj:`str`): An optional name to reference the table by so it can
                 be accessed from the front-end. If not provided, a name will
                 be generated.
             index (:obj:`str`): A column name to be used as the primary key.
-                Ignored if a `Table` is supplied.
+                Ignored if a ``Table`` or ``View`` is supplied.
             limit (:obj:`int`): A upper limit on the number of rows in the Table.
-                Cannot be set at the same time as `index`, ignored if a `Table`
-                is passed in.
+                Cannot be set at the same time as `index`. Ignored if a
+                ``Table`` or ``View`` is supplied.
 
         Examples:
             >>> from perspective import Table, PerspectiveViewer
@@ -162,16 +190,21 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
             >>> viewer = PerspectiveViewer()
             >>> viewer.load(tbl)
             >>> viewer.load(data, index="a") # viewer state is reset
+            >>> viewer2 = PerspectiveViewer()
+            >>> viewer2.load(tbl.view())
         """
         name = options.pop("name", str(random()))
-        if isinstance(table_or_data, Table):
-            table = table_or_data
+
+        if isinstance(data, Table):
+            table = data
+        elif isinstance(data, View):
+            table = data._table
         else:
-            table = Table(table_or_data, **options)
+            table = Table(data, **options)
 
         self.manager.host_table(name, table)
 
-        # Reset the viewer when `load()` is called again.
+        # Reset the viewer when `load()` is called multiple times.
         if self.table_name is not None:
             self.reset()
 
@@ -182,14 +215,24 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
 
         self.table_name = name
 
+        # If a `perspective.View` is loaded, then use it as the view that
+        # new clients will be built from. Otherwise, create a new view.
+        VIEW = data if isinstance(data, View) else table.view()
+
+        # Create a view from the table, and host it with the manager so it can
+        # be accessed remotely. This view should not be deleted or changed,
+        # and remains private to the viewer.
+        self._perspective_view_name = str(random())
+        self.manager.host_view(self._perspective_view_name, VIEW)
+
     def update(self, data):
         """Update the table under management by the viewer with new data.
         This function follows the semantics of `Table.update()`, and will be
         affected by whether an index is set on the underlying table.
 
         Args:
-            data (:obj:`dict`|:obj:`list`|:obj:`pandas.DataFrame`): the update data for the
-                table.
+            data (:obj:`dict`|:obj:`list`|:obj:`pandas.DataFrame`): the
+            update data for the table.
         """
         self.table.update(data)
 
@@ -202,40 +245,26 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         """Replaces the rows of this viewer's `Table` with new data.
 
         Args:
-            data (:obj:`dict`|:obj:`list`|:obj:`pandas.DataFrame`): new data to set into the
-                table - must conform to the table's schema.
+            data (:obj:`dict`|:obj:`list`|:obj:`pandas.DataFrame`): new data
+            to set into the table - must conform to the table's schema.
         """
         if self.table is not None:
             self.table.replace(data)
 
     def save(self):
-        """Get the viewer's attribute as a dictionary, symmetric with `restore` so that a
-        viewer's configuration can be reproduced."""
+        """Get the viewer's attribute as a dictionary, symmetric with `restore`
+        so that a viewer's configuration can be reproduced."""
         return {
-            "row_pivots": self.row_pivots,
-            "column_pivots": self.column_pivots,
-            "filters": self.filters,
-            "computed_columns": self.computed_columns,
-            "sort": self.sort,
-            "aggregates": self.aggregates,
-            "columns": self.columns,
-            "plugin": self.plugin,
+            attr: getattr(self, attr)
+            for attr in PerspectiveViewer.PERSISTENT_ATTRIBUTES
         }
 
     def restore(self, **kwargs):
-        """Restore a given set of attributes, passed as kwargs (e.g. dictionary). Symmetric with `save` so that
-        a given viewer's configuration can be reproduced"""
+        """Restore a given set of attributes, passed as kwargs
+        (e.g. dictionary). Symmetric with `save` so that a given viewer's
+        configuration can be reproduced."""
         for k, v in six.iteritems(kwargs):
-            if k in (
-                "row_pivots",
-                "column_pivots",
-                "filters",
-                "sort",
-                "aggregates",
-                "columns",
-                "computed_columns",
-                "plugin",
-            ):
+            if k in PerspectiveViewer.PERSISTENT_ATTRIBUTES:
                 setattr(self, k, v)
 
     def reset(self):
@@ -250,54 +279,27 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         self.aggregates = {}
         self.columns = []
         self.plugin = "datagrid"
+        self.editable = False
 
     def delete(self, delete_table=True):
         """Delete the Viewer's data and clears its internal state. If
-        ``delete_table`` is True, the underlying `perspective.Table` and all
-        associated ``View`` objects will be deleted.
+        ``delete_table`` is True, the underlying `perspective.Table` and the
+        internal `View` object will be deleted.
 
         Args:
             delete_table (:obj:`bool`) : whether the underlying `Table` will be
                 deleted. Defaults to True.
         """
-        if self.view:
-            self.view.delete()
-            self.view_name = None
-
-        for view in self.manager._views.values():
-            view.delete()
-
         if delete_table:
+            if self._view:
+                self._view.delete()
+                self._perspective_view_name = None
+
             self.table.delete()
             self.manager._tables.pop(self.table_name)
             self.table_name = None
 
         self.reset()
-
-    def _new_view(self):
-        """Create a new View, and assign its name to the viewer.  Do not call
-        this function - it will be called automatically when the state of the
-        viewer changes. There should only be one View associated with the
-        Viewer at any given time - when a new View is created, the old one
-        is destroyed.
-        """
-        if not self.table_name:
-            return
-
-        name = str(random())
-        table = self.manager.get_table(self.table_name)
-        view = table.view(
-            row_pivots=self.row_pivots,
-            column_pivots=self.column_pivots,
-            columns=self.columns,
-            aggregates=self.aggregates,
-            sort=self.sort,
-            filter=self.filters,
-            computed_columns=self.computed_columns,
-        )
-
-        self.manager.host_view(name, view)
-        self.view_name = name
 
     def __setattr__(self, name, value):
         """Override __setattr__ in order to allow Enums to be validated

--- a/python/perspective/perspective/viewer/viewer_traitlets.py
+++ b/python/perspective/perspective/viewer/viewer_traitlets.py
@@ -46,6 +46,7 @@ class PerspectiveTraitlets(HasTraits):
     plugin_config = Dict(default_value={}).tag(sync=True)
     dark = Bool(None, allow_none=True).tag(sync=True)
     editable = Bool(False).tag(sync=True)
+    server = Bool(False).tag(sync=True)
     client = Bool(False).tag(sync=True)
 
     @validate("plugin")

--- a/scripts/test_js.js
+++ b/scripts/test_js.js
@@ -48,9 +48,8 @@ function jest() {
         --color
         --verbose 
         --maxWorkers=50%
-        --noStackTrace
         ${getarg("--bail") && "--bail"}
-        ${getarg("--debug") || "--silent 2>&1"} 
+        ${getarg("--debug") || "--silent 2>&1 --noStackTrace"} 
         --testNamePattern="${get_regex()}"`;
 }
 
@@ -107,7 +106,6 @@ try {
                 -- 
                 yarn test:run
                 ${debug}
-                --noStackTrace
                 ${getarg("--interactive") && "--runInBand"}
                 --testNamePattern="${get_regex()}"`;
         } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,6 +1266,16 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jupyter-widgets/base-manager@^1.0.0-alpha.0":
+  version "1.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@jupyter-widgets/base-manager/-/base-manager-1.0.0-alpha.0.tgz#d69da034574fcb08dcf3f85d453b77efadc87a21"
+  integrity sha512-WHSsGXWxvdsTd1xeZP9enBWhR+ZeV5ZxyFhlc7bETgGlakwKnLJMkFeYQ5thx7d9kgpgxZMroOHLEcLkgWLO1g==
+  dependencies:
+    "@jupyter-widgets/base" "^4.0.0-alpha.0"
+    "@jupyterlab/services" "^5.0.2"
+    "@lumino/coreutils" "^1.4.2"
+    base64-js "^1.2.1"
+
 "@jupyter-widgets/base@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@jupyter-widgets/base/-/base-3.0.0.tgz#3996d566cddb742d275b007e0713de1e17f55a44"
@@ -1279,6 +1289,21 @@
     "@types/lodash" "^4.14.134"
     backbone "1.2.3"
     base64-js "^1.2.1"
+    jquery "^3.1.1"
+    lodash "^4.17.4"
+
+"@jupyter-widgets/base@^4.0.0-alpha.0":
+  version "4.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@jupyter-widgets/base/-/base-4.0.0-alpha.0.tgz#ffa6d1c631653f1b147db916e685d130b35ec79f"
+  integrity sha512-kufdXKDTJdyYPPJwF6gIhAwyjTBW+qf9AZ4F/RBPNxGMvAHQVNKr2lxBE7gLiY54IKBPmcUds1J9aU/uVPuU7g==
+  dependencies:
+    "@jupyterlab/services" "^5.0.2"
+    "@lumino/coreutils" "^1.4.2"
+    "@lumino/messaging" "^1.3.3"
+    "@lumino/widgets" "^1.11.1"
+    "@types/backbone" "^1.4.1"
+    "@types/lodash" "^4.14.134"
+    backbone "1.2.3"
     jquery "^3.1.1"
     lodash "^4.17.4"
 
@@ -13879,7 +13904,7 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-superstore-arrow@^1.0.0:
+superstore-arrow@1.0.0, superstore-arrow@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/superstore-arrow/-/superstore-arrow-1.0.0.tgz#55a0ecdc872a31e8914c3502dd8e7790da44f849"
   integrity sha512-kDG1JykWoNYi0CYv1NWEwqZoNl/Yc/i4GIzfVQSeNvMfnOdyzUw/3gIXrw8qZtSQQCf9yp5jnXvWkvsfqJlBqA==
@@ -14402,22 +14427,6 @@ truncate-html@^1.0.3:
   dependencies:
     "@types/cheerio" "^0.22.8"
     cheerio "0.22.0"
-
-ts-jest@^24.1.0:
-  version "24.2.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.2.0.tgz#7abca28c2b4b0a1fdd715cd667d65d047ea4e768"
-  integrity sha512-Yc+HLyldlIC9iIK8xEN7tV960Or56N49MDP7hubCZUeI7EbIOTsas6rXCMB4kQjLACJ7eDOF4xWEO5qumpKsag==
-  dependencies:
-    bs-logger "0.x"
-    buffer-from "1.x"
-    fast-json-stable-stringify "2.x"
-    json5 "2.x"
-    lodash.memoize "4.x"
-    make-error "1.x"
-    mkdirp "0.x"
-    resolve "1.x"
-    semver "^5.5"
-    yargs-parser "10.x"
 
 ts-jest@^25.1.0:
   version "25.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12602,10 +12602,10 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-regular-table@=0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.1.3.tgz#27fc0f54f9ac8682c8fcaf982689cc1e9efbe44e"
-  integrity sha512-41PadI6lCijE/371w1v3V7bm4bMZzHC0fG2hZBi+SRkTXPneCll6a4+kNXDxsgbPX8ahiBbcXtm/ASEavxHaPQ==
+regular-table@=0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.1.4.tgz#14b0cd6b5745cc64424c6ec0742710e09848ff03"
+  integrity sha512-qHdxRGHZT4SgCK37pfWxlDfLzgWFGezsHmaVcmZj4Lu3JUxUZdbz+Bvr0t6S31gQv5mDfyjdZ7OzDDlRaD6pxg==
 
 relateurl@0.2.x:
   version "0.2.7"


### PR DESCRIPTION
* [@sc1f] Adds `server` kwarg to `PerspectiveWidget()` Jupyterlab widget.  When `True`, the browser `<perspective-viewer>` will use a python, server-side `Table()` virtually, rather than creating a WebAssembly `Table()` and cloning the contents.  This mode is great for extra-large datasets, but comes at the cost of client interactive performance, and server memory/CPU. 
* Fixes 2 discrepancies with the Javascript API:
  - Fixes missing offset (called `psp_offset` in wasm) for correcting column_only `end_col` values.
  - Adds `id` kwarg for `to_columns()`, which is equivalent to `__index__` for 0-sided contexts, and `__row_path__` otherwise, and is necessary for GUI features like persistent selection and editing.
* Fixes a longstanding bug in `perspective-jupyterlab` which caused `Create New Output` derived viewers to be mis-sized.
* Fixes `perspective-viewer-datagrid` to not swallow scroll events when fully-scrolled, for convenient notebook scrolling.
* Switches `perspective-jupyterlab` to `material-dense` theme.

<img width="500" alt="Screen Shot 2020-09-14 at 4 15 30 AM" src="https://user-images.githubusercontent.com/60666/93061188-38888680-f641-11ea-9840-582a5b17738a.png">