### PR TITLE
Release GIL for `Table` methods

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -514,6 +514,7 @@ set (SOURCE_FILES
 	${PSP_CPP_SRC}/src/cpp/pool.cpp
 	${PSP_CPP_SRC}/src/cpp/port.cpp
 	${PSP_CPP_SRC}/src/cpp/process_state.cpp
+	${PSP_CPP_SRC}/src/cpp/pyutils.cpp
 	${PSP_CPP_SRC}/src/cpp/raii.cpp
 	${PSP_CPP_SRC}/src/cpp/raii_impl_linux.cpp
 	${PSP_CPP_SRC}/src/cpp/raii_impl_osx.cpp

--- a/cpp/perspective/src/cpp/pyutils.cpp
+++ b/cpp/perspective/src/cpp/pyutils.cpp
@@ -8,39 +8,28 @@
  */
 
 #include <perspective/first.h>
+#include <perspective/base.h>
 #include <perspective/pyutils.h>
-#include <frameobject.h>
-#include <iostream>
-#include <perspective/pythonhelpers.h>
-
+#ifdef PSP_ENABLE_PYTHON
 namespace perspective {
 
-bool
-curthread_has_gil() {
-    auto tstate = _PyThreadState_Current;
-    return tstate && (tstate == PyGILState_GetThisThreadState());
-}
-
-void
-print_python_stack() {
-    auto tstate = PyThreadState_GET();
-    if (0 != tstate && 0 != tstate->frame) {
-        auto f = tstate->frame;
-        std::cout << "Python stack trace:" << std::endl;
-        while (0 != f) {
-            auto line = PyCode_Addr2Line(f->f_code, f->f_lasti);
-            auto filename = PyString_AsString(f->f_code->co_filename);
-            auto funcname = PyString_AsString(f->f_code->co_name);
-            std::cout << "\t" << filename << ":" << line << " : " << funcname << std::endl;
-            f = f->f_back;
+PerspectiveScopedGILRelease::PerspectiveScopedGILRelease(std::thread::id event_loop_thread_id) : m_thread_state(NULL) {
+    if (event_loop_thread_id != std::thread::id()) {
+        if (std::this_thread::get_id() != event_loop_thread_id) {
+            std::stringstream err;
+            err << "Perspective called from wrong thread; Expected " << event_loop_thread_id << "; Got " << std::this_thread::get_id() << std::endl;
+            PSP_COMPLAIN_AND_ABORT(err.str());
         }
+        m_thread_state = PyEval_SaveThread();
     }
 }
 
-std::string
-repr(PyObject* pyo) {
-    PyObjectPtr repr(PyObject_Repr(pyo));
-    return std::string(PyString_AsString(repr.get()));
+PerspectiveScopedGILRelease::~PerspectiveScopedGILRelease() {
+     if (m_thread_state != NULL) {
+        PyEval_RestoreThread(m_thread_state);
+    }
 }
 
 } // end namespace perspective
+
+#endif

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -770,6 +770,14 @@ View<CTX_T>::is_column_only() const {
     return m_view_config->is_column_only();
 }
 
+#ifdef PSP_ENABLE_PYTHON
+template <typename CTX_T>
+std::thread::id 
+View<CTX_T>::get_event_loop_thread_id() const {
+    return m_table->get_pool()->get_event_loop_thread_id();
+};
+#endif
+
 /******************************************************************************
  *
  * Private

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -25,6 +25,9 @@
 #include <perspective/computed_column_map.h>
 #include <perspective/computed_function.h>
 #include <tsl/ordered_map.h>
+#ifdef PSP_ENABLE_PYTHON
+#include <thread>
+#endif
 #ifdef PSP_PARALLEL_FOR
 #include <tbb/parallel_sort.h>
 #include <tbb/tbb.h>
@@ -189,6 +192,10 @@ public:
 
     void pprint() const;
     std::string repr() const;
+
+#ifdef PSP_ENABLE_PYTHON
+    void set_event_loop_thread_id(std::thread::id id);
+#endif
 
 protected:
     /**
@@ -390,6 +397,10 @@ private:
     std::vector<t_custom_column> m_custom_columns;
     std::function<void()> m_pool_cleanup;
     bool m_was_updated;
+
+#ifdef PSP_ENABLE_PYTHON
+    std::thread::id m_event_loop_thread_id;
+#endif
 };
 
 /**

--- a/cpp/perspective/src/include/perspective/pool.h
+++ b/cpp/perspective/src/include/perspective/pool.h
@@ -15,6 +15,10 @@
 #include <mutex>
 #include <atomic>
 
+#ifdef PSP_ENABLE_PYTHON
+#include <thread>
+#endif
+
 #if defined PSP_ENABLE_WASM
     #include <emscripten/val.h>
     typedef emscripten::val t_val;
@@ -57,6 +61,11 @@ public:
         t_uindex gnode_id, const std::string& name, t_ctx_type type, std::int64_t ptr);
 #endif
 
+#ifdef PSP_ENABLE_PYTHON
+    void set_event_loop();
+    std::thread::id get_event_loop_thread_id() const;
+#endif
+
     /**
      * @brief Call the binding language's `update_callback` method,
      * set at initialize time.
@@ -74,7 +83,7 @@ public:
     void send(t_uindex gnode_id, t_uindex port_id, const t_data_table& table);
 
     void _process();
-    void _process_helper();
+
     void init();
     void stop();
     void set_sleep(t_uindex ms);
@@ -102,6 +111,9 @@ protected:
     bool validate_gnode_id(t_uindex gnode_id) const;
 
 private:
+#ifdef PSP_ENABLE_PYTHON
+    std::thread::id m_event_loop_thread_id;
+#endif
     std::mutex m_mtx;
     std::vector<t_gnode*> m_gnodes;
 

--- a/cpp/perspective/src/include/perspective/pyutils.h
+++ b/cpp/perspective/src/include/perspective/pyutils.h
@@ -1,0 +1,30 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+#pragma once
+#include <perspective/first.h>
+
+#ifdef PSP_ENABLE_PYTHON
+#include <thread>
+
+namespace perspective {
+
+class PerspectiveScopedGILRelease {
+    public:
+        PerspectiveScopedGILRelease(std::thread::id event_loop_thread_id);
+        ~PerspectiveScopedGILRelease();
+    private:
+        PyThreadState* m_thread_state;
+};
+
+
+void _set_event_loop();
+
+} // namespace perspective
+#endif

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -21,6 +21,9 @@
 #include <cstddef>
 #include <memory>
 #include <map>
+#ifdef PSP_ENABLE_PYTHON
+#include <thread>
+#endif
 
 namespace perspective {
 
@@ -224,6 +227,9 @@ public:
     t_stepdelta get_step_delta(t_index bidx, t_index eidx) const;
     t_dtype get_column_dtype(t_uindex idx) const;
     bool is_column_only() const;
+#ifdef PSP_ENABLE_PYTHON
+    std::thread::id get_event_loop_thread_id() const;
+#endif
 
 private:
     /**

--- a/python/perspective/perspective/include/perspective/python.h
+++ b/python/perspective/perspective/include/perspective/python.h
@@ -30,6 +30,7 @@
 #include <perspective/binding.h>
 #include <perspective/exception.h>
 #include <perspective/exports.h>
+#include <perspective/pyutils.h>
 #include <perspective/python/accessor.h>
 #include <perspective/python/base.h>
 #include <perspective/python/computed.h>
@@ -255,6 +256,7 @@ PYBIND11_MODULE(libbinding, m)
         .def(py::init<>())
         .def("set_update_delegate", &t_pool::set_update_delegate)
         .def("unregister_gnode", &t_pool::unregister_gnode)
+        .def("set_event_loop", &t_pool::set_event_loop)
         .def("_process", &t_pool::_process);
 
     /******************************************************************************
@@ -384,7 +386,6 @@ PYBIND11_MODULE(libbinding, m)
     m.def("make_computations", &make_computations);
     m.def("scalar_to_py", &scalar_to_py);
     m.def("_set_nthreads", &_set_nthreads);
-    m.def("_set_event_loop", &_set_event_loop);
 }
 
 #endif

--- a/python/perspective/perspective/include/perspective/python/serialization.h
+++ b/python/perspective/perspective/include/perspective/python/serialization.h
@@ -11,6 +11,7 @@
 
 #include <perspective/base.h>
 #include <perspective/binding.h>
+#include <perspective/pyutils.h>
 #include <perspective/python/base.h>
 #include <perspective/python/utils.h>
 

--- a/python/perspective/perspective/include/perspective/python/table.h
+++ b/python/perspective/perspective/include/perspective/python/table.h
@@ -11,6 +11,7 @@
 
 #include <perspective/base.h>
 #include <perspective/binding.h>
+#include <perspective/pyutils.h>
 #include <perspective/python/base.h>
 
 namespace perspective {

--- a/python/perspective/perspective/include/perspective/python/utils.h
+++ b/python/perspective/perspective/include/perspective/python/utils.h
@@ -19,16 +19,6 @@
 namespace perspective {
 namespace binding {
 
-class PerspectiveScopedGILRelease {
-    public:
-        PerspectiveScopedGILRelease();
-        ~PerspectiveScopedGILRelease();
-    private:
-        PyThreadState* thread_state;
-};
-
-
-void _set_event_loop();
 
 void _set_nthreads(int nthreads);
 

--- a/python/perspective/perspective/include/perspective/python/view.h
+++ b/python/perspective/perspective/include/perspective/python/view.h
@@ -11,6 +11,7 @@
 
 #include <perspective/base.h>
 #include <perspective/binding.h>
+#include <perspective/pyutils.h>
 #include <perspective/python/base.h>
 #include <perspective/python/utils.h>
 

--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -315,7 +315,10 @@ class _PerspectiveManagerInternal(object):
 
         for name, view in self._views.items():
             if view._client_id == client_id:
-                view.delete()
+                if self._loop_callback:
+                    self._loop_callback(view.delete)
+                else:
+                    view.delete()
                 names.append(name)
                 count += 1
 

--- a/python/perspective/perspective/src/serialization.cpp
+++ b/python/perspective/perspective/src/serialization.cpp
@@ -25,7 +25,7 @@ template <typename CTX_T>
 std::shared_ptr<t_data_slice<CTX_T>>
 get_data_slice(std::shared_ptr<View<CTX_T>> view, std::uint32_t start_row,
     std::uint32_t end_row, std::uint32_t start_col, std::uint32_t end_col) {
-    PerspectiveScopedGILRelease acquire;
+    PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
     auto data_slice = view->get_data(start_row, end_row, start_col, end_col);
     return data_slice;
 }

--- a/python/perspective/perspective/src/utils.cpp
+++ b/python/perspective/perspective/src/utils.cpp
@@ -22,30 +22,6 @@
 namespace perspective {
 namespace binding {
 
-std::thread::id* event_loop_thread;
-
-PerspectiveScopedGILRelease::PerspectiveScopedGILRelease() : thread_state(0) {
-    if (event_loop_thread != NULL) {
-        if (std::this_thread::get_id() != *event_loop_thread) {
-            std::cerr << "Perspective called from wrong thread; Expected " << *event_loop_thread << "; Got " << std::this_thread::get_id() << std::endl;
-        }
-        thread_state = PyEval_SaveThread();
-    }
-}
-
-PerspectiveScopedGILRelease::~PerspectiveScopedGILRelease() {
-     if (event_loop_thread != NULL) {
-        if (std::this_thread::get_id() != *event_loop_thread) {
-            std::cerr << "Perspective called from wrong thread; Expected " << *event_loop_thread << "; Got " << std::this_thread::get_id() << std::endl;
-        }
-        PyEval_RestoreThread(thread_state);
-    }
-}
-
-void _set_event_loop() {
-    event_loop_thread = new std::thread::id(std::this_thread::get_id());
-}
-
 std::shared_ptr<tbb::global_control> control = 
     std::make_shared<tbb::global_control>(
         tbb::global_control::max_allowed_parallelism,

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -243,7 +243,7 @@ make_view(std::shared_ptr<Table> table, const std::string& name, const std::stri
     std::shared_ptr<t_schema> schema = std::make_shared<t_schema>(table->get_schema());
     std::shared_ptr<t_view_config> config = make_view_config<t_val>(schema, date_parser, view_config);
     {
-        PerspectiveScopedGILRelease acquire;
+        PerspectiveScopedGILRelease acquire(table->get_pool()->get_event_loop_thread_id());
         auto ctx = make_context<CTX_T>(table, schema, config, name);
         auto view_ptr = std::make_shared<View<CTX_T>>(table, ctx, name, separator, config);
         return view_ptr;
@@ -276,7 +276,7 @@ to_arrow_zero(
     std::int32_t start_col,
     std::int32_t end_col
 ) {
-    PerspectiveScopedGILRelease acquire;
+    PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
     std::shared_ptr<std::string> str = 
         view->to_arrow(start_row, end_row, start_col, end_col);
     return py::bytes(*str);
@@ -290,7 +290,7 @@ to_arrow_one(
     std::int32_t start_col, 
     std::int32_t end_col
 ) {
-    PerspectiveScopedGILRelease acquire;
+    PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
     std::shared_ptr<std::string> str = 
         view->to_arrow(start_row, end_row, start_col, end_col);
     return py::bytes(*str);
@@ -304,7 +304,7 @@ to_arrow_two(
     std::int32_t start_col, 
     std::int32_t end_col
 ) {
-    PerspectiveScopedGILRelease acquire;
+    PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
     std::shared_ptr<std::string> str = 
         view->to_arrow(start_row, end_row, start_col, end_col);
     return py::bytes(*str);
@@ -312,7 +312,7 @@ to_arrow_two(
 
 py::bytes
 get_row_delta_zero(std::shared_ptr<View<t_ctx0>> view) {
-    PerspectiveScopedGILRelease acquire;
+    PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
     std::shared_ptr<t_data_slice<t_ctx0>> slice = view->get_row_delta();
     std::shared_ptr<std::string> arrow = view->data_slice_to_arrow(slice);
     return py::bytes(*arrow);
@@ -320,7 +320,7 @@ get_row_delta_zero(std::shared_ptr<View<t_ctx0>> view) {
 
 py::bytes
 get_row_delta_one(std::shared_ptr<View<t_ctx1>> view) {
-    PerspectiveScopedGILRelease acquire;
+    PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
     std::shared_ptr<t_data_slice<t_ctx1>> slice = view->get_row_delta();
     std::shared_ptr<std::string> arrow = view->data_slice_to_arrow(slice);
     return py::bytes(*arrow);
@@ -329,7 +329,7 @@ get_row_delta_one(std::shared_ptr<View<t_ctx1>> view) {
 py::bytes
 get_row_delta_two(
     std::shared_ptr<View<t_ctx2>> view) {
-    PerspectiveScopedGILRelease acquire;
+    PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
     std::shared_ptr<t_data_slice<t_ctx2>> slice = view->get_row_delta();
     std::shared_ptr<std::string> arrow = view->data_slice_to_arrow(slice);
     return py::bytes(*arrow);


### PR DESCRIPTION
Releases the Python GIL during `Table()` calls, as well as `table.update()`, `table.remove()` and anything else which triggers the internal `gnode._process()` method for calculating conflated updates.

Additionally, `test_async.py` has been rewritten to test `PerspectiveManager()` on parallel threads, carefully preserving calling thread state.