### PR TITLE
Fix distributed editing in PerspectiveWidget

### DIFF
--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -409,6 +409,10 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
         if self._pending_binary:
             msg = self._pending_binary
 
+            # manager looks at the `binary_length` flag so make sure to
+            # get rid of it before passing to `_process`.
+            del msg["binary_length"]
+
             # arrow is a `MemoryView` - convert to bytes
             arrow = buffers[0].tobytes()
             msg["args"].insert(0, arrow)


### PR DESCRIPTION
The `editable` attribute on non-server mode PerspectiveWidget was broken because `binary_length` was not removed before passing the message to the manager.

When Tornado batching and other wire API upgrades were added, we moved parsing of `binary_length` flags to the manager instead of the tornado handler. The widget did not follow suit with this change, which means it was passing `binary_length` to the manager even though the two-part message (regular, and binary) was already composed properly, which caused strange effects down the line, namely `update` was being called with the manager's JSON message instead of the dataset.

This fixes the issue, so that `editable` in `PerspectiveWidget` should be working as intended.