### PR TITLE
Validate view config in engine, fix computed column state bugs

### DIFF
--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -521,8 +521,9 @@ str_to_filter_op(const std::string& str) {
     } else if (str == "is not null" || str == "is not None") {
         return t_filter_op::FILTER_OP_IS_NOT_NULL;
     } else {
-        PSP_COMPLAIN_AND_ABORT("Encountered unknown filter operation.");
-        // use and as default
+        std::stringstream ss;
+        ss << "Unknown filter operator string: `" << str << std::endl;
+        PSP_COMPLAIN_AND_ABORT(ss.str());
         return t_filter_op::FILTER_OP_AND;
     }
 }
@@ -540,7 +541,9 @@ str_to_sorttype(const std::string& str) {
     } else if (str == "desc abs" || str == "col desc abs") {
         return SORTTYPE_DESCENDING_ABS;
     } else {
-        PSP_COMPLAIN_AND_ABORT("Encountered unknown sort type string");
+        std::stringstream ss;
+        ss << "Unknown sort type string: `" << str << std::endl;
+        PSP_COMPLAIN_AND_ABORT(ss.str());
         return SORTTYPE_DESCENDING;
     }
 }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1431,8 +1431,11 @@ namespace binding {
 
             t_dtype output_column_type = computation.m_return_type;
 
-            // Add the column to the schema.
-            schema->add_column(computed_column_name, output_column_type);
+            // Add the column to the schema if the column does not already
+            // exist in the schema.
+            if (schema->get_colidx_safe(computed_column_name) == -1) {
+                schema->add_column(computed_column_name, output_column_type);
+            }
 
             // Add the computed column to the config.
             auto tp = std::make_tuple(

--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -75,31 +75,54 @@ Table::get_computed_schema(
     computed_column_names.reserve(computed_columns.size());
     computed_column_types.reserve(computed_columns.size());
     
-    // Computed columns live on the `t_gstate` master table, so use that schema
-    auto schema = m_gnode->get_table_sptr()->get_schema();
+    // Computed columns live on the `t_gstate` master table, so this
+    // schema will always contain ALL computed columns created by ALL views
+    // on this table instance.
+    auto master_table_schema = m_gnode->get_table_sptr()->get_schema();
 
+    // However, we need to keep track of the "real" columns at the time the
+    // table was instantiated, which exists on the output schema that will
+    // not be mutated at a later time.
+    auto gnode_schema = get_schema();
+
+    // Validate each computed column: check that the name does not collide
+    // with any "real" columns, that the input columns are valid and exist,
+    // and that the computation is valid given the input types.
     for (const auto& computed : computed_columns) {
         bool skip = false;
         std::string name = std::get<0>(computed);
 
-        // If the computed column has already been created, i.e. it exists on
-        // the master table, return that type instead of doing a further lookup.
-        if (schema.has_column(name)) {
+        // Cannot overwrite real columns - this column and all columns to its
+        // right are invalidated.
+        if (gnode_schema.has_column(name)) {
+            std::cerr 
+                << "Cannot overwrite non-computed column `"
+                << name
+                << "` with a computed column."
+                << std::endl;
+            break;
+        } else if (master_table_schema.has_column(name)) {
+            // The computed column we are looking for already exists and is not
+            // a "real" column, so use the type that has already been checked
+            // and move on to the next computed column.
             computed_column_names.push_back(name);
-            computed_column_types.push_back(schema.get_dtype(name));
+            computed_column_types.push_back(master_table_schema.get_dtype(name));
             continue;
-        }
+        } 
 
         t_computed_function_name computed_function_name = std::get<1>(computed);
         std::vector<std::string> input_columns = std::get<2>(computed);
 
-        // Look up return types
+        // Validate that all input columns for each computed column exist.
         std::vector<t_dtype> input_types;
         for (const auto& input_column : input_columns) {
-            // If input column is not in the table schema, then it must be
-            // in the computed schema as the column definitions read L-R
             t_dtype type;
-            if (!schema.has_column(input_column)) {
+
+            // If input column is not in the master table schema, then it must
+            // be in the computed schema as the column definitions read L-R,
+            // so all valid dependents for this column have already been
+            // processed at this point.
+            if (!master_table_schema.has_column(input_column)) {
                 auto it = std::find(
                     computed_column_names.begin(),
                     computed_column_names.end(),
@@ -108,7 +131,7 @@ Table::get_computed_schema(
                     // Column doesn't exist anywhere, so treat this column
                     // as completely invalid. This also means that columns
                     // on its right, which may or may not depend on this column,
-                    // are also invalidated.
+                    // are invalidated, and we stop iteration entirely.
                     std::cerr 
                         << "Input column `"
                         << input_column
@@ -122,47 +145,48 @@ Table::get_computed_schema(
                     type = computed_column_types[name_idx];
                 }
             } else {
-                type = schema.get_dtype(input_column);
+                type = master_table_schema.get_dtype(input_column);
             }
             input_types.push_back(type);
         }
 
-        t_computation computation = t_computed_column::get_computation(
-            computed_function_name, input_types);
-
-        if (computation.m_name == INVALID_COMPUTED_FUNCTION) {
-            // Build error message and set skip to true
-            std::vector<t_dtype> expected_dtypes = 
-                t_computed_column::get_computation_input_types(computed_function_name);
-
-            std::stringstream ss;
-            ss
-                << "Error: `"
-                << computed_function_name_to_string(computed_function_name)
-                << "`"
-                << " expected input column types: [ ";
-            for (t_dtype dtype : expected_dtypes) {
-                ss << "`" << get_dtype_descr(dtype) << "` ";
-            }
-            ss << "], but received: [ ";
-            for (t_dtype dtype : input_types) {
-                ss << "`" << get_dtype_descr(dtype) << "` ";
-            }
-            ss << "]." << std::endl;
-            std::cerr << ss.str();
-            skip = true;
-        }
-
         if (skip) {
-            // this column depends on a column that does not exist, or has
-            // an invalid type, so don't write into the
+            // this column depends on a column that does not exist, so it
+            // does not need to be typechecked.
             continue;
+        } else {
+            // Type check the computation.
+            t_computation computation = t_computed_column::get_computation(
+                computed_function_name, input_types);
+
+            if (computation.m_name == INVALID_COMPUTED_FUNCTION) {
+                // Build error message and continue to the next computed column.
+                std::vector<t_dtype> expected_dtypes = 
+                    t_computed_column::get_computation_input_types(computed_function_name);
+
+                std::stringstream ss;
+                ss
+                    << "Error: `"
+                    << computed_function_name_to_string(computed_function_name)
+                    << "`"
+                    << " expected input column types: [ ";
+                for (t_dtype dtype : expected_dtypes) {
+                    ss << "`" << get_dtype_descr(dtype) << "` ";
+                }
+                ss << "], but received: [ ";
+                for (t_dtype dtype : input_types) {
+                    ss << "`" << get_dtype_descr(dtype) << "` ";
+                }
+                ss << "]." << std::endl;
+                std::cerr << ss.str();
+                continue;
+            }
+
+            t_dtype output_column_type = computation.m_return_type;
+
+            computed_column_names.push_back(name);
+            computed_column_types.push_back(output_column_type);
         }
-
-        t_dtype output_column_type = computation.m_return_type;
-
-        computed_column_names.push_back(name);
-        computed_column_types.push_back(output_column_type);
     }
 
     t_schema computed_schema(computed_column_names, computed_column_types);

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -54,7 +54,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
     }
 
     for (const std::string& col : m_columns) {
-        if (schema->get_colidx_safe(col) == -1 && computed_column_names.count(col) == 0) {
+        if (!schema->has_column(col) && computed_column_names.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View columns." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -63,7 +63,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
 
     for (const auto& agg : m_aggregates) {
         const std::string& col = agg.first;
-        if (schema->get_colidx_safe(col) == -1 && computed_column_names.count(col) == 0) {
+        if (!schema->has_column(col) && computed_column_names.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View aggregates." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -71,7 +71,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
     }
 
     for (const std::string& col : m_row_pivots) {
-        if (schema->get_colidx_safe(col) == -1 && computed_column_names.count(col) == 0) {
+        if (!schema->has_column(col) && computed_column_names.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View row_pivots." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -79,7 +79,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
     }
 
     for (const std::string& col : m_column_pivots) {
-        if (schema->get_colidx_safe(col) == -1 && computed_column_names.count(col) == 0) {
+        if (!schema->has_column(col) && computed_column_names.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View column_pivots." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -88,7 +88,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
 
     for (const auto& filter : m_filter) {
         const std::string& col = std::get<0>(filter);
-        if (schema->get_colidx_safe(col) == -1 && computed_column_names.count(col) == 0) {
+        if (!schema->has_column(col) && computed_column_names.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View filters." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -97,7 +97,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
 
     for (const auto& sort : m_sort) {
         const std::string& col = sort[0];
-        if (schema->get_colidx_safe(col) == -1 && computed_column_names.count(col) == 0) {
+        if (!schema->has_column(col) && computed_column_names.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View sorts." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -66,10 +66,14 @@ public:
     t_uindex size() const;
 
     /**
-     * @brief The schema of the underlying `t_data_table`, which contains the `psp_pkey`,
-     * `psp_op` and `psp_pkey` meta columns.
+     * @brief The schema of the underlying `t_data_table`, which contains the
+     * `psp_pkey`, `psp_op` and `psp_pkey` meta columns, and none of the
+     * computed columns that are created by views on this table. For a
+     * `t_schema` with all computed columns created by all views, use
+     * `m_gnode->get_table_sptr()->get_schema()`.
      *
-     * The output schema is generally subject to further processing before it is human-readable.
+     * The output schema is generally subject to further processing before
+     * it can be used, as meta columns need to be removed.
      *
      * @return t_schema
      */

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -15,6 +15,7 @@
 #include <perspective/scalar.h>
 #include <perspective/computed.h>
 #include <tsl/ordered_map.h>
+#include <unordered_set>
 #include <tuple>
 
 namespace perspective {
@@ -55,6 +56,14 @@ public:
      * @param schema
      */
     void init(std::shared_ptr<t_schema> schema);
+
+    /**
+     * @brief Validate the view config to make sure that no invalid columns
+     * have been specified. If an invalid column is present, call
+     * PSP_COMPLAIN_AND_ABORT, which will abort() in WASM and raise an
+     * exception in Python.
+     */
+    void validate(std::shared_ptr<t_schema> schema);
 
     /**
      * @brief Add filter terms manually, as the filter term must be calculated from the value

--- a/packages/perspective-bench/bench/versions.js
+++ b/packages/perspective-bench/bench/versions.js
@@ -34,7 +34,7 @@ const JPMC_VERSIONS = [
 
 const FINOS_VERSIONS = ["0.3.1", "0.3.0", "0.3.0-rc.3", "0.3.0-rc.2", "0.3.0-rc.1"];
 
-const UMD_VERSIONS = ["0.5.5", "0.5.4", "0.5.3", "0.5.2", "0.5.1", "0.5.0", "0.4.8", "0.4.7", "0.4.6", "0.4.5", "0.4.4", "0.4.2", "0.4.1", "0.4.0", "0.3.9", "0.3.8", "0.3.7", "0.3.6"];
+const UMD_VERSIONS = ["0.5.6", "0.5.5", "0.5.4", "0.5.3", "0.5.2", "0.5.1", "0.5.0", "0.4.8", "0.4.7", "0.4.6", "0.4.5", "0.4.4", "0.4.2", "0.4.1", "0.4.0", "0.3.9", "0.3.8", "0.3.7", "0.3.6"];
 
 async function run() {
     await PerspectiveBench.run("master", "bench/perspective.benchmark.js", `http://${process.env.PSP_DOCKER_PUPPETEER ? `localhost` : `host.docker.internal`}:8080/perspective.js`, {

--- a/packages/perspective-bench/src/html/benchmark.html
+++ b/packages/perspective-bench/src/html/benchmark.html
@@ -19,8 +19,17 @@
     <script src="perspective-viewer-datagrid.js"></script>
     <script src="perspective-viewer-d3fc.js"></script>
 
-    <link rel='stylesheet' href="index.css">
     <link rel='stylesheet' href="material.css" is="custom-style">
+
+    <style>
+        perspective-viewer {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+        }
+    </style>
 
 </head>
 

--- a/packages/perspective-viewer/src/html/expression_editor.html
+++ b/packages/perspective-viewer/src/html/expression_editor.html
@@ -8,5 +8,5 @@ the Apache License 2.0.  The full license can be found in the LICENSE file.
 -->
 
 <template id="perspective-expression-editor">
-    <div role="textbox" contenteditable="true" class="perspective-expression-editor__edit_area"></div>
+    <div role="textbox" contenteditable="true" spellcheck="false" class="perspective-expression-editor__edit_area"></div>
 </template>

--- a/packages/perspective-viewer/src/js/computed_expressions/widget.js
+++ b/packages/perspective-viewer/src/js/computed_expressions/widget.js
@@ -371,6 +371,8 @@ class ComputedExpressionWidget extends HTMLElement {
 
     @throttlePromise
     async _type_check_expression(computed_schema, expected_types) {
+        // TODO: refactor this to encompass all checks for invalid columns,
+        // invalid inputs, invalid names etc.
         const parsed = this._parsed_expression || [];
         const invalid = [];
 

--- a/packages/perspective-viewer/src/js/viewer/dom_element.js
+++ b/packages/perspective-viewer/src/js/viewer/dom_element.js
@@ -95,8 +95,19 @@ export class DomElement extends PerspectiveElement {
             row.setAttribute("filter", filter);
 
             if (type === "string") {
-                // Get all unique values for the column
-                const view = this._table.view({row_pivots: [name], columns: []});
+                // Get all unique values for the column - because all options
+                // must be valid column names, recreate computed columns
+                // if the filter column is a computed column.
+                const computed_columns = this._get_view_parsed_computed_columns();
+                const computed_names = computed_columns.map(x => x.column);
+
+                // If `name` is in computed columns, recreate the current
+                // viewer's computed columns.
+                const view = this._table.view({
+                    row_pivots: [name],
+                    columns: [],
+                    computed_columns: computed_names.includes(name) ? computed_columns : []
+                });
                 view.to_json().then(json => {
                     row.choices(this._autocomplete_choices(json));
                 });

--- a/packages/perspective-viewer/test/js/computed_expressions.spec.js
+++ b/packages/perspective-viewer/test/js/computed_expressions.spec.js
@@ -314,7 +314,8 @@ utils.with_server({}, () => {
                 await page.keyboard.press("Enter");
             });
 
-            // Functionality
+            // Functionality - make sure the UI will validate error cases so
+            // the engine is not affected.
             test.capture("A type-invalid expression should show an error message", async page => {
                 await page.shadow_click("perspective-viewer", "#config_button");
                 await page.$("perspective-viewer");
@@ -329,8 +330,7 @@ utils.with_server({}, () => {
                 await page.waitForSelector("perspective-viewer:not([updating])");
             });
 
-            // TODO: unskip and assert content of error message
-            test.skip("An expression with invalid inputs should show an error message", async page => {
+            test.capture("An expression with invalid inputs should show an error message", async page => {
                 await page.shadow_click("perspective-viewer", "#config_button");
                 await page.$("perspective-viewer");
                 await page.shadow_click("perspective-viewer", "#add-computed-expression");
@@ -344,13 +344,37 @@ utils.with_server({}, () => {
                 await page.waitForSelector("perspective-viewer:not([updating])");
             });
 
-            // TODO: unskip and assert content of error message
-            test.skip("An expression that overwrites a real column should show an error message", async page => {
+            test.capture("An expression that overwrites a real column should show an error message", async page => {
                 await page.shadow_click("perspective-viewer", "#config_button");
                 await page.$("perspective-viewer");
                 await page.shadow_click("perspective-viewer", "#add-computed-expression");
                 await page.shadow_type(
                     "'Profit' + 'Profit' as 'Sales'",
+                    "perspective-viewer",
+                    "perspective-computed-expression-widget",
+                    "perspective-expression-editor",
+                    ".perspective-expression-editor__edit_area"
+                );
+                await page.waitForSelector("perspective-viewer:not([updating])");
+            });
+
+            test.capture("An expression that overwrites a computed column with a different type should show an error message", async page => {
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.$("perspective-viewer");
+                await page.shadow_click("perspective-viewer", "#add-computed-expression");
+                await page.shadow_type(
+                    "'Profit' + 'Sales' as 'Computed'",
+                    "perspective-viewer",
+                    "perspective-computed-expression-widget",
+                    "perspective-expression-editor",
+                    ".perspective-expression-editor__edit_area"
+                );
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.keyboard.press("Enter");
+                await page.waitForSelector("perspective-viewer:not([updating])");
+
+                await page.shadow_type(
+                    'uppercase("Category") as "Computed"',
                     "perspective-viewer",
                     "perspective-computed-expression-widget",
                     "perspective-expression-editor",

--- a/packages/perspective-viewer/test/js/computed_expressions.spec.js
+++ b/packages/perspective-viewer/test/js/computed_expressions.spec.js
@@ -315,6 +315,50 @@ utils.with_server({}, () => {
             });
 
             // Functionality
+            test.capture("A type-invalid expression should show an error message", async page => {
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.$("perspective-viewer");
+                await page.shadow_click("perspective-viewer", "#add-computed-expression");
+                await page.shadow_type(
+                    "uppercase('Sales')",
+                    "perspective-viewer",
+                    "perspective-computed-expression-widget",
+                    "perspective-expression-editor",
+                    ".perspective-expression-editor__edit_area"
+                );
+                await page.waitForSelector("perspective-viewer:not([updating])");
+            });
+
+            // TODO: unskip and assert content of error message
+            test.skip("An expression with invalid inputs should show an error message", async page => {
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.$("perspective-viewer");
+                await page.shadow_click("perspective-viewer", "#add-computed-expression");
+                await page.shadow_type(
+                    "'aaaa' + 'Sales'",
+                    "perspective-viewer",
+                    "perspective-computed-expression-widget",
+                    "perspective-expression-editor",
+                    ".perspective-expression-editor__edit_area"
+                );
+                await page.waitForSelector("perspective-viewer:not([updating])");
+            });
+
+            // TODO: unskip and assert content of error message
+            test.skip("An expression that overwrites a real column should show an error message", async page => {
+                await page.shadow_click("perspective-viewer", "#config_button");
+                await page.$("perspective-viewer");
+                await page.shadow_click("perspective-viewer", "#add-computed-expression");
+                await page.shadow_type(
+                    "'Profit' + 'Profit' as 'Sales'",
+                    "perspective-viewer",
+                    "perspective-computed-expression-widget",
+                    "perspective-expression-editor",
+                    ".perspective-expression-editor__edit_area"
+                );
+                await page.waitForSelector("perspective-viewer:not([updating])");
+            });
+
             test.capture("Typing enter should save a valid expression", async page => {
                 await page.shadow_click("perspective-viewer", "#config_button");
                 await page.$("perspective-viewer");

--- a/packages/perspective-viewer/test/results/linux.docker.json
+++ b/packages/perspective-viewer/test/results/linux.docker.json
@@ -54,7 +54,7 @@
     "Computed_Expressions_On_restore,_computed_expressions_in_classic_syntax_are_parsed_correctly_": "563f8c45e0ec32bc4b07d30ed5f0086e",
     "superstore_adds_computed_column_via_attribute": "f2fa526d6f0c168a47ab272bb7ae5771",
     "superstore_user_defined_aggregates_maintained_on_computed_columns": "c7aa2902feb512ceb1e1487de80878ff",
-    "__GIT_COMMIT__": "4500cfd6cee1b3b6fa266c4e843bf00577abad5c",
+    "__GIT_COMMIT__": "b83d6ac3ffddf11c7efbe73494a6c1a4e06a94b4",
     "blank_Handles_reloading_with_a_schema_": "9d171ff4c95a7f31eff2e7127b8caedf",
     "superstore_doesn_t_leak_tables_": "5bb762b2860eb5af067bb83afbca3264",
     "superstore_doesn_t_leak_elements_": "5bb762b2860eb5af067bb83afbca3264",
@@ -78,5 +78,8 @@
     "superstore_replaces_all_rows_": "03995f23192c53d36160ab55127ff5c0",
     "blank_When_transferables_are_enabled,_transfers_an_arrow_in_load_": "dcfab9d5536933ba80b87b503985f398",
     "blank_When_transferables_are_enabled,_transfers_an_arrow_in_update_": "dcfab9d5536933ba80b87b503985f398",
-    "Computed_Expressions_A_type-invalid_expression_should_show_an_error_message": "e03a4b9a23540a6684827a13ea5e6a8e"
+    "Computed_Expressions_A_type-invalid_expression_should_show_an_error_message": "e03a4b9a23540a6684827a13ea5e6a8e",
+    "Computed_Expressions_An_expression_with_invalid_inputs_should_show_an_error_message": "1b855c2069cc817903fe03f105fe36e8",
+    "Computed_Expressions_An_expression_that_overwrites_a_real_column_should_show_an_error_message": "869cdfa4d961688724b83d2498d23ef1",
+    "Computed_Expressions_An_expression_that_overwrites_a_computed_column_with_a_different_type_should_show_an_error_message": "e6258611a5776a0e529ec8df24f25683"
 }

--- a/packages/perspective-viewer/test/results/linux.docker.json
+++ b/packages/perspective-viewer/test/results/linux.docker.json
@@ -54,7 +54,7 @@
     "Computed_Expressions_On_restore,_computed_expressions_in_classic_syntax_are_parsed_correctly_": "563f8c45e0ec32bc4b07d30ed5f0086e",
     "superstore_adds_computed_column_via_attribute": "f2fa526d6f0c168a47ab272bb7ae5771",
     "superstore_user_defined_aggregates_maintained_on_computed_columns": "c7aa2902feb512ceb1e1487de80878ff",
-    "__GIT_COMMIT__": "ffcc3be9fb137f23a21e3737e07e809e55e71e49",
+    "__GIT_COMMIT__": "4500cfd6cee1b3b6fa266c4e843bf00577abad5c",
     "blank_Handles_reloading_with_a_schema_": "9d171ff4c95a7f31eff2e7127b8caedf",
     "superstore_doesn_t_leak_tables_": "5bb762b2860eb5af067bb83afbca3264",
     "superstore_doesn_t_leak_elements_": "5bb762b2860eb5af067bb83afbca3264",
@@ -77,5 +77,6 @@
     "superstore_Responsive_Layout_shows_horizontal_columns_on_small_vertical_and_horizontal_viewports_": "e51afee0ec45554b3a27d1ec313305f6",
     "superstore_replaces_all_rows_": "03995f23192c53d36160ab55127ff5c0",
     "blank_When_transferables_are_enabled,_transfers_an_arrow_in_load_": "dcfab9d5536933ba80b87b503985f398",
-    "blank_When_transferables_are_enabled,_transfers_an_arrow_in_update_": "dcfab9d5536933ba80b87b503985f398"
+    "blank_When_transferables_are_enabled,_transfers_an_arrow_in_update_": "dcfab9d5536933ba80b87b503985f398",
+    "Computed_Expressions_A_type-invalid_expression_should_show_an_error_message": "e03a4b9a23540a6684827a13ea5e6a8e"
 }

--- a/packages/perspective/test/js/computed/expressions.js
+++ b/packages/perspective/test/js/computed/expressions.js
@@ -449,7 +449,7 @@ module.exports = perspective => {
             table.delete();
         });
 
-        it("Should be able to create multiple computed column in multiple `view()`s with the same name", async function() {
+        it("Should be able to create multiple computed column in multiple `view()`s with the same name and the same type", async function() {
             const table = perspective.table(common.int_float_data);
             const view = table.view({
                 computed_columns: ['"w" + "x" as "float + int"']

--- a/packages/perspective/test/js/computed/expressions.js
+++ b/packages/perspective/test/js/computed/expressions.js
@@ -449,7 +449,7 @@ module.exports = perspective => {
             table.delete();
         });
 
-        it.skip("Should be able to create multiple computed column in multiple `view()`s with the same name", async function() {
+        it("Should be able to create multiple computed column in multiple `view()`s with the same name", async function() {
             const table = perspective.table(common.int_float_data);
             const view = table.view({
                 computed_columns: ['"w" + "x" as "float + int"']
@@ -531,6 +531,16 @@ module.exports = perspective => {
                 z: "boolean"
             });
             view.delete();
+            table.delete();
+        });
+
+        it("Should not be able to overwrite an existing 'real' column.", async function() {
+            const table = perspective.table(common.int_float_data);
+            expect(() =>
+                table.view({
+                    computed_columns: ['"w" + "x" as "w"']
+                })
+            ).toThrow();
             table.delete();
         });
 

--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -144,7 +144,7 @@ class _PerspectiveManagerInternal(object):
         except (PerspectiveError, PerspectiveCppError) as error:
             # Log errors and return them to the client
             error_string = str(error)
-            message = self._make_error_message(msg["id"], error_string)
+            error_message = self._make_error_message(msg["id"], error_string)
             logging.error("[PerspectiveManager._process] %s", error_string)
             post_callback(self._message_to_json(msg["id"], error_message))
 

--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -141,9 +141,11 @@ class _PerspectiveManagerInternal(object):
                 self._views[msg["view_name"]] = new_view
             elif cmd == "table_method" or cmd == "view_method":
                 self._process_method_call(msg, post_callback, client_id)
-        except (PerspectiveError, PerspectiveCppError) as e:
-            # Catch errors and return them to client
-            error_message = self._make_error_message(msg["id"], str(e))
+        except (PerspectiveError, PerspectiveCppError) as error:
+            # Log errors and return them to the client
+            error_string = str(error)
+            message = self._make_error_message(msg["id"], error_string)
+            logging.error("[PerspectiveManager._process] %s", error_string)
             post_callback(self._message_to_json(msg["id"], error_message))
 
     def _process_method_call(self, msg, post_callback, client_id):
@@ -235,7 +237,9 @@ class _PerspectiveManagerInternal(object):
                     message = self._make_message(msg["id"], result)
                     post_callback(self._message_to_json(msg["id"], message))
         except Exception as error:
-            message = self._make_error_message(msg["id"], str(error))
+            error_string = str(error)
+            message = self._make_error_message(msg["id"], error_string)
+            logging.error("[PerspectiveManager._process_method_call] %s", error_string)
             post_callback(self._message_to_json(msg["id"], message))
 
     def _process_subscribe(self, msg, table_or_view, post_callback, client_id):
@@ -290,7 +294,9 @@ class _PerspectiveManagerInternal(object):
             else:
                 logging.info("callback not found for remote call {}".format(msg))
         except Exception as error:
-            message = self._make_error_message(msg["id"], str(error))
+            error_string = str(error)
+            message = self._make_error_message(msg["id"], error_string)
+            logging.error("[PerspectiveManager._process_subscribe] %s", error_string)
             post_callback(self._message_to_json(msg["id"], message))
 
     def _process_bytes(self, binary, msg, post_callback):

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -156,6 +156,7 @@ make_view_config(std::shared_ptr<t_schema> schema, t_val date_parser, t_val conf
          */
         std::vector<t_dtype> input_types(input_columns.size());
 
+        // If the input columns are invalid, an error will be thrown here.
         for (auto i = 0; i < input_columns.size(); ++i) {
             input_types[i] = schema->get_dtype(input_columns[i]);
         }
@@ -163,31 +164,45 @@ make_view_config(std::shared_ptr<t_schema> schema, t_val date_parser, t_val conf
         t_computation computation = t_computed_column::get_computation(
             computed_function_name, input_types);
         
+        // Throw an exception if the computation is invalid - the UI will
+        // prevent users from saving invalidly-typed computations.
         if (computation.m_name == INVALID_COMPUTED_FUNCTION) {
-            std::cerr 
-                << "Could not build computed column definition for `" 
-                << computed_column_name 
-                << "`" 
-                << std::endl;
-            continue;
+            // Get actual input types
+            auto valid_input_types = t_computed_column::get_computation_input_types(computed_function_name);
+            std::stringstream ss;
+            ss << "View creation failed: could not build computed column '"
+               << computed_column_name
+               << "' as the input column types are invalid."
+               << std::endl;
+            PSP_COMPLAIN_AND_ABORT(ss.str());
         }
 
         t_dtype output_column_type = computation.m_return_type;
 
-        // Add the column to the schema if the column does not already
-        // exist in the schema.
-        if (schema->get_colidx_safe(computed_column_name) == -1) {
+        // If the computed column does not overwrite a "real" column, add it
+        // to the schema, otherwise throw an exception. The viewer UI will
+        // prevent users from overwriting "real" columns, so the only case
+        // here is when views are created programatically, where we should
+        // fail fast and report the error cleanly.
+        if (!schema->has_column(computed_column_name)) {
             schema->add_column(computed_column_name, output_column_type);
-        }
 
-        // Add the computed column to the config.
-        auto tp = std::make_tuple(
-            computed_column_name,
-            computed_function_name,
-            input_columns,
-            computation);
+            // Add the computed column to the config.
+            auto tp = std::make_tuple(
+                computed_column_name,
+                computed_function_name,
+                input_columns,
+                computation);
 
-        computed_columns.push_back(tp);
+            computed_columns.push_back(tp);
+        } else {
+            std::stringstream ss;
+            ss << "View creation failed: cannot overwrite Table column '"
+               << computed_column_name
+               << "' with a computed column."
+               << std::endl;
+            PSP_COMPLAIN_AND_ABORT(ss.str());
+        }        
     }
 
     // construct filters with filter terms, and fill the vector of tuples

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -174,7 +174,8 @@ make_view_config(std::shared_ptr<t_schema> schema, t_val date_parser, t_val conf
 
         t_dtype output_column_type = computation.m_return_type;
 
-        // Add the column to the schema.
+        // Add the column to the schema if the column does not already
+        // exist in the schema.
         if (schema->get_colidx_safe(computed_column_name) == -1) {
             schema->add_column(computed_column_name, output_column_type);
         }

--- a/python/perspective/perspective/tests/table/test_exception.py
+++ b/python/perspective/perspective/tests/table/test_exception.py
@@ -11,20 +11,28 @@ from perspective import Table, PerspectiveError, PerspectiveCppError
 
 
 class TestException(object):
-
     def test_exception_from_core(self):
         tbl = Table({"a": [1, 2, 3]})
+
         with raises(PerspectiveCppError) as ex:
             # creating view with unknown column should throw
             tbl.view(row_pivots=["b"])
-            assert str(ex.value) == "Column b does not exist in schema."
+
+        assert (
+            str(ex.value)
+            == "Invalid column 'b' found in View row_pivots.\n"
+        )
 
     def test_exception_from_core_catch_generic(self):
         tbl = Table({"a": [1, 2, 3]})
         # `PerspectiveCppError` should inherit from `Exception`
         with raises(Exception) as ex:
             tbl.view(row_pivots=["b"])
-            assert str(ex.value) == "Column b does not exist in schema."
+
+        assert (
+            str(ex.value)
+            == "Invalid column 'b' found in View row_pivots.\n"
+        )
 
     def test_exception_from_core_correct_types(self):
         tbl = Table({"a": [1, 2, 3]})
@@ -33,8 +41,16 @@ class TestException(object):
         with raises(PerspectiveError) as ex:
             tbl.view()
             tbl.delete()
-            assert str(ex.value) == "Cannot delete a Table with active views still linked to it - call delete() on each view, and try again."
+
+        assert (
+            str(ex.value)
+            == "Cannot delete a Table with active views still linked to it - call delete() on each view, and try again."
+        )
 
         with raises(PerspectiveCppError) as ex:
             tbl.view(row_pivots=["b"])
-            assert str(ex.value) == "Column b does not exist in schema."
+
+        assert (
+            str(ex.value)
+            == "Invalid column 'b' found in View row_pivots.\n"
+        )

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -1488,7 +1488,7 @@ class TestView(object):
                 computed_columns=[
                     {
                         "column": "abc",
-                        "computed_function_name": "uppercase",
+                        "computed_function_name": "exp",
                         "inputs": ["a"]
                     }
                 ]

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -1479,6 +1479,13 @@ class TestView(object):
             tbl.view(sort=[["x", "desc"]])
         assert str(ex.value) == "Invalid column 'x' found in View sorts.\n"
 
+    def test_should_throw_on_first_invalid(self):
+        data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
+        tbl = Table(data)
+        with raises(PerspectiveCppError) as ex:
+            tbl.view(row_pivots=["a"], column_pivots=["c"], filter=[["a", ">", 1]], aggregates={"a": "avg"}, sort=[["x", "desc"]])
+        assert str(ex.value) == "Invalid column 'x' found in View sorts.\n"
+
     def test_invalid_columns_not_in_computed_should_throw(self):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)


### PR DESCRIPTION
This PR makes several bug-fixes on the View creation and computed column features of the Perspective engine.

Most notably, it introduces full validation of view configurations for invalid columns, i.e. a column that is not present in the table. While this is not an issue for most Perspective users, restoring a configuration that has invalid columns, for example, can cause issues that were previously difficult to debug. Now, all configuration options on the view are validated, and if an invalid column is specified, `abort()` is called in Javascript or a `PerspectiveCppException` will be thrown in Python with a specific error message detailing the invalid column name and where it was found.

Additionally, this PR fixes several edge cases with computed column state:

- Previously, one could create computed columns that had the same name as a "table column", i.e. column on the underlying table. Now, this will error in the computed columns UI on `perspective-viewer`, and the engine will `abort()` or throw `PerspectiveCppException` if attempted directly through the API.
- Previously, one could create computed columns that had the same name as another computed column, but retype it (i.e. replacing `a + b as c` with `uppercase(name) as c`). Now, this will error in the computed columns UI, and the engine will `abort()` or throw `PerspectiveCppException`.
- ~~Previously, if multiple views were created at the same time with shared computed columns, deletion of any one of the views would cause the shared column to no longer calculate on subsequent update cycles, as view deletion also removes the view's computed columns from listening to further updates. Now, multiple views can share the same computed columns and as long as one view is in scope containing the shared column, the shared column will continue to correctly update.~~
  - ~~This is/has not been an error on `perspective-viewer`, as the Viewer keeps track of one view at a time and does not simultaneously create multiple views, but it is a reproducible edge case that is now fixed.~~

Finally, more granular benchmarks for computed columns have been added to better gauge performance.

Edit: the additional complexity introduced with patching the shared-dependency issue has been removed from this PR, and the issue will be handled with additional feature/debt relief work that is part of building out the computed columns feature.