### PR TITLE
Spelling and grammar fixes in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ data or streaming updates via [Apache Arrow](https://arrow.apache.org/).
 
 * [Project Site](https://perspective.finos.org/)
 * [Installation](https://perspective.finos.org/docs/md/installation.html)
-* [Javascript User's Guide](https://perspective.finos.org/docs/md/js.html)
+* [JavaScript User's Guide](https://perspective.finos.org/docs/md/js.html)
 * [Python User's Guide](https://perspective.finos.org/docs/md/python.html)
 * [Developer's Guide](https://perspective.finos.org/docs/md/development.html)
 * [Conceptual Overview](https://perspective.finos.org/docs/md/concepts.html)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ data or streaming updates via [Apache Arrow](https://arrow.apache.org/).
 
 - A fast, memory efficient streaming query engine, written in C++ and compiled to [WebAssembly](https://webassembly.org/), with read/write/stream support for [Apache Arrow](https://arrow.apache.org/).
 
-- A framework-agnostic query configuration UI component, based on [Web Components](https://www.webcomponents.org/), and a WebWorker and/or WebSocket data engine host for stable interactivity at high frequency.
+- A framework-agnostic query configuration UI component, based on [Web Components](https://www.webcomponents.org/), and a Web Worker and/or WebSocket data engine host for stable interactivity at high frequency.
 
 - A customizable HTML Data Grid plugin, and a Chart plugin built on [D3FC](https://d3fc.io/).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,6 @@
 # Perspective Documentation Site
 
-This is the source for the [Perspective documentaiton github-pages site](https://perspective.finos.org/) - 
-what you're looking for is probably there.  Links to the source documenation
+This is the source for the [Perspective documentation github-pages site](https://perspective.finos.org/); what you're looking for is probably there. Links to the source documentation
 from which the site is rendered:
 
 * [Installation](https://github.com/finos/perspective/blob/master/docs/md/installation.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Perspective Documentation Site
 
-This is the source for the [Perspective documentation github-pages site](https://perspective.finos.org/); what you're looking for is probably there. Links to the source documentation
+This is the source for the [Perspective documentation GitHub Pages site](https://perspective.finos.org/); what you're looking for is probably there. Links to the source documentation
 from which the site is rendered:
 
 * [Installation](https://github.com/finos/perspective/blob/master/docs/md/installation.md)

--- a/docs/core/Footer.js
+++ b/docs/core/Footer.js
@@ -29,7 +29,7 @@ class Footer extends React.Component {
                     <div>
                         <h5>Docs</h5>
                         <a href={"/docs/md/installation.html"}>Installation</a>
-                        <a href={"/docs/md/js.html"}>Javascript User Guide</a>
+                        <a href={"/docs/md/js.html"}>JavaScript User Guide</a>
                         <a href={"/docs/md/python.html"}>Python User Guide</a>
                         <a href={"/docs/obj/perspective.html"}>Perspective API</a>
                         <a href={"/docs/obj/perspective-viewer.html"}>Perspective Viewer API</a>

--- a/docs/md/concepts.md
+++ b/docs/md/concepts.md
@@ -29,8 +29,8 @@ a `View`:
 For language-specific guidance, API documentation, or quick-start user guides,
 use the sidebar to find the documentation for the language of choice. Though
 the way these concepts operate in practice may vary slightly across different
-languages based on nuance, the concepts documented here hold true across all
-implementations of the Perspective library.
+languages, the concepts documented here hold true across all implementations of
+the Perspective library.
 
 <!--truncate-->
 
@@ -108,7 +108,7 @@ A `Table` can be initialized in two ways:
   empty.
 - With a dataset in a supported format;  in this case, a `schema` is inferred
   from the dataset's structure upon initialization.  Perspective supports a
-  variety of table-like data structures in Python and Javascript such as CSV,
+  variety of table-like data structures in Python and JavaScript such as CSV,
   `pandas.DataFrame` and JSON; see the language specific API documentation for
   a comprehensive list of supported formats.
 
@@ -151,7 +151,7 @@ some column values `undefined`, and _removes_ to delete a row by `index`.
 
 Once a `Table` has been created, it can be updated with new data conforming to
 the `Table`'s `schema`. The dataset used for `update()` must conform with the
-formats supported by Perspective, and cannot be a `schema` (as the `schema`
+formats supported by Perspective and cannot be a `schema` (as the `schema`
 is immutable).
 
 If a `Table` was initialized with a `schema` instead of a dataset, use `update`
@@ -217,10 +217,10 @@ with an array of primary key values indicating which rows should be removed.
 
 Due to Perspective's runtime composition, it is important to clean up resources
 that might have been created by the engine in C++ but cannot be reached by the
-binding language's garbage collector (Javascript, Python etc.)
+binding language's garbage collector (JavaScript, Python etc.)
 
 The `Table`'s `delete` method guarantees the cleanup of all resources associated
-with a `Table`, which is _especially important_ in Javascript, as the JS garbage
+with a `Table`, which is _especially important_ in JavaScript, as the JS garbage
 collector [cannot automatically clean up](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#memory-management)
 objects created in C++ through Emscripten.
 
@@ -266,7 +266,7 @@ view.delete();
 ```
 
 `View` objects are immutable with respect to the arguments provided to the
-`view()` method;  to change these parameters, you must create a new `View` on
+`view()` method. To change these parameters, you must create a new `View` on
 the same `Table`. However, `View`s are live with respect to the `Table`'s data,
 and will (within a conflation window) update with the latest state as its
 parent's state updates, including incrementally recalculating all aggregates,
@@ -323,13 +323,13 @@ what you see.
 ### Row Pivots
 
 A row pivot _groups_ the dataset by the unique values of each column used as a
-row pivot - a close analogue in SQL would be the `GROUP BY` statement.
+row pivot. A close analogue to this would be the `GROUP BY` statement in SQL.
 
 The underlying dataset is aggregated to show the values belonging to
 each group, and a total row is calculated for each group, showing the currently
 selected aggregated value (e.g. `sum`) of the column. Row pivots are useful for
 hierarchies, categorizing data and attributing values, i.e. showing the number
-of units sold based on State and City.
+of units sold based on state and city.
 
 In Perspective, row pivots are represented as an array of string column names
 which will be applied as row pivots:
@@ -392,7 +392,7 @@ column pivots are also easily transposable in `perspective-viewer`.
 ### Aggregates
 
 Aggregates perform a calculation over an entire column, and are displayed when
-one or more [Row Pivots](#row-pivots) are applied to the `View`. Aggregates can
+one or more [row pivots](#row-pivots) are applied to the `View`. Aggregates can
 be specified by the user, or Perspective will use the following sensible default
 aggregates based on column type:
 
@@ -401,7 +401,7 @@ aggregates based on column type:
 
 Perspective provides a large selection of aggregate functions that can be
 applied to columns in the `View` constructor using a dictionary of column
-name to aggregate function name:
+names to aggregate function names:
 
 ```javascript
 const view = table.view({

--- a/docs/md/development.md
+++ b/docs/md/development.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to Perspective! This guide will
 teach you everything you need to know to get started hacking on the Perspective
 codebase.
 
-If you're coming to this project as principally a Javascript developer, please
+If you're coming to this project as principally a JavaScript developer, please
 be aware that Perspective is quite a bit more complex than a typical NPM package
 due to the mixed-language nature of the project; we've done quite a bit to make
 sure the newcomer experience is as straightforward as possible, but some things
@@ -20,7 +20,7 @@ and uses [lerna](https://lernajs.io/) to manage dependencies. The
 [Emscripten](https://github.com/kripken/emscripten) compiler, which is used to
 compile the core C++ engine to WebAssembly, and must be installed independently.
 
-This guide provides instructions for both the Javascript and Python libraries.
+This guide provides instructions for both the JavaScript and Python libraries.
 To switch your development toolchain between the two, use `yarn setup`. Once the
 setup script has been run, common commands like `yarn build` and `yarn test`
 automatically call the correct build and test tools.
@@ -56,7 +56,7 @@ To build Perspective using Docker, select the option in `yarn setup`.
 
 ## `Perspective.js`
 
-To build the Javascript library, which includes WebAssembly compilation,
+To build the JavaScript library, which includes WebAssembly compilation,
 [Emscripten](https://github.com/kripken/emscripten) and its prerequisites are
 required. A Docker image is provided with the correct environment and
 prerequisites.
@@ -111,8 +111,8 @@ yarn build_python --python2
 `perspective-python` requires the following system dependencies to be installed before it can be
 built from source:
 
-- Boost (version 1.67)
-- CMake (version 3.15.4 or higher)
+- [Boost](https://www.boost.org/) (version 1.67)
+- [CMake](https://cmake.org/) (version 3.15.4 or higher)
 - TBB
 
 ## System-Specific Instructions
@@ -140,8 +140,8 @@ Installing and activating the latest
 
 #### `perspective-python`
 
-If building the Python 2 version of the library, make sure your version of
-Python 2 is the latest version (`2.7.17`) supplied by Homebrew, and not the
+If you're building the Python 2 version of the library, make sure your version
+of Python 2 is the latest version (`2.7.17`) supplied by Homebrew, and not the
 earlier version that ships with MacOS. To install Python 2 using Homebrew:
 
 ```bash
@@ -153,7 +153,7 @@ brew install python2
 You need to use bash in order to build Perspective packages. To successfully
 build on Windows 10, enable
 [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
-(WSL) and install the linux distribution of your choice.
+(WSL) and install the Linux distribution of your choice.
 
 Create symbolic links to easily access Windows directories and projects modified
 via Windows. This way you can modify any of the Perspective files using your
@@ -167,10 +167,10 @@ prerequisite tools.
 When installing Emscripten, make sure to follow
 [Linux specific instructions](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#linux).
 
-On Ubuntu, cmake will mistakenly resolve the system headers in `/usr/include`
+On Ubuntu, Cmake will mistakenly resolve the system headers in `/usr/include`
 rather than the emscripten supplied versions. You can resolve this by moving
 `boost` and `flatbuffers` dependencies to somewhere other than `/usr/include` -
-into perspective's own `src` dir, for example (as per
+into Perspective's own `src` dir (as per
 [here](http://vclf.blogspot.com/2014/08/emscripten-linking-to-boost-libraries.html)).
 
 ```bash
@@ -195,17 +195,17 @@ build the test suite for every package and run them.
 yarn test
 ```
 
-A Test name regex can be passed to `jest` via the same `-t` flag:
+A test name regex can be passed to `jest` via the same `-t` flag:
 
 ```bash
 yarn test -t 'button test (A|B)'
 ```
 
-### Javascript
+### JavaScript
 
-The Javascript test suite is composed of two sections: a Node.js test which
+The JavaScript test suite is composed of two sections: a Node.js test, which
 asserts behavior of the `@finos/perspective` library, and a suite of
-[Puppeteer](https://developers.google.com/web/tools/puppeteer/) tests which
+[Puppeteer](https://developers.google.com/web/tools/puppeteer/) tests, which
 assert the behavior of the rest of the UI facing packages. For the latter,
 you'll need Docker installed, as these tests use a Puppeteer and Chrome build
 installed in a Docker container.
@@ -228,7 +228,7 @@ flag:
 yarn test --write
 ```
 
-For quick local iteration and debugging failing tests, the puppeteer tests can
+For quick local iteration and debugging failing tests, the Puppeteer tests can
 use a local copy of Puppeteer, rather than relying on the supplied Docker image.
 These will run much quicker, and can be optionally run without `--headless` mode
 for debugging test failures quickly. However, due to rendering inconsistencies
@@ -236,14 +236,14 @@ between platforms, the resulting test hashes will not match the ones saved in
 `results.json`, so you will need to re-run the suite with the `--write` flag to
 generate a `results.local.json` file specific to your OS.
 
-To toggle between Local and Docker Puppeteer, run
+To toggle between local and Docker Puppeteer, run
 
 ```bash
 yarn toggle_puppeteer
 ```
 
-This will install a local copy of puppeteer via `yarn` the first time it is run,
-if a local puppeteer is not found.
+This will install a local copy of Puppeteer via `yarn` the first time it is run,
+if a local Puppeteer is not found.
 
 ### Python
 
@@ -252,14 +252,14 @@ the Python library.
 
 If you have built the library with the `--python2` flag, make sure to run the
 test suite using the `--python2` flag as well. Running a version of
-perspective-python built against Python 2 in Python 3 (and vice versa) is not
+`perspective-python` built against Python 2 in Python 3 (and vice versa) is not
 supported.
 
 Verbosity in the tests can be enabled with the `--verbose` flag.
 
 #### Timezones in Python Tests
 
-Python tests are configured to use the `UTC` timezone. If running tests locally,
+Python tests are configured to use the `UTC` time zone. If running tests locally,
 you might find that datetime-related tests fail to assert the correct values. To
 correct this, run tests with the `TZ=UTC`, i.e.
 

--- a/docs/md/development.md
+++ b/docs/md/development.md
@@ -257,7 +257,7 @@ supported.
 
 Verbosity in the tests can be enabled with the `--verbose` flag.
 
-#### Timezones in Python Tests
+#### Time zones in Python Tests
 
 Python tests are configured to use the `UTC` time zone. If running tests locally,
 you might find that datetime-related tests fail to assert the correct values. To

--- a/docs/md/development.md
+++ b/docs/md/development.md
@@ -156,7 +156,7 @@ build on Windows 10, enable
 (WSL) and install the Linux distribution of your choice.
 
 Create symbolic links to easily access Windows directories and projects modified
-via Windows. This way you can modify any of the Perspective files using your
+via Windows. This way, you can modify any of the Perspective files using your
 favorite editors on Windows and build via Linux.
 
 Follow the Linux specific instructions to install Emscripten and all

--- a/docs/md/development.md
+++ b/docs/md/development.md
@@ -14,7 +14,7 @@ sure the newcomer experience is as straightforward as possible, but some things
 might not work the way you're used to!
 
 Perspective is organized as a
-[monorepo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md),
+[monorepo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md)
 and uses [lerna](https://lernajs.io/) to manage dependencies. The
 `@finos/perspective` modules has an additional, unmanaged dependency—the
 [Emscripten](https://github.com/kripken/emscripten) compiler, which is used to

--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -3,12 +3,12 @@ id: installation
 title: Installation
 ---
 
-## Javascript
+## JavaScript
 
 Because Perspective uses both WebAssembly and Web Workers, each of which place
 constraints on how assets and scripts must be loaded, the installation process
-for Perspective in a Javascript environment is more complex than most "pure"
-Javascript libraries.
+for Perspective in a JavaScript environment is more complex than most "pure"
+JavaScript libraries.
 
 ### From NPM
 
@@ -20,7 +20,7 @@ via NPM:
 $ yarn add @finos/perspective-viewer @finos/perspective-viewer-d3fc @finos/perspective-viewer-datagrid
 ```
 
-#### An important note about Hosting
+#### An important note about hosting
 
 All uses of Perspective from NPM require the browser to have access to
 Perspective's `.worker.*.js` and `.wasm` assets _in addition_ to the bundled
@@ -36,7 +36,7 @@ step runs.
 When importing `perspective` from NPM modules for a browser application, you
 should use `@finos/perspective-webpack-plugin` to manage the `.worker.*.js` and
 `.wasm` assets for you. The plugin handles downloading and packaging
-Perspective's additional assets, and is easy to set up in your `webpack.config`:
+Perspective's additional assets and is easy to set up in your `webpack.config`:
 
 ```javascript
 const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
@@ -55,7 +55,7 @@ module.exports = {
 
 Perspective can be loaded directly from
 [unpkg.com](https://unpkg.com/@finos/perspective-viewer), which is the easiest
-way to get started with Perspective in the browser, and absolutely perfect
+way to get started with Perspective in the browser and perfect
 for spinning up quick instances of `perspective-viewer`. An example is
 demonstrated in [`superstore-arrow.html`](https://github.com/finos/perspective/blob/master/examples/simple/superstore-arrow.html),
 which loads a dataset stored in the Apache Arrow format using the `Fetch` API.
@@ -69,7 +69,7 @@ Add these scripts to your `.html`'s `<head>` section:
 <script src="https://unpkg.com/@finos/perspective-viewer-d3fc"></script>
 ```
 
-Once added to your page, you can access the Javascript API through the
+Once added to your page, you can access the JavaScript API through the
 `perspective` symbol:
 
 ```javascript
@@ -126,8 +126,8 @@ pip install perspective-python
 If you are installing from a source distribution (sdist), make sure you have
 CMake and Boost headers present on your machine:
 
-- CMake (version 3.15.4 or higher)
-- Boost Headers (version 1.67)
+- [CMake](https://cmake.org/) (version 3.15.4 or higher)
+- [Boost Headers](https://www.boost.org/) (version 1.67)
 
 Try installing in verbose mode:
 
@@ -139,15 +139,15 @@ The most common culprits are:
 
 - CMake version too old
 - Boost headers are missing or too old
-- PyArrow not installed prior to installing perspective
+- PyArrow not installed prior to installing Perspective
 
-Additionally, due to PEP-518 and build isolation, its possible that the version of PyArrow that pip uses to build perspective-python is different from the one you have installed. To disable this, pass the `--no-build-isolation` flag to pip.
+Additionally, due to PEP-518 and build isolation, it is possible that the version of PyArrow that `pip` uses to build `perspective-python` is different from the one you have installed. To disable this, pass the `--no-build-isolation` flag to `pip`.
 
 #### Wheels PyArrow linkage
 
-Because we compile Apache Arrow from source to webassembly via Emscripten, we have a tight coupling on the specific version of Apache Arrow that must be used. As such, we link against a specific Apache Arrow version which must be present. Currently, our wheels build against PyArrow==0.17.1 for Python 3.* and PyArrow==0.16.0 for Python 2.7.
+Because we compile Apache Arrow from source to WebAssembly via Emscripten, we have a tight coupling on the specific version of Apache Arrow that must be used. As such, we link against a specific Apache Arrow version which must be present. Currently, our wheels build against PyArrow==0.17.1 for Python 3.* and PyArrow==0.16.0 for Python 2.7.
 
-To ignore compiled wheels and install from source with pip, install via
+To ignore compiled wheels and install from source with `pip`, install via
 
 ```bash
 pip install --no-binary perspective-python
@@ -161,8 +161,8 @@ transformations/visualizations of various data formats within JupyterLab.
 
 <img src="https://perspective.finos.org/img/jupyterlab.png"></img>
 
-To use the JupyterLab plugin, make sure you have installed `perspective-python`
-and then install the extension from the Jupyter lab extension directory:
+To use the JupyterLab plugin, make sure you have installed `perspective-python`, 
+and then install the extension from the JupyterLab extension directory:
 
 ```bash
 jupyter labextension install @finos/perspective-jupyterlab
@@ -178,7 +178,7 @@ jupyter labextension install @jupyter-widgets/jupyterlab-manager
 
 For hackers, contributors, and masochists, Perspective can be installed directly
 from source available on [Github](https://github.com/finos/perspective). Doing
-so is quite a bit more complex than a standard pure Javascript NPM package, so
+so is quite a bit more complex than a standard pure JavaScript NPM package, so
 if you're not looking to hack on Perspective itself, you are likely better off
 choosing the CDN or NPM methods above. See the
 [developer docs](development.html) for details.

--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -25,7 +25,7 @@ $ yarn add @finos/perspective-viewer @finos/perspective-viewer-d3fc @finos/persp
 All uses of Perspective from NPM require the browser to have access to
 Perspective's `.worker.*.js` and `.wasm` assets _in addition_ to the bundled
 `.js` scripts. By default, Perspective [inlines](https://github.com/finos/perspective/pull/870)
-these assets into the `.js` scripts, and delivers them in one file. This has no
+these assets into the `.js` scripts and delivers them in one file. This has no
 performance impact, but does increase asset load time. Any non-trivial application
 should make use of `@finos/perspective-webpack-plugin`, which automatically
 splits the assets into separate files and downloads them when the bundling

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -1,14 +1,14 @@
 ---
 id: js
-title: Javascript User Guide
+title: JavaScript User Guide
 ---
 
-Perspective's Javascript library offers a flexible, intuitive UI on top of a
+Perspective's JavaScript library offers a flexible, intuitive UI on top of a
 fast, powerful streaming data engine. Developers are able to pick and
 choose the modules they require for their use case, and users are presented
 with a clean user interface through which to analyze data.
 
-This document offers an overview of the Javascript library, providing:
+This document offers an overview of the JavaScript library, providing:
 
 - A quick start guide for integrating Perspective in your application
 - An overview of Perspective's module structure
@@ -36,7 +36,7 @@ which modules they need for their specific use case. The main modules are:
 
 `<perspective-viewer>` by itself only implements a trivial debug renderer, which
 prints the currently configured `view()` as a CSV. Plugin modules for popular
-Javascript libraries such as [d3fc](https://d3fc.io/) are packaged separately
+JavaScript libraries such as [d3fc](https://d3fc.io/) are packaged separately
 and must be imported individually.
 
 Perspective offers these plugin modules:
@@ -58,7 +58,7 @@ they are compatible with perspective versions < 1.0.0:
 - `@finos/perspective-viewer-highcharts`  
   [DEPRECATED] A `<perspective-viewer>` plugin for
   [HighCharts](https://github.com/highcharts/highcharts). This plugin has a
-  `highcharts` as a peerDependency, and requires a
+  `highcharts` as a `peerDependency`, and requires a
   [mixed commercial license](https://shop.highsoft.com/).
 
 When imported after `@finos/perspective-viewer`, the plugin modules will
@@ -82,7 +82,7 @@ your project:
 - For Perspective as a simple, browser-based data visualization widget, you
   will need to import:
 
-  - `@finos/perspective`, as detailed [here](#perspective-library)
+  - `@finos/perspective`, detailed [here](#perspective-library)
   - `@finos/perspective-viewer`, detailed [here](#perspective-viewer-web-component)
   - `@finos/perspective-viewer-datagrid` for data grids
   - `@finos/perspective-viewer-d3fc` for charting
@@ -134,7 +134,7 @@ const perspective = require("@finos/perspective");
 ```
 
 `@finos/perspective` also comes with a pre-built bundle which exports the global
-`perspective` module name in vanilla Javascript, when e.g. importing
+`perspective` module name in vanilla JavaScript, when e.g. importing
 [via a CDN](/docs/md/installation.html#from-cdn).
 
 ```html
@@ -144,7 +144,7 @@ const perspective = require("@finos/perspective");
 #### Instantiating a new `worker()`
 
 Once imported, you'll need to instantiate a `perspective` engine via the
-`worker()` method. This will create a new WebWorker (browser) or
+`worker()` method. This will create a new Web Worker (browser) or
 Process (Node.js), and load the WebAssembly binary; all calculation and data
 accumulation will occur in this separate process.
 
@@ -160,7 +160,7 @@ interact with your data in each instance.
 ### Importing in Node.js
 
 The Node.js runtime for the `@finos/perspective` module runs in-process by
-default, and does not implement a `child_process` interface. Hence, there is no
+default and does not implement a `child_process` interface. Hence, there is no
 `worker()` method, and the module object itself directly exports the full
 `perspective` API.
 
@@ -278,7 +278,7 @@ Appended rows that exceed the `limit` overwrite old rows starting at position 0.
 
 #### Unset values via `null`
 
-Any value on a `table()` can be unset using the Javascript value `null`.
+Any value on a `table()` can be unset using the JavaScript value `null`.
 
 Values may be unset on construction, as any `null` in the dataset will be
 treated as an unset value. Values can also be explicitly unset via `update()`
@@ -359,9 +359,9 @@ async function print_data() {
 
 ### Deleting a `table()` or `view()`
 
-Unlike standard Javascript objects, Perspective objects such as `table()` and
+Unlike standard JavaScript objects, Perspective objects such as `table()` and
 `view()` store their associated data in the WebAssembly heap. Due of this, and
-the current lack of a hook into the Javascript runtime's garbage collector from
+the current lack of a hook into the JavaScript runtime's garbage collector from
 WebAssembly, the memory allocated to these Perspective objects does not
 automatically get cleaned up when the object falls out of scope.
 
@@ -416,11 +416,11 @@ via a `perspective.config.js` or `perspective.config.json` file in your
 project's root or parent path, or via the `"perspective"` key in your project's
 `package.json`.
 
-Note that, while in Node.js this config file is read at runtime, for the browser
+Note that, while in Node.js, this config file is read at runtime; for the browser,
 this file must be read at compile time (handled automatically via
 [`@finos/perspective-webpack-plugin`](https://github.com/finos/perspective/tree/master/packages/perspective-webpack-plugin)).
 
-Thus, to update it you must either rebuild your code, or supply the JSON
+Thus, to update it, you must either rebuild your code, or supply the JSON
 configuration object to the `worker()` constructor on initialization.
 
 ```javascript
@@ -488,7 +488,7 @@ module.exports = {
 `perspective` library and formatting its output to the provided visualization
 plugins.
 
-If you are using babel or another build environment which supports ES6 modules,
+If you are using Babel or another build environment which supports ES6 modules,
 you only need to import the `perspective-viewer` libraries somewhere in your
 application - these modules export nothing, but rather register the components
 for use within your site's regular HTML:
@@ -518,8 +518,8 @@ standard HTML on your site. A simple example:
 ### Theming
 
 Theming is supported in `perspective-viewer` and its accompanying plugins.
-A number of themes come bundled with `perspective-viewer`, and you can import
-any of these themes directly into your app and the `perspective-viewer`s
+A number of themes come bundled with `perspective-viewer`; you can import
+any of these themes directly into your app, and the `perspective-viewer`s
 will be themed accordingly:
 
 ```javascript
@@ -560,7 +560,7 @@ _*index.html*_
 If you choose not to bundle the themes yourself, they are available through
 the [unpkg.com](https://unpkg.com/@finos/perspective-viewer/dist/umd/).
 
-These can be directly linked in your HTML:
+These can be directly linked in your HTML file:
 
 ```html
 <link
@@ -633,9 +633,9 @@ table.update([{x: 5, y: "e", z: true}]);
 ### Remote Perspective via `WebSocketServer()` and Node.js
 
 For exceptionally large datasets, a `<perspective-viewer>` can be bound to a
-`perspective.table()` instance running in node.js remotely, rather than creating
+`perspective.table()` instance running in Node.js remotely, rather than creating
 one in a Web Worker and downloading the entire data set. This trades off network
-bandwidth and server resource requirements, for a smaller browser memory and CPU
+bandwidth and server resource requirements for a smaller browser memory and CPU
 footprint.
 
 In Node.js:
@@ -679,9 +679,9 @@ elem.load(client_table);
 
 `<perspective-viewer>` instances bound in this way are otherwise no different
 than `<perspective-viewer>`s which rely on a Web Worker, and can even share a
-host application with Web Worker bound `table()`s. The same `promise` based API
-is used to communicate with the server instantiated `view()`, only in this case
-it is over a Web Socket.
+host application with Web Worker-bound `table()`s. The same `promise`-based API
+is used to communicate with the server-instantiated `view()`, only in this case
+it is over a websocket.
 
 ### Remote Perspective via `perspective-python` and Tornado
 
@@ -708,7 +708,7 @@ MANAGER.host_table("data_source", TABLE)
 
 app = tornado.web.Application([
     (r"/", MainHandler),
-    # create a websocket endpoint that the client Javascript can access
+    # create a websocket endpoint that the client JavaScript can access
     (r"/websocket", PerspectiveTornadoHandler, {"manager": MANAGER, "check_origin": True})
 ])
 
@@ -718,7 +718,7 @@ loop = tornado.ioloop.IOLoop.current()
 loop.start()
 ```
 
-The Javascript implementation of this does not require Webpack or any bundler,
+The JavaScript implementation of this does not require Webpack or any bundler,
 and can be achieved in a single HTML file:
 
 _*index.html*_
@@ -734,10 +734,10 @@ _*index.html*_
 
     /* `table` is a proxy for the `Table` we created on the server.
 
-        All operations that are possible through the Javascript API are possible
+        All operations that are possible through the JavaScript API are possible
         on the Python API as well, thus calling `view()`, `schema()`, `update()`
         etc. on `const table` will pass those operations to the Python `Table`,
-        execute the commands, and return the result back to Javascript.*/
+        execute the commands, and return the result back to JavaScript.*/
     const table = websocket.open_table("data_source_one");
 
     // Load this in the `<perspective-viewer>`.
@@ -748,7 +748,7 @@ _*index.html*_
 
 Any operation performed on the `<perspective-viewer>` instance or on
 `const table` will be forwarded to Python, which will execute the operation and
-return the results back to Javascript.
+return the results back to JavaScript.
 
 ### Setting & reading `perspective-viewer` configuration via attributes
 
@@ -820,15 +820,15 @@ elem.addEventListener("perspective-update-complete", function(event) {
 
 ### Click events
 
-Whenever a `<perspective-viewer>`'s grid or chart are clicked, a
+Whenever a `<perspective-viewer>`'s grid or chart is clicked, a
 `perspective-click` DOM event is fired containing a detail object with `config`,
-`column_names` and `row`.
+`column_names`, and `row`.
 
 The `config` object contains an array of `filters` that can be applied to a
 `<perspective-viewer>` through the use of `restore()` updating it to show the
 filtered subset of data.
 
-The `column_names` property contains an array of matching columns and the `row`
+The `column_names` property contains an array of matching columns, and the `row`
 property returns the associated row data.
 
 ```javascript

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -360,8 +360,8 @@ async function print_data() {
 ### Deleting a `table()` or `view()`
 
 Unlike standard JavaScript objects, Perspective objects such as `table()` and
-`view()` store their associated data in the WebAssembly heap. Due of this, and
-the current lack of a hook into the JavaScript runtime's garbage collector from
+`view()` store their associated data in the WebAssembly heap. Because of this, as
+well as the current lack of a hook into the JavaScript runtime's garbage collector from
 WebAssembly, the memory allocated to these Perspective objects does not
 automatically get cleaned up when the object falls out of scope.
 

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -36,7 +36,7 @@ which modules they need for their specific use case. The main modules are:
 
 `<perspective-viewer>` by itself only implements a trivial debug renderer, which
 prints the currently configured `view()` as a CSV. Plugin modules for popular
-JavaScript libraries such as [d3fc](https://d3fc.io/) are packaged separately
+JavaScript libraries, such as [d3fc](https://d3fc.io/), are packaged separately
 and must be imported individually.
 
 Perspective offers these plugin modules:
@@ -49,7 +49,7 @@ Perspective offers these plugin modules:
   library.
 
 Also available are these legacy modules; though no longer under development,
-they are compatible with perspective versions < 1.0.0:
+they are compatible with Perspective versions < 1.0.0:
 
 - `@finos/perspective-viewer-hypergrid`  
   A `<perspective-viewer>` plugin for
@@ -58,21 +58,21 @@ they are compatible with perspective versions < 1.0.0:
 - `@finos/perspective-viewer-highcharts`  
   [DEPRECATED] A `<perspective-viewer>` plugin for
   [HighCharts](https://github.com/highcharts/highcharts). This plugin has a
-  `highcharts` as a `peerDependency`, and requires a
+  `highcharts` as a `peerDependency` and requires a
   [mixed commercial license](https://shop.highsoft.com/).
 
 When imported after `@finos/perspective-viewer`, the plugin modules will
 register themselves automatically, and the renderers they export will be
 available in the `view` dropdown in the `<perspective-viewer>` UI.
 
-Developers can choose to opt into the features, bundle size inflation and
+Developers can choose to opt into the features, bundle size inflation, and
 licensing for these dependencies as needed.
 
 ### What modules should I import?
 
-Depending on your requirements, you may need just one, or all Perspective
-modules. Some basic guidelines to help you decide what is most appropriate for
-your project:
+Depending on your requirements, you may need just one, or all, Perspective
+modules. Here are some basic guidelines to help you decide what is most appropriate
+for your project:
 
 - For Perspective's high-performance streaming data engine (in WebAssembly), or
   for a purely Node.js based application, import:
@@ -96,7 +96,7 @@ your project:
 
 As a library, `perspective` provides a suite of streaming pivot, aggregate,
 filter and sort operations for tabular data. The engine can be instantiated in
-process, or in a Web Worker (browser only); in both cases, `perspective` exports
+process or in a Web Worker (browser only); in both cases, `perspective` exports
 a nearly identical API.
 
 It exports Perspective's data interfaces:
@@ -110,12 +110,12 @@ It exports Perspective's data interfaces:
   - `view()`s also live in a Web Worker when used in a browser.
   - A single `table()` may have many `view()`s attached at once.
 
-`@finos/perspective` also exports process management functions such as
+`@finos/perspective` also exports process management functions, such as
 `worker()` and `websocket()` (in the browser) and `WebSocketServer()`
-(in node.js). See the [API documentation](/obj/perspective.html) for a complete
+(in Node.js). See the [API documentation](/obj/perspective.html) for a complete
 reference on all exported methods.
 
-This module is a dependency of `@finos/perspective-viewer`, and is not needed if
+This module is a dependency of `@finos/perspective-viewer` and is not needed if
 you only intend to use `<perspective-viewer>` to visualize simple data.
 
 ### Importing in the browser
@@ -134,7 +134,7 @@ const perspective = require("@finos/perspective");
 ```
 
 `@finos/perspective` also comes with a pre-built bundle which exports the global
-`perspective` module name in vanilla JavaScript, when e.g. importing
+`perspective` module name in vanilla JavaScript, e.g. when importing
 [via a CDN](/docs/md/installation.html#from-cdn).
 
 ```html
@@ -145,7 +145,7 @@ const perspective = require("@finos/perspective");
 
 Once imported, you'll need to instantiate a `perspective` engine via the
 `worker()` method. This will create a new Web Worker (browser) or
-Process (Node.js), and load the WebAssembly binary; all calculation and data
+Process (Node.js) and load the WebAssembly binary; all calculation and data
 accumulation will occur in this separate process.
 
 ```javascript

--- a/docs/md/python.md
+++ b/docs/md/python.md
@@ -5,19 +5,19 @@ title: Python User Guide
 
 Perspective for Python uses the exact same C++ data engine used by the
 [WebAssembly version](https://perspective.finos.org/docs/md/js.html). The
-library consists of many of the same abstractions and API as in Javascript,
+library consists of many of the same abstractions and API as in JavaScript,
 as well as Python-specific data loading support for [NumPy](https://numpy.org/),
 [Pandas](https://pandas.pydata.org/) (and
-[Apache Arrow](https://arrow.apache.org/), as in Javascript).
+[Apache Arrow](https://arrow.apache.org/), as in JavaScript).
 
 Additionally, `perspective-python` provides a session manager suitable for
 integration into server systems such as
 [Tornado websockets](https://www.tornadoweb.org/en/stable/websocket.html), which
 allows fully _virtual_ Perspective tables to be interacted with by multiple
-`<perspective-viewer>` in a Web Browser.
+`<perspective-viewer>` in a web browser.
 
 As `<perspective-viewer>` will only consume the data necessary to render the
-current screen, this runtime mode allows _ludicrous_ _size_ datasets with
+current screen, this runtime mode allows _ludicrously-sized_ datasets with
 instant-load after they've been manifest on the server (at the expense of
 network latency on UI interaction).
 
@@ -29,10 +29,10 @@ makes it simple to extend a Tornado server with virtual Perspective support.
 The `perspective` module exports several tools:
 
 - `Table`, the table constructor for Perspective, which implements the `table`
-  and `view` API in the same manner as the Javascript library.
+  and `view` API in the same manner as the JavaScript library.
 - `PerspectiveWidget` the JupyterLab widget for interactive visualization.
 - `PerspectiveTornadoHandler`, an integration with [Tornado](https://www.tornadoweb.org/)
-that interfaces seamlessly with `<perspective-viewer>` in Javascript.
+that interfaces seamlessly with `<perspective-viewer>` in JavaScript.
 - `PerspectiveManager` the session manager for a shared server deployment of
 `perspective-python`.
 
@@ -50,7 +50,7 @@ on GitHub.
 ## `Table`
 
 A `Table` can be created from a dataset or a schema, the specifics of which are
-[discussed](#loading-data-with-table) in the Javascript section of the user's
+[discussed](#loading-data-with-table) in the JavaScript section of the user's
 guide. In Python, however, Perspective supports additional data types that are
 commonly used when processing data:
 
@@ -59,7 +59,7 @@ commonly used when processing data:
 - `bytes` (encoding an Apache Arrow)
 - `objects` (either extracting a repr or via reference)
 
-A `Table` is created in a similar fashion to its Javascript equivalent:
+A `Table` is created in a similar fashion to its JavaScript equivalent:
 
 ```python
 from datetime import date, datetime
@@ -88,7 +88,7 @@ row_data = view.to_records()
 
 ### Pandas & Numpy Support
 
-Perspective supports dictionaries of 1-dimensional `numpy.ndarray`, as well as
+Perspective supports dictionaries of one-dimensional `numpy.ndarray`, as well as
 structured arrays and record arrays. When passing in dictionaries of NumPy
 arrays, make sure that your dataset contains only NumPy arrays, and not a
 mixture of arrays and Python lists — this will raise an exception. Numpy
@@ -114,7 +114,7 @@ table = perspective.Table(data, index="index")
 
 ### Schemas & Supported Data Types
 
-Unlike Javascript, where schemas must be created using string representations of
+Unlike JavaScript, where schemas must be created using string representations of
 their types, `perspective-python` leverages Python's type system for schema
 creation.
 
@@ -136,13 +136,13 @@ and even valid millisecond/seconds from epoch timestamps. Similarly, updating
 string columns with integer data will cause a cast to string, updating floats
 with ints cause a float cast, and etc.
 
-Type inference works similarly—a column that contains `pandas.Timestamp`
+Type inference works similarly: a column that contains `pandas.Timestamp`
 objects will have its type inferred as `datetime`, which allows it to be updated
 with any of the datetime types that were just mentioned. Thus, Perspective is
 aware of the basic type primitives that it supports, but agnostic towards the
 actual Python `type` of the data that it receives.
 
-Type inference can also leverage python converters, e.g. `__int__`, `__float__`, etc.
+Type inference can also leverage Python converters, e.g. `__int__`, `__float__`, etc.
 
 #### Loading Custom Objects
 
@@ -151,23 +151,23 @@ implementing `_psp_repr_` to return `object`. Perspective stores a reference
 to your object as an unsigned 64-bit integer (e.g. a pointer), and uses  `__repr__`
 (or `_psp_repr` if implemented) to represent the object.
 
-You can customize how perspective extracts data from your objects by implementing these
+You can customize how Perspective extracts data from your objects by implementing these
 two methods into your object:
 
 - `_psp_repr_`: Since `__repr__` can only return strings, this lets you return other values
-- `_psp_dtype_`: perpspective will look at this to determine how to cast your objects' repr.
+- `_psp_dtype_`: Perpspective will look at this to determine how to cast your objects' repr.
 
 #### Time Zone Handling
 
 - ["Naive"](https://docs.python.org/3/library/datetime.html#aware-and-naive-objects)
   datetimes are assumed to be local time.
 - ["Aware"](https://docs.python.org/3/library/datetime.html#aware-and-naive-objects)
-  datetimes use the timezone specified in the `tzinfo`.
+  datetimes use the time zone specified in the `tzinfo`.
 
-All `datetime` columns (regardless of input timezone) are output to the user as
+All `datetime` columns (regardless of input time zone) are output to the user as
 `datetime.datetime` objects in _local time_ according to the Python runtime.
 
-This behavior is consistent with Perspective's behavior in Javascript. For more
+This behavior is consistent with Perspective's behavior in JavaScript. For more
 details, see this in-depth [explanation](https://github.com/finos/perspective/pull/867)
 of `perspective-python` semantics around time zone handling.
 
@@ -175,7 +175,7 @@ of `perspective-python` semantics around time zone handling.
 
 - Naive `pandas.Timestamp` objects are _always_ treated as UTC times, and will
   be converted to local time when output to the user.
-- Aware `pandas.Timestamp` objects use the timezone specified in `tzinfo`. Use
+- Aware `pandas.Timestamp` objects use the time zone specified in `tzinfo`. Use
   `tz_localize` or `tz_convert` to provide the `Timestamp` with a time zone.
 
 ### Callbacks and Events
@@ -216,7 +216,7 @@ Callbacks defined with a lambda function cannot be removed, as lambda functions 
 
 `PerspectiveManager` offers an interface for hosting multiple
 `perspective.Table` and `perspective.View` instances, extending their
-interfaces to operate with the [Javascript library](/docs/md/js.html) over a
+interfaces to operate with the [JavaScript library](/docs/md/js.html) over a
 websocket connection.
 
 `PerspectiveManager` is required to enable `perspective-python` to
@@ -235,7 +235,7 @@ server performance.  There are a few important differences when running
 
   * Calls to methods like `update()` will return immediately, and the reciprocal 
     `on_update()` callbacks will be invoked on an event later scheduled.  Calls
-    to other methods which require an up-to-date object however will still
+    to other methods which require an up-to-date object, but will still
     synchronously apply the pending update.
   * Updates will be _conflated_ when multiple calls to `update()` occur before
     the scheduled application.  In such cases, you may receive a single
@@ -264,7 +264,7 @@ thread.start()
 `PerspectiveManager` has the ability to "host" `perspective.Table` and
 `perspective.View` instances. Hosted tables/views can have their methods
 called from other sources than the Python server, i.e. by a `perspective-viewer` running
-in a Javascript client over the network, interfacing with `perspective-python` through
+in a JavaScript client over the network, interfacing with `perspective-python` through
 the websocket API.
 
 The server has full control of all hosted `Table` and `View`
@@ -305,7 +305,7 @@ table = Table(data)
 manager.host_table("data_source", table)
 ```
 
-The `name` provided is important, as it enables Perspective in Javascript to look
+The `name` provided is important, as it enables Perspective in JavaScript to look
 up a `Table` and get a handle to it over the network. This enables
 several powerful server/client implementations of Perspective, as explained in
 the next section.
@@ -313,7 +313,7 @@ the next section.
 ### Distributed Mode
 
 Using Tornado and [`PerspectiveTornadoHandler`](/docs/md/python.html#perspectivetornadohandler),
-as well as `Perspective`'s Javascript library, we can set up "distributed"
+as well as `Perspective`'s JavaScript library, we can set up "distributed"
 Perspective instances that allows multiple browser `perspective-viewer`
 clients to read from a common `perspective-python` server. In exchange for sending the
 entire dataset to the client on initialization, server load is reduced and
@@ -355,7 +355,7 @@ MANAGER.host_table("data_source", TABLE)
 
 app = tornado.web.Application([
     (r"/", MainHandler),
-    # create a websocket endpoint that the client Javascript can access
+    # create a websocket endpoint that the client JavaScript can access
     (r"/websocket", PerspectiveTornadoHandler, {"manager": MANAGER, "check_origin": True})
 ])
 
@@ -424,10 +424,10 @@ _*index.html*_
 
     /* `table` is a proxy for the `Table` we created on the server.
 
-        All operations that are possible through the Javascript API are possible
+        All operations that are possible through the JavaScript API are possible
         on the Python API as well, thus calling `view()`, `schema()`, `update()`
         etc. on `const table` will pass those operations to the Python `Table`,
-        execute the commands, and return the result back to Javascript.*/
+        execute the commands, and return the result back to JavaScript.*/
     const table = websocket.open_table("data_source_one");
 
     // Load this in the `<perspective-viewer>`.
@@ -470,7 +470,7 @@ As well as keyword arguments specific to `PerspectiveWidget` itself:
   in Python, or if it sends data to the front-end WebAssembly engine for
   processing.
 
-Several Enums are provided to make lookup of specific plugin types, aggregate
+Several enums are provided to make lookup of specific plugin types, aggregate
 types, etc. much easier:
 
 - [`Aggregate`](https://github.com/finos/perspective/blob/master/python/perspective/perspective/core/aggregate.py)
@@ -505,9 +505,9 @@ defaults to client mode when initializing the widget.
 
 A widget is created through the `PerspectiveWidget` constructor, which takes as
 its first, required parameter a `perspective.Table`, a dataset, a schema, or
-`None`, which serves as a special value that tells the Widget to defer loading
-any data until later. In maintaining consistency with the Javascript API,
-Widgets cannot be created with empty dictionaries or lists—`None` should be used
+`None`, which serves as a special value that tells the widget to defer loading
+any data until later. In maintaining consistency with the JavaScript API,
+widgets cannot be created with empty dictionaries or lists—`None` should be used
 if the intention is to await data for loading later on.
 
 A widget can be constructed from a dataset:
@@ -550,8 +550,8 @@ has a dataset, and the new data has different columns to the old one, then the
 widget state (pivots, sort, etc.) is cleared to prevent applying settings on
 columns that don't exist.
 
-Like `__init__`, load accepts a `perspective.Table`, a dataset, or a schema. If
-running in client mode, `load` defers to the browser's Perspective engine. This
+Like `__init__`, `load()` accepts a `perspective.Table`, a dataset, or a schema. If
+running in client mode, `load()` defers to the browser's Perspective engine. This
 means that loading Python-only datasets, especially ones that cannot be
 serialized into JSON, may cause some issues.
 
@@ -581,7 +581,7 @@ widget.table.size() # True
 ```
 
 Calling `replace(data)` on the widget with new data will remove the table's old
-data, and replace it with the new dataset, while preserving all widget state.
+data and replace it with the new dataset while preserving all widget states.
 
 ```python
 widget.replace(df2)
@@ -606,16 +606,16 @@ widget.plugin  # "datagrid"
 Perspective ships with a pre-built Tornado handler that makes integration with
 `tornado.websockets` extremely easy. This allows you to run an instance of
 `Perspective` on a server using Python, open a websocket to a `Table`, and
-access the `Table` in Javascript and through `<perspective-viewer>`.
+access the `Table` in JavaScript and through `<perspective-viewer>`.
 
 All instructions sent to the `Table` are processed in Python, which executes the
-commands, and returns its output through the websocket back to Javascript.
+commands, and returns its output through the websocket back to JavaScript.
 
 ### Python setup
 
 To use the handler, we need to first have an instance of a `Table` and a
-`PerspectiveManager`—the manager acts as the interface between the Javascript
-and the Python layers, implementing a JSON API that allows the two Perspective
+`PerspectiveManager`. The manager acts as the interface between the JavaScript
+and Python layers, implementing a JSON API that allows the two Perspective
 runtimes to communicate.
 
 ```python
@@ -628,7 +628,7 @@ Once the manager has been created, create a `Table` instance and call
 and allows the manager to send instructions to the Table.
 
 The name that you host the table under is important—it acts as a unique accessor
-on the Javascript side, which will look for a Table hosted at the websocket with
+on the JavaScript side, which will look for a Table hosted at the websocket with
 the name you specify.
 
 ```python
@@ -637,14 +637,14 @@ MANAGER.host_table("data_source_one", TABLE)
 ```
 
 After the manager and table setup is complete, create a websocket endpoint and
-provide it a reference to PerspectiveTornadoHandler. You must provide the
+provide it a reference to `PerspectiveTornadoHandler`. You must provide the
 configuration object in the route tuple, and it must contain `manager`, which is
 a reference to the `PerspectiveManager` you just created.
 
 ```python
 app = tornado.web.Application([
     (r"/", MainHandler),
-    # create a websocket endpoint that the client Javascript can access
+    # create a websocket endpoint that the client JavaScript can access
     (r"/websocket", PerspectiveTornadoHandler, {"manager": MANAGER, "check_origin": True})
 ])
 ```
@@ -655,10 +655,10 @@ where the server is hosted. See
 [Tornado docs](https://www.tornadoweb.org/en/stable/websocket.html#tornado.websocket.WebSocketHandler.check_origin)
 for more details.
 
-### Javascript setup
+### JavaScript setup
 
 Once the server is up and running, you can access the Table you just hosted
-using `perspective.websocket` and `open_table()`. First create a client that
+using `perspective.websocket` and `open_table()`. First, create a client that
 expects a Perspective server to accept connections at the specified URL:
 
 ```javascript
@@ -672,10 +672,10 @@ const table = websocket.open_table("data_source_one");
 ```
 
 `table` is a proxy for the `Table` we created on the server. All operations that
-are possible through the Javascript API are possible on the Python API as well,
-thus calling `view()`, `schema()`, `update()` etc on `const table` will pass
+are possible through the JavaScript API are possible on the Python API as well,
+thus calling `view()`, `schema()`, `update()` etc. on `const table` will pass
 those operations to the Python `Table`, execute the commands, and return the
-result back to Javascript. Similarly, providing this `table` to a
+result back to JavaScript. Similarly, providing this `table` to a
 `<perspective-viewer>` instance will allow virtual rendering:
 
 ```javascript
@@ -685,7 +685,7 @@ viewer.toggleConfig();
 
 `perspective.websocket` expects a Websocket URL where it will send instructions.
 When `open_table` is called, the name to a hosted Table is passed through, and a
-request is sent through the socket to fetch the Table. No actual Table instance
+request is sent through the socket to fetch the Table. No actual `Table` instance
 is passed inbetween the runtimes; all instructions are proxied through
 websockets.
 

--- a/docs/sidebars.json
+++ b/docs/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Getting Started": ["md/installation", "md/js", "md/python", "md/concepts", "md/styles", "md/development"],
-    "Javascript API": ["obj/perspective", "obj/perspective-viewer"],
+    "JavaScript API": ["obj/perspective", "obj/perspective-viewer"],
     "Python API": ["obj/perspective-python"]
   }
 }


### PR DESCRIPTION
Hello,

I am submitting a few spelling and grammar revisions to the Perspective documentation; fixes were primarily made to the .md files in /docs.

Main issues:
- JavaScript capitalization typo: Javascript to JavaScript (fixed across all docs)
- Consistency fixes: timezone and time zone (fixed to time zone), webworker and Web Worker (fixed to Web Worker), perspective and Perspective (fixed to Perspective), etc.
- Other various capitalization errors
- Some variables fixed to monospace font
- Added reference links to Boost and Cmake
- Misplaced commas
