### PR TITLE
WIP: datetime filtering fixes

### DIFF
--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -61,7 +61,7 @@ namespace binding {
         std::string datetime_string;
 
         if (filter_term.instanceof(t_val::global("Date"))) {
-            datetime_string = filter_term.call<t_val>("toLocaleString").as<std::string>();
+            datetime_string = filter_term.call<t_val>("toISOString").as<std::string>();
         } else {
             datetime_string = filter_term.as<std::string>();
         }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -57,7 +57,17 @@ namespace binding {
 
     t_val
     is_valid_datetime(t_val filter_term) {
-        return t_val(apachearrow::parseAsArrowTimestamp(filter_term.as<std::string>()) != -1);
+        // Convert `Date()` values to string before parsing
+        std::string datetime_string;
+
+        if (filter_term.instanceof(t_val::global("Date"))) {
+            datetime_string = filter_term.call<t_val>("toLocaleString").as<std::string>();
+        } else {
+            datetime_string = filter_term.as<std::string>();
+        }
+
+        std::cout << datetime_string << std::endl;
+        return t_val(apachearrow::parseAsArrowTimestamp(datetime_string) != -1);
     }
 
     bool val_to_date(t_val& item, t_date* out) {

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -137,84 +137,107 @@ module.exports = perspective => {
 
                 it("w == datetime with time as string", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", "==", "2020/12/01 23:30:55"]];
+                    const filter = [["w", "==", "2020-12-01 23:30:55"]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual(datetime_range_data[0]);
+                    expect(json).toEqual([{w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}]);
                     view.delete();
                     table.delete();
                 });
 
                 it("w > datetime with time as string", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", ">", "2020/10/01 23:30:55"]];
+                    const filter = [["w", ">", "2020-10-01 23:30:55"]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 10, 1, 19, 30, 55), x: 3, y: "c", z: true},
+                        {w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });
 
                 it("w < datetime with time as string", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", "<", "2020/10/01 23:30:55"]];
+                    const filter = [["w", "<", "2020-10-01 23:30:55"]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     let json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 2, 1, 12, 30, 55), x: 1, y: "a", z: true},
+                        {w: +new Date(2020, 9, 1, 15, 30, 55), x: 2, y: "b", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });
 
-                it("w == datetime with time as toLocaleString", async function() {
+                it("w == datetime with time as toISOString", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", "==", new Date(2020, 2, 1, 12, 30, 55).toLocaleString()]];
+                    const filter = [["w", "==", new Date(2020, 2, 1, 12, 30, 55).toISOString()]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual(datetime_range_data[0]);
+                    expect(json).toEqual([
+                        {
+                            w: +new Date(2020, 2, 1, 12, 30, 55),
+                            x: 1,
+                            y: "a",
+                            z: true
+                        }
+                    ]);
                     view.delete();
                     table.delete();
                 });
 
-                it("w > datetime with time as toLocaleString", async function() {
+                it("w > datetime with time as toISOString", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", ">", new Date(2020, 9, 1, 15, 30, 55).toLocaleString()]];
+                    const filter = [["w", ">", new Date(2020, 9, 1, 15, 30, 55).toISOString()]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 10, 1, 19, 30, 55), x: 3, y: "c", z: true},
+                        {w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });
 
-                it("w < datetime with time as toLocaleString", async function() {
+                it("w < datetime with time as toISOString", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", "<", new Date(2020, 9, 1, 15, 30, 55).toLocaleString()]];
+                    const filter = [["w", "<", new Date(2020, 9, 1, 15, 30, 55).toISOString()]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     let json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {
+                            w: +new Date(2020, 2, 1, 12, 30, 55),
+                            x: 1,
+                            y: "a",
+                            z: true
+                        }
+                    ]);
                     view.delete();
                     table.delete();
                 });
@@ -228,7 +251,14 @@ module.exports = perspective => {
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual(datetime_range_data[0]);
+                    expect(json).toEqual([
+                        {
+                            w: +new Date(2020, 2, 1, 12, 30, 55),
+                            x: 1,
+                            y: "a",
+                            z: true
+                        }
+                    ]);
                     view.delete();
                     table.delete();
                 });
@@ -242,7 +272,10 @@ module.exports = perspective => {
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 10, 1, 19, 30, 55), x: 3, y: "c", z: true},
+                        {w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });
@@ -256,7 +289,77 @@ module.exports = perspective => {
                         filter
                     });
                     let json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {
+                            w: +new Date(2020, 2, 1, 12, 30, 55),
+                            x: 1,
+                            y: "a",
+                            z: true
+                        }
+                    ]);
+                    view.delete();
+                    table.delete();
+                });
+            });
+
+            describe("Filter on datetime column in EST", () => {
+                beforeAll(() => {
+                    process.env.TZ = "US/Eastern";
+                });
+
+                afterAll(() => {
+                    process.env.TZ = "UTC";
+                });
+
+                it("w == datetime with time as string", async function() {
+                    expect(process.env.TZ).toEqual("US/Eastern");
+                    const table = perspective.table(datetime_range_data);
+                    const filter = [["w", "==", "2020-12-01 23:30:55"]];
+                    const valid = await table.is_valid_filter(filter[0]);
+                    expect(valid).toEqual(true);
+                    const view = table.view({
+                        filter
+                    });
+                    const json = await view.to_json();
+                    expect(json).toEqual([{w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}]);
+                    view.delete();
+                    table.delete();
+                });
+
+                it("w > datetime with time as string", async function() {
+                    expect(process.env.TZ).toEqual("US/Eastern");
+                    const table = perspective.table(datetime_range_data);
+                    const filter = [["w", ">", "2020-10-01 23:30:55"]];
+                    const valid = await table.is_valid_filter(filter[0]);
+                    expect(valid).toEqual(true);
+                    const view = table.view({
+                        filter
+                    });
+
+                    console.log(new Date("2020-10-01 23:30:55").toLocaleString());
+                    const json = await view.to_json();
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 10, 1, 19, 30, 55), x: 3, y: "c", z: true},
+                        {w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}
+                    ]);
+                    view.delete();
+                    table.delete();
+                });
+
+                it("w < datetime with time as string", async function() {
+                    expect(process.env.TZ).toEqual("US/Eastern");
+                    const table = perspective.table(datetime_range_data);
+                    const filter = [["w", "<", "2020-10-01 23:30:55"]];
+                    const valid = await table.is_valid_filter(filter[0]);
+                    expect(valid).toEqual(true);
+                    const view = table.view({
+                        filter
+                    });
+                    let json = await view.to_json();
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 2, 1, 12, 30, 55), x: 1, y: "a", z: true},
+                        {w: +new Date(2020, 9, 1, 15, 30, 55), x: 2, y: "b", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });


### PR DESCRIPTION
This draft PR will contain fixes for Perspective's datetime filters, specifically the issues mentioned in #1242 (and any others that may come up) - I'm using this draft PR as a place for notetaking/progress-checking and commentary.

Tasks:
- [ ] Fix how the datestring is being converted to timestamp
  - `==` filter compares the Unix timestamps - conversion not working properly?
- [ ] Improve UX for datetime filters
  - Make datestring format more lenient?
  - Add a hint to what formats are supported/make the default format more intuitive?
- [ ] Codify the errors that are happening, so we know exactly what to fix
- [ ] Enable programmatic filters using `Date()` values, not just strings
  - _Implemented already, although needs more tests_