### PR TITLE
Add `get_index()` and `get_limit()` to the public API, internal code cleanup

### DIFF
--- a/packages/perspective/src/js/api/table_api.js
+++ b/packages/perspective/src/js/api/table_api.js
@@ -107,8 +107,6 @@ table.prototype.columns = async_queue("columns", "table_method");
 
 table.prototype.clear = async_queue("clear", "table_method");
 
-table.prototype.on_clear = subscribe("on_clear", "table_method", true);
-
 table.prototype.replace = async_queue("replace", "table_method");
 
 table.prototype.delete = async_queue("delete", "table_method");

--- a/packages/perspective/src/js/api/table_api.js
+++ b/packages/perspective/src/js/api/table_api.js
@@ -81,6 +81,10 @@ table.prototype.view = function(config) {
 
 // Dispatch table methods that do not create new objects (getters, setters etc.)
 // to the queue for processing.
+table.prototype.get_index = async_queue("get_index", "table_method");
+
+table.prototype.get_limit = async_queue("get_limit", "table_method");
+
 table.prototype.make_port = async_queue("make_port", "table_method");
 
 table.prototype.remove_port = async_queue("remove_port", "table_method");

--- a/packages/perspective/src/js/api/table_api.js
+++ b/packages/perspective/src/js/api/table_api.js
@@ -107,6 +107,8 @@ table.prototype.columns = async_queue("columns", "table_method");
 
 table.prototype.clear = async_queue("clear", "table_method");
 
+table.prototype.on_clear = subscribe("on_clear", "table_method", true);
+
 table.prototype.replace = async_queue("replace", "table_method");
 
 table.prototype.delete = async_queue("delete", "table_method");

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1091,6 +1091,22 @@ export default function(Module) {
     };
 
     /**
+     * Returns the user-specified index column for this
+     * {@link module:perspective~table} or null if an index is not set.
+     */
+    table.prototype.get_index = function() {
+        return this.index;
+    };
+
+    /**
+     * Returns the user-specified limit column for this
+     * {@link module:perspective~table} or null if an limit is not set.
+     */
+    table.prototype.get_limit = function() {
+        return this.limit;
+    };
+
+    /**
      * Remove all rows in this {@link module:perspective~table} while preserving
      * the schema and construction options.
      */

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1059,7 +1059,6 @@ export default function(Module) {
         this.limit = limit;
         this.computed = computed || [];
         this.update_callbacks = [];
-        this.clear_callbacks = [];
         this._delete_callbacks = [];
         this.views = [];
         this.overridden_types = overridden_types;
@@ -1093,12 +1092,6 @@ export default function(Module) {
         }
     };
 
-    table.prototype._clear_callback = function() {
-        for (let e in this.clear_callbacks) {
-            this.clear_callbacks[e].callback();
-        }
-    };
-
     /**
      * Returns the user-specified index column for this
      * {@link module:perspective~table} or null if an index is not set.
@@ -1122,28 +1115,14 @@ export default function(Module) {
     table.prototype.clear = function() {
         _remove_process(this.get_id());
         this._Table.reset_gnode(this.gnode_id);
-        for (const callback of this.clear_callbacks) {
-            callback();
-        }
-    };
-
-    /**
-     * Register a callback with this {@link module:perspective~table}. Whenever
-     * the {@link module:perspective~table} is cleared, this callback will be
-     * invoked.
-     *
-     * @param {function} callback A callback function with no parameters
-     *      that will be invoked on `clear()`.
-     */
-    table.prototype.on_clear = function(callback) {
-        this.clear_callbacks.push(callback);
     };
 
     /**
      * Replace all rows in this {@link module:perspective~table} the input data.
      */
     table.prototype.replace = function(data) {
-        this.clear();
+        _remove_process(this.get_id());
+        this._Table.reset_gnode(this.gnode_id);
         this.update(data);
         _call_process(this.get_id());
     };

--- a/packages/perspective/test/js/clear.js
+++ b/packages/perspective/test/js/clear.js
@@ -20,6 +20,51 @@ module.exports = perspective => {
             view.delete();
             table.delete();
         });
+
+        it("Should call an on_clear() callback", async function(done) {
+            const table = perspective.table([{x: 1}]);
+            const view = table.view();
+            let json = await view.to_json();
+            expect(json).toHaveLength(1);
+
+            const clear_callback = async function() {
+                expect(await table.size()).toEqual(0);
+                view.delete();
+                table.delete();
+                done();
+            };
+
+            table.on_clear(clear_callback);
+            table.clear();
+        });
+
+        it("Should call multiple on_clear() callbacks in order", async function(done) {
+            const table = perspective.table([{x: 1}]);
+            const view = table.view();
+            let json = await view.to_json();
+            expect(json).toHaveLength(1);
+
+            const order = [];
+
+            const finish = function() {
+                if (order.length === 3) {
+                    expect(order).toEqual([0, 1, 2]);
+                    view.delete();
+                    table.delete();
+                    done();
+                }
+            };
+
+            for (let i = 0; i < 3; i++) {
+                table.on_clear(async () => {
+                    expect(await table.size()).toEqual(0);
+                    order.push(i);
+                    finish();
+                });
+            }
+
+            table.clear();
+        });
     });
 
     describe("Replace", function() {
@@ -41,6 +86,193 @@ module.exports = perspective => {
             expect(json).toEqual([{x: 5, y: 6}]);
             view.delete();
             table.delete();
+        });
+
+        it("replaces the rows in the table with the input data and fires on_clear", async function() {
+            const table = perspective.table([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+            const view = table.view();
+
+            let json = await view.to_json();
+            expect(json).toHaveLength(2);
+            expect(json).toEqual([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+
+            let cleared = false;
+            table.on_clear(async () => {
+                expect(await table.size()).toEqual(0);
+                cleared = true;
+            });
+
+            table.replace([{x: 5, y: 6}]);
+
+            expect(cleared).toEqual(true);
+
+            json = await view.to_json();
+            expect(json).toHaveLength(1);
+            expect(json).toEqual([{x: 5, y: 6}]);
+
+            view.delete();
+            table.delete();
+        });
+
+        it("replaces the rows in the table with the input data and fires an on_update", async function(done) {
+            const table = perspective.table([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+
+            const view = table.view();
+
+            const callback = async function(updated) {
+                expect(updated.port_id).toEqual(0);
+                const json = await view.to_json();
+                expect(json).toHaveLength(1);
+                expect(json).toEqual([{x: 5, y: 6}]);
+                view.delete();
+                table.delete();
+                done();
+            };
+
+            view.on_update(callback);
+
+            let json = await view.to_json();
+            expect(json).toHaveLength(2);
+            expect(json).toEqual([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+
+            table.replace([{x: 5, y: 6}]);
+        });
+
+        it("replaces the rows in the table with the input data and fires an on_clear before on_update", async function(done) {
+            const table = perspective.table([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+
+            const view = table.view();
+
+            let cleared = false;
+
+            const callback = async function(updated) {
+                expect(cleared).toEqual(true);
+                expect(await table.size()).toEqual(1);
+                expect(updated.port_id).toEqual(0);
+                const json = await view.to_json();
+                expect(json).toHaveLength(1);
+                expect(json).toEqual([{x: 5, y: 6}]);
+                view.delete();
+                table.delete();
+                done();
+            };
+
+            view.on_update(callback);
+
+            let json = await view.to_json();
+            expect(json).toHaveLength(2);
+            expect(json).toEqual([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+
+            table.on_clear(async () => {
+                expect(await table.size()).toEqual(0);
+                cleared = true;
+            });
+
+            table.replace([{x: 5, y: 6}]);
+        });
+
+        it("replaces the rows in the table with the input data and fires an on_update with the correct delta", async function(done) {
+            const table = perspective.table([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+
+            const view = table.view();
+
+            const callback = async function(updated) {
+                expect(updated.port_id).toEqual(0);
+                const table2 = perspective.table(updated.delta);
+                const view2 = table2.view();
+
+                const json = await view.to_json();
+                expect(json).toHaveLength(1);
+                expect(json).toEqual([{x: 5, y: 6}]);
+
+                const json2 = await view2.to_json();
+                expect(json2).toEqual(json);
+
+                view2.delete();
+                table2.delete();
+                view.delete();
+                table.delete();
+                done();
+            };
+
+            view.on_update(callback, {mode: "row"});
+
+            let json = await view.to_json();
+            expect(json).toHaveLength(2);
+            expect(json).toEqual([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+
+            table.replace([{x: 5, y: 6}]);
+        });
+
+        it("replaces the rows in the table with the input data and fires an on_clear and then on_update with the correct delta", async function(done) {
+            const table = perspective.table([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+
+            const view = table.view();
+
+            let cleared = false;
+
+            const callback = async function(updated) {
+                expect(cleared).toEqual(true);
+                expect(updated.port_id).toEqual(0);
+                const table2 = perspective.table(updated.delta);
+                const view2 = table2.view();
+
+                const json = await view.to_json();
+                expect(json).toHaveLength(1);
+                expect(json).toEqual([{x: 5, y: 6}]);
+
+                const json2 = await view2.to_json();
+                expect(json2).toEqual(json);
+
+                view2.delete();
+                table2.delete();
+                view.delete();
+                table.delete();
+                done();
+            };
+
+            view.on_update(callback, {mode: "row"});
+
+            let json = await view.to_json();
+            expect(json).toHaveLength(2);
+            expect(json).toEqual([
+                {x: 1, y: 2},
+                {x: 3, y: 4}
+            ]);
+
+            table.on_clear(async () => {
+                cleared = true;
+                expect(await table.size()).toEqual(0);
+            });
+
+            table.replace([{x: 5, y: 6}]);
         });
 
         it("replace the rows in the table atomically", async function() {

--- a/packages/perspective/test/js/clear.js
+++ b/packages/perspective/test/js/clear.js
@@ -20,51 +20,6 @@ module.exports = perspective => {
             view.delete();
             table.delete();
         });
-
-        it("Should call an on_clear() callback", async function(done) {
-            const table = perspective.table([{x: 1}]);
-            const view = table.view();
-            let json = await view.to_json();
-            expect(json).toHaveLength(1);
-
-            const clear_callback = async function() {
-                expect(await table.size()).toEqual(0);
-                view.delete();
-                table.delete();
-                done();
-            };
-
-            table.on_clear(clear_callback);
-            table.clear();
-        });
-
-        it("Should call multiple on_clear() callbacks in order", async function(done) {
-            const table = perspective.table([{x: 1}]);
-            const view = table.view();
-            let json = await view.to_json();
-            expect(json).toHaveLength(1);
-
-            const order = [];
-
-            const finish = function() {
-                if (order.length === 3) {
-                    expect(order).toEqual([0, 1, 2]);
-                    view.delete();
-                    table.delete();
-                    done();
-                }
-            };
-
-            for (let i = 0; i < 3; i++) {
-                table.on_clear(async () => {
-                    expect(await table.size()).toEqual(0);
-                    order.push(i);
-                    finish();
-                });
-            }
-
-            table.clear();
-        });
     });
 
     describe("Replace", function() {
@@ -84,38 +39,6 @@ module.exports = perspective => {
             json = await view.to_json();
             expect(json).toHaveLength(1);
             expect(json).toEqual([{x: 5, y: 6}]);
-            view.delete();
-            table.delete();
-        });
-
-        it("replaces the rows in the table with the input data and fires on_clear", async function() {
-            const table = perspective.table([
-                {x: 1, y: 2},
-                {x: 3, y: 4}
-            ]);
-            const view = table.view();
-
-            let json = await view.to_json();
-            expect(json).toHaveLength(2);
-            expect(json).toEqual([
-                {x: 1, y: 2},
-                {x: 3, y: 4}
-            ]);
-
-            let cleared = false;
-            table.on_clear(async () => {
-                expect(await table.size()).toEqual(0);
-                cleared = true;
-            });
-
-            table.replace([{x: 5, y: 6}]);
-
-            expect(cleared).toEqual(true);
-
-            json = await view.to_json();
-            expect(json).toHaveLength(1);
-            expect(json).toEqual([{x: 5, y: 6}]);
-
             view.delete();
             table.delete();
         });
@@ -146,45 +69,6 @@ module.exports = perspective => {
                 {x: 1, y: 2},
                 {x: 3, y: 4}
             ]);
-
-            table.replace([{x: 5, y: 6}]);
-        });
-
-        it("replaces the rows in the table with the input data and fires an on_clear before on_update", async function(done) {
-            const table = perspective.table([
-                {x: 1, y: 2},
-                {x: 3, y: 4}
-            ]);
-
-            const view = table.view();
-
-            let cleared = false;
-
-            const callback = async function(updated) {
-                expect(cleared).toEqual(true);
-                expect(await table.size()).toEqual(1);
-                expect(updated.port_id).toEqual(0);
-                const json = await view.to_json();
-                expect(json).toHaveLength(1);
-                expect(json).toEqual([{x: 5, y: 6}]);
-                view.delete();
-                table.delete();
-                done();
-            };
-
-            view.on_update(callback);
-
-            let json = await view.to_json();
-            expect(json).toHaveLength(2);
-            expect(json).toEqual([
-                {x: 1, y: 2},
-                {x: 3, y: 4}
-            ]);
-
-            table.on_clear(async () => {
-                expect(await table.size()).toEqual(0);
-                cleared = true;
-            });
 
             table.replace([{x: 5, y: 6}]);
         });
@@ -224,53 +108,6 @@ module.exports = perspective => {
                 {x: 1, y: 2},
                 {x: 3, y: 4}
             ]);
-
-            table.replace([{x: 5, y: 6}]);
-        });
-
-        it("replaces the rows in the table with the input data and fires an on_clear and then on_update with the correct delta", async function(done) {
-            const table = perspective.table([
-                {x: 1, y: 2},
-                {x: 3, y: 4}
-            ]);
-
-            const view = table.view();
-
-            let cleared = false;
-
-            const callback = async function(updated) {
-                expect(cleared).toEqual(true);
-                expect(updated.port_id).toEqual(0);
-                const table2 = perspective.table(updated.delta);
-                const view2 = table2.view();
-
-                const json = await view.to_json();
-                expect(json).toHaveLength(1);
-                expect(json).toEqual([{x: 5, y: 6}]);
-
-                const json2 = await view2.to_json();
-                expect(json2).toEqual(json);
-
-                view2.delete();
-                table2.delete();
-                view.delete();
-                table.delete();
-                done();
-            };
-
-            view.on_update(callback, {mode: "row"});
-
-            let json = await view.to_json();
-            expect(json).toHaveLength(2);
-            expect(json).toEqual([
-                {x: 1, y: 2},
-                {x: 3, y: 4}
-            ]);
-
-            table.on_clear(async () => {
-                cleared = true;
-                expect(await table.size()).toEqual(0);
-            });
 
             table.replace([{x: 5, y: 6}]);
         });

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -1112,8 +1112,8 @@ module.exports = perspective => {
             });
 
             it("get_index() on an indexed table", async function() {
-                const table = perspective.table(data, {index: "datetime"});
-                expect(await table.get_index()).toEqual("datetime");
+                const table = perspective.table(data, {index: "x"});
+                expect(await table.get_index()).toEqual("x");
             });
 
             it("get_limit() on table without limit", async function() {

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -1104,5 +1104,27 @@ module.exports = perspective => {
             view.delete();
             table.delete();
         }, 3000);
+
+        describe("get_index/get_limit", function() {
+            it("get_index() on unindexed table", async function() {
+                const table = perspective.table(data);
+                expect(await table.get_index()).toBeNull();
+            });
+
+            it("get_index() on an indexed table", async function() {
+                const table = perspective.table(data, {index: "datetime"});
+                expect(await table.get_index()).toEqual("datetime");
+            });
+
+            it("get_limit() on table without limit", async function() {
+                const table = perspective.table(data);
+                expect(await table.get_limit()).toBeNull();
+            });
+
+            it("get_limit() on table with limit", async function() {
+                const table = perspective.table(data, {limit: 2});
+                expect(await table.get_limit()).toEqual(2);
+            });
+        });
     });
 };

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -705,6 +705,58 @@ module.exports = perspective => {
             });
             table.update(data);
         });
+
+        it("`on_update()` should be triggered in sequence", function(done) {
+            var table = perspective.table(meta);
+            var view = table.view();
+
+            let order = [];
+
+            const finish = function() {
+                if (order.length === 3) {
+                    expect(order).toEqual([0, 1, 2]);
+                    view.delete();
+                    table.delete();
+                    done();
+                }
+            };
+
+            for (let i = 0; i < 3; i++) {
+                view.on_update(() => {
+                    order.push(i);
+                    finish();
+                });
+            }
+
+            table.update(data);
+        });
+
+        it("`on_update()` should be triggered in sequence across multiple views", function(done) {
+            var table = perspective.table(meta);
+            const views = [table.view(), table.view(), table.view()];
+
+            let order = [];
+
+            const finish = function() {
+                if (order.length === 3) {
+                    expect(order).toEqual([0, 1, 2]);
+                    for (const view of views) {
+                        view.delete();
+                    }
+                    table.delete();
+                    done();
+                }
+            };
+
+            for (let i = 0; i < views.length; i++) {
+                views[i].on_update(() => {
+                    order.push(i);
+                    finish();
+                });
+            }
+
+            table.update(data);
+        });
     });
 
     describe("Limit", function() {

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -69,6 +69,20 @@ const arrow_indexed_result = [
 
 module.exports = perspective => {
     describe("Removes", function() {
+        it("should not remove without explicit index", async function() {
+            const table = perspective.table(meta);
+            table.update(data);
+            const view = table.view();
+            table.remove([0, 1]);
+            const result = await view.to_json();
+            expect(await view.num_rows()).toEqual(4);
+            expect(result.length).toEqual(4);
+            expect(result).toEqual(data);
+            // expect(await table.size()).toEqual(2);
+            view.delete();
+            table.delete();
+        });
+
         it("after an `update()`", async function() {
             const table = perspective.table(meta, {index: "x"});
             table.update(data);

--- a/python/perspective/perspective/client/table_api.py
+++ b/python/perspective/perspective/client/table_api.py
@@ -58,6 +58,12 @@ class PerspectiveTableProxy(object):
     def remove_port(self):
         return self._async_queue("remove_port", "table_method")
 
+    def get_index(self):
+        return self._async_queue("get_index", "table_method")
+
+    def get_limit(self):
+        return self._async_queue("get_limit", "table_method")
+
     def compute(self):
         return self._async_queue("compute", "table_method")
 

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -57,15 +57,17 @@ class Table(object):
 
         self._date_validator = _PerspectiveDateValidator()
 
-        self._limit = limit or 4294967295
-        self._index = index or ""
+        self._limit = limit
+        self._index = index
 
-        # Always create tables on port 0
+        # C++ make_table does not accept `None`, so pass in defaults of ""
+        # for `index` and 4294967295 for `limit`, but always store `self._index`
+        # and `self._limit` as user-provided kwargs or `None`.
         self._table = make_table(
             None,
             _accessor,
-            self._limit,
-            self._index,
+            self._limit or 4294967295,
+            self._index or "",
             t_op.OP_INSERT,
             False,
             self._is_arrow,
@@ -304,8 +306,8 @@ class Table(object):
             self._table = make_table(
                 self._table,
                 _accessor,
-                self._limit,
-                self._index,
+                self._limit or 4294967295,
+                self._index or "",
                 t_op.OP_INSERT,
                 True,
                 True,
@@ -331,7 +333,7 @@ class Table(object):
             _accessor.try_cast_numpy_arrays()
 
         if "__INDEX__" in _accessor._names:
-            if self._index != "":
+            if self._index is not None:
                 index_pos = _accessor._names.index(self._index)
                 index_dtype = _accessor._types[index_pos]
                 _accessor._types.append(index_dtype)
@@ -341,8 +343,8 @@ class Table(object):
         self._table = make_table(
             self._table,
             _accessor,
-            self._limit,
-            self._index,
+            self._limit or 4294967295,
+            self._index or "",
             t_op.OP_INSERT,
             True,
             False,
@@ -366,7 +368,7 @@ class Table(object):
             >>> tbl.view().to_records()
             [{"a": 1}]
         """
-        if self._index == "":
+        if self._index is None:
             return
         pkeys = list(map(lambda idx: {self._index: idx}, pkeys))
         types = [self._table.get_schema().get_dtype(self._index)]
@@ -376,8 +378,8 @@ class Table(object):
         t = make_table(
             self._table,
             _accessor,
-            self._limit,
-            self._index,
+            self._limit or 4294967295,
+            self._index or "",
             t_op.OP_DELETE,
             True,
             False,

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -75,7 +75,7 @@ class Table(object):
         )
 
         self._gnode_id = self._table.get_gnode().get_id()
-        self._callbacks = _PerspectiveCallBackCache()
+        self._update_callbacks = _PerspectiveCallBackCache()
         self._delete_callbacks = _PerspectiveCallBackCache()
         self._views = []
         self._delete_callback = None
@@ -530,5 +530,5 @@ class Table(object):
             came from.
         """
         cache = {}
-        for callback in self._callbacks:
+        for callback in self._update_callbacks:
             callback["callback"](port_id=port_id, cache=cache)

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -380,11 +380,13 @@ class Table(object):
         """
         if self._index is None:
             return
+
         pkeys = list(map(lambda idx: {self._index: idx}, pkeys))
         types = [self._table.get_schema().get_dtype(self._index)]
         _accessor = _PerspectiveAccessor(pkeys)
         _accessor._names = [self._index]
         _accessor._types = types
+
         t = make_table(
             self._table,
             _accessor,
@@ -395,6 +397,7 @@ class Table(object):
             False,
             port_id,
         )
+
         self._state_manager.set_process(t.get_pool(), t.get_id())
 
     def view(

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -101,6 +101,16 @@ class Table(object):
         """Returns whether the computed column feature is enabled."""
         return True
 
+    def get_index(self):
+        """Returns the Table's index column, or ``None`` if an index is not
+        specified by the user."""
+        return self._index
+
+    def get_limit(self):
+        """Returns the Table's limit, or ``None`` if an index is not
+        specified by the user."""
+        return self._limit
+
     def clear(self):
         """Removes all the rows in the :class:`~perspective.Table`, but
         preserves everything else including the schema and any callbacks or

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -79,7 +79,7 @@ class View(object):
             )
 
         self._column_only = self._view.is_column_only()
-        self._callbacks = self._table._callbacks
+        self._update_callbacks = self._table._update_callbacks
         self._delete_callbacks = _PerspectiveCallBackCache()
         self._client_id = None
 
@@ -268,7 +268,7 @@ class View(object):
             self._wrapped_on_update_callback, mode=mode, callback=callback
         )
 
-        self._callbacks.add_callback(
+        self._update_callbacks.add_callback(
             {
                 "name": self._name,
                 "orig_callback": callback,
@@ -298,7 +298,9 @@ class View(object):
         self._table._state_manager.call_process(self._table._table.get_id())
         if not callable(callback):
             return ValueError("remove_update callback should be a callable function!")
-        self._callbacks.remove_callbacks(lambda cb: cb["orig_callback"] == callback)
+        self._update_callbacks.remove_callbacks(
+            lambda cb: cb["orig_callback"] == callback
+        )
 
     def on_delete(self, callback):
         """Set a callback to be run when the :func:`perspective.View.delete()`
@@ -335,7 +337,7 @@ class View(object):
         self._table._state_manager.remove_process(self._table._table.get_id())
         self._table._views.pop(self._table._views.index(self._name))
         # remove the callbacks associated with this view
-        self._callbacks.remove_callbacks(lambda cb: cb["name"] == self._name)
+        self._update_callbacks.remove_callbacks(lambda cb: cb["name"] == self._name)
         [cb() for cb in self._delete_callbacks]
 
     def remove_delete(self, callback):

--- a/python/perspective/perspective/tests/manager/test_manager.py
+++ b/python/perspective/perspective/tests/manager/test_manager.py
@@ -99,7 +99,7 @@ class TestPerspectiveManager(object):
             "b": str
         }
 
-        assert manager._tables["table1"]._index == "a"
+        assert manager._tables["table1"].get_index() == "a"
 
     def test_manager_create_indexed_table_and_update(self):
         message = {"id": 1, "name": "table1", "cmd": "table", "args": [data], "options": {"index": "a"}}
@@ -111,7 +111,7 @@ class TestPerspectiveManager(object):
             "a": int,
             "b": str
         }
-        assert manager._tables["table1"]._index == "a"
+        assert manager._tables["table1"].get_index() == "a"
         update_message = {"id": 2, "name": "table1", "cmd": "table_method", "method": "update", "args": [{"a": [1, 2, 3], "b": ["str1", "str2", "str3"]}]}
         manager._process(update_message, self.post)
         assert manager._tables["table1"].view().to_dict() == {
@@ -129,7 +129,7 @@ class TestPerspectiveManager(object):
             "a": int,
             "b": str
         }
-        assert manager._tables["table1"]._index == "a"
+        assert manager._tables["table1"].get_index() == "a"
         remove_message = {"id": 2, "name": "table1", "cmd": "table_method", "method": "remove", "args": [[1, 2]]}
         manager._process(remove_message, self.post)
         assert manager._tables["table1"].view().to_dict() == {

--- a/python/perspective/perspective/tests/table/test_table.py
+++ b/python/perspective/perspective/tests/table/test_table.py
@@ -558,6 +558,20 @@ class TestTable(object):
             "b": [2, 4, 3, 1]
         }
 
+    def test_table_get_index(self):
+        tbl = Table({
+            "a": ["", "a", None, "b"],
+            "b": [4, 3, 2, 1]
+        }, index="a")
+        assert tbl.get_index() == "a"
+
+    def test_table_get_index_none(self):
+        tbl = Table({
+            "a": ["", "a", None, "b"],
+            "b": [4, 3, 2, 1]
+        })
+        assert tbl.get_index() is None
+
     # limit
 
     def test_table_limit(self):
@@ -567,6 +581,16 @@ class TestTable(object):
         assert tbl.view().to_records() == [
             {"a": 3, "b": 4}
         ]
+
+    def test_table_get_limit(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data, limit=1)
+        assert tbl.get_limit() == 1
+
+    def test_table_get_limit_none(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        assert tbl.get_limit() is None
 
     # clear
 

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -821,7 +821,7 @@ class TestView(object):
         view.on_update(cb2)
         view.on_update(cb1)
         view.remove_update(cb1)
-        assert len(view._callbacks) == 1
+        assert len(view._update_callbacks) == 1
         tbl.update(data)
         assert s.get() == 2
 

--- a/python/perspective/perspective/tests/widget/test_widget.py
+++ b/python/perspective/perspective/tests/widget/test_widget.py
@@ -72,11 +72,11 @@ class TestWidget:
 
     def test_widget_schema_with_index(self):
         widget = PerspectiveWidget({"a": int}, index="a")
-        assert widget.table._index == "a"
+        assert widget.table.get_index() == "a"
 
     def test_widget_schema_with_limit(self):
         widget = PerspectiveWidget({"a": int}, limit=5)
-        assert widget.table._limit == 5
+        assert widget.table.get_limit() == 5
 
     def test_widget_no_data_with_index(self):
         # should fail

--- a/python/perspective/perspective/tests/widget/test_widget.py
+++ b/python/perspective/perspective/tests/widget/test_widget.py
@@ -109,16 +109,41 @@ class TestWidget:
             }
         }
 
+    def test_widget_eventual_data_server(self):
+        widget = PerspectiveWidget(None, plugin="x_bar", server=True)
+        assert widget.plugin == "x_bar"
+        widget.load({"a": np.arange(0, 50)}, index="a")
+        load_msg = widget._make_load_message()
+        assert load_msg.to_dict() == {
+            "id": -2,
+            "type": "table",
+            "data": {
+                "table_name": widget.table_name,
+            }
+        }
+
     def test_widget_eventual_data_indexed(self):
-        table = Table({"a": np.arange(0, 50)})
         widget = PerspectiveWidget(None, plugin="x_bar")
         assert widget.plugin == "x_bar"
+        widget.load({"a": np.arange(0, 50)}, index="a")
+        load_msg = widget._make_load_message()
+        assert load_msg.to_dict() == {
+            "id": -2,
+            "type": "table",
+            "data": {
+                "table_name": widget.table_name,
+                "view_name": widget._perspective_view_name,
+                "options": {
+                    "index": "a"
+                }
+            }
+        }
 
-        with raises(PerspectiveError):
-            widget._make_load_message()
-
-        widget.load(table, index="a")
-
+    def test_widget_eventual_table_indexed(self):
+        table = Table({"a": np.arange(0, 50)}, index="a")
+        widget = PerspectiveWidget(None, plugin="x_bar")
+        assert widget.plugin == "x_bar"
+        widget.load(table)
         load_msg = widget._make_load_message()
         assert load_msg.to_dict() == {
             "id": -2,

--- a/python/perspective/perspective/tests/widget/test_widget.py
+++ b/python/perspective/perspective/tests/widget/test_widget.py
@@ -32,8 +32,23 @@ class TestWidget:
             "data": {
                 "table_name": widget.table_name,
                 "view_name": widget._perspective_view_name,
+                "options": {}
+            }
+        }
+
+    def test_widget_indexed(self):
+        data = {"a": np.arange(0, 50)}
+        widget = PerspectiveWidget(data, plugin="x_bar", index="a")
+        assert widget.plugin == "x_bar"
+        load_msg = widget._make_load_message()
+        assert load_msg.to_dict() == {
+            "id": -2,
+            "type": "table",
+            "data": {
+                "table_name": widget.table_name,
+                "view_name": widget._perspective_view_name,
                 "options": {
-                    "index": ""
+                    "index": "a"
                 }
             }
         }
@@ -90,8 +105,29 @@ class TestWidget:
             "data": {
                 "table_name": widget.table_name,
                 "view_name": widget._perspective_view_name,
+                "options": {}
+            }
+        }
+
+    def test_widget_eventual_data_indexed(self):
+        table = Table({"a": np.arange(0, 50)})
+        widget = PerspectiveWidget(None, plugin="x_bar")
+        assert widget.plugin == "x_bar"
+
+        with raises(PerspectiveError):
+            widget._make_load_message()
+
+        widget.load(table, index="a")
+
+        load_msg = widget._make_load_message()
+        assert load_msg.to_dict() == {
+            "id": -2,
+            "type": "table",
+            "data": {
+                "table_name": widget.table_name,
+                "view_name": widget._perspective_view_name,
                 "options": {
-                    "index": ""
+                    "index": "a"
                 }
             }
         }
@@ -107,8 +143,23 @@ class TestWidget:
             "data": {
                 "table_name": widget.table_name,
                 "view_name": widget._perspective_view_name,
+                "options": {}
+            }
+        }
+
+    def test_widget_load_table_indexed(self):
+        table = Table({"a": np.arange(0, 50)}, index="a")
+        widget = PerspectiveWidget(table, plugin="x_bar")
+        assert widget.plugin == "x_bar"
+        load_msg = widget._make_load_message()
+        assert load_msg.to_dict() == {
+            "id": -2,
+            "type": "table",
+            "data": {
+                "table_name": widget.table_name,
+                "view_name": widget._perspective_view_name,
                 "options": {
-                    "index": ""
+                    "index": "a"
                 }
             }
         }
@@ -125,9 +176,7 @@ class TestWidget:
             "data": {
                 "table_name": widget.table_name,
                 "view_name": widget._perspective_view_name,
-                "options": {
-                    "index": ""
-                }
+                "options": {}
             }
         }
 

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -305,7 +305,7 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
             super(PerspectiveWidget, self).load(data, **options)
 
             # Do not enable editing if the table is unindexed.
-            if self.editable and self.table._index is None:
+            if self.editable and self.table.get_index() is None:
                 logging.critical("Cannot edit on an unindexed `perspective.Table`!")
                 self.editable = False
 

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -305,7 +305,7 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
             super(PerspectiveWidget, self).load(data, **options)
 
             # Do not enable editing if the table is unindexed.
-            if self.editable and self.table._index == "":
+            if self.editable and self.table._index is None:
                 logging.critical("Cannot edit on an unindexed `perspective.Table`!")
                 self.editable = False
 

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -446,7 +446,7 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
                 post_callback = partial(self.post, msg_id=parsed["id"])
                 self.manager._process(parsed, post_callback)
 
-    def _make_load_message(self, index=None, limit=None):
+    def _make_load_message(self):
         """Send a message to the front-end either containing the name of a
         hosted view in Python, so the front-end can create a table in the
         Perspective WebAssembly client, or if `server` is True, the name of a
@@ -481,10 +481,13 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
                 "options": {},
             }
 
-            if self.table._index is not None:
-                msg_data["options"]["index"] = self.table._index
-            elif self.table._limit is not None:
-                msg_data["options"]["limit"] = self.table._limit
+            index = self.table.get_index()
+            limit = self.table.get_limit()
+
+            if index is not None:
+                msg_data["options"]["index"] = index
+            elif limit is not None:
+                msg_data["options"]["limit"] = limit
 
         if msg_data is not None:
             return _PerspectiveWidgetMessage(-2, "table", msg_data)


### PR DESCRIPTION
This PR adds `get_index()` and `get_limit()`, which allows for Table consumers to access the value of user-provided index columns or limits, or `null` if not set by the user. This is useful in the distributed Perspective use case, as clients need to mirror the Table exactly:

```javascript
const remote_table = websocket.open_table("table");
const remote_view = remote_table.view();

const arrow = await remote_view.to_arrow();
const index = await remote_table.get_index();
const client_table = worker.table(arrow, {index: index});
```

Additionally, this PR does a little internal cleanup of Perspective core code in both Javascript and Python, and adds a large amount of new tests.