### PR TITLE
Update Azure Windows boost to 1.72

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -195,11 +195,15 @@ jobs:
       env:
         # Set `BOOST_ROOT` manually, as `BOOST_ROOT` is removed in the VM:
         # https://github.com/actions/virtual-environments/issues/687
+        #
         # 06/18/2020 - seems like boost got moved to `x86_64` inside
         # the boost folder, which broke builds for a bit.
-        BOOST_ROOT: "C:/hostedtoolcache/windows/Boost/1.69.0/x86_64/"
-        BOOST_INCLUDEDIR: "C:/hostedtoolcache/windows/Boost/1.69.0/x86_64/include"
-        BOOST_LIBRARYDIR: "C:/hostedtoolcache/windows/Boost/1.69.0/x86_64/libs"
+        #
+        # 11/24/2020 - boost 1.69 was removed, so update to 1.72:
+        # https://github.com/actions/virtual-environments/issues/1847
+        BOOST_ROOT: "C:/hostedtoolcache/windows/Boost/1.72.0/x86_64/"
+        BOOST_INCLUDEDIR: "C:/hostedtoolcache/windows/Boost/1.72.0/x86_64/include"
+        BOOST_LIBRARYDIR: "C:/hostedtoolcache/windows/Boost/1.72.0/x86_64/libs"
 
 # - job: 'MacOS_Mojave'
 #   pool:


### PR DESCRIPTION
This PR fixes the Windows build on Azure by updating the version of boost to 1.72, which is the only pre-installed version after [this PR](https://github.com/actions/virtual-environments/issues/1847) on `virtual-environments`.

Keeping a link to the [software installed on WIndows 2016 image](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md) for future reference.

**@texodus please merge this first and make sure builds work for subsequent PRs.** 