### PR TITLE
Separate 'release' and 'debug' builds

### DIFF
--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -17,7 +17,6 @@
     ],
     "typings": "index.d.ts",
     "scripts": {
-        "prebuild": "mkdirp dist && mkdirp obj",
         "build": "npm-run-all build:babel:* build:webpack build:webpack:umd:inline",
         "build:babel:esm": "babel src/js --source-maps --out-dir dist/esm",
         "build:babel:emsdk": "BABEL_MODULE=auto babel dist/obj --source-maps --out-dir dist/cjs",

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -28,12 +28,10 @@ function clean_screenshots() {
 
 try {
     if (!process.env.PSP_PROJECT || args.indexOf("--deps") > -1) {
-        clean`cpp/perspective/obj`;
+        clean`packages/perspective/build`;
     }
     if (process.env.PSP_PROJECT === "python") {
         clean(
-            "cpp/perspective/obj",
-            "cpp/perspective/cppbuild",
             "python/perspective/dist",
             "python/perspective/build",
             "python/perspective/docs/build",


### PR DESCRIPTION
A small QoL developer improvement to store `build` and `release` CMake artifacts in separate directories, such that a perspective developer can switch build settings without rebuilding the entirety of the project from scratch.