### PR TITLE
Send large arrow binaries as chunks, add client-level Websocket heartbeat

### DIFF
--- a/examples/tornado-python/server.py
+++ b/examples/tornado-python/server.py
@@ -59,8 +59,7 @@ def make_app():
                 tornado.web.StaticFileHandler,
                 {"path": "./", "default_filename": "index.html"},
             ),
-        ],
-        websocket_ping_interval=15,
+        ]
     )
 
 

--- a/packages/perspective-jupyterlab/src/ts/client.ts
+++ b/packages/perspective-jupyterlab/src/ts/client.ts
@@ -6,6 +6,7 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+/* eslint-disable @typescript-eslint/camelcase */
 
 import {DOMWidgetView} from "@jupyter-widgets/base";
 import {Client} from "@finos/perspective/dist/esm/api/client";
@@ -51,11 +52,15 @@ export class PerspectiveJupyterClient extends Client {
      * @param msg {any} the message to pass to the `PerspectiveManager`.
      */
     send(msg: any): void {
-        // Handle calls to `update` with a binary by setting `is_transferable`
+        // Handle calls to `update` with a binary by setting `binary_length`
         // to true, so the kernel knows to handle the arraybuffer properly.
         if (msg.method === "update" && msg.args.length === 2 && msg.args[0] instanceof ArrayBuffer) {
-            msg.is_transferable = true;
-            const buffers = [msg.args[0]];
+            const binary_msg = msg.args[0];
+            const buffers = [binary_msg];
+
+            // Set `binary_length` to true so the manager expects a binary
+            // message.
+            msg.binary_length = binary_msg.byteLength;
 
             // Remove the arraybuffer from the message args, so it can be
             // passed along in `buffers`.
@@ -64,7 +69,7 @@ export class PerspectiveJupyterClient extends Client {
             const serialized = JSON.stringify(msg);
 
             // Send the first update message over the Jupyter comm with
-            // `is_transferable` set, so the kernel knows the expect the arrow.
+            // `binary_length` set, so the kernel knows the expect the arrow.
             this.view.send({
                 id: msg.id,
                 type: "cmd",

--- a/packages/perspective-jupyterlab/test/js/unit/view.spec.js
+++ b/packages/perspective-jupyterlab/test/js/unit/view.spec.js
@@ -185,7 +185,7 @@ describe("PerspectiveView", function() {
             const to_arrow_pre_msg = {
                 id: 1,
                 cmd: "view_method",
-                is_transferable: true,
+                binary_length: arrow.byteLength,
                 method: "to_arrow",
                 name: "view",
                 subscribe: false
@@ -194,7 +194,7 @@ describe("PerspectiveView", function() {
             view = await manager.create_view(model)();
 
             // Two messages are sent by the server: the first being the
-            // original message with `is_transferable` set to true,
+            // original message with `binary_length` set to true,
             // and the second the binary itself with the message as `null`.
             view._handle_message({
                 id: 1,
@@ -202,7 +202,7 @@ describe("PerspectiveView", function() {
                 data: to_arrow_pre_msg
             });
 
-            expect(view._pending_arrow).toEqual(1);
+            expect(view._pending_binary).toEqual(1);
 
             view._handle_message(null, [new DataView(arrow)]);
 
@@ -229,7 +229,7 @@ describe("PerspectiveView", function() {
             const on_update_pre_msg = {
                 id: 1,
                 cmd: "view_method",
-                is_transferable: true,
+                binary_length: arrow.byteLength,
                 data: {
                     port_id: 123
                 }
@@ -238,7 +238,7 @@ describe("PerspectiveView", function() {
             view = await manager.create_view(model)();
 
             // Two messages are sent by the server: the first being the
-            // original message with `is_transferable` set to true,
+            // original message with `binary_length` set to true,
             // and the second the binary itself with the message as `null`.
             view._handle_message({
                 id: 1,
@@ -246,7 +246,7 @@ describe("PerspectiveView", function() {
                 data: on_update_pre_msg
             });
 
-            expect(view._pending_arrow).toEqual(1);
+            expect(view._pending_binary).toEqual(1);
             expect(view._pending_port_id).toEqual(123);
 
             view._handle_message(null, [new DataView(arrow)]);

--- a/packages/perspective/src/js/perspective.node.js
+++ b/packages/perspective/src/js/perspective.node.js
@@ -176,6 +176,11 @@ class WebSocketServer extends WebSocketManager {
     }
 }
 
+/**
+ * Create a new Websocket connection to `url`, setting up the protocol for
+ * a Perspective server and Perspective client to communicate.
+ * @param {*} url
+ */
 const websocket = url => {
     return new WebSocketClient(new WebSocket(url));
 };

--- a/packages/perspective/src/js/websocket.js
+++ b/packages/perspective/src/js/websocket.js
@@ -1,7 +1,8 @@
 import {Client} from "./api/client.js";
 import {Server} from "./api/server.js";
 
-const HEARTBEAT_TIMEOUT = 15000;
+// Initiate a `ping` to the server every 30 seconds
+const PING_TIMEOUT = 30000;
 let CLIENT_ID_GEN = 0;
 
 export class WebSocketClient extends Client {
@@ -12,13 +13,13 @@ export class WebSocketClient extends Client {
         this._ws.onopen = () => {
             this.send({id: -1, cmd: "init"});
         };
-        const heartbeat = () => {
-            this._ws.send("heartbeat");
-            setTimeout(heartbeat, HEARTBEAT_TIMEOUT);
+        const ping = () => {
+            this._ws.send("ping");
+            setTimeout(ping, PING_TIMEOUT);
         };
-        setTimeout(heartbeat, 15000);
+        setTimeout(ping, PING_TIMEOUT);
         this._ws.onmessage = msg => {
-            if (msg.data === "heartbeat") {
+            if (msg.data === "pong") {
                 return;
             }
             if (this._pending_arrow) {
@@ -138,8 +139,8 @@ export class WebSocketManager extends Server {
         ws.on("message", msg => {
             ws.isAlive = true;
 
-            if (msg === "heartbeat") {
-                ws.send("heartbeat");
+            if (msg === "ping") {
+                ws.send("pong");
                 return;
             }
 

--- a/packages/perspective/src/js/websocket.js
+++ b/packages/perspective/src/js/websocket.js
@@ -189,7 +189,8 @@ export class WebSocketManager extends Server {
     }
 
     /**
-     * Send an asynchronous message to the Perspective web worker.
+     * Send an asynchronous message to the Perspective client through
+     * the websocket.
      *
      * If the `transferable` param is set, pass two messages: the string
      * representation of the message and then the ArrayBuffer data that needs to

--- a/packages/perspective/src/js/websocket.js
+++ b/packages/perspective/src/js/websocket.js
@@ -160,9 +160,6 @@ export class WebSocketManager extends Server {
         this.requests = {};
         this.websockets = {};
 
-        // Send binary messages in chunks above this threshold (in bytes)
-        this.chunk_threshold = 200 * 1000 * 1000;
-
         // Send chunks of this size (in bytes)
         this.chunk_size = 50 * 1000 * 1000;
 
@@ -275,9 +272,7 @@ export class WebSocketManager extends Server {
             const binary_msg = transferable[0];
             msg.binary_length = binary_msg.byteLength;
             req.ws.send(JSON.stringify(msg));
-            setTimeout(() => {
-                this._post_chunked(req, binary_msg, 0, this.chunk_size, binary_msg.byteLength);
-            }, 0);
+            this._post_chunked(req, binary_msg, 0, this.chunk_size, binary_msg.byteLength);
         } else {
             req.ws.send(JSON.stringify(msg));
         }

--- a/packages/perspective/test/js/remote.spec.js
+++ b/packages/perspective/test/js/remote.spec.js
@@ -84,7 +84,7 @@ describe("WebSocketManager", function() {
         });
     });
 
-    it("Calls `update` and sends arraybuffers using `is_transferable`", async () => {
+    it("Calls `update` and sends arraybuffers using `binary_length`", async () => {
         const data = [{x: 1}];
         const table = perspective.table(data);
         const view = table.view();
@@ -104,7 +104,7 @@ describe("WebSocketManager", function() {
         server.eject_table("test");
     });
 
-    it("Calls `update` and sends arraybuffers using `is_transferable` multiple times", async () => {
+    it("Calls `update` and sends arraybuffers using `binary_length` multiple times", async () => {
         const data = [{x: 1}];
         const table = perspective.table(data);
         const view = table.view();

--- a/python/perspective/perspective/manager/manager.py
+++ b/python/perspective/perspective/manager/manager.py
@@ -42,8 +42,26 @@ class PerspectiveManager(_PerspectiveManagerInternal):
         clean up associated resources.
     """
 
-    def __init__(self, lock=False):
+    def __init__(
+        self,
+        lock=False,
+        chunk_threshold=200 * 1000 * 1000,
+        chunk_size=50 * 1000 * 1000,
+    ):
+        """Create a new ``PerspectiveManager`` instance.
+
+        Keyword Args:
+            lock (:obj:`bool`): [description]. Defaults to False.
+            chunk_threshold (:obj:`int`): [description]. Binary messages above
+                this length in bytes will be passed as chunks of ``chunk_size``.
+                Defaults to  200MB.
+            chunk_size (:obj:`int`): Binary messages above ``chunk_threshold``
+                will be passed in chunks of this length (in bytes). Defaults
+                to 20MB.
+        """
         super(PerspectiveManager, self).__init__(lock=lock)
+        self._chunk_threshold = chunk_threshold
+        self._chunk_size = chunk_size
         self._loop_callback = None
 
     def lock(self):

--- a/python/perspective/perspective/manager/manager.py
+++ b/python/perspective/perspective/manager/manager.py
@@ -42,26 +42,13 @@ class PerspectiveManager(_PerspectiveManagerInternal):
         clean up associated resources.
     """
 
-    def __init__(
-        self,
-        lock=False,
-        chunk_threshold=200 * 1000 * 1000,
-        chunk_size=50 * 1000 * 1000,
-    ):
+    def __init__(self, lock=False):
         """Create a new ``PerspectiveManager`` instance.
 
         Keyword Args:
             lock (:obj:`bool`): [description]. Defaults to False.
-            chunk_threshold (:obj:`int`): [description]. Binary messages above
-                this length in bytes will be passed as chunks of ``chunk_size``.
-                Defaults to  200MB.
-            chunk_size (:obj:`int`): Binary messages above ``chunk_threshold``
-                will be passed in chunks of this length (in bytes). Defaults
-                to 20MB.
         """
         super(PerspectiveManager, self).__init__(lock=lock)
-        self._chunk_threshold = chunk_threshold
-        self._chunk_size = chunk_size
         self._loop_callback = None
 
     def lock(self):

--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -64,7 +64,9 @@ class _PerspectiveManagerInternal(object):
 
     def __process(self, msg, post_callback, client_id=None):
         if isinstance(msg, string_types):
-            if msg == "heartbeat":  # TODO fix this
+            if msg == "ping":
+                # Ignore ping heartbeats that reach the manager - they should
+                # be handled in the transport layer.
                 return
             msg = json.loads(msg)
 

--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -312,6 +312,11 @@ class _PerspectiveManagerInternal(object):
                 byte messages without serializing to JSON.
         """
         msg["is_transferable"] = True
+
+        # Pass the total length of the arrow to the client, so it knows to
+        # wait until the arrow has been received in whole.
+        msg["arrow_length"] = len(binary)
+
         post_callback(json.dumps(msg, cls=DateTimeEncoder))
         post_callback(binary, binary=True)
 

--- a/python/perspective/perspective/tests/tornado_handler/test_tornado_handler.py
+++ b/python/perspective/perspective/tests/tornado_handler/test_tornado_handler.py
@@ -9,7 +9,7 @@ import random
 import pytest
 
 import tornado
-from tornado import gen, ioloop
+from tornado import gen
 from datetime import datetime
 
 from ...table import Table
@@ -277,7 +277,6 @@ class TestPerspectiveTornadoHandler(object):
         view = table.view()
 
         output = yield view.to_arrow()
-
 
         for i in range(10):
             table.update(output)

--- a/python/perspective/perspective/tests/tornado_handler/test_tornado_handler_chunked.py
+++ b/python/perspective/perspective/tests/tornado_handler/test_tornado_handler_chunked.py
@@ -1,0 +1,95 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+import random
+import pytest
+
+import tornado
+from tornado import gen
+from datetime import datetime
+
+from ...table import Table
+from ...manager import PerspectiveManager
+from ...tornado_handler import PerspectiveTornadoHandler, websocket
+
+
+data = {
+    "a": [i for i in range(10)],
+    "b": [i * 1.5 for i in range(10)],
+    "c": [str(i) for i in range(10)],
+    "d": [datetime(2020, 3, i, i, 30, 45) for i in range(1, 11)],
+}
+
+MANAGER = PerspectiveManager(chunk_threshold=1000, chunk_size=500)
+
+APPLICATION = tornado.web.Application(
+    [
+        (
+            r"/websocket",
+            PerspectiveTornadoHandler,
+            {"manager": MANAGER, "check_origin": True},
+        )
+    ]
+)
+
+
+@pytest.fixture(scope="module")
+def app():
+    return APPLICATION
+
+
+class TestPerspectiveTornadoHandlerChunked(object):
+    def setup_method(self):
+        """Flush manager state before each test method execution."""
+        MANAGER._tables = {}
+        MANAGER._views = {}
+
+    @gen.coroutine
+    def websocket_client(self, port):
+        """Connect and initialize a websocket client connection to the
+        Perspective tornado server.
+        """
+        client = yield websocket("ws://127.0.0.1:{0}/websocket".format(port))
+
+        # Compatibility with Python < 3.3
+        raise gen.Return(client)
+
+    @pytest.mark.gen_test(run_sync=False)
+    def test_tornado_handler_create_view_to_arrow_chunked(
+        self, app, http_client, http_port, sentinel
+    ):
+        table_name = str(random.random())
+        _table = Table(data)
+        MANAGER.host_table(table_name, _table)
+
+        client = yield self.websocket_client(http_port)
+        table = client.open_table(table_name)
+        view = table.view()
+        output = yield view.to_arrow()
+        expected = yield table.schema()
+
+        assert Table(output).schema(as_string=True) == expected
+
+    @pytest.mark.gen_test(run_sync=False)
+    def test_tornado_handler_create_view_to_arrow_update_chunked(
+        self, app, http_client, http_port, sentinel
+    ):
+        table_name = str(random.random())
+        _table = Table(data)
+        MANAGER.host_table(table_name, _table)
+
+        client = yield self.websocket_client(http_port)
+        table = client.open_table(table_name)
+        view = table.view()
+
+        output = yield view.to_arrow()
+
+        for i in range(10):
+            table.update(output)
+
+        size2 = yield table.size()
+        assert size2 == 110

--- a/python/perspective/perspective/tests/tornado_handler/test_tornado_handler_chunked.py
+++ b/python/perspective/perspective/tests/tornado_handler/test_tornado_handler_chunked.py
@@ -24,14 +24,14 @@ data = {
     "d": [datetime(2020, 3, i, i, 30, 45) for i in range(1, 11)],
 }
 
-MANAGER = PerspectiveManager(chunk_threshold=1000, chunk_size=500)
+MANAGER = PerspectiveManager()
 
 APPLICATION = tornado.web.Application(
     [
         (
             r"/websocket",
             PerspectiveTornadoHandler,
-            {"manager": MANAGER, "check_origin": True},
+            {"manager": MANAGER, "check_origin": True, "chunk_size": 500},
         )
     ]
 )

--- a/python/perspective/perspective/tornado_handler/tornado_client.py
+++ b/python/perspective/perspective/tornado_handler/tornado_client.py
@@ -38,7 +38,6 @@ class PerspectiveTornadoClient(PerspectiveClient):
         self._ws = None
         self._pending_arrow = None
         self._pending_port_id = None
-        self._total_chunk_length = 0
         self._pending_arrow_length = 0
         self._full_arrow = b""
 
@@ -79,9 +78,8 @@ class PerspectiveTornadoClient(PerspectiveClient):
             arrow = msg
 
             self._full_arrow += arrow
-            self._total_chunk_length += len(arrow)
 
-            if self._total_chunk_length == self._pending_arrow_length:
+            if len(self._full_arrow) == self._pending_arrow_length:
                 # Chunking is complete
                 arrow = self._full_arrow
             else:
@@ -102,7 +100,6 @@ class PerspectiveTornadoClient(PerspectiveClient):
             self._pending_arrow = None
             self._pending_arrow_length = None
             self._pending_port_id = None
-            self._total_chunk_length = 0
             self._full_arrow = b""
         elif isinstance(msg, six.string_types):
             msg = json.loads(msg)

--- a/python/perspective/perspective/tornado_handler/tornado_handler.py
+++ b/python/perspective/perspective/tornado_handler/tornado_handler.py
@@ -22,8 +22,8 @@ class PerspectiveTornadoHandler(tornado.websocket.WebSocketHandler):
     with `IOLoop.current()` in order to defer expensive operations until the
     next free iteration of the event loop.
 
-    To keep the websocket connection alive, set your Tornado application's
-    ``websocket_ping_interval`` configuration variable.
+    The Perspective client and server will automatically keep the Websocket
+    alive without timing out.
 
     Examples:
         >>> MANAGER = PerspectiveManager()
@@ -81,7 +81,9 @@ class PerspectiveTornadoHandler(tornado.websocket.WebSocketHandler):
         callback. Contains special logic to handle passing :obj:`ArrayBuffer`
         objects over the wire from JS to Python, and vice-versa.
         """
-        if message == "heartbeat":
+        if message == "ping":
+            # Respond to ping heartbeats from the client.
+            self.write_message("pong")
             return
 
         # The message is an ArrayBuffer, and it needs to be combined with the

--- a/python/perspective/perspective/tornado_handler/tornado_handler.py
+++ b/python/perspective/perspective/tornado_handler/tornado_handler.py
@@ -56,10 +56,6 @@ class PerspectiveTornadoHandler(tornado.websocket.WebSocketHandler):
         self._chunk_threshold = self._manager._chunk_threshold
         self._chunk_size = self._manager._chunk_size
 
-        # Trigger special flow when receiving an ArrayBuffer/binary
-        self._is_transferable = False
-        self._is_transferable_pre_message = None
-
         if self._manager is None:
             raise PerspectiveError(
                 "A `PerspectiveManager` instance must be provided to the tornado handler!"


### PR DESCRIPTION
This PR implements chunked sending/chunked loading of binaries in Perspective's websocket implementations in both Python and Javascript. Apache Arrow binaries above a certain size will be sent to the Perspective client in chunks, which prevents the Websocket from locking on a particularly large binary and closing due to a timeout, as once that binary is on the wire all heartbeat messages/other messages are blocked from being sent/received. 

The default chunk threshold is configured to be 200MB, and arrows will be transported in 50MB chunks. In Python, these settings can be altered in the `PerspectiveManager` constructor by initializing a new `PerspectiveManager` with `chunk_threshold` and `chunk_size`, which are defined in bytes:

```python
manager = PerspectiveManager(
    chunk_threshold=500 * 1000 * 1000,  # in bytes
    chunk_size=100 * 1000 * 1000
)
```

In `NodeJS`, these settings can be altered on the `WebsocketManager`:

```javascript
const manager = new WebsocketManager();
manager.chunk_threshold = 500 * 1000 * 1000;  // in bytes
manager.chunk_size = 100 * 1000 * 1000;
```

Additionally, this PR implements a client-level heartbeat message (ping/pong) between Perspective client and server, which should aid in debugging as heartbeat messages now show up in the browser debug console. In Tornado, servers previously set up with `websocket_ping_interval` should remove their `websocket_ping_interval` setting and depend on the client-level heartbeats to keep the Perspective websocket connection alive.

### Changelog
- Implements chunked binary sending on `PerspectiveTornadoServer` in Python and `WebSocketManager` in JS
- Implements chunked binary receiving in `WebSocketClient` in JS and `PerspectiveTornadoClient` in Python
- Adds tests for chunked send/receive in Python
- Adds ping/pong heartbeat for Websockets