### PR TITLE
Remove host_view and open_view from public API

### DIFF
--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -35,6 +35,12 @@
       "node_modules/react/README": {
         "title": "node_modules/react/README"
       },
+      "obj/perspective-python": {	
+        "title": "perspective-python API"	
+      },	
+      "obj/perspective-viewer": {	
+        "title": "perspective-viewer API"	
+      },
       "obj/perspective": {
         "title": "perspective API"
       },

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -35,12 +35,6 @@
       "node_modules/react/README": {
         "title": "node_modules/react/README"
       },
-      "obj/perspective-python": {
-        "title": "perspective-python API"
-      },
-      "obj/perspective-viewer": {
-        "title": "perspective-viewer API"
-      },
       "obj/perspective": {
         "title": "perspective API"
       },

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -740,14 +740,10 @@ const fs = require("fs");
 // module's directory.
 const host = new WebSocketServer({assets: [__dirname], port: 8080});
 
-// Read an arrow file from the file system and load it as a named table.
+// Read an arrow file from the file system and host it as a named table.
 const arr = fs.readFileSync(__dirname + "/superstore.arrow");
 const tbl = table(arr);
 host.host_table("table_one", tbl);
-
-// Or host a view
-const view = tbl.view({filter: [["State", "==", "Texas"]]});
-host.host_view("view_one", view);
 ```
 
 In the browser:
@@ -760,11 +756,16 @@ const websocket = perspective.websocket(window.location.origin.replace("http", "
 
 // Bind the viewer to the preloaded data source.  `table` and `view` objects
 // live on the server.
-elem.load(websocket.open_table("table_one"));
+const server_table = websocket.open_table("table_one");
+elem.load(server_table);
 
-// Or load data from a view.  The browser now also has a copy of this view in
-// its own `table`, as well as its updates.  Transfer uses Arrows.
-elem.load(websocket.open_view("view_one"));
+// Or load data from a table using a view. The browser now also has a copy of
+// this view in its own `table`, as well as its updates transferred to the
+// browser using Apache Arrow.
+const worker = perspective.worker();
+const server_view = server_table.view();
+const client_table = worker.table(server_view);
+elem.load(client_table);
 ```
 
 `<perspective-viewer>` instances bound in this way are otherwise no different

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -100,7 +100,7 @@ different visualization on load or transform the dataset, use the viewer's attri
 ```
 
 For more details about the full attribute API, see the
-[`<perspective-viewer>`](/js.html#setting--reading-viewer-configuration-via-attributes)section of this user guide.
+[`<perspective-viewer>`](#setting--reading-viewer-configuration-via-attributes)section of this user guide.
 
 ## Module Structure
 

--- a/docs/md/python.md
+++ b/docs/md/python.md
@@ -302,31 +302,44 @@ of `PerspectiveManager` with a string name and the instance to be hosted:
 ```python
 manager = PerspectiveManager()
 table = Table(data)
-view = table.view()
 manager.host_table("data_source", table)
-manager.host_view("view_1", view)
 ```
 
 The `name` provided is important, as it enables Perspective in Javascript to look
-up a `Table`/`View` and get a handle to it over the network. This enables
+up a `Table` and get a handle to it over the network. This enables
 several powerful server/client implementations of Perspective, as explained in
 the next section.
 
-### Using a hosted `Table` in Javascript
+### Distributed Mode
 
 Using Tornado and [`PerspectiveTornadoHandler`](/docs/md/python.html#perspectivetornadohandler),
-as well as `Perspective`'s Javascript library, we can create a client/server
-architecture that hosts and transforms _massive_ datasets with minimal
-client resource usage.
+as well as `Perspective`'s Javascript library, we can set up "distributed"
+Perspective instances that allows multiple browser `perspective-viewer`
+clients to read from a common `perspective-python` server. In exchange for sending the
+entire dataset to the client on initialization, server load is reduced and
+client performance is not network-dependent.
 
-Perspective's design allows a `table()` created in Javascript to _proxy_ its
-operations to a `Table` created in Python, which executes the operations in
-the Python kernel, and returns the results of the operation to the browser.
-All of this is _enabled_ through `PerspectiveManager`, which handles messaging,
-processing method calls, serializing outputs for the network, etc.
+[Example](https://github.com/finos/perspective/tree/master/examples/tornado-python)
 
-In Python, use `PerspectiveManager` and `PerspectiveTornadoHandler` to create
-a websocket server that exposes a `Table`:
+This architecture works by maintaining two `Tables`—one on the server, and one
+on the client that mirrors the server's `Table` automatically using `on_update`.
+All updates to the table on the server are automatically applied to each client,
+which makes this architecture a natural fit for streaming dashboards and other
+distributed use-cases.
+
+Because the `Table` is mirrored, the user gets all the performance benefits of
+Perspective in WebAssembly, and can examine server-hosted datasets with zero
+network lag on their interactions.
+
+In conjunction with [Async Mode](#async-mode), distributed Perspective offers
+consistently high performance over large numbers of clients and large datasets.
+As server dataset sizes increase, the initial load time of a client will
+increase, but once the data is loaded there is no network lag visible to the
+user.
+
+Using the [tornado-python](https://github.com/finos/perspective/tree/master/examples/tornado-python)
+example, one can easily create a distributed Perspective server using
+`server.py` and `index.html`:
 
 _*server.py*_
 
@@ -335,7 +348,7 @@ from perspective import Table, PerspectiveManager, PerspectiveTornadoHandler
 
 # Create an instance of PerspectiveManager, and host a Table
 MANAGER = PerspectiveManager()
-TABLE = Table(large_dataset)
+TABLE = Table(data)
 
 # The Table is exposed at `localhost:8888/websocket` with the name `data_source`
 MANAGER.host_table("data_source", TABLE)
@@ -352,13 +365,51 @@ loop = tornado.ioloop.IOLoop.current()
 loop.start()
 ```
 
-`PerspectiveTornadoHandler`, as outlined in the [docs](/docs/md/python.html#perspectivetornadohandler),
-takes a `PerspectiveManager` instance exposes it over a websocket at the URL
-specified. This allows a `table()` in Javascript to access the `Table` in
-Python and read data from it.
+Instead of calling `load(server_table)`, create a `View` using `server_table`
+and pass that into `viewer.load()`. This will automatically register an
+`on_update` callback that synchronizes state between the server and the client.
 
-Most importantly, the client code in Javascript does not require Webpack or any
-bundler, and can be implemented in a single HTML file:
+_*index.html*_
+
+```html
+<perspective-viewer id="viewer" editable></perspective-viewer>
+
+<script>
+  window.addEventListener("WebComponentsReady", async function () {
+    // Create a client that expects a Perspective server
+    // to accept connections at the specified URL.
+    const websocket = perspective.websocket("ws://localhost:8888/websocket");
+
+    // Get a handle to the Table on the server
+    const server_table = websocket.open_table("data_source_one");
+
+    // Create a new view
+    const server_view = table.view();
+
+    // Create a Table on the client using `perspective.worker()`
+    const worker = perspective.worker();
+    const client_table = worker.table(view);
+
+    // Load the client table in the `<perspective-viewer>`.
+    document.getElementById("viewer").load(client_table);
+  });
+</script>
+```
+
+For a more complex example that offers distributed editing of the server
+dataset, see [client_server_editing.html](https://github.com/finos/perspective/blob/master/examples/tornado-python/client_server_editing.html).
+
+### Server Mode
+
+An alternative architecture uses a single `Table` on the Python server, which
+allows hosting of _massive_ datasets with minimal client resource usage. This
+comes at the expense of client-side performance, as all operations must be
+proxied over the network to the server.
+
+The server setup is identical to [Distributed Mode](#distributed-mode) above,
+but instead of creating a view, the client calls `load(server_table)`:
+In Python, use `PerspectiveManager` and `PerspectiveTornadoHandler` to create
+a websocket server that exposes a `Table`:
 
 _*index.html*_
 
@@ -384,45 +435,6 @@ _*index.html*_
   });
 </script>
 ```
-
-### Using a hosted `View` in Javascript
-
-An alternative client/server architecture using `PerspectiveTornadoHandler` and
-`PerspectiveManager` involves hosting a `View`, and creating a new `table()` in
-Javascript on top of the Python `View`.
-
-When the `table()` is created in Javascript, it serializes the Python `View`'s
-data into Arrow, transfers it into the Javascript `table()`, and sets up an
-`on_update` callback to `update()` the Table whenever the Python `View`'s
-`Table` updates.
-
-Implementing the server in Python is extremely similar to the implementation
-described in the last section.
-
-Replace `host_table` with `host_view`:
-
-```python
-# we have an instance of `PerspectiveManager`
-TABLE = Table(data)
-VIEW = TABLE.view()
-MANAGER.host_view("view_one", VIEW)
-
-# Continue with Tornado setup
-```
-
-Changes to the client code are also minimal. Use `open_view` instead of
-`open_table`:
-
-```javascript
-// const websocket has been defined already
-const view = websocket.open_view("view_one");
-const table = perspective.table(view);
-// continue with loading the table into `<perspective-viewer>
-```
-
-The benefit of this design is that only new updates will be sent to the client,
-efficiently serialized in the Apache Arrow format. In exchange for sending the
-entire dataset to the client on initialization, it reduces load on the server.
 
 ## `PerspectiveWidget`
 

--- a/examples/git-history/chained.html
+++ b/examples/git-history/chained.html
@@ -41,7 +41,8 @@
         window.addEventListener('WebComponentsReady', async function() {
             var elem = document.getElementById('view1');
             var client = perspective.websocket();
-            let view = client.open_view('data_source_one');
+            let table = client.open_table('data_source');
+            let view = table.view();
             let arrow = await view.to_arrow();
             elem.load(perspective.worker().table(arrow));
         });

--- a/examples/remote-express-typescript/assets/index.html
+++ b/examples/remote-express-typescript/assets/index.html
@@ -47,10 +47,9 @@
             const worker = perspective.worker();
             worker.initialize_profile_thread();
 
-            // Get a proxy for a view named "data_source_one", registered on
-            // the server with a reciprocal call to `host_view()`.
-            // No data is transferred, `view` is a virtual handle for data on
-            // the server.
+            // Open a `Table` that is hosted on the server. All instructions
+            // will be proxied to the server `Table` - no calculations are
+            // done on the client.
             const table = websocket.open_table('remote_table');
 
             // Create a `table` from this, owned by the local WebWorker.

--- a/examples/remote-express/index.html
+++ b/examples/remote-express/index.html
@@ -47,10 +47,9 @@
             const worker = perspective.worker();
             worker.initialize_profile_thread();
 
-            // Get a proxy for a view named "data_source_one", registered on
-            // the server with a reciprocal call to `host_view()`.
-            // No data is transferred, `view` is a virtual handle for data on
-            // the server.
+            // Open a `Table` that is hosted on the server. All instructions
+            // will be proxied to the server `Table` - no calculations are
+            // done on the client.
             const table = websocket.open_table('remote_table');
 
             // Create a `table` from this, owned by the local WebWorker.

--- a/examples/remote-workspace/server.js
+++ b/examples/remote-workspace/server.js
@@ -2,4 +2,4 @@ const perspective = require("@finos/perspective");
 const {securities} = require("../datasources");
 
 const host = new perspective.WebSocketServer();
-securities().then(table => host.host_view("securities", table.view()));
+securities().then(table => host.host_table("securities_table", table));

--- a/examples/remote-workspace/src/index.js
+++ b/examples/remote-workspace/src/index.js
@@ -17,8 +17,8 @@ import "./index.less";
 window.addEventListener("load", () => {
     const websocket = perspective.websocket("ws://localhost:8080");
     const worker = perspective.shared_worker();
-    const view = websocket.open_view("securities");
-    const table = worker.table(view, {limit: 10000});
+    const server_table = websocket.open_table("securities_table");
+    const table = worker.table(server_table.view(), {limit: 10000});
 
     const workspace = document.createElement("perspective-workspace");
     document.body.appendChild(workspace);

--- a/examples/tornado-python/client_server_editing.html
+++ b/examples/tornado-python/client_server_editing.html
@@ -55,17 +55,20 @@
             const websocket = perspective.websocket("ws://localhost:8080/websocket");
             const worker = perspective.shared_worker();
 
-            // Get handles to both the `Table` and `View`, as we manually set
-            // up the client/server editing.
+            // Get handles to the `Table` on the server, and create a
+            // `view()` on the server.
             const server_table = websocket.open_table("data_source_one");
-            const server_view = websocket.open_view("view_one");
+            const server_view = server_table.view();
             
             // Serialize the current state of the view to an arrow, and create
             // a Table on the client that has the same index as the Table
-            // on the server. Client/server editing does not work on an
-            // unindexed Table.
+            // on the server using `get_index()`.
+            //
+            // Client/server editing does not work on an unindexed Table.
             const arrow = await server_view.to_arrow();
-            const client_table = worker.table(arrow, {index: "Row ID"});
+            const client_table = worker.table(arrow, {
+                index: await server_table.get_index()
+            });
             const client_view = client_table.view();// client -> server
 
             await viewer.load(client_table);

--- a/examples/tornado-python/index.html
+++ b/examples/tornado-python/index.html
@@ -52,16 +52,23 @@
              * state is automatically synchronized between the two.
              * 
              * To create a Perspective client running in "distributed mode",
-             * host a `View` in the Python server and create a `Table` in the
-             * client using a proxy to the hosted `View`.
+             * host a `Table` in the Python server, create a `Table` on the
+             * client through a `View` on the server. This synchronizes the
+             * server's `Table` with the client's `Table`.
              */
             const worker = perspective.worker();
 
             /**
-             * `view` is a proxy to the hosted `View` in the Python server. All
-             * public API methods are available through this proxied view.
+             * `server_table` is a proxy to the hosted `Table` in the Python
+             * server. All public API methods are available through this
+             * proxied table.
              */
-            const view = websocket.open_view('view_one');
+            const server_table = websocket.open_table("data_source_one");
+
+            /**
+             * Create a `View` on the server.
+             */
+            const server_view = server_table.view();
 
             /**
              * When a `View` is passed into `table()` to create a new `Table`,
@@ -74,11 +81,16 @@
              * `Table` and its data (and associated viewer) are still fully
              * functional, but will not be kept up-to-date with server state.
              * 
+             * Use `table.get_index()` in order to create a `Table` on the
+             * client that has the exact same settings as the server.
+             * 
              * For a more complex example of manually controlling state
              * synchronization between server and client, see
              * `client_server_editing.html`.
              */
-            const table = worker.table(view);
+            const table = worker.table(server_view, {
+                index: await server_table.get_index()
+            });
             
             // Load the local table in the `<perspective-viewer>`.
             document.getElementById('viewer').load(table);

--- a/examples/tornado-python/server.py
+++ b/examples/tornado-python/server.py
@@ -31,7 +31,6 @@ def perspective_thread(manager):
     with open(file_path, mode="rb") as file:
         table = Table(file.read(), index="Row ID")
         manager.host_table("data_source_one", table)
-        manager.host_view("view_one", table.view())
     psp_loop.start()
 
 

--- a/examples/workspace-editing-python/src/index.js
+++ b/examples/workspace-editing-python/src/index.js
@@ -29,12 +29,11 @@ const websocket = perspective.websocket(URL);
 const worker = perspective.shared_worker();
 
 /**
- * `open_table` and `open_view` allow you to call API methods on remotely
- * hosted Perspective tables and views, just as you would on a locally created
- * table/view.
+ * `open_table` allows you to call API methods on remotely hosted Perspective
+ * tables just as you would on a locally created table.
  */
 const server_table = websocket.open_table("data_source_one");
-const server_view = websocket.open_view("view_one");
+const server_view = server_table.view();
 
 // All viewers are based on the same table, which then feed edits back to a
 // table on the server with a schema.

--- a/examples/workspace-editing-python/src/server.py
+++ b/examples/workspace-editing-python/src/server.py
@@ -40,7 +40,6 @@ def perspective_thread(manager):
     with open(file_path, mode="rb") as file:
         table = Table(file.read(), index="Row ID")
         manager.host_table("data_source_one", table)
-        manager.host_view("view_one", table.view())
 
     psp_loop.start()
 

--- a/packages/perspective-jupyterlab/src/ts/client.ts
+++ b/packages/perspective-jupyterlab/src/ts/client.ts
@@ -52,7 +52,6 @@ export class PerspectiveJupyterClient extends Client {
      * @param msg {any} the message to pass to the `PerspectiveManager`.
      */
     send(msg: any): void {
-        console.log("SENDING", msg);
         // Handle calls to `update` with a binary by setting `binary_length`
         // to true, so the kernel knows to handle the arraybuffer properly.
         if (msg.method === "update" && msg.args.length === 2 && msg.args[0] instanceof ArrayBuffer) {

--- a/packages/perspective-jupyterlab/src/ts/client.ts
+++ b/packages/perspective-jupyterlab/src/ts/client.ts
@@ -52,6 +52,7 @@ export class PerspectiveJupyterClient extends Client {
      * @param msg {any} the message to pass to the `PerspectiveManager`.
      */
     send(msg: any): void {
+        console.log("SENDING", msg);
         // Handle calls to `update` with a binary by setting `binary_length`
         // to true, so the kernel knows to handle the arraybuffer properly.
         if (msg.method === "update" && msg.args.length === 2 && msg.args[0] instanceof ArrayBuffer) {

--- a/packages/perspective-jupyterlab/src/ts/view.ts
+++ b/packages/perspective-jupyterlab/src/ts/view.ts
@@ -242,21 +242,30 @@ export class PerspectiveView extends DOMWidgetView {
         const table_options = msg.data["options"] || {};
 
         if (this.pWidget.client) {
-            // In client mode, retrieve the serialized data and the options
-            // passed by the user, and create a new table on the client end.
+            /**
+             * In client mode, retrieve the serialized data and the options
+             * passed by the user, and create a new table on the client end.
+             */
             const data = msg.data["data"];
             this.pWidget.load(data, table_options);
         } else {
             if (this.pWidget.server && msg.data["table_name"]) {
-                // Get a remote table handle, and load the remote table in
-                // the client.
+                /**
+                 * Get a remote table handle, and load the remote table in
+                 * the client for server mode Perspective.
+                 */
                 const table = this.perspective_client.open_table(msg.data["table_name"]);
                 this.pWidget.load(table, table_options);
-            } else if (msg.data["table_name"] && msg.data["view_name"]) {
-                // Get a remote view handle from the Jupyter kernel, and
-                // create a client-side table using the view handle.
+            } else if (msg.data["table_name"]) {
+                /**
+                 * Get a remote table handle from the Jupyter kernel, and
+                 * create a view on that handle to run Perspective in
+                 * distributed mode.
+                 */
                 const kernel_table: Table = this.perspective_client.open_table(msg.data["table_name"]);
-                const kernel_view: View = this.perspective_client.open_view(msg.data["view_name"]);
+                const kernel_view: View = kernel_table.view();
+
+                console.log(kernel_view);
 
                 // If the widget is editable, set up client/server editing
                 if (this.pWidget.editable) {
@@ -272,16 +281,21 @@ export class PerspectiveView extends DOMWidgetView {
                         let client_edit_port: number, server_edit_port: number;
 
                         // Create ports on the client and kernel.
-                        Promise.all([this.pWidget.load(client_table), this.pWidget.getEditPort(), kernel_table.make_port()]).then(outs => {
-                            client_edit_port = outs[1];
-                            server_edit_port = outs[2];
+                        Promise.all([this.pWidget.load(client_table), this.pWidget.getEditPort(), kernel_table.make_port()]).then(ports => {
+                            client_edit_port = ports[1];
+                            server_edit_port = ports[2];
+
+                            console.log(ports[1], ports[2]);
                         });
 
-                        // When the client updates, if the update comes through
-                        // the edit port then forward it to the server.
+                        /**
+                         * When the client updates, if the update comes through
+                         * the edit port then forward it to the server.
+                         */
                         client_view.on_update(
                             updated => {
                                 if (updated.port_id === client_edit_port) {
+                                    console.log("CLIENT UPDATE");
                                     kernel_table.update(updated.delta, {
                                         port_id: server_edit_port
                                     });
@@ -290,12 +304,15 @@ export class PerspectiveView extends DOMWidgetView {
                             {mode: "row"}
                         );
 
-                        // If the server updates, and the edit is not coming
-                        // from the server edit port, then synchronize state
-                        // with the client.
+                        /**
+                         * If the server updates, and the edit is not coming
+                         * from the server edit port, then synchronize state
+                         * with the client.
+                         */
                         kernel_view.on_update(
                             updated => {
                                 if (updated.port_id !== server_edit_port) {
+                                    console.log("KERNEL UPDATE");
                                     client_table.update(updated.delta); // any port, we dont care
                                 }
                             },
@@ -303,8 +320,10 @@ export class PerspectiveView extends DOMWidgetView {
                         );
                     });
                 } else {
-                    // Just load the view into the widget, everything else
-                    // is handled.
+                    /**
+                     * Just load the view into the widget, as the load
+                     * semantics are handled by Perspective.
+                     */
                     this.pWidget.load(kernel_view, table_options);
                 }
             } else {

--- a/packages/perspective-jupyterlab/src/ts/view.ts
+++ b/packages/perspective-jupyterlab/src/ts/view.ts
@@ -265,8 +265,6 @@ export class PerspectiveView extends DOMWidgetView {
                 const kernel_table: Table = this.perspective_client.open_table(msg.data["table_name"]);
                 const kernel_view: View = kernel_table.view();
 
-                console.log(kernel_view);
-
                 // If the widget is editable, set up client/server editing
                 if (this.pWidget.editable) {
                     let worker: PerspectiveWorker;
@@ -284,8 +282,6 @@ export class PerspectiveView extends DOMWidgetView {
                         Promise.all([this.pWidget.load(client_table), this.pWidget.getEditPort(), kernel_table.make_port()]).then(ports => {
                             client_edit_port = ports[1];
                             server_edit_port = ports[2];
-
-                            console.log(ports[1], ports[2]);
                         });
 
                         /**
@@ -295,7 +291,6 @@ export class PerspectiveView extends DOMWidgetView {
                         client_view.on_update(
                             updated => {
                                 if (updated.port_id === client_edit_port) {
-                                    console.log("CLIENT UPDATE");
                                     kernel_table.update(updated.delta, {
                                         port_id: server_edit_port
                                     });
@@ -312,7 +307,6 @@ export class PerspectiveView extends DOMWidgetView {
                         kernel_view.on_update(
                             updated => {
                                 if (updated.port_id !== server_edit_port) {
-                                    console.log("KERNEL UPDATE");
                                     client_table.update(updated.delta); // any port, we dont care
                                 }
                             },

--- a/packages/perspective-jupyterlab/test/js/unit/view.spec.js
+++ b/packages/perspective-jupyterlab/test/js/unit/view.spec.js
@@ -97,8 +97,15 @@ describe("PerspectiveView", function() {
         });
 
         it("Should handle a well-formed table message from the kernel", async function() {
-            const table_name = uuid();
             view = await manager.create_view(model)();
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+            mock_client.open_table.mockReturnValue({
+                view: jest.fn()
+            });
+
+            // Mock the output of open_table() so `view()` is valid
+
+            const table_name = uuid();
             view._handle_message({
                 id: -2,
                 type: "table",
@@ -106,8 +113,6 @@ describe("PerspectiveView", function() {
                     table_name: table_name
                 }
             });
-
-            const mock_client = PerspectiveJupyterClient.mock.instances[0];
 
             // `open_table` should be called correctly
             const open_table_arg = mock_client.open_table.mock.calls[0][0];
@@ -121,8 +126,13 @@ describe("PerspectiveView", function() {
         });
 
         it("Should handle a well-formed table message with index from the kernel", async function() {
-            const table_name = uuid();
             view = await manager.create_view(model)();
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+            mock_client.open_table.mockReturnValue({
+                view: jest.fn()
+            });
+
+            const table_name = uuid();
             view._handle_message({
                 id: -2,
                 type: "table",
@@ -133,8 +143,6 @@ describe("PerspectiveView", function() {
                     }
                 }
             });
-
-            const mock_client = PerspectiveJupyterClient.mock.instances[0];
 
             // `open_table` should be called correctly
             const open_table_arg = mock_client.open_table.mock.calls[0][0];
@@ -148,8 +156,13 @@ describe("PerspectiveView", function() {
         });
 
         it("Should handle a well-formed table message with limit from the kernel", async function() {
-            const table_name = uuid();
             view = await manager.create_view(model)();
+            const mock_client = PerspectiveJupyterClient.mock.instances[0];
+            mock_client.open_table.mockReturnValue({
+                view: jest.fn()
+            });
+
+            const table_name = uuid();
             view._handle_message({
                 id: -2,
                 type: "table",
@@ -160,8 +173,6 @@ describe("PerspectiveView", function() {
                     }
                 }
             });
-
-            const mock_client = PerspectiveJupyterClient.mock.instances[0];
 
             // `open_table` should be called correctly
             const open_table_arg = mock_client.open_table.mock.calls[0][0];

--- a/packages/perspective-jupyterlab/test/js/unit/view.spec.js
+++ b/packages/perspective-jupyterlab/test/js/unit/view.spec.js
@@ -96,24 +96,22 @@ describe("PerspectiveView", function() {
             });
         });
 
-        it("Should handle a well-formed table/view message from the kernel", async function() {
+        it("Should handle a well-formed table message from the kernel", async function() {
             const table_name = uuid();
-            const view_name = uuid();
             view = await manager.create_view(model)();
             view._handle_message({
                 id: -2,
                 type: "table",
                 data: {
-                    table_name: table_name,
-                    view_name: view_name
+                    table_name: table_name
                 }
             });
 
             const mock_client = PerspectiveJupyterClient.mock.instances[0];
 
-            // `open_view` should be called correctly
-            const open_view_arg = mock_client.open_view.mock.calls[0][0];
-            expect(open_view_arg).toEqual(view_name);
+            // `open_table` should be called correctly
+            const open_table_arg = mock_client.open_table.mock.calls[0][0];
+            expect(open_table_arg).toEqual(table_name);
 
             const send_arg = mock_client.send.mock.calls[0][0];
             expect(send_arg).toEqual({
@@ -122,16 +120,14 @@ describe("PerspectiveView", function() {
             });
         });
 
-        it("Should handle a well-formed table/view message with index from the kernel", async function() {
+        it("Should handle a well-formed table message with index from the kernel", async function() {
             const table_name = uuid();
-            const view_name = uuid();
             view = await manager.create_view(model)();
             view._handle_message({
                 id: -2,
                 type: "table",
                 data: {
                     table_name: table_name,
-                    view_name: view_name,
                     options: {
                         index: "a"
                     }
@@ -140,9 +136,9 @@ describe("PerspectiveView", function() {
 
             const mock_client = PerspectiveJupyterClient.mock.instances[0];
 
-            // `open_view` should be called correctly
-            const open_view_arg = mock_client.open_view.mock.calls[0][0];
-            expect(open_view_arg).toEqual(view_name);
+            // `open_table` should be called correctly
+            const open_table_arg = mock_client.open_table.mock.calls[0][0];
+            expect(open_table_arg).toEqual(table_name);
 
             const send_arg = mock_client.send.mock.calls[0][0];
             expect(send_arg).toEqual({
@@ -151,16 +147,14 @@ describe("PerspectiveView", function() {
             });
         });
 
-        it("Should handle a well-formed view message with limit from the kernel", async function() {
+        it("Should handle a well-formed table message with limit from the kernel", async function() {
             const table_name = uuid();
-            const view_name = uuid();
             view = await manager.create_view(model)();
             view._handle_message({
                 id: -2,
                 type: "table",
                 data: {
                     table_name: table_name,
-                    view_name: view_name,
                     options: {
                         limit: 1000
                     }
@@ -169,9 +163,9 @@ describe("PerspectiveView", function() {
 
             const mock_client = PerspectiveJupyterClient.mock.instances[0];
 
-            // `open_view` should be called correctly
-            const open_view_arg = mock_client.open_view.mock.calls[0][0];
-            expect(open_view_arg).toEqual(view_name);
+            // `open_table` should be called correctly
+            const open_table_arg = mock_client.open_table.mock.calls[0][0];
+            expect(open_table_arg).toEqual(table_name);
 
             const send_arg = mock_client.send.mock.calls[0][0];
             expect(send_arg).toEqual({

--- a/packages/perspective/README.md
+++ b/packages/perspective/README.md
@@ -31,6 +31,8 @@ For more information, see the
         * [.remove_delete(callback)](#module_perspective..view+remove_delete)
     * [~table](#module_perspective..table)
         * [new table()](#new_module_perspective..table_new)
+        * [.get_index()](#module_perspective..table+get_index)
+        * [.get_limit()](#module_perspective..table+get_limit)
         * [.clear()](#module_perspective..table+clear)
         * [.replace()](#module_perspective..table+replace)
         * [.delete()](#module_perspective..table+delete)
@@ -282,6 +284,7 @@ serialize.
     - .end_col <code>number</code> - The ending column index from which to
 serialize.
 
+
 * * *
 
 <a name="module_perspective..view+col_to_js_typed_array"></a>
@@ -415,8 +418,6 @@ receives an object with two keys: `port_id`, indicating which port the
 update was triggered on, and `delta`, whose value is dependent on the
 `mode` parameter:
     - "none" (default): `delta` is `undefined`.
-    - "cell": `delta` is the new data for each updated cell, serialized
-         to JSON format.
     - "row": `delta` is an Arrow of the updated rows.
 
 **Example**  
@@ -479,6 +480,8 @@ view.remove_delete(callback);
 
 * [~table](#module_perspective..table)
     * [new table()](#new_module_perspective..table_new)
+    * [.get_index()](#module_perspective..table+get_index)
+    * [.get_limit()](#module_perspective..table+get_limit)
     * [.clear()](#module_perspective..table+clear)
     * [.replace()](#module_perspective..table+replace)
     * [.delete()](#module_perspective..table+delete)
@@ -509,6 +512,26 @@ by invoking the [table](#module_perspective..table) factory method, either
 on the perspective module object, or an a
 [module:perspective~worker](module:perspective~worker) instance.
 
+
+* * *
+
+<a name="module_perspective..table+get_index"></a>
+
+#### table.get\_index()
+Returns the user-specified index column for this
+[table](#module_perspective..table) or null if an index is not set.
+
+**Kind**: instance method of [<code>table</code>](#module_perspective..table)  
+
+* * *
+
+<a name="module_perspective..table+get_limit"></a>
+
+#### table.get\_limit()
+Returns the user-specified limit column for this
+[table](#module_perspective..table) or null if an limit is not set.
+
+**Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 
 * * *
 
@@ -553,9 +576,8 @@ invoked.
 **Kind**: instance method of [<code>table</code>](#module_perspective..table)  
 **Params**
 
-- callback <code>function</code> - A callback function invoked on delete.  The
-    parameter to this callback shares a structure with the return type of
-    [module:perspective~table#to_json](module:perspective~table#to_json).
+- callback <code>function</code> - A callback function with no parameters
+     that will be invoked on `delete()`.
 
 
 * * *

--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -146,7 +146,6 @@ declare module "@finos/perspective" {
 
     export class WebSocketClient {
         open_table(name: string): Table;
-        open_view(name: string): View;
         terminate(): void;
         initialize_profile_thread(): void;
         send(msg: any): void;
@@ -162,7 +161,6 @@ declare module "@finos/perspective" {
     export class WebSocketManager {
         add_connection(ws: ws): void;
         host_table(name: string, table: Table): void;
-        host_view(name: string, view: View): void;
         eject_table(name: string): void;
         eject_view(name: string): void;
     }

--- a/packages/perspective/src/js/api/client.js
+++ b/packages/perspective/src/js/api/client.js
@@ -8,7 +8,6 @@
  */
 
 import {table, proxy_table} from "./table_api.js";
-import {proxy_view} from "./view_api.js";
 import {bindall} from "../utils.js";
 
 /**
@@ -85,10 +84,6 @@ export class Client {
      */
     open_table(name) {
         return new proxy_table(this, name);
-    }
-
-    open_view(name) {
-        return new proxy_view(this, name);
     }
 
     /**

--- a/packages/perspective/src/js/websocket/manager.js
+++ b/packages/perspective/src/js/websocket/manager.js
@@ -186,18 +186,6 @@ export class WebSocketManager extends Server {
     }
 
     /**
-     * Expose a Perspective `view` through the WebSocket, allowing
-     * it to be accessed by a unique name from a client.  Hosted objects
-     * are automatically `eject`ed when their `delete()` method is called.
-     *
-     * @param {String} name
-     * @param {perspective.view} view `view` to host.
-     */
-    host_view(name, view) {
-        this._host(this._views, name, view);
-    }
-
-    /**
      * Cease hosting a `table` on this server.  Hosted objects
      * are automatically `eject`ed when their `delete()` method is called.
      *

--- a/python/perspective/bench/tornado/async_server.py
+++ b/python/perspective/bench/tornado/async_server.py
@@ -114,7 +114,6 @@ def server(queue, is_async):
     manager = perspective.PerspectiveManager()
     table = get_table()
     manager.host_table("data_source_one", table)
-    manager.host_view("view_one", table.view())
 
     if is_async:
         thread = threading.Thread(target=perspective_thread, args=(manager,))

--- a/python/perspective/bench/tornado/distributed_mode.py
+++ b/python/perspective/bench/tornado/distributed_mode.py
@@ -26,16 +26,6 @@ async def make_view_arrow(client):
     return [end]
 
 
-async def open_view_arrow(client):
-    """Test how long it takes to open a remote view and retrieve an arrow"""
-    view = client.open_view("view_one")
-    start = time.time()
-    arrow = await view.to_arrow(end_row=ARROW_LENGTH)
-    end = time.time() - start
-    assert len(arrow) > 0
-    return [end]
-
-
 if __name__ == "__main__":
     """To allow your test script to run within the benchmark harness,
     import and create a `PerspectiveTornadoBenchmark`, and call its
@@ -56,6 +46,3 @@ if __name__ == "__main__":
     logging.info("Create view, request arrow length %d", ARROW_LENGTH)
     runner = PerspectiveTornadoBenchmark(make_view_arrow)
     runner.run()
-    logging.info("Open view, request arrow length %d", ARROW_LENGTH)
-    runner2 = PerspectiveTornadoBenchmark(open_view_arrow)
-    runner2.run()

--- a/python/perspective/perspective/client/client.py
+++ b/python/perspective/perspective/client/client.py
@@ -11,7 +11,6 @@ from random import random
 from ..core.exception import PerspectiveError
 from .table_api import PerspectiveTableProxy
 from .table_api import table as make_table
-from .view_api import PerspectiveViewProxy
 
 
 class PerspectiveClient(object):
@@ -44,10 +43,6 @@ class PerspectiveClient(object):
     def open_table(self, name):
         """Return a proxy Table to a `Table` hosted in a server somewhere."""
         return PerspectiveTableProxy(self, name)
-
-    def open_view(self, name):
-        """Return a proxy View to a `View` hosted in a server somewhere."""
-        return PerspectiveViewProxy(self, name)
 
     def _handle(self, msg):
         """Given a response from the Perspective server, resolve the Future

--- a/python/perspective/perspective/manager/manager.py
+++ b/python/perspective/perspective/manager/manager.py
@@ -11,7 +11,6 @@ import string
 from functools import partial
 from ..core.exception import PerspectiveError
 from ..table import Table
-from ..table.view import View
 from .session import PerspectiveSession
 from .manager_internal import _PerspectiveManagerInternal
 
@@ -27,14 +26,14 @@ class PerspectiveManager(_PerspectiveManagerInternal):
     The core functionality resides in `process()`, which receives
     JSON-serialized messages from a client (implemented by `perspective-viewer`
     in the browser), executes the commands in the message, and returns the
-    results of those commands back to the `post_callback`. Table/View instances
-    should be passed to the manager using `host_table` or `host_view` - this
-    allows server code to call Table/View APIs natively instead of proxying
-    them through the Manager. Because Perspective is designed to be used in a
-    shared context, i.e. multiple clients all accessing the same `Table`,
-    PerspectiveManager comes with the context of `sessions` - an
-    encapsulation of the actions and resources used by a single connection
-    to Perspective, which can be cleaned up after the connection is closed.
+    results of those commands back to the `post_callback`. Table instances
+    should be passed to the manager using `host_table` - this allows server
+    code to call Table APIs natively instead of proxying them through the
+    Manager. Because Perspective is designed to be used in a shared context,
+    i.e. multiple clients all accessing the same `Table`, PerspectiveManager
+    comes with the context of `sessions` - an encapsulation of the actions
+    and resources used by a single connection to Perspective, which can be
+    cleaned up after the connection is closed.
 
     - When a client connects, for example through a websocket, a new session
         should be spawned using `new_session()`.
@@ -53,7 +52,7 @@ class PerspectiveManager(_PerspectiveManagerInternal):
 
     def lock(self):
         """Block messages that can mutate the state of :obj:`~perspective.Table`
-         and :obj:`~perspective.View` objects under management.
+        objects under management.
 
         All ``PerspectiveManager`` objects exposed over the internet should be
         locked to prevent content from being mutated by clients.
@@ -62,33 +61,25 @@ class PerspectiveManager(_PerspectiveManagerInternal):
 
     def unlock(self):
         """Unblock messages that can mutate the state of
-        :obj:`~perspective.Table` and :obj:`~perspective.View` objects under
-        management."""
+        :obj:`~perspective.Table` objects under management."""
         self._lock = False
 
     def host(self, item, name=None):
-        """Given a :obj:`~perspective.Table` or :obj:`~perspective.View`,
-        place it under management and allow operations on it to be passed
-        through the Manager instance.
+        """Given a :obj:`~perspective.Table`, place it under management and
+        allow operations on it to be passed through the Manager instance.
 
         Args:
-            table_or_view (:obj:`~perspective.Table`/:obj:`~perspective.View`) :
-                a Table or View to be managed.
+            item (:obj:`~perspective.Table`) : a Table to be managed.
 
         Keyword Args:
             name (:obj:`str`) : an optional name to allow retrieval through
-                ``get_table`` or ``get_view``. A name will be generated if not
-                provided.
+                ``get_table``. A name will be generated if not provided.
         """
         name = name or gen_name()
         if isinstance(item, Table):
             self.host_table(name, item)
-        elif isinstance(item, View):
-            self.host_view(name, item)
         else:
-            raise PerspectiveError(
-                "Only `Table()` and `View()` instances can be hosted."
-            )
+            raise PerspectiveError("Only `Table()` instances can be hosted.")
 
     def host_table(self, name, table):
         """Given a reference to a `Table`, manage it and allow operations on it
@@ -108,19 +99,9 @@ class PerspectiveManager(_PerspectiveManagerInternal):
         self._tables[name] = table
         return name
 
-    def host_view(self, name, view):
-        """Given a :obj:`~perspective.View`, add it to the manager's views
-        container.
-        """
-        self._views[name] = view
-
     def get_table(self, name):
         """Return a table under management by name."""
         return self._tables.get(name, None)
-
-    def get_view(self, name):
-        """Return a view under management by name."""
-        return self._views.get(name, None)
 
     def new_session(self):
         return PerspectiveSession(self)

--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -50,6 +50,10 @@ class _PerspectiveManagerInternal(object):
         # special message flow.
         self._pending_binary = None
 
+    def _get_view(self, name):
+        """Return a view under management by name."""
+        return self._views.get(name, None)
+
     def _process(self, msg, post_callback, client_id=None):
         """Given a message from the client, process it through the Perspective
         engine.

--- a/python/perspective/perspective/manager/session.py
+++ b/python/perspective/perspective/manager/session.py
@@ -46,7 +46,7 @@ class PerspectiveSession(object):
         # remove all callbacks from the view's cache
         for cb in self.manager._callback_cache:
             if cb["client_id"] == self.client_id:
-                view = self.manager.get_view(cb["name"])
+                view = self.manager._get_view(cb["name"])
                 if view:
                     view.remove_update(cb["callback"])
         # remove all callbacks from the manager's cache

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -350,9 +350,9 @@ class View(object):
         """Delete the :class:`~perspective.View` and clean up all associated
         callbacks.
 
-        This method must be called to clean up resources used by the
-        :class:`~perspective.View`, as it will last for the lifetime of the
-        underlying :class:`~perspective.Table` otherwise.
+        This method must be called to clean up callbacks used by the
+        :class:`~perspective.View`, as well as allow for deletion of the
+        underlying :class:`~perspective.Table`.
 
         Examples:
             >>> table = perspective.Table(data)

--- a/python/perspective/perspective/tests/manager/test_manager.py
+++ b/python/perspective/perspective/tests/manager/test_manager.py
@@ -23,7 +23,6 @@ class TestPerspectiveManager(object):
     def post(self, msg):
         '''boilerplate callback to simulate a client's `post()` method.'''
         msg = json.loads(msg)
-        print("self.post:", msg)
         assert msg["id"] is not None
 
     def validate_post(self, msg, expected=None):
@@ -41,22 +40,6 @@ class TestPerspectiveManager(object):
             "a": int,
             "b": str
         }
-
-    def test_manager_host_view(self):
-        manager = PerspectiveManager()
-        table = Table(data)
-        view = table.view()
-        manager.host_view("view1", view)
-        assert manager.get_view("view1").to_dict() == data
-
-    def test_manager_host_table_or_view(self):
-        manager = PerspectiveManager()
-        table = Table(data)
-        view = table.view()
-        manager.host(table, name="table1")
-        manager.host(view, name="view1")
-        assert manager.get_table("table1").size() == 3
-        assert manager.get_view("view1").to_dict() == data
 
     def test_manager_host_invalid(self):
         manager = PerspectiveManager()
@@ -137,28 +120,13 @@ class TestPerspectiveManager(object):
             "b": ["c"]
         }
 
-    def test_manager_create_view(self):
-        message = {"id": 1, "name": "view1", "cmd": "view_method", "method": "schema", "args": []}
-        manager = PerspectiveManager()
-        table = Table(data)
-        view = table.view()
-        manager.host_table("table1", table)
-        manager.host_view("view1", view)
-        manager._process(message, self.post)
-        assert manager.get_view("view1").schema() == {
-            "a": int,
-            "b": str
-        }
-
     def test_locked_manager_create_view(self):
-        message = {"id": 1, "name": "view1", "cmd": "view_method", "method": "schema", "args": []}
+        message = {"id": 1, "table_name": "table1", "view_name": "view1", "cmd": "view"}
         manager = PerspectiveManager(lock=True)
         table = Table(data)
-        view = table.view()
         manager.host_table("table1", table)
-        manager.host_view("view1", view)
         manager._process(message, self.post)
-        assert manager.get_view("view1").schema() == {
+        assert manager._get_view("view1").schema() == {
             "a": int,
             "b": str
         }
@@ -329,26 +297,24 @@ class TestPerspectiveManager(object):
         message = {"id": 1, "name": "table1", "cmd": "table_method", "method": "schema", "args": [False]}
         manager = PerspectiveManager()
         table = Table(data)
-        view = table.view()
         manager.host_table("table1", table)
-        manager.host_view("view1", view)
         manager._process(message, post_callback)
 
     def test_manager_view_schema(self):
         post_callback = partial(self.validate_post, expected={
-            "id": 1,
+            "id": 2,
             "data": {
                 "a": "integer",
                 "b": "integer"
             }
         })
 
-        message = {"id": 1, "name": "view1", "cmd": "view_method", "method": "schema", "args": [False]}
+        make_view_message = {"id": 1, "table_name": "table1", "view_name": "view1", "cmd": "view", "config": {"row_pivots": ["a"]}}
+        message = {"id": 2, "name": "view1", "cmd": "view_method", "method": "schema", "args": [False]}
         manager = PerspectiveManager()
         table = Table(data)
-        view = table.view(row_pivots=["a"])
         manager.host_table("table1", table)
-        manager.host_view("view1", view)
+        manager._process(make_view_message, self.post)
         manager._process(message, post_callback)
 
     def test_manager_table_computed_schema(self):
@@ -378,7 +344,6 @@ class TestPerspectiveManager(object):
         table = Table(data)
         view = table.view()
         manager.host_table("table1", table)
-        manager.host_view("view1", view)
         manager._process(message, post_callback)
 
     def test_manager_table_get_computation_input_types(self):
@@ -396,31 +361,29 @@ class TestPerspectiveManager(object):
         }
         manager = PerspectiveManager()
         table = Table(data)
-        view = table.view()
         manager.host_table("table1", table)
-        manager.host_view("view1", view)
         manager._process(message, post_callback)
 
     def test_manager_view_computed_schema(self):
         post_callback = partial(self.validate_post, expected={
-            "id": 1,
+            "id": 2,
             "data": {
                 "abc": "float"
             }
         })
 
-        message = {"id": 1, "name": "view1", "cmd": "view_method", "method": "computed_schema", "args": [False]}
-        manager = PerspectiveManager()
-        table = Table(data)
-        view = table.view(computed_columns=[
+        make_view_message = {"id": 1, "table_name": "table1", "view_name": "view1", "cmd": "view", "config": {"computed_columns": [
             {
                 "column": "abc",
                 "computed_function_name": "+",
                 "inputs": ["a", "a"]
             }
-        ])
+        ]}}
+        message = {"id": 2, "name": "view1", "cmd": "view_method", "method": "computed_schema", "args": [False]}
+        manager = PerspectiveManager()
+        table = Table(data)
         manager.host_table("table1", table)
-        manager.host_view("view1", view)
+        manager._process(make_view_message, self.post)
         manager._process(message, post_callback)
 
     # serialization
@@ -955,7 +918,7 @@ class TestPerspectiveManager(object):
         make_view = {"id": 2, "table_name": "table1", "view_name": "view1", "cmd": "view"}
         manager._process(make_view, self.post)
 
-        view = manager.get_view("view1")
+        view = manager._get_view("view1")
         view.on_delete(delete_callback)
 
         delete_view = {"id": 3, "name": "view1", "cmd": "view_method", "method": "delete"}
@@ -977,7 +940,7 @@ class TestPerspectiveManager(object):
         make_view = {"id": 2, "table_name": "table1", "view_name": "view1", "cmd": "view"}
         manager._process(make_view, self.post)
 
-        view = manager.get_view("view1")
+        view = manager._get_view("view1")
         view.on_delete(delete_callback)
         view.remove_delete(delete_callback)
 

--- a/python/perspective/perspective/tests/manager/test_session.py
+++ b/python/perspective/perspective/tests/manager/test_session.py
@@ -14,11 +14,9 @@ data = {"a": [1, 2, 3], "b": ["a", "b", "c"]}
 
 
 class TestPerspectiveSession(object):
-
     def post(self, msg):
         '''boilerplate callback to simulate a client's `post()` method.'''
         msg = json.loads(msg)
-        print("self.post: ", msg)
         assert msg["id"] is not None
 
     def validate_post(self, msg, expected=None):
@@ -49,7 +47,7 @@ class TestPerspectiveSession(object):
 
         # make sure the client ID is attached to the new view
         assert len(manager._views.keys()) == 1
-        assert manager.get_view("view1")._client_id == client_id
+        assert manager._get_view("view1")._client_id == client_id
 
         to_dict_message = {"id": 2, "name": "view1", "cmd": "view_method", "method": "to_dict"}
 
@@ -87,7 +85,7 @@ class TestPerspectiveSession(object):
             assert key in manager_views
 
         for i, session in enumerate(sessions):
-            view = manager.get_view("view" + str(i))
+            view = manager._get_view("view" + str(i))
             assert view._client_id == session.client_id
 
         # arbitrarily do an update
@@ -118,7 +116,7 @@ class TestPerspectiveSession(object):
 
         # make sure the client ID is attached to the new view
         assert len(manager._views.keys()) == 1
-        assert manager.get_view("view1")._client_id == client_id
+        assert manager._get_view("view1")._client_id == client_id
 
         def callback(updated):
             assert updated["port_id"] == 0
@@ -184,7 +182,7 @@ class TestPerspectiveSession(object):
             assert key in manager_views
 
         for i, session in enumerate(sessions):
-            view = manager.get_view("view" + str(i))
+            view = manager._get_view("view" + str(i))
             assert view._client_id == session.client_id
 
         def callback(updated):

--- a/python/perspective/perspective/tests/viewer/test_viewer.py
+++ b/python/perspective/perspective/tests/viewer/test_viewer.py
@@ -72,14 +72,6 @@ class TestViewer:
         assert viewer.columns == ["a"]
         assert viewer.table.size() == 1
 
-    def test_viewer_load_view(self):
-        table = Table({"a": [1, 2, 3]})
-        viewer = PerspectiveViewer()
-        view = table.view()
-        viewer.load(view)
-        assert viewer._view == view
-        assert viewer.table == table
-
     def test_viewer_load_clears_state(self):
         table = Table({"a": [1, 2, 3]})
         viewer = PerspectiveViewer(dark=True, row_pivots=["a"])
@@ -211,17 +203,6 @@ class TestViewer:
         assert viewer.table_name is None
         assert viewer.table is None
 
-    def test_viewer_delete_view(self):
-        table = Table({"a": [1, 2, 3]})
-        viewer = PerspectiveViewer(plugin="x_bar", filters=[["a", "==", 2]])
-        viewer.load(table.view())
-        assert viewer.filters == [["a", "==", 2]]
-        viewer.delete()
-        assert viewer._perspective_view_name is None
-        assert viewer._view is None
-        assert viewer.table_name is None
-        assert viewer.table is None
-
     def test_viewer_delete_without_table(self):
         table = Table({"a": [1, 2, 3]})
         viewer = PerspectiveViewer(plugin="x_bar", filters=[["a", "==", 2]])
@@ -230,8 +211,6 @@ class TestViewer:
         viewer.delete(delete_table=False)
         assert viewer.table_name is not None
         assert viewer.table is not None
-        assert viewer._perspective_view_name is not None
-        assert viewer._view is not None
         assert viewer.filters == []
 
     def test_save_restore(self):

--- a/python/perspective/perspective/tests/widget/test_widget.py
+++ b/python/perspective/perspective/tests/widget/test_widget.py
@@ -31,7 +31,6 @@ class TestWidget:
             "type": "table",
             "data": {
                 "table_name": widget.table_name,
-                "view_name": widget._perspective_view_name,
                 "options": {}
             }
         }
@@ -46,7 +45,6 @@ class TestWidget:
             "type": "table",
             "data": {
                 "table_name": widget.table_name,
-                "view_name": widget._perspective_view_name,
                 "options": {
                     "index": "a"
                 }
@@ -104,7 +102,6 @@ class TestWidget:
             "type": "table",
             "data": {
                 "table_name": widget.table_name,
-                "view_name": widget._perspective_view_name,
                 "options": {}
             }
         }
@@ -132,7 +129,6 @@ class TestWidget:
             "type": "table",
             "data": {
                 "table_name": widget.table_name,
-                "view_name": widget._perspective_view_name,
                 "options": {
                     "index": "a"
                 }
@@ -150,7 +146,6 @@ class TestWidget:
             "type": "table",
             "data": {
                 "table_name": widget.table_name,
-                "view_name": widget._perspective_view_name,
                 "options": {
                     "index": "a"
                 }
@@ -167,7 +162,6 @@ class TestWidget:
             "type": "table",
             "data": {
                 "table_name": widget.table_name,
-                "view_name": widget._perspective_view_name,
                 "options": {}
             }
         }
@@ -182,38 +176,15 @@ class TestWidget:
             "type": "table",
             "data": {
                 "table_name": widget.table_name,
-                "view_name": widget._perspective_view_name,
                 "options": {
                     "index": "a"
                 }
             }
         }
 
-    def test_widget_load_view(self):
-        table = Table({"a": np.arange(0, 50)})
-        view = table.view()
-        widget = PerspectiveWidget(view, plugin="x_bar")
-        assert widget.plugin == "x_bar"
-        load_msg = widget._make_load_message()
-        assert load_msg.to_dict() == {
-            "id": -2,
-            "type": "table",
-            "data": {
-                "table_name": widget.table_name,
-                "view_name": widget._perspective_view_name,
-                "options": {}
-            }
-        }
-
     def test_widget_load_table_ignore_limit(self):
         table = Table({"a": np.arange(0, 50)})
         widget = PerspectiveWidget(table, limit=1)
-        assert widget.table.size() == 50
-
-    def test_widget_load_view_ignore_limit(self):
-        table = Table({"a": np.arange(0, 50)})
-        view = table.view()
-        widget = PerspectiveWidget(view, plugin="x_bar", limit=1)
         assert widget.table.size() == 50
 
     def test_widget_pass_index(self):
@@ -235,19 +206,6 @@ class TestWidget:
     def test_widget_load_table_server(self):
         table = Table({"a": np.arange(0, 50)})
         widget = PerspectiveWidget(table, server=True)
-        load_msg = widget._make_load_message()
-        assert load_msg.to_dict() == {
-            "id": -2,
-            "type": "table",
-            "data": {
-                "table_name": widget.table_name
-            }
-        }
-
-    def test_widget_load_view_server(self):
-        table = Table({"a": np.arange(0, 50)})
-        view = table.view()
-        widget = PerspectiveWidget(view, server=True)
         load_msg = widget._make_load_message()
         assert load_msg.to_dict() == {
             "id": -2,
@@ -319,18 +277,4 @@ class TestWidget:
         })
         widget.post = MethodType(mocked_post, widget)
         widget.delete()
-        assert widget._view is None
-        assert widget.table is None
-
-    def test_widget_delete_view(self):
-        data = {"a": np.arange(0, 50)}
-        table = Table(data)
-        view = table.view()
-        widget = PerspectiveWidget(view)
-        mocked_post = partial(mock_post, assert_msg={
-            "cmd": "delete"
-        })
-        widget.post = MethodType(mocked_post, widget)
-        widget.delete()
-        assert widget._view is None
         assert widget.table is None

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -24,6 +24,7 @@ from ..libpsp import is_libpsp
 
 if is_libpsp():
     from ..libpsp import Table, View, PerspectiveManager
+    from ..core.exception import PerspectiveError
 
 
 class PerspectiveViewer(PerspectiveTraitlets, object):
@@ -121,11 +122,6 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         # attached PerspectiveManager
         self.table_name = None
 
-        # If `is_libpsp()` and the viewer has a Table, an internal view will be
-        # created to allow remote clients to host their own table that listens
-        # to updates from this table.
-        self._perspective_view_name = None
-
         # Viewer configuration
         self.plugin = validate_plugin(plugin)
         self.columns = validate_columns(columns) or []
@@ -143,13 +139,6 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
     def table(self):
         """Returns the ``perspective.Table`` under management by the viewer."""
         return self.manager.get_table(self.table_name)
-
-    @property
-    def _view(self):
-        """Returns the internal ``perspective.View`` under management by the
-        viewer, which has no bearing to the view that is displayed in the
-        widget."""
-        return self.manager.get_view(self._perspective_view_name)
 
     def load(self, data, **options):
         """Given a ``perspective.Table``, a ``perspective.View``,
@@ -198,7 +187,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         if isinstance(data, Table):
             table = data
         elif isinstance(data, View):
-            table = data._table
+            raise PerspectiveError("Only `Table` or data can be loaded.")
         else:
             table = Table(data, **options)
 
@@ -214,16 +203,6 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
             self.columns = table.columns()
 
         self.table_name = name
-
-        # If a `perspective.View` is loaded, then use it as the view that
-        # new clients will be built from. Otherwise, create a new view.
-        VIEW = data if isinstance(data, View) else table.view()
-
-        # Create a view from the table, and host it with the manager so it can
-        # be accessed remotely. This view should not be deleted or changed,
-        # and remains private to the viewer.
-        self._perspective_view_name = str(random())
-        self.manager.host_view(self._perspective_view_name, VIEW)
 
     def update(self, data):
         """Update the table under management by the viewer with new data.
@@ -291,10 +270,6 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
                 deleted. Defaults to True.
         """
         if delete_table:
-            if self._view:
-                self._view.delete()
-                self._perspective_view_name = None
-
             self.table.delete()
             self.manager._tables.pop(self.table_name)
             self.table_name = None

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -270,6 +270,14 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
                 deleted. Defaults to True.
         """
         if delete_table:
+            # Delete all created views on the widget's manager instance
+            for view in six.itervalues(self.manager._views):
+                view.delete()
+
+            # Reset view cache
+            self.manager._views = {}
+
+            # Delete table
             self.table.delete()
             self.manager._tables.pop(self.table_name)
             self.table_name = None

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -473,7 +473,7 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
             # kernel and the front-end proxies pivots, sorts, data requests
             # etc. to the kernel and does not run a Table in the front-end.
             msg_data = {"table_name": self.table_name}
-        elif self._perspective_view_name is not None:
+        elif self.table_name is not None:
             # If a view is hosted by the widget's manager (by default),
             # run Perspective in client-server mode: a Table will be created
             # in the front-end that mirrors the Table hosted in the kernel,
@@ -481,7 +481,6 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
             # and the server.
             msg_data = {
                 "table_name": self.table_name,
-                "view_name": self._perspective_view_name,
                 "options": {},
             }
 


### PR DESCRIPTION
This PR removes `host_view` and `open_view` from the public API.

With the improvements in the speed to create a flat view in #1235, the difference between using a `View` created on a server and creating a `View` on the client using a handle to the server's table is minimal, if non-existent in most use-cases. This allows us to remove the `host_view` API, which doesn't fit in very well with our established public API semantics of "table as data container, view as query and data serializer."

'host_view' shoe-horns in the ability to access a `View` over the network so that we can use it to create a table, and makes the explanations around distributed/server/client mode more complicated. Because the old context implementation added a small overhead (scaling linearly with the size of the underlying data), `host_view` made sense for performance reasons.

With the removal of `host_view` and `open_view`, Perspective's remote API only allows the hosting and opening of `Table` objects. This makes it far easier to reason about, especially when it comes to the distinctions between distributed, server, and client mode while maintaining the same feature set in the public API.

Both distributed and server mode is easier to implement:

```python
manager = PerspectiveManager()
manager.host_table("data_source", TABLE)
```

```js
const worker = perspective.worker();
const websocket = perspective.websocket(URL);

// Open the table on the server - this is all that is needed for server mode
const remote_table = websocket.open_table("data_source");

// For distributed mode, create a view
const view = remote_table.view();

// Pass it into the JS table constructor
const client_table = worker.table(view);
```

It is also trivial to host subsets of a table based on already-created views:

```python
# Table with large dataset that might be too big to transmit in one go
table = perspective.Table(big_dataset)

# Create a view on a subset of the data
filtered_view = table.view(filter=[["Sales", ">", 100]])

# Create a table using the filtered view
filtered_table = perspective.Table(filtered_view.to_arrow())

# Add an `on_update` callback to keep the tables in sync
def updater(port_id, delta):
    filtered_table.update(delta)

filtered_view.on_update(updater, mode="row")

# Easy to host the tables
manager.host_table("data_source", table)
manager.host_table("data_source_filtered", filtered_table)
```

### Changelog
- Remove `host_view` and `open_view` from JS and Python
- Refactor Jupyterlab widget to create a new view instead of using `open_view`
- Fix regression in `PerspectiveWidget.delete()`to delete all views created on widget's manager instance before deleting table
- Update examples to use `open_table` and view creation
- Update documentation to include distributed/server mode in Python docs
