### PR TITLE
GIL release for perspective-python Async mode

### DIFF
--- a/examples/tornado-python/server.py
+++ b/examples/tornado-python/server.py
@@ -4,40 +4,57 @@ import logging
 import tornado.websocket
 import tornado.web
 import tornado.ioloop
+import threading
 
 from perspective import Table, PerspectiveManager, PerspectiveTornadoHandler
 
 
 here = os.path.abspath(os.path.dirname(__file__))
 file_path = os.path.join(
-    here, "..", "..", "node_modules", "superstore-arrow", "superstore.arrow")
+    here, "..", "..", "node_modules", "superstore-arrow", "superstore.arrow"
+)
+
+
+def perspective_thread(manager):
+    """Perspective application thread starts its own tornado IOLoop, and
+    adds the table with the name "data_source_one", which will be used
+    in the front-end."""
+    psp_loop = tornado.ioloop.IOLoop()
+    manager.set_loop_callback(psp_loop.add_callback)
+    with open(file_path, mode="rb") as file:
+        table = Table(file.read(), index="Row ID")
+        manager.host_table("data_source_one", table)
+        manager.host_view("view_one", table.view())
+    psp_loop.start()
 
 
 def make_app():
-    with open(file_path, mode='rb') as file:
-        # Create an instance of `PerspectiveManager` and a table.
-        MANAGER = PerspectiveManager()
-        TABLE = Table(file.read(), index="Row ID")
+    manager = PerspectiveManager()
 
-        # Track the table with the name "data_source_one", which will be used
-        # in the front-end to access the Table.
-        MANAGER.host_table("data_source_one", TABLE)
-        MANAGER.host_view("view_one", TABLE.view())
+    thread = threading.Thread(target=perspective_thread, args=(manager,))
+    thread.daemon = True
+    thread.start()
 
-        return tornado.web.Application([
-            # create a websocket endpoint that the client Javascript can access
-            (r"/websocket", PerspectiveTornadoHandler, {
-                "manager": MANAGER,
-                "check_origin": True
-            }),
-            (r"/node_modules/(.*)", tornado.web.StaticFileHandler, {
-                "path": "../../node_modules/@finos/"
-            }),
-            (r"/(.*)", tornado.web.StaticFileHandler, {
-                "path": "./",
-                "default_filename": "index.html"
-            })
-        ], websocket_ping_interval=15)
+    return tornado.web.Application(
+        [
+            (
+                r"/websocket",
+                PerspectiveTornadoHandler,
+                {"manager": manager, "check_origin": True},
+            ),
+            (
+                r"/node_modules/(.*)",
+                tornado.web.StaticFileHandler,
+                {"path": "../../node_modules/@finos/"},
+            ),
+            (
+                r"/(.*)",
+                tornado.web.StaticFileHandler,
+                {"path": "./", "default_filename": "index.html"},
+            ),
+        ],
+        websocket_ping_interval=15,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/tornado-streaming-python/server.py
+++ b/examples/tornado-streaming-python/server.py
@@ -1,5 +1,6 @@
 import random
 import logging
+import threading
 import tornado.websocket
 import tornado.web
 import tornado.ioloop
@@ -11,67 +12,100 @@ def data_source():
     rows = []
     modifier = random.random() * random.randint(1, 50)
     for i in range(5):
-        rows.append({
-            "name": SECURITIES[random.randint(0, len(SECURITIES) - 1)],
-            "client": CLIENTS[random.randint(0, len(CLIENTS) - 1)],
-            "open": (random.random() * 75 + random.randint(0, 9)) * modifier,
-            "high": (random.random() * 105 + random.randint(1, 3)) * modifier,
-            "low": (random.random() * 85 + random.randint(1, 3)) * modifier,
-            "close": (random.random() * 90 + random.randint(1, 3)) * modifier,
-            "lastUpdate": datetime.now(),
-            "date": date.today()
-        })
+        rows.append(
+            {
+                "name": SECURITIES[random.randint(0, len(SECURITIES) - 1)],
+                "client": CLIENTS[random.randint(0, len(CLIENTS) - 1)],
+                "open": (random.random() * 75 + random.randint(0, 9)) * modifier,
+                "high": (random.random() * 105 + random.randint(1, 3)) * modifier,
+                "low": (random.random() * 85 + random.randint(1, 3)) * modifier,
+                "close": (random.random() * 90 + random.randint(1, 3)) * modifier,
+                "lastUpdate": datetime.now(),
+                "date": date.today(),
+            }
+        )
     return rows
 
 
-SECURITIES = ["AAPL.N", "AMZN.N", "QQQ.N", "NVDA.N", "TSLA.N",
-              "FB.N", "MSFT.N", "TLT.N", "XIV.N", "YY.N",
-              "CSCO.N", "GOOGL.N", "PCLN.N"]
+SECURITIES = [
+    "AAPL.N",
+    "AMZN.N",
+    "QQQ.N",
+    "NVDA.N",
+    "TSLA.N",
+    "FB.N",
+    "MSFT.N",
+    "TLT.N",
+    "XIV.N",
+    "YY.N",
+    "CSCO.N",
+    "GOOGL.N",
+    "PCLN.N",
+]
 
-CLIENTS = ["Homer", "Marge", "Bart", "Lisa", "Maggie",
-           "Moe", "Lenny", "Carl", "Krusty"]
+CLIENTS = ["Homer", "Marge", "Bart", "Lisa", "Maggie", "Moe", "Lenny", "Carl", "Krusty"]
 
 
-def make_app():
-    # Create an instance of `PerspectiveManager` and a table.
-    MANAGER = PerspectiveManager()
-    TABLE = Table({
-        "name": str,
-        "client": str,
-        "open": float,
-        "high": float,
-        "low": float,
-        "close": float,
-        "lastUpdate": datetime,
-        "date": date
-    }, limit=2500)
+def perspective_thread(manager):
+    """Perspective application thread starts its own tornado IOLoop, and
+    adds the table with the name "data_source_one", which will be used
+    in the front-end."""
+    psp_loop = tornado.ioloop.IOLoop()
+    manager.set_loop_callback(psp_loop.add_callback)
+    table = Table(
+        {
+            "name": str,
+            "client": str,
+            "open": float,
+            "high": float,
+            "low": float,
+            "close": float,
+            "lastUpdate": datetime,
+            "date": date,
+        },
+        limit=2500,
+    )
 
     # Track the table with the name "data_source_one", which will be used in
     # the front-end to access the Table.
-    MANAGER.host_table("data_source_one", TABLE)
+    manager.host_table("data_source_one", table)
 
     # update with new data every 50ms
     def updater():
-        TABLE.update(data_source())
+        table.update(data_source())
 
-    callback = tornado.ioloop.PeriodicCallback(
-        callback=updater, callback_time=50)
+    callback = tornado.ioloop.PeriodicCallback(callback=updater, callback_time=50)
     callback.start()
+    psp_loop.start()
 
-    return tornado.web.Application([
-        # create a websocket endpoint that the client Javascript can access
-        (r"/websocket", PerspectiveTornadoHandler, {
-            "manager": MANAGER,
-            "check_origin": True
-        }),
-        (r"/node_modules/(.*)", tornado.web.StaticFileHandler, {
-            "path": "../../node_modules/@finos/"
-        }),
-        (r"/(.*)", tornado.web.StaticFileHandler, {
-            "path": "./",
-            "default_filename": "index.html"
-        })
-    ])
+
+def make_app():
+    manager = PerspectiveManager()
+
+    thread = threading.Thread(target=perspective_thread, args=(manager,))
+    thread.daemon = True
+    thread.start()
+
+    return tornado.web.Application(
+        [
+            # create a websocket endpoint that the client Javascript can access
+            (
+                r"/websocket",
+                PerspectiveTornadoHandler,
+                {"manager": manager, "check_origin": True},
+            ),
+            (
+                r"/node_modules/(.*)",
+                tornado.web.StaticFileHandler,
+                {"path": "../../node_modules/@finos/"},
+            ),
+            (
+                r"/(.*)",
+                tornado.web.StaticFileHandler,
+                {"path": "./", "default_filename": "index.html"},
+            ),
+        ]
+    )
 
 
 if __name__ == "__main__":

--- a/packages/perspective/src/js/api/client.js
+++ b/packages/perspective/src/js/api/client.js
@@ -48,8 +48,9 @@ export class Client {
      * Process an asynchronous message.
      */
     post(msg, resolve, reject, keep_alive = false) {
+        ++this._worker.msg_id;
         if (resolve || reject) {
-            this._worker.handlers[++this._worker.msg_id] = {resolve, reject, keep_alive};
+            this._worker.handlers[this._worker.msg_id] = {resolve, reject, keep_alive};
         }
         msg.id = this._worker.msg_id;
         if (this._worker.initialized.value) {

--- a/python/perspective/bench/giltest.py
+++ b/python/perspective/bench/giltest.py
@@ -1,0 +1,172 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+import multiprocessing
+import asyncio
+import os
+import os.path
+import perspective
+import pprint
+import time
+import tornado
+import threading
+import numpy
+
+TABLE_SCALAR = 20
+DOWNLOAD_ITERATIONS = 1
+NUM_CLIENTS = 10
+
+file_path = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "..",
+    "..",
+    "..",
+    "node_modules",
+    "superstore-arrow",
+    "superstore.arrow",
+)
+
+
+# Client
+
+
+def least_sq(y):
+    y = numpy.sort(y)
+    n = len(y)
+    x = numpy.arange(1, n + 1)
+    x_mean = numpy.mean(x)
+    y_mean = numpy.mean(y)
+    numerator = 0
+    denominator = 0
+    for i in range(n):
+        numerator += (x[i] - x_mean) * (y[i] - y_mean)
+        denominator += (x[i] - x_mean) ** 2
+
+    m = numerator / denominator
+    b = y_mean - (m * x_mean)
+
+    pprint.pprint(list(map(lambda x: round(x, 2), y)))
+    print("Bias Coef {:.2f}".format(m))
+    print("Intercept {:.2f}".format(b))
+    print("Range {:.2f}".format(y[n - 1] - y[0]))
+    print("Mean {:.2f}".format(numpy.mean(y)))
+
+
+async def session():
+    """Perform client test."""
+    times = numpy.zeros(DOWNLOAD_ITERATIONS)
+    client = await perspective.tornado_handler.websocket("ws://127.0.0.1:8080/")
+    table = client.open_table("data_source_one")
+    view = table.view()
+    for i in range(DOWNLOAD_ITERATIONS):
+        start = time.time()
+        arrow = await view.to_arrow()
+        times[i] = time.time() - start
+        assert len(arrow) > 0
+    client.terminate()
+    return times
+
+
+def client(i):
+    """Start a client in this thread."""
+    return asyncio.run(session())
+
+
+def start_client(queue):
+    """Start a pool of clients, when `queue.get()` unblocks."""
+    queue.get()
+    with multiprocessing.Pool(processes=NUM_CLIENTS) as pool:
+        samples = pool.map(client, range(NUM_CLIENTS))
+        least_sq(numpy.array(samples).flatten())
+
+
+# Server
+
+
+def perspective_thread(manager):
+    """Start a new perspective loop in this thread."""
+    loop = asyncio.new_event_loop()
+    manager.set_loop_callback(loop.call_soon_threadsafe)
+    loop.run_forever()
+
+
+def get_table():
+    """Get a test table, made from "superstore.arrow" repeated `TABLE_SCALAR`
+    times."""
+    with open(file_path, mode="rb") as file:
+        arrow = file.read()
+    table = perspective.Table(arrow)
+    for _ in range(TABLE_SCALAR - 1):
+        table.update(arrow)
+    return table
+
+
+def make_app(manager):
+    """Make a tornado server for the thread local event loop."""
+    app = tornado.web.Application(
+        [
+            (
+                r"/",
+                perspective.tornado_handler.PerspectiveTornadoHandler,
+                {"manager": manager},
+            )
+        ]
+    )
+
+    app.listen(8080)
+
+
+def server(queue, is_async):
+    """Start a server, within this process."""
+    manager = perspective.PerspectiveManager()
+    table = get_table()
+    manager.host_table("data_source_one", table)
+    manager.host_view("view_one", table.view())
+
+    if is_async:
+        thread = threading.Thread(target=perspective_thread, args=(manager,))
+        thread.daemon = True
+        thread.start()
+
+    loop = tornado.ioloop.IOLoop.current()
+    loop.add_callback(queue.put, True)
+    if not is_async:
+        manager.set_loop_callback(loop.add_callback)
+
+    make_app(manager)
+    loop.start()
+
+
+def start_server(queue, is_async):
+    """Start a server process."""
+    server_process = multiprocessing.Process(target=server, args=(queue, is_async))
+    server_process.daemon = True
+    server_process.start()
+
+
+# Main
+
+
+def run(is_async):
+    """Runs an entire test scenario, server and client pool, then prints run
+    statistics.  The server under test can be run in `sync` or `async` modes."""
+    queue = multiprocessing.Queue()
+    start_server(queue, is_async)
+    start_client(queue)
+
+
+if __name__ == "__main__":
+    print("Sync mode")
+    proc = multiprocessing.Process(target=run, args=(False,))
+    proc.start()
+    proc.join()
+
+    print("\nAsync mode")
+    proc = multiprocessing.Process(target=run, args=(True,))
+    proc.start()
+    proc.join()

--- a/python/perspective/perspective/client/dispatch.py
+++ b/python/perspective/perspective/client/dispatch.py
@@ -59,9 +59,7 @@ def subscribe(client, name, method, cmd, *args, **kwargs):
         "callback_id": client._callback_id,
     }
 
-    future = tornado.concurrent.Future()
-    client.post(msg, future, keep_alive=True)
-    return future
+    client.post(msg, keep_alive=True)
 
 
 def unsubscribe(client, name, method, cmd, *args, **kwargs):
@@ -90,6 +88,4 @@ def unsubscribe(client, name, method, cmd, *args, **kwargs):
         "callback_id": callback_id,
     }
 
-    future = tornado.concurrent.Future()
-    client.post(msg, future, keep_alive=True)
-    return future
+    client.post(msg, keep_alive=True)

--- a/python/perspective/perspective/include/perspective/python.h
+++ b/python/perspective/perspective/include/perspective/python.h
@@ -384,6 +384,7 @@ PYBIND11_MODULE(libbinding, m)
     m.def("make_computations", &make_computations);
     m.def("scalar_to_py", &scalar_to_py);
     m.def("_set_nthreads", &_set_nthreads);
+    m.def("_set_event_loop", &_set_event_loop);
 }
 
 #endif

--- a/python/perspective/perspective/include/perspective/python/utils.h
+++ b/python/perspective/perspective/include/perspective/python/utils.h
@@ -19,6 +19,17 @@
 namespace perspective {
 namespace binding {
 
+class PerspectiveScopedGILRelease {
+    public:
+        PerspectiveScopedGILRelease();
+        ~PerspectiveScopedGILRelease();
+    private:
+        PyThreadState* thread_state;
+};
+
+
+void _set_event_loop();
+
 void _set_nthreads(int nthreads);
 
 /******************************************************************************

--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -57,6 +57,12 @@ class _PerspectiveManagerInternal(object):
                 parameters: `data` (str), and `binary` (bool), a kwarg that
                 specifies whether `data` is a binary string.
         """
+        if self._loop_callback:
+            self._loop_callback(self.__process, msg, post_callback, client_id)
+        else:
+            self.__process(msg, post_callback, client_id)
+
+    def __process(self, msg, post_callback, client_id=None):
         if isinstance(msg, string_types):
             if msg == "heartbeat":  # TODO fix this
                 return

--- a/python/perspective/perspective/src/serialization.cpp
+++ b/python/perspective/perspective/src/serialization.cpp
@@ -25,6 +25,7 @@ template <typename CTX_T>
 std::shared_ptr<t_data_slice<CTX_T>>
 get_data_slice(std::shared_ptr<View<CTX_T>> view, std::uint32_t start_row,
     std::uint32_t end_row, std::uint32_t start_col, std::uint32_t end_col) {
+    PerspectiveScopedGILRelease acquire;
     auto data_slice = view->get_data(start_row, end_row, start_col, end_col);
     return data_slice;
 }

--- a/python/perspective/perspective/src/table.cpp
+++ b/python/perspective/perspective/src/table.cpp
@@ -59,51 +59,55 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor,
         std::int32_t size = bytes.attr("__len__")().cast<std::int32_t>();
         void * ptr = malloc(size);
         std::memcpy(ptr, bytes.cast<std::string>().c_str(), size);
-        arrow_loader.initialize((uintptr_t)ptr, size);
+        {
+            PerspectiveScopedGILRelease acquire;
+        
+            arrow_loader.initialize((uintptr_t)ptr, size);
 
-        // Always use the `Table` column names and data types on update.
-        if (table_initialized && is_update) {
-            auto gnode_output_schema = gnode->get_output_schema();
-            auto schema = gnode_output_schema.drop({"psp_okey"});
-            column_names = schema.columns();
-            data_types = schema.types();
+            // Always use the `Table` column names and data types on update.
+            if (table_initialized && is_update) {
+                auto gnode_output_schema = gnode->get_output_schema();
+                auto schema = gnode_output_schema.drop({"psp_okey"});
+                column_names = schema.columns();
+                data_types = schema.types();
 
-            auto data_table = gnode->get_table();
-            if (data_table->size() == 0) {
-                /**
-                 * If updating a table created from schema, a 32-bit int/float
-                 * needs to be promoted to a 64-bit int/float if specified in
-                 * the Arrow schema.
-                 */
-                std::vector<t_dtype> arrow_dtypes = arrow_loader.types();
-                for (auto idx = 0; idx < column_names.size(); ++idx) {
-                    const std::string& name = column_names[idx];
-                    bool can_retype = name != "psp_okey" && name != "psp_pkey" && name != "psp_op";
-                    bool is_32_bit = data_types[idx] == DTYPE_INT32 || data_types[idx] == DTYPE_FLOAT32;
-                    if (can_retype && is_32_bit) {
-                        t_dtype arrow_dtype = arrow_dtypes[idx];
-                        switch (arrow_dtype) {
-                            case DTYPE_INT64:
-                            case DTYPE_FLOAT64: {
-                                std::cout << "Promoting column `" 
-                                            << column_names[idx] 
-                                            << "` to maintain consistency with Arrow type."
-                                            << std::endl;
-                                gnode->promote_column(name, arrow_dtype);
-                            } break;
-                            default: {
-                                continue;
+                auto data_table = gnode->get_table();
+                if (data_table->size() == 0) {
+                    /**
+                     * If updating a table created from schema, a 32-bit int/float
+                     * needs to be promoted to a 64-bit int/float if specified in
+                     * the Arrow schema.
+                     */
+                    std::vector<t_dtype> arrow_dtypes = arrow_loader.types();
+                    for (auto idx = 0; idx < column_names.size(); ++idx) {
+                        const std::string& name = column_names[idx];
+                        bool can_retype = name != "psp_okey" && name != "psp_pkey" && name != "psp_op";
+                        bool is_32_bit = data_types[idx] == DTYPE_INT32 || data_types[idx] == DTYPE_FLOAT32;
+                        if (can_retype && is_32_bit) {
+                            t_dtype arrow_dtype = arrow_dtypes[idx];
+                            switch (arrow_dtype) {
+                                case DTYPE_INT64:
+                                case DTYPE_FLOAT64: {
+                                    std::cout << "Promoting column `" 
+                                                << column_names[idx] 
+                                                << "` to maintain consistency with Arrow type."
+                                                << std::endl;
+                                    gnode->promote_column(name, arrow_dtype);
+                                } break;
+                                default: {
+                                    continue;
+                                }
                             }
                         }
                     }
                 }
+                // Make sure promoted types are used to construct data table
+                auto new_schema = gnode->get_output_schema().drop({"psp_okey"});
+                data_types = new_schema.types();
+            } else {
+                column_names = arrow_loader.names();
+                data_types = arrow_loader.types();
             }
-            // Make sure promoted types are used to construct data table
-            auto new_schema = gnode->get_output_schema().drop({"psp_okey"});
-            data_types = new_schema.types();
-        } else {
-            column_names = arrow_loader.names();
-            data_types = arrow_loader.types();
         }
     } else if (is_update || is_delete) {
         /**
@@ -174,9 +178,9 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor,
     data_table.init();
     std::uint32_t row_count;
     if (is_arrow) {
+        PerspectiveScopedGILRelease acquire;
         row_count = arrow_loader.row_count();
         data_table.extend(arrow_loader.row_count());
-
         arrow_loader.fill_table(data_table, input_schema, index, offset, limit, is_update);
     } else if (is_numpy) {
         row_count = numpy_loader.row_count();
@@ -189,7 +193,7 @@ std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor,
     }
 
     // calculate offset, limit, and set the gnode
-    tbl->init(data_table, row_count, op, port_id);
+    tbl->init(data_table, row_count, op, port_id);    
 
     //pool->_process();
     return tbl;

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -241,11 +241,13 @@ std::shared_ptr<View<CTX_T>>
 make_view(std::shared_ptr<Table> table, const std::string& name, const std::string& separator,
     t_val view_config, t_val date_parser) {
     std::shared_ptr<t_schema> schema = std::make_shared<t_schema>(table->get_schema());
-    std::shared_ptr<t_view_config> config = 
-        make_view_config<t_val>(schema, date_parser, view_config);
-    auto ctx = make_context<CTX_T>(table, schema, config, name);
-    auto view_ptr = std::make_shared<View<CTX_T>>(table, ctx, name, separator, config);
-    return view_ptr;
+    std::shared_ptr<t_view_config> config = make_view_config<t_val>(schema, date_parser, view_config);
+    {
+        PerspectiveScopedGILRelease acquire;
+        auto ctx = make_context<CTX_T>(table, schema, config, name);
+        auto view_ptr = std::make_shared<View<CTX_T>>(table, ctx, name, separator, config);
+        return view_ptr;
+    }
 }
 
 std::shared_ptr<View<t_ctx0>>
@@ -274,6 +276,7 @@ to_arrow_zero(
     std::int32_t start_col,
     std::int32_t end_col
 ) {
+    PerspectiveScopedGILRelease acquire;
     std::shared_ptr<std::string> str = 
         view->to_arrow(start_row, end_row, start_col, end_col);
     return py::bytes(*str);
@@ -287,6 +290,7 @@ to_arrow_one(
     std::int32_t start_col, 
     std::int32_t end_col
 ) {
+    PerspectiveScopedGILRelease acquire;
     std::shared_ptr<std::string> str = 
         view->to_arrow(start_row, end_row, start_col, end_col);
     return py::bytes(*str);
@@ -300,6 +304,7 @@ to_arrow_two(
     std::int32_t start_col, 
     std::int32_t end_col
 ) {
+    PerspectiveScopedGILRelease acquire;
     std::shared_ptr<std::string> str = 
         view->to_arrow(start_row, end_row, start_col, end_col);
     return py::bytes(*str);
@@ -307,6 +312,7 @@ to_arrow_two(
 
 py::bytes
 get_row_delta_zero(std::shared_ptr<View<t_ctx0>> view) {
+    PerspectiveScopedGILRelease acquire;
     std::shared_ptr<t_data_slice<t_ctx0>> slice = view->get_row_delta();
     std::shared_ptr<std::string> arrow = view->data_slice_to_arrow(slice);
     return py::bytes(*arrow);
@@ -314,6 +320,7 @@ get_row_delta_zero(std::shared_ptr<View<t_ctx0>> view) {
 
 py::bytes
 get_row_delta_one(std::shared_ptr<View<t_ctx1>> view) {
+    PerspectiveScopedGILRelease acquire;
     std::shared_ptr<t_data_slice<t_ctx1>> slice = view->get_row_delta();
     std::shared_ptr<std::string> arrow = view->data_slice_to_arrow(slice);
     return py::bytes(*arrow);
@@ -322,6 +329,7 @@ get_row_delta_one(std::shared_ptr<View<t_ctx1>> view) {
 py::bytes
 get_row_delta_two(
     std::shared_ptr<View<t_ctx2>> view) {
+    PerspectiveScopedGILRelease acquire;
     std::shared_ptr<t_data_slice<t_ctx2>> slice = view->get_row_delta();
     std::shared_ptr<std::string> arrow = view->data_slice_to_arrow(slice);
     return py::bytes(*arrow);

--- a/python/perspective/perspective/tests/core/test_async.py
+++ b/python/perspective/perspective/tests/core/test_async.py
@@ -174,7 +174,7 @@ class TestAsync(object):
             tbl2.update([data[i]])
 
         assert SENTINEL.get() != 0
-        assert SENTINEL_2.get() == -5
+        assert SENTINEL_2.get() == -6
 
         assert tbl2_id not in _PerspectiveStateManager.TO_PROCESS
 
@@ -388,7 +388,7 @@ class TestAsync(object):
             tbl2.update([port_data[idx]], port_id=port_id)
 
         assert SENTINEL.get() != 0
-        assert SENTINEL_2.get() == -11
+        assert SENTINEL_2.get() == -12
 
         tbl2.delete()
         tbl.delete()

--- a/python/perspective/perspective/tests/core/test_async.py
+++ b/python/perspective/perspective/tests/core/test_async.py
@@ -32,18 +32,16 @@ class AsyncSentinel(object):
 SENTINEL = AsyncSentinel(0)
 
 
-def queue_process_async(table_id, state_manager, loop=None):
+def queue_process_async(loop, f, *args, **kwargs):
     """Create our own `queue_process` method that uses a Tornado IOLoop."""
-    if loop:
-        SENTINEL.set(SENTINEL.get() + 1)
-        loop.add_callback(state_manager.call_process, table_id=table_id)
+    SENTINEL.set(SENTINEL.get() + 1)
+    loop.add_callback(f, *args, **kwargs)
 
 
-def queue_process_async_delay(table_id, state_manager, delay=0.25, loop=None):
+def queue_process_async_delay(loop, delay, f, *args, **kwargs):
     """Create our own `queue_process` method that uses a Tornado IOLoop."""
-    if loop:
-        SENTINEL.set(SENTINEL.get() + 1)
-        loop.call_later(delay, state_manager.call_process, table_id=table_id)
+    SENTINEL.set(SENTINEL.get() + 1)
+    loop.call_later(delay, f, *args, **kwargs)
 
 
 data = [{"a": i, "b": i * 0.5, "c": str(i)} for i in range(10)]
@@ -56,7 +54,7 @@ class TestAsync(object):
     def setup_class(cls):
         cls.loop = tornado.ioloop.IOLoop()
         cls.loop.make_current()
-        cls.wrapped_queue_process = partial(queue_process_async, loop=cls.loop)
+        cls.wrapped_queue_process = partial(queue_process_async, cls.loop)
         cls.thread = Thread(target=cls.loop.start)
         cls.thread.daemon = True
         cls.thread.start()
@@ -90,7 +88,7 @@ class TestAsync(object):
             "c": str
         })
         manager = PerspectiveManager()
-        manager._set_queue_process(TestAsync.wrapped_queue_process)
+        manager.set_loop_callback(TestAsync.wrapped_queue_process)
         manager.host(tbl)
 
         assert tbl.size() == 0
@@ -120,8 +118,8 @@ class TestAsync(object):
         manager.host_table("tbl", tbl)
         manager2.host_table("tbl2", tbl2)
 
-        manager._set_queue_process(TestAsync.wrapped_queue_process)
-        manager2._set_queue_process(TestAsync.wrapped_queue_process)
+        manager.set_loop_callback(TestAsync.wrapped_queue_process)
+        manager2.set_loop_callback(TestAsync.wrapped_queue_process)
 
         for i in range(5):
             tbl.update([data[i]])
@@ -144,9 +142,9 @@ class TestAsync(object):
         # mutate when synchronously calling queue_process for each update
         SENTINEL_2 = AsyncSentinel(0)
 
-        def sync_queue_process(table_id, state_manager):
+        def sync_queue_process(f, *args, **kwargs):
             SENTINEL_2.set(SENTINEL_2.get() - 1)
-            state_manager.call_process(table_id)
+            f(*args, **kwargs)
 
         tbl = Table({
             "a": int,
@@ -165,8 +163,8 @@ class TestAsync(object):
         manager2.host_table("tbl2", tbl2)
 
         # manager uses tornado, manager2 is synchronous
-        manager._set_queue_process(TestAsync.wrapped_queue_process)
-        manager2._set_queue_process(sync_queue_process)
+        manager.set_loop_callback(TestAsync.wrapped_queue_process)
+        manager2.set_loop_callback(sync_queue_process)
 
         tbl_id = tbl._table.get_id()
         tbl2_id = tbl2._table.get_id()
@@ -191,10 +189,8 @@ class TestAsync(object):
 
     def test_async_multiple_managers_delayed_process(self):
         from time import sleep
-        short_delay_queue_process = partial(queue_process_async_delay,
-                                            delay=0.5, loop=TestAsync.loop)
-        long_delay_queue_process = partial(queue_process_async_delay,
-                                           delay=1, loop=TestAsync.loop)
+        short_delay_queue_process = partial(queue_process_async_delay, TestAsync.loop, 0.5)
+        long_delay_queue_process = partial(queue_process_async_delay, TestAsync.loop, 1)
 
         tbl = Table({
             "a": int,
@@ -216,8 +212,8 @@ class TestAsync(object):
         # will be called, either by user action or loop iteration. By adding
         # the delay, we can artificially queue up actions for later execution
         # and see that it's working properly.
-        manager._set_queue_process(short_delay_queue_process)
-        manager2._set_queue_process(long_delay_queue_process)
+        manager.set_loop_callback(short_delay_queue_process)
+        manager2.set_loop_callback(long_delay_queue_process)
 
         tbl_id = tbl._table.get_id()
         tbl2_id = tbl2._table.get_id()
@@ -266,7 +262,7 @@ class TestAsync(object):
         assert port_ids == list(range(0, 11))
 
         manager = PerspectiveManager()
-        manager._set_queue_process(TestAsync.wrapped_queue_process)
+        manager.set_loop_callback(TestAsync.wrapped_queue_process)
         manager.host(tbl)
 
         assert tbl.size() == 0
@@ -321,8 +317,8 @@ class TestAsync(object):
         manager.host_table("tbl", tbl)
         manager2.host_table("tbl2", tbl2)
 
-        manager._set_queue_process(TestAsync.wrapped_queue_process)
-        manager2._set_queue_process(TestAsync.wrapped_queue_process)
+        manager.set_loop_callback(TestAsync.wrapped_queue_process)
+        manager2.set_loop_callback(TestAsync.wrapped_queue_process)
 
         random.shuffle(port_ids)
 
@@ -338,9 +334,9 @@ class TestAsync(object):
         # mutate when synchronously calling queue_process for each update
         SENTINEL_2 = AsyncSentinel(0)
 
-        def sync_queue_process(table_id, state_manager):
+        def sync_queue_process(f, *args, **kwargs):
             SENTINEL_2.set(SENTINEL_2.get() - 1)
-            state_manager.call_process(table_id)
+            f(*args, **kwargs)
 
         tbl = Table({
             "a": int,
@@ -381,8 +377,8 @@ class TestAsync(object):
         manager2.host_table("tbl2", tbl2)
 
         # manager uses tornado, manager2 is synchronous
-        manager._set_queue_process(TestAsync.wrapped_queue_process)
-        manager2._set_queue_process(sync_queue_process)
+        manager.set_loop_callback(TestAsync.wrapped_queue_process)
+        manager2.set_loop_callback(sync_queue_process)
 
         random.shuffle(port_ids)
 
@@ -399,10 +395,8 @@ class TestAsync(object):
 
     def test_async_multiple_managers_delayed_process_multiple_ports(self):
         from time import sleep
-        short_delay_queue_process = partial(queue_process_async_delay,
-                                            delay=0.5, loop=TestAsync.loop)
-        long_delay_queue_process = partial(queue_process_async_delay,
-                                           delay=1, loop=TestAsync.loop)
+        short_delay_queue_process = partial(queue_process_async_delay, TestAsync.loop, 0.5)
+        long_delay_queue_process = partial(queue_process_async_delay, TestAsync.loop, 1)
 
         tbl = Table({
             "a": int,
@@ -424,8 +418,8 @@ class TestAsync(object):
         # will be called, either by user action or loop iteration. By adding
         # the delay, we can artificially queue up actions for later execution
         # and see that it's working properly.
-        manager._set_queue_process(short_delay_queue_process)
-        manager2._set_queue_process(long_delay_queue_process)
+        manager.set_loop_callback(short_delay_queue_process)
+        manager2.set_loop_callback(long_delay_queue_process)
 
         tbl_id = tbl._table.get_id()
         tbl2_id = tbl2._table.get_id()

--- a/python/perspective/perspective/tests/manager/test_manager.py
+++ b/python/perspective/perspective/tests/manager/test_manager.py
@@ -998,11 +998,11 @@ class TestPerspectiveManager(object):
             "a": [1, 2, 3, 4, 5, 6]
         }
 
-        def fake_queue_process(table_id, state_manager):
+        def fake_queue_process(f, *args, **kwargs):
             s.set(s.get() + 1)
-            state_manager.call_process(table_id)
+            f(*args, **kwargs)
 
-        manager._set_queue_process(fake_queue_process)
+        manager.set_loop_callback(fake_queue_process)
         table.update({"a": [7, 8, 9]})
         assert s.get() == 1
 
@@ -1011,11 +1011,11 @@ class TestPerspectiveManager(object):
         manager = PerspectiveManager()
         table = Table({"a": [1, 2, 3]})
 
-        def fake_queue_process(table_id, state_manager):
+        def fake_queue_process(f, *args, **kwargs):
             s.set(s.get() + 1)
-            state_manager.call_process(table_id)
+            f(*args, **kwargs)
 
-        manager._set_queue_process(fake_queue_process)
+        manager.set_loop_callback(fake_queue_process)
         manager.host_table("tbl", table)
         table.update({"a": [4, 5, 6]})
         table.update({"a": [4, 5, 6]})
@@ -1034,11 +1034,11 @@ class TestPerspectiveManager(object):
         manager.host_table("tbl", table)
         manager2.host_table("tbl2", table2)
 
-        def fake_queue_process(table_id, state_manager):
+        def fake_queue_process(f, *args, **kwargs):
             s2.set(s2.get() + 1)
-            state_manager.call_process(table_id)
+            f(*args, **kwargs)
 
-        manager2._set_queue_process(fake_queue_process)
+        manager2.set_loop_callback(fake_queue_process)
 
         table.update({"a": [4, 5, 6]})
         assert table.view().to_dict() == {

--- a/python/perspective/perspective/tests/manager/test_manager.py
+++ b/python/perspective/perspective/tests/manager/test_manager.py
@@ -1004,7 +1004,7 @@ class TestPerspectiveManager(object):
 
         manager.set_loop_callback(fake_queue_process)
         table.update({"a": [7, 8, 9]})
-        assert s.get() == 1
+        assert s.get() == 2
 
     def test_manager_set_queue_process_before_host_table(self, sentinel):
         s = sentinel(0)
@@ -1020,7 +1020,7 @@ class TestPerspectiveManager(object):
         table.update({"a": [4, 5, 6]})
         table.update({"a": [4, 5, 6]})
 
-        assert s.get() == 2
+        assert s.get() == 3
 
     def test_manager_set_queue_process_multiple(self, sentinel):
         # manager2's queue process should not affect manager1,
@@ -1055,4 +1055,4 @@ class TestPerspectiveManager(object):
             "a": [1, 2, 3, 7, 8, 9]
         }
         assert s.get() == 0
-        assert s2.get() == 1
+        assert s2.get() == 2

--- a/python/perspective/perspective/tornado_handler/tornado_client.py
+++ b/python/perspective/perspective/tornado_handler/tornado_client.py
@@ -28,7 +28,7 @@ class PerspectiveTornadoClient(PerspectiveClient):
     # Send a heartbeat every 15 seconds
     HEARTBEAT_TIMEOUT = 15 * 1000
 
-    def __init__(self, loop=None):
+    def __init__(self):
         """Create a `PerspectiveTornadoClient` that interfaces with a
         Perspective server over a Websocket, using the given
         `loop` instance, which defaults to ioloop.IOLoop.current() if


### PR DESCRIPTION
Adds `set_loop_callback()` public method to the `PerspectiveManager` class, which takes as an argument a loop-queueing function, such as asyncio `call_soon()` and Tornado `add_callback()`.  Once invoked, Perspective will presume to be owned by the calling thread, and will release the Python GIL for the bulk of reading/writing Apache Arrow data, as well as calculating
new `View` contexts.  There are some new restrictions in this mode, namely that Perspective is no longer thread safe, covered in the documentation.