### PR TITLE
Improve `datetime` parsing performance

### DIFF
--- a/cpp/perspective/src/cpp/arrow_csv.cpp
+++ b/cpp/perspective/src/cpp/arrow_csv.cpp
@@ -252,14 +252,15 @@ namespace apachearrow {
         auto maybe_reader = arrow::csv::TableReader::Make(
             pool, input, read_options, parse_options, convert_options);
 
-        resetTimestampParsers(is_update);
-
         std::shared_ptr<arrow::csv::TableReader> reader = *maybe_reader;
 
         auto maybe_table = reader->Read();
         if (!maybe_table.ok()) {
             PSP_COMPLAIN_AND_ABORT(maybe_table.status().ToString());
         }
+
+        resetTimestampParsers(is_update);
+
         return *maybe_table;
     }
 

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -57,7 +57,9 @@ namespace binding {
 
     t_val
     is_valid_datetime(t_val filter_term) {
-        return t_val(apachearrow::parseAsArrowTimestamp(filter_term.as<std::string>()) != -1);
+        t_val data(apachearrow::parseAsArrowTimestamp(filter_term.as<std::string>()) != -1);
+        apachearrow::resetTimestampParsers();
+        return data;
     }
 
     bool val_to_date(t_val& item, bool is_update, t_date* out) {
@@ -1294,7 +1296,9 @@ namespace binding {
             return true;
         } else if (column_type == DTYPE_DATE || column_type == DTYPE_TIME) {
             if (filter_term.typeOf().as<std::string>().compare("string") == 0) {
-                return has_value(filter_term) && apachearrow::parseAsArrowTimestamp(filter_term.as<std::string>()) != -1;
+                bool is_valid = has_value(filter_term) && apachearrow::parseAsArrowTimestamp(filter_term.as<std::string>()) != -1;
+                apachearrow::resetTimestampParsers();
+                return is_valid;
             } else {
                 return has_value(filter_term);
             }         

--- a/cpp/perspective/src/include/perspective/arrow_csv.h
+++ b/cpp/perspective/src/include/perspective/arrow_csv.h
@@ -15,7 +15,9 @@
 namespace perspective {
 namespace apachearrow {
 
-    int64_t parseAsArrowTimestamp(const std::string& input);
+    void resetTimestampParsers(bool is_update = false);
+
+    int64_t parseAsArrowTimestamp(const std::string& input, bool is_update = false);
 
     /**
      * @brief Initialize the arrow loader with a CSV.

--- a/packages/perspective/src/js/view_formatters.js
+++ b/packages/perspective/src/js/view_formatters.js
@@ -34,7 +34,8 @@ const csvFormatter = Object.assign({}, jsonFormatter, {
                 case "object":
                 case "string":
                     // CSV escapes with double double quotes, for real.
-                    // [Section 2.7 of the fake CSV spec](https://tools.ietf.org/html/rfc4180)
+                    // Fake CSV spec
+                    // [Section 2.7 ](https://tools.ietf.org/html/rfc4180)
                     return x.indexOf(delimiter) > -1 ? `"${x.replace(/\"/g, '""')}"` : x.toString();
                 case "number":
                     return x;

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -1045,6 +1045,13 @@ module.exports = perspective => {
                 expect(result["d"]).toEqual("datetime");
             });
 
+            it("Correctly parses an MM/DD/YYYY formatted string with timezone", async function() {
+                let table = perspective.table({d: ["2/22/2020"]});
+                let view = table.view({});
+                let result = await view.schema();
+                expect(result["d"]).toEqual("datetime");
+            });
+
             it.skip("Correctly parses an RFC 2822 formatted string", async function() {
                 let table = perspective.table({d: ["Wed, 05 Oct 2011 22:26:12 -0400"]});
                 let view = table.view({});
@@ -1061,14 +1068,6 @@ module.exports = perspective => {
                     let result = await view.schema();
                     expect(result["d"]).toEqual("datetime");
                 }
-            });
-
-            // Only implemented in the C++ date parser - skip
-            it.skip("Correctly parses a 'dd mm yyyy' formatted string", async function() {
-                let table = perspective.table({d: ["15 08 08"]});
-                let view = table.view({});
-                let result = await view.schema();
-                expect(result["d"]).toEqual("datetime");
             });
 
             it("Does not (for now) parse a date string in non-US formatting", async function() {

--- a/scripts/build_js.js
+++ b/scripts/build_js.js
@@ -97,7 +97,7 @@ function compileCPP(packageName) {
     const base_dir = path.join(__dirname, "..", "packages", packageName, "build", dir_name);
     mkdirp.sync(base_dir);
     const cmd = bash`
-        emcmake cmake ../../../../cpp/perspective ${process.env.PSP_DEBUG}-DCMAKE_BUILD_TYPE
+        emcmake cmake ../../../../cpp/perspective -DCMAKE_BUILD_TYPE=${dir_name}
         && emmake make -j${process.env.PSP_CPU_COUNT || os.cpus().length}
     `;
     if (process.env.PSP_DOCKER) {


### PR DESCRIPTION
Improves datetime parsing performance by discarding format string candidates per-column as they fail on non-empty strings, which has a nice performance boost across the board for data types that use string datetime encodings.

<img width="641" alt="Screen Shot 2020-10-15 at 4 56 12 AM" src="https://user-images.githubusercontent.com/60666/96101536-8fcd8100-0ea3-11eb-8039-efabf7d0d1f9.png">
