### PR TITLE
Fix: version conflict that makes `npm install` failed

### DIFF
--- a/packages/perspective-webpack-plugin/package.json
+++ b/packages/perspective-webpack-plugin/package.json
@@ -27,7 +27,7 @@
         "worker-loader": "^2.0.0"
     },
     "peerDependencies": {
-        "@finos/perspective": "^0.4.2",
+        "@finos/perspective": "^0.5.6",
         "webpack": "^4.35"
     }
 }


### PR DESCRIPTION
Fix: version conflict that makes `npm install` failed
Reason: perspective-webpack-plugin@0.5.6 require depends on perspective@0.4.2

Bug reproduction:
```
dependencies: {
    "@finos/perspective": "^0.5.6",
    "@finos/perspective-webpack-plugin": "^0.5.6",
}
```
```bash
> npm install
npm ERR! Could not resolve dependency:
npm ERR! peer @finos/perspective@"^0.4.2" from @finos/perspective-webpack-plugin@0.5.6
npm ERR! node_modules/@finos/perspective-webpack-plugin
npm ERR!   @finos/perspective-webpack-plugin@"^0.5.6" from the root project
```