### PR TITLE
Fix flapping tests for render warnings

### DIFF
--- a/packages/perspective-viewer/test/js/render_warning_tests.js
+++ b/packages/perspective-viewer/test/js/render_warning_tests.js
@@ -98,8 +98,8 @@ exports.default = function(plugin_name, columns) {
         await page.shadow_click("perspective-viewer", "#config_button");
         await page.evaluate((element, view_columns) => element.setAttribute("columns", view_columns), viewer, view_columns);
         await page.evaluate(element => element.setAttribute("column-pivots", '["Row ID"]'), viewer);
-        await page.shadow_click("perspective-viewer", ".plugin_information__action");
         await page.waitForSelector("perspective-viewer:not([updating])");
+        await page.shadow_click("perspective-viewer", ".plugin_information__action");
         await page.evaluate(element => element.setAttribute("column-pivots", '["Profit"]'), viewer);
         await page.waitForSelector("perspective-viewer:not([updating])");
     });

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -426,7 +426,7 @@ module.exports = perspective => {
             view.delete();
             table.delete();
         });
-        
+
         it("abs sum", async function() {
             var table = perspective.table([
                 {x: 3, y: 1},
@@ -451,7 +451,7 @@ module.exports = perspective => {
             view.delete();
             table.delete();
         });
-        
+
         it("mean after update", async function() {
             var table = perspective.table([
                 {x: 3, y: 1},
@@ -585,7 +585,7 @@ module.exports = perspective => {
             view.delete();
             table.delete();
         });
-        
+
         it("abs sum", async function() {
             var table = perspective.table([
                 {x: 3, y: 1},


### PR DESCRIPTION
Fixes [this test](https://dev.azure.com/finosfoundation/perspective/_build/results?buildId=1750&view=logs&j=430750e5-873f-5cdb-f7d1-334fffa69fc8&t=e9a709ee-98dc-5d78-ab76-09541ac9f110&l=1427), which flaps due to not awaiting the application of the `View()` before attempting to click the render warning dismissal.