### PR TITLE
Fix #1241 - date and datetime values in client mode are parsed properly

### DIFF
--- a/python/perspective/perspective/tests/client_mode/test_client_mode.py
+++ b/python/perspective/perspective/tests/client_mode/test_client_mode.py
@@ -90,6 +90,121 @@ class TestClient(object):
             "c": [str(i) for i in range(10)]
         }
 
+    def test_widget_client_date(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": [date(2020, i, 1) for i in range(1, 13)]}
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+
+        # `data` is mutated at this point, so check against the expected
+        # formatting just to make sure.
+        assert widget._data == {
+            "a": ["2020-{:02d}-01".format(i) for i in range(1, 13)]
+        }
+
+    def test_widget_client_np_date(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": np.array([date(2020, i, 1) for i in range(1, 13)], dtype="datetime64[D]")}
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": ["2020-{:02d}-01".format(i) for i in range(1, 13)]
+        }
+
+    def test_widget_client_np_date_object(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": np.array([date(2020, i, 1) for i in range(1, 13)], dtype="object")}
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": ["2020-{:02d}-01".format(i) for i in range(1, 13)]
+        }
+
+    def test_widget_client_df_date(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = pd.DataFrame({
+            "a": [date(2020, i, 1) for i in range(1, 13)]
+        }, dtype="datetime64[D]")
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "index": [i for i in range(12)],
+            "a": ["2020-{:02d}-01 00:00:00".format(i) for i in range(1, 13)]
+        }
+
+    def test_widget_client_df_date_object(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = pd.DataFrame({
+            "a": [date(2020, i, 1) for i in range(1, 13)]
+        }, dtype="object")
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "index": [i for i in range(12)],
+            "a": ["2020-{:02d}-01".format(i) for i in range(1, 13)]
+        }
+
+    def test_widget_client_datetime(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": [datetime(2020, i, 1, 12, 30, 45) for i in range(1, 13)]}
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]
+        }
+
+    def test_widget_client_np_datetime(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": np.array([datetime(2020, i, 1, 12, 30, 45) for i in range(1, 13)], dtype="datetime64")}
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]
+        }
+
+    def test_widget_client_np_datetime_object(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = {"a": np.array([datetime(2020, i, 1, 12, 30, 45) for i in range(1, 13)], dtype="object")}
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]
+        }
+
+    def test_widget_client_df_datetime(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = pd.DataFrame({
+            "a": [datetime(2020, i, 1, 12, 30, 45) for i in range(1, 13)]
+        }, dtype="datetime64[ns]")
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "index": [i for i in range(12)],
+            "a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]
+        }
+
+    def test_widget_client_df_datetime_object(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = pd.DataFrame({
+            "a": [datetime(2020, i, 1, 12, 30, 45) for i in range(1, 13)]
+        }, dtype="object")
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "index": [i for i in range(12)],
+            "a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]
+        }
+
     def test_widget_client_np_structured_array(self):
         import perspective
         assert perspective.is_libpsp() is False
@@ -110,6 +225,50 @@ class TestClient(object):
         assert widget._data == {
             "a": [1, 3],
             "b": [2, 4]
+        }
+
+    def test_widget_client_np_structured_array_date(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = np.array([(date(2020, 1, 1), date(2020, 2, 1)), (date(2020, 3, 1), date(2020, 4, 1))], dtype=[("a", "datetime64[D]"), ("b", "datetime64[D]")])
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": ["2020-01-01", "2020-03-01"],
+            "b": ["2020-02-01", "2020-04-01"]
+        }
+
+    def test_widget_client_np_recarray_date(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = np.array([(date(2020, 1, 1), date(2020, 2, 1)), (date(2020, 3, 1), date(2020, 4, 1))], dtype=[("a", "datetime64[D]"), ("b", "datetime64[D]")])
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": ["2020-01-01", "2020-03-01"],
+            "b": ["2020-02-01", "2020-04-01"]
+        }
+
+    def test_widget_client_np_structured_array_date_object(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = np.array([(date(2020, 1, 1), date(2020, 2, 1)), (date(2020, 3, 1), date(2020, 4, 1))], dtype=[("a", "object"), ("b", "object")])
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": ["2020-01-01", "2020-03-01"],
+            "b": ["2020-02-01", "2020-04-01"]
+        }
+
+    def test_widget_client_np_recarray_date_object(self):
+        import perspective
+        assert perspective.is_libpsp() is False
+        data = np.array([(date(2020, 1, 1), date(2020, 2, 1)), (date(2020, 3, 1), date(2020, 4, 1))], dtype=[("a", "object"), ("b", "object")])
+        widget = perspective.PerspectiveWidget(data)
+        assert hasattr(widget, "table") is False
+        assert widget._data == {
+            "a": ["2020-01-01", "2020-03-01"],
+            "b": ["2020-02-01", "2020-04-01"]
         }
 
     def test_widget_client_schema(self):

--- a/python/perspective/perspective/tests/client_mode/test_client_mode.py
+++ b/python/perspective/perspective/tests/client_mode/test_client_mode.py
@@ -128,7 +128,7 @@ class TestClient(object):
         assert perspective.is_libpsp() is False
         data = pd.DataFrame({
             "a": [date(2020, i, 1) for i in range(1, 13)]
-        }, dtype="datetime64[D]")
+        }, dtype="datetime64[ns]")
         widget = perspective.PerspectiveWidget(data)
         assert hasattr(widget, "table") is False
         assert widget._data == {

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -12,7 +12,6 @@ import numpy
 import pandas
 import json
 
-from re import match
 from datetime import date, datetime
 from functools import partial
 from ipywidgets import Widget
@@ -50,6 +49,24 @@ def _type_to_string(t):
         )
 
 
+def _serialize_datetime(values):
+    """For a list of values, stringify the `date` and `datetime` values
+    using strftime."""
+    cleaned = []
+
+    for v in values:
+        if type(v) is datetime:
+            # isinstance(datetime, date) will always return True, so
+            # do a type comparison instead.
+            cleaned.append(v.strftime("%Y-%m-%d %H:%M:%S"))
+        elif type(v) is date:
+            cleaned.append(v.strftime("%Y-%m-%d"))
+        else:
+            cleaned.append(v)
+
+    return cleaned
+
+
 def _serialize(data):
     """In client mode, PerspectiveWidget will normalize the data before
     passing it to the front-end.
@@ -64,12 +81,12 @@ def _serialize(data):
                 raise PerspectiveError(
                     "Received {} in list dataset, expected `dict`!".format(type(row))
                 )
-            for k, v in six.iteritems(row):
-                # isinstance(datetime, date) will always return True, so
-                # do a type comparison instead.
-                if type(v) is date:
-                    # Convert to datetime() which is parsable
-                    row[k] = datetime(v.year, v.month, v.day)
+
+            for k in six.iterkeys(row):
+                if type(row[k]) is datetime:
+                    row[k] = row[k].strftime("%Y-%m-%d %H:%M:%S.%f")
+                elif type(row[k]) is date:
+                    row[k] = row[k].strftime("%Y-%m-%d")
         return data
     elif isinstance(data, dict):
         formatted = data
@@ -88,12 +105,9 @@ def _serialize(data):
                 }
                 break
 
-        for column_name, values in six.iteritems(formatted):
-            # Remove `datetime.date` values
-            formatted[column_name] = [
-                datetime(v.year, v.month, v.day) if type(v) is date else v
-                for v in values
-            ]
+        for column_name in six.iterkeys(formatted):
+            # Replace `datetime.datetime` and `datetime.date` with string
+            formatted[column_name] = _serialize_datetime(formatted[column_name])
 
         return formatted
     elif isinstance(data, numpy.ndarray):
@@ -106,12 +120,9 @@ def _serialize(data):
         columns = [data[col].tolist() for col in data.dtype.names]
         formatted = dict(zip(data.dtype.names, columns))
 
-        for column_name, values in six.iteritems(formatted):
-            # Remove `datetime.date` values
-            formatted[column_name] = [
-                datetime(v.year, v.month, v.day) if type(v) is date else v
-                for v in values
-            ]
+        for column_name in six.iterkeys(formatted):
+            # Replace `datetime.datetime` and `datetime.date` with string
+            formatted[column_name] = _serialize_datetime(formatted[column_name])
 
         return formatted
     elif isinstance(data, pandas.DataFrame) or isinstance(data, pandas.Series):
@@ -126,16 +137,11 @@ def _serialize(data):
             # `numpy.issubdtype` - match strings here instead.
             str_dtype = str(column.dtype)
             if "datetime64" in str_dtype:
-                # Convert datetime/date to string depending on the unit
-                unit = match(r"\[.+\]", str_dtype) or "ms"
-
                 # Convert all datetimes to string for serializing
-                d[name] = numpy.datetime_as_string(column.values, unit=unit).tolist()
+                d[name] = column.dt.strftime("%Y-%m-%d %H:%M:%S").tolist()
             elif str_dtype == "object":
-                d[name] = [
-                    datetime(v.year, v.month, v.day) if type(v) is date else v
-                    for v in values
-                ]
+                # Replace `datetime.datetime` and `datetime.date` with string
+                d[name] = _serialize_datetime(values)
             else:
                 d[name] = values.tolist()
         return d

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -11,10 +11,13 @@ import logging
 import numpy
 import pandas
 import json
+
+from re import match
 from datetime import date, datetime
 from functools import partial
 from ipywidgets import Widget
 from traitlets import observe, Unicode
+
 from ..core.data import deconstruct_pandas
 from ..core.exception import PerspectiveError
 from ..libpsp import is_libpsp
@@ -48,39 +51,93 @@ def _type_to_string(t):
 
 
 def _serialize(data):
-    # Attempt to serialize data and pass it to the front-end as JSON
+    """In client mode, PerspectiveWidget will normalize the data before
+    passing it to the front-end.
+
+    Widget comms use a custom serializer and messages are not manually
+    serialized to JSON by the user, so take special care to remove certain
+    unparsable values such as `datetime.date`."""
     if isinstance(data, list):
+        # Check if any values are `datetime.date`
+        for row in data:
+            if not isinstance(row, dict):
+                raise PerspectiveError(
+                    "Received {} in list dataset, expected `dict`!".format(type(row))
+                )
+            for k, v in six.iteritems(row):
+                # isinstance(datetime, date) will always return True, so
+                # do a type comparison instead.
+                if type(v) is date:
+                    # Convert to datetime() which is parsable
+                    row[k] = datetime(v.year, v.month, v.day)
         return data
     elif isinstance(data, dict):
-        for v in data.values():
-            # serialize schema values to string
+        formatted = data
+
+        for v in six.itervalues(data):
             if isinstance(v, type):
-                return {k: _type_to_string(data[k]) for k in data}
+                # serialize schema values to string
+                return {
+                    column_name: _type_to_string(data[column_name])
+                    for column_name in data
+                }
             elif isinstance(v, numpy.ndarray):
-                return {k: data[k].tolist() for k in data}
-            else:
-                return data
+                # Convert dicts of numpy arrays to dicts of lists
+                formatted = {
+                    column_name: data[column_name].tolist() for column_name in data
+                }
+                break
+
+        for column_name, values in six.iteritems(formatted):
+            # Remove `datetime.date` values
+            formatted[column_name] = [
+                datetime(v.year, v.month, v.day) if type(v) is date else v
+                for v in values
+            ]
+
+        return formatted
     elif isinstance(data, numpy.ndarray):
         # structured or record array
         if not isinstance(data.dtype.names, tuple):
             raise NotImplementedError(
                 "Data should be dict of numpy.ndarray or a structured array."
             )
+
         columns = [data[col].tolist() for col in data.dtype.names]
-        return dict(zip(data.dtype.names, columns))
+        formatted = dict(zip(data.dtype.names, columns))
+
+        for column_name, values in six.iteritems(formatted):
+            # Remove `datetime.date` values
+            formatted[column_name] = [
+                datetime(v.year, v.month, v.day) if type(v) is date else v
+                for v in values
+            ]
+
+        return formatted
     elif isinstance(data, pandas.DataFrame) or isinstance(data, pandas.Series):
         # Take flattened dataframe and make it serializable
         d = {}
+
         for name in data.columns:
             column = data[name]
             values = column.values
+
             # Timezone-aware datetime64 dtypes throw an exception when using
             # `numpy.issubdtype` - match strings here instead.
             str_dtype = str(column.dtype)
             if "datetime64" in str_dtype:
+                # Convert datetime/date to string depending on the unit
+                unit = match(r"\[.+\]", str_dtype) or "ms"
+
                 # Convert all datetimes to string for serializing
-                values = numpy.datetime_as_string(column.values, unit="ms")
-            d[name] = values.tolist()
+                d[name] = numpy.datetime_as_string(column.values, unit=unit).tolist()
+            elif str_dtype == "object":
+                d[name] = [
+                    datetime(v.year, v.month, v.day) if type(v) is date else v
+                    for v in values
+                ]
+            else:
+                d[name] = values.tolist()
         return d
     else:
         raise NotImplementedError(


### PR DESCRIPTION
This PR fixes the issue reported in #1241 - `date` and `datetime` values are now serialized properly to the widget front-end in client mode, and the serialization is now consistent between the `list`, `dict`, `numpy.array` and `pandas.DataFrame` formats.

Previously, we relied on the Widget comm serializer to convert values before passing them to the widget front-end, however this would break on `date` values and render an error. It would also convert `datetime` values to a default representation with microseconds, which could not be parsed as a string by the front-end.

This PR introspects all data in client mode in order to serialize date/datetime values to string using a format that is guaranteed to be compatible with Perspective's JS front-end, with the caveat that microseconds are stripped before data is passed to `PerspectiveWidget` in client mode. 

Additionally, the browser treats all date/datetime strings as local time, which might cause timezone conversion issues when the Jupyter kernel is in a different timezone than the browser. In this case, use a Pandas Dataframe for better time-zone control, or attempt to resolve the install issues so that Perspective can make full use of its C++ bindings.