### PR TITLE
Explicitly import `tornado.locks`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,7 +108,11 @@ jobs:
 
     - bash: python -m pip install "black==20.8b1" flake8-black
       condition: and(succeeded(), ne(variables['python.version'], '2.7'))
-      displayName: 'Install Python deps'
+      displayName: 'Install Python deps (py3)'
+
+    - bash: python -m pip install "tornado==4.5.3"
+      condition: and(succeeded(), eq(variables['python.version'], '2.7'))
+      displayName: 'Install Python deps (py2)'
 
     - bash: yarn build_python  --ci $(python_flag) $(manylinux_flag)
       displayName: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,11 +108,7 @@ jobs:
 
     - bash: python -m pip install "black==20.8b1" flake8-black
       condition: and(succeeded(), ne(variables['python.version'], '2.7'))
-      displayName: 'Install Python deps (py3)'
-
-    - bash: python -m pip install "tornado==4.5.3"
-      condition: and(succeeded(), eq(variables['python.version'], '2.7'))
-      displayName: 'Install Python deps (py2)'
+      displayName: 'Install Python deps'
 
     - bash: yarn build_python  --ci $(python_flag) $(manylinux_flag)
       displayName: 'build'

--- a/python/perspective/perspective/tornado_handler/tornado_handler.py
+++ b/python/perspective/perspective/tornado_handler/tornado_handler.py
@@ -7,6 +7,7 @@
 #
 
 from functools import partial
+import tornado.locks
 import tornado.websocket
 from tornado.gen import coroutine
 from tornado.ioloop import IOLoop

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -53,13 +53,12 @@ requires = [
     "python-dateutil>=2.8.0",
     "six>=1.11.0",
     "traitlets>=4.3.2",
+    "tornado>=4.5.3",
 ]
 
 if sys.version_info.major < 3:
-    requires.append("backports.shutil-which")
-    requires.append("tornado==4.5.3")
-else:
-    requires.append("tornado>=4.5.3")
+    requires.pop()
+    requires += ["tornado==4.5.3", "backports.shutil-which"]
 
 if (sys.version_info.major == 2 and sys.version_info.minor < 7) or (
     sys.version_info.major == 3 and sys.version_info.minor < 6

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -57,6 +57,9 @@ requires = [
 
 if sys.version_info.major < 3:
     requires.append("backports.shutil-which")
+    requires.append("tornado==4.5.3")
+else:
+    requires.append("tornado>=4.5.3")
 
 if (sys.version_info.major == 2 and sys.version_info.minor < 7) or (
     sys.version_info.major == 3 and sys.version_info.minor < 6

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -52,13 +52,12 @@ requires = [
     "pyarrow>=0.16.0,<1",
     "python-dateutil>=2.8.0",
     "six>=1.11.0",
-    "traitlets>=4.3.2",
     "tornado>=4.5.3",
+    "traitlets>=4.3.2",
 ]
 
 if sys.version_info.major < 3:
-    requires.pop()
-    requires += ["tornado==4.5.3", "backports.shutil-which"]
+    requires += ["backports.shutil-which"]
 
 if (sys.version_info.major == 2 and sys.version_info.minor < 7) or (
     sys.version_info.major == 3 and sys.version_info.minor < 6


### PR DESCRIPTION
`tornado.locks` is not included in the `__init__.py` of older Tornado versions, and this causes an issue when hosting Perspective servers as we don't explicitly import `tornado.locks`. This patch makes the import explicit and pins a version of Tornado for our Python 2 builds.