### PR TITLE
Thread-safe Readers

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -323,7 +323,7 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
     set(ASYNC_MODE_FLAGS "")
 
     # Boost is a system dependency and must be present and built on the system.
-    find_package(Boost REQUIRED)
+    find_package(Boost COMPONENTS thread system REQUIRED)
 
     if(NOT Boost_FOUND)
         message(FATAL_ERROR "${Red}Boost could not be located${ColorReset}")
@@ -691,8 +691,7 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         endif()
 
         # Link against minimal arrow static library
-        target_link_libraries(psp arrow re2)
-
+        target_link_libraries(psp arrow re2 Boost::thread)
         target_link_libraries(binding psp)
 
         # The compiled libraries will be put in CMAKE_LIBRARY_OUTPUT_DIRECTORY by default. In the

--- a/cpp/perspective/src/cpp/gnode.cpp
+++ b/cpp/perspective/src/cpp/gnode.cpp
@@ -48,6 +48,10 @@ calc_negate(t_tscalar val) {
 
 t_gnode::t_gnode(const t_schema& input_schema, const t_schema& output_schema)
     : m_mode(NODE_PROCESSING_SIMPLE_DATAFLOW)
+#ifdef PSP_ENABLE_PYTHON
+    , m_event_loop_thread_id(std::thread::id())
+    , m_lock(nullptr)
+#endif
     , m_gnode_type(GNODE_TYPE_PKEYED)
     , m_input_schema(input_schema)
     , m_output_schema(output_schema)
@@ -598,7 +602,7 @@ t_gnode::process(t_uindex port_id) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "Cannot `process` on an uninited gnode.");
 #ifdef PSP_ENABLE_PYTHON
-    PerspectiveScopedGILRelease acquire(m_event_loop_thread_id);
+    PerspectiveScopedGILRelease acquire(m_event_loop_thread_id, m_lock, false);
 #endif
 
     t_process_table_result result = _process_table(port_id);
@@ -1385,6 +1389,11 @@ t_gnode::repr() const {
 void
 t_gnode::set_event_loop_thread_id(std::thread::id id) {
     m_event_loop_thread_id = id;
+}
+
+void
+t_gnode::set_lock(boost::shared_mutex* lock) {
+    m_lock = lock;
 }
 #endif
 

--- a/cpp/perspective/src/cpp/pyutils.cpp
+++ b/cpp/perspective/src/cpp/pyutils.cpp
@@ -10,27 +10,36 @@
 #include <perspective/first.h>
 #include <perspective/base.h>
 #include <perspective/pyutils.h>
+
 #ifdef PSP_ENABLE_PYTHON
+
 namespace perspective {
 
-PerspectiveScopedGILRelease::PerspectiveScopedGILRelease(
-    std::thread::id event_loop_thread_id)
-    : m_thread_state(NULL) {
+PerspectiveScopedGILRelease::PerspectiveScopedGILRelease(std::thread::id event_loop_thread_id, boost::shared_mutex* lock, bool is_read) : m_thread_state(NULL) {
     if (event_loop_thread_id != std::thread::id()) {
-        if (std::this_thread::get_id() != event_loop_thread_id) {
+        if (!is_read && std::this_thread::get_id() != event_loop_thread_id) {
             std::stringstream err;
-            err << "Perspective called from wrong thread; Expected "
-                << event_loop_thread_id << "; Got "
-                << std::this_thread::get_id() << std::endl;
+            err << "Perspective write called from wrong thread; Expected " << event_loop_thread_id << "; Got " << std::this_thread::get_id() << std::endl;
             PSP_COMPLAIN_AND_ABORT(err.str());
         }
+        m_is_read = is_read;
         m_thread_state = PyEval_SaveThread();
+        // if (is_read) {
+        //     m_lock = (intptr_t)new boost::shared_lock<boost::shared_mutex>(*lock);
+        // } else {
+        //     m_lock = (intptr_t)new boost::unique_lock<boost::shared_mutex>(*lock);
+        // }
     }
 }
 
 PerspectiveScopedGILRelease::~PerspectiveScopedGILRelease() {
     if (m_thread_state != NULL) {
         PyEval_RestoreThread(m_thread_state);
+        // if (m_is_read) {
+        //     delete ((boost::shared_lock<boost::shared_mutex>*)m_lock);
+        // } else {
+        //     delete ((boost::unique_lock<boost::shared_mutex>*)m_lock);
+        // }
     }
 }
 

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -1310,6 +1310,12 @@ std::thread::id
 View<CTX_T>::get_event_loop_thread_id() const {
     return m_table->get_pool()->get_event_loop_thread_id();
 };
+
+template <typename CTX_T>
+boost::shared_mutex*
+View<CTX_T>::get_lock() const {
+    return m_table->get_pool()->get_lock();
+}
 #endif
 
 /******************************************************************************

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -25,11 +25,19 @@
 #include <perspective/expression_tables.h>
 #include <perspective/regex.h>
 #include <tsl/ordered_map.h>
+#include <chrono>
+
+#ifdef PSP_ENABLE_PYTHON
+#include <thread>
+#include <boost/thread/shared_mutex.hpp>
+#endif
+
 #ifdef PSP_PARALLEL_FOR
 #include <thread>
 #include <perspective/parallel_for.h>
 #endif
-#include <chrono>
+
+
 
 namespace perspective {
 
@@ -210,6 +218,7 @@ public:
 
 #ifdef PSP_PARALLEL_FOR
     void set_event_loop_thread_id(std::thread::id id);
+    void set_lock(boost::shared_mutex* lock);
 #endif
 
 protected:
@@ -366,6 +375,7 @@ private:
 
 #ifdef PSP_ENABLE_PYTHON
     std::thread::id m_event_loop_thread_id;
+    boost::shared_mutex* m_lock;
 #endif
 };
 

--- a/cpp/perspective/src/include/perspective/pool.h
+++ b/cpp/perspective/src/include/perspective/pool.h
@@ -17,6 +17,7 @@
 
 #ifdef PSP_ENABLE_PYTHON
 #include <thread>
+#include <boost/thread/shared_mutex.hpp>
 #endif
 
 #if defined PSP_ENABLE_WASM
@@ -64,6 +65,7 @@ public:
 #ifdef PSP_ENABLE_PYTHON
     void set_event_loop();
     std::thread::id get_event_loop_thread_id() const;
+    boost::shared_mutex* get_lock() const;
 #endif
 
     /**
@@ -112,6 +114,7 @@ protected:
 private:
 #ifdef PSP_ENABLE_PYTHON
     std::thread::id m_event_loop_thread_id;
+    boost::shared_mutex* m_lock;
 #endif
     std::mutex m_mtx;
     std::vector<t_gnode*> m_gnodes;

--- a/cpp/perspective/src/include/perspective/pyutils.h
+++ b/cpp/perspective/src/include/perspective/pyutils.h
@@ -12,16 +12,19 @@
 
 #ifdef PSP_ENABLE_PYTHON
 #include <thread>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/shared_mutex.hpp>
 
 namespace perspective {
 
 class PERSPECTIVE_EXPORT PerspectiveScopedGILRelease {
-public:
-    PerspectiveScopedGILRelease(std::thread::id event_loop_thread_id);
-    ~PerspectiveScopedGILRelease();
-
-private:
-    PyThreadState* m_thread_state;
+    public:
+        PerspectiveScopedGILRelease(std::thread::id event_loop_thread_id, boost::shared_mutex* lock, bool is_read);
+        ~PerspectiveScopedGILRelease();
+    private:
+        PyThreadState* m_thread_state;
+        bool m_is_read;
+        intptr_t m_lock;
 };
 
 void _set_event_loop();

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -260,6 +260,7 @@ public:
     bool is_column_only() const;
 #ifdef PSP_ENABLE_PYTHON
     std::thread::id get_event_loop_thread_id() const;
+    boost::shared_mutex* get_lock() const;
 #endif
 
 private:

--- a/examples/tornado-python/index.html
+++ b/examples/tornado-python/index.html
@@ -9,92 +9,83 @@
 
 <!DOCTYPE html>
 <html>
+    <head>
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+        />
 
-<head>
+        <script src="http://localhost:8080/node_modules/perspective-viewer/dist/umd/perspective-viewer.js"></script>
+        <script src="http://localhost:8080/node_modules/perspective-viewer-datagrid/dist/umd/perspective-viewer-datagrid.js"></script>
+        <script src="http://localhost:8080/node_modules/perspective-viewer-d3fc/dist/umd/perspective-viewer-d3fc.js"></script>
+        <script src="http://localhost:8080/node_modules/perspective/dist/umd/perspective.js"></script>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+        <link
+            rel="stylesheet"
+            crossorigin="anonymous"
+            href="/node_modules/@finos/perspective-viewer/dist/css/themes.css"
+        />
 
-    <script src="http://localhost:8080/node_modules/perspective-viewer/dist/umd/perspective-viewer.js"></script>
-    <script src="http://localhost:8080/node_modules/perspective-viewer-datagrid/dist/umd/perspective-viewer-datagrid.js"></script>
-    <script src="http://localhost:8080/node_modules/perspective-viewer-d3fc/dist/umd/perspective-viewer-d3fc.js"></script>
-    <script src="http://localhost:8080/node_modules/perspective/dist/umd/perspective.js"></script>
+        <style>
+            perspective-viewer {
+                position: absolute;
+                top: 50px;
+                left: 0;
+                right: 0;
+                bottom: 0;
+            }
+            #state {
+                padding: 12px;
+                font-family: "Open Sans";
+                font-size: 16px;
+            }
+        </style>
+    </head>
 
-    <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
+    <body>
+        <perspective-viewer id="viewer"></perspective-viewer>
 
-    <style>
-        perspective-viewer{position:absolute;top:0;left:0;right:0;bottom:0;}
-    </style>
+        <script>
+            window.addEventListener("DOMContentLoaded", async function () {
+                /**
+                 * `perspective.websocket` connects to a remote Perspective server
+                 * that accepts WebSocket connections at the specified URL.
+                 *
+                 * Use `perspective.websocket` to set up Perspective in server or
+                 * distributed modes.
+                 */
+                window.state.innerText = "Connecting ...";
+                const websocket = perspective.websocket(
+                    "ws://localhost:8080/websocket"
+                );
+                const websocket2 = perspective.websocket(
+                    "ws://localhost:8080/websocket"
+                );
+                const worker = perspective.worker();
 
-</head>
+                /**
+                 * `server_table` is a proxy to the hosted `Table` in the Python
+                 * server. All public API methods are available through this
+                 * proxied table.
+                 */
+                const server_table = await websocket.open_table(
+                    "data_source_one"
+                );
 
-<body>
-    <perspective-viewer id="viewer"></perspective-viewer>
+                /**
+                 * Create a `View` on the server.
+                 */
+                const server_view = await server_table.view();
 
-    <script>
+                //  const table = worker.table(view);
 
-        window.addEventListener('DOMContentLoaded', async function () {
+                // Load the local table in the `<perspective-viewer>`.
 
-            /**
-             * `perspective.websocket` connects to a remote Perspective server
-             * that accepts WebSocket connections at the specified URL.
-             * 
-             * Use `perspective.websocket` to set up Perspective in server or
-             * distributed modes.
-             */
-            const websocket = perspective.websocket("ws://localhost:8080/websocket");
-
-            /**
-             * This shows Perspective running in "distributed mode": a `Table`
-             * is present on the Python server AND in the browser client, and
-             * state is automatically synchronized between the two.
-             * 
-             * To create a Perspective client running in "distributed mode",
-             * host a `Table` in the Python server, create a `Table` on the
-             * client through a `View` on the server. This synchronizes the
-             * server's `Table` with the client's `Table`.
-             */
-            const worker = perspective.worker();
-
-            /**
-             * `server_table` is a proxy to the hosted `Table` in the Python
-             * server. All public API methods are available through this
-             * proxied table.
-             */
-            const server_table = await websocket.open_table("data_source_one");
-
-            /**
-             * Create a `View` on the server.
-             */
-            const server_view = await server_table.view();
-
-            /**
-             * When a `View` is passed into `table()` to create a new `Table`,
-             * it automatically sets up an `on_update` callback to synchronize
-             * the state of the server and client.
-             * 
-             * `const table` is a local Perspective `Table` that runs in
-             * WebAssembly, with its state kept in sync through the WebSocket
-             * connection. If the WebSocket connection closes/times out, the
-             * `Table` and its data (and associated viewer) are still fully
-             * functional, but will not be kept up-to-date with server state.
-             * 
-             * Use `table.get_index()` in order to create a `Table` on the
-             * client that has the exact same settings as the server.
-             * 
-             * For a more complex example of manually controlling state
-             * synchronization between server and client, see
-             * `client_server_editing.html`.
-             */
-            const table = worker.table(server_view, {
-                index: await server_table.get_index()
+                await document
+                    .getElementById("viewer")
+                    .load(websocket2.open_table("data_source_one"));
+                window.state.innerText = "Server";
             });
-            
-            // Load the local table in the `<perspective-viewer>`.
-            document.getElementById('viewer').load(table);
-        });
-
-    </script>
-
-</body>
-
+        </script>
+    </body>
 </html>

--- a/examples/tornado-python/server.py
+++ b/examples/tornado-python/server.py
@@ -12,7 +12,9 @@ import tornado.websocket
 import tornado.web
 import tornado.ioloop
 import threading
+import concurrent.futures
 
+from functools import partial
 from perspective import Table, PerspectiveManager, PerspectiveTornadoHandler
 
 
@@ -21,25 +23,38 @@ file_path = os.path.join(
     here, "..", "..", "node_modules", "superstore-arrow", "superstore.arrow"
 )
 
+class PerspectiveStaticFileHandler(tornado.web.StaticFileHandler):
+    def set_extra_headers(self, path):
+        self.set_header("Cache-control", "no-cache")
 
-def perspective_thread(manager):
+
+def perspective_thread(manager, table):
     """Perspective application thread starts its own tornado IOLoop, and
     adds the table with the name "data_source_one", which will be used
     in the front-end."""
     psp_loop = tornado.ioloop.IOLoop()
-    manager.set_loop_callback(psp_loop.add_callback)
-    with open(file_path, mode="rb") as file:
-        table = Table(file.read(), index="Row ID")
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        manager.set_loop_callback(partial(psp_loop.run_in_executor, executor))
         manager.host_table("data_source_one", table)
-    psp_loop.start()
+        psp_loop.start()
 
 
-def make_app():
+def make_app():  
+    with open(file_path, mode="rb") as file:
+        data = file.read();
+        table = Table(data)
+        for i in range(250):
+            table.update(data)
+
     manager = PerspectiveManager()
-
-    thread = threading.Thread(target=perspective_thread, args=(manager,))
+    thread = threading.Thread(target=perspective_thread, args=(manager, table))
     thread.daemon = True
     thread.start()
+
+    # manager2 = PerspectiveManager()
+    # thread2 = threading.Thread(target=perspective_thread, args=(manager2, table))
+    # thread2.daemon = True
+    # thread2.start()  
 
     return tornado.web.Application(
         [
@@ -48,14 +63,19 @@ def make_app():
                 PerspectiveTornadoHandler,
                 {"manager": manager, "check_origin": True},
             ),
+            # (
+            #     r"/interactive",
+            #     PerspectiveTornadoHandler,
+            #     {"manager": manager2, "check_origin": True},
+            # ),
             (
                 r"/node_modules/(.*)",
-                tornado.web.StaticFileHandler,
+                PerspectiveStaticFileHandler,
                 {"path": "../../node_modules/@finos/"},
             ),
             (
                 r"/(.*)",
-                tornado.web.StaticFileHandler,
+                PerspectiveStaticFileHandler,
                 {"path": "./", "default_filename": "index.html"},
             ),
         ]

--- a/packages/perspective/src/js/api/server.js
+++ b/packages/perspective/src/js/api/server.js
@@ -235,6 +235,9 @@ export class Server {
                         return;
                     }
                 }
+                this.post({
+                    id: msg.id,
+                });
                 break;
         }
     }

--- a/packages/perspective/src/js/api/view_api.js
+++ b/packages/perspective/src/js/api/view_api.js
@@ -41,11 +41,12 @@ export function view(worker, table_name, config) {
             reject
         );
 
-        if (
-            this._worker._initialized === true &&
-            !this._worker._features?.wait_for_response
-        ) {
-            resolve(this);
+        if (!this._worker._features?.wait_for_response) {
+            if (this._worker._initialized === true) {
+                resolve(this);
+            } else {
+                reject("Worker not initialized");
+            }
         }
     });
 }

--- a/python/perspective/perspective/src/serialization.cpp
+++ b/python/perspective/perspective/src/serialization.cpp
@@ -25,7 +25,8 @@ namespace binding {
     std::shared_ptr<t_data_slice<CTX_T>>
     get_data_slice(std::shared_ptr<View<CTX_T>> view, std::uint32_t start_row,
         std::uint32_t end_row, std::uint32_t start_col, std::uint32_t end_col) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         auto data_slice
             = view->get_data(start_row, end_row, start_col, end_col);
         return data_slice;

--- a/python/perspective/perspective/src/table.cpp
+++ b/python/perspective/perspective/src/table.cpp
@@ -78,7 +78,7 @@ namespace binding {
 
             {
                 PerspectiveScopedGILRelease acquire(
-                    pool->get_event_loop_thread_id());
+                    pool->get_event_loop_thread_id(), pool->get_lock(), true);
 
                 // With the GIL released, load the arrow
                 if (is_csv) {
@@ -289,9 +289,9 @@ namespace binding {
 
         if (is_arrow) {
             PerspectiveScopedGILRelease acquire(
-                pool->get_event_loop_thread_id());
+                pool->get_event_loop_thread_id(), pool->get_lock(), true);
             row_count = arrow_loader.row_count();
-            data_table.extend(row_count);
+            data_table.extend(arrow_loader.row_count());
             arrow_loader.fill_table(
                 data_table, input_schema, index, offset, limit, is_update);
         } else if (is_numpy) {

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -329,7 +329,8 @@ namespace binding {
     py::bytes
     to_arrow_unit(std::shared_ptr<View<t_ctxunit>> view, std::int32_t start_row,
         std::int32_t end_row, std::int32_t start_col, std::int32_t end_col) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         std::shared_ptr<std::string> str
             = view->to_arrow(start_row, end_row, start_col, end_col, true);
         return py::bytes(*str);
@@ -338,7 +339,8 @@ namespace binding {
     py::bytes
     to_arrow_zero(std::shared_ptr<View<t_ctx0>> view, std::int32_t start_row,
         std::int32_t end_row, std::int32_t start_col, std::int32_t end_col) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         std::shared_ptr<std::string> str
             = view->to_arrow(start_row, end_row, start_col, end_col, true);
         return py::bytes(*str);
@@ -347,7 +349,8 @@ namespace binding {
     py::bytes
     to_arrow_one(std::shared_ptr<View<t_ctx1>> view, std::int32_t start_row,
         std::int32_t end_row, std::int32_t start_col, std::int32_t end_col) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         std::shared_ptr<std::string> str
             = view->to_arrow(start_row, end_row, start_col, end_col, true);
         return py::bytes(*str);
@@ -356,7 +359,8 @@ namespace binding {
     py::bytes
     to_arrow_two(std::shared_ptr<View<t_ctx2>> view, std::int32_t start_row,
         std::int32_t end_row, std::int32_t start_col, std::int32_t end_col) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         std::shared_ptr<std::string> str
             = view->to_arrow(start_row, end_row, start_col, end_col, true);
         return py::bytes(*str);
@@ -365,28 +369,32 @@ namespace binding {
     std::string
     to_csv_unit(std::shared_ptr<View<t_ctxunit>> view, std::int32_t start_row,
         std::int32_t end_row, std::int32_t start_col, std::int32_t end_col) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         return *view->to_csv(start_row, end_row, start_col, end_col);
     }
 
     std::string
     to_csv_zero(std::shared_ptr<View<t_ctx0>> view, std::int32_t start_row,
         std::int32_t end_row, std::int32_t start_col, std::int32_t end_col) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         return *view->to_csv(start_row, end_row, start_col, end_col);
     }
 
     std::string
     to_csv_one(std::shared_ptr<View<t_ctx1>> view, std::int32_t start_row,
         std::int32_t end_row, std::int32_t start_col, std::int32_t end_col) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         return *view->to_csv(start_row, end_row, start_col, end_col);
     }
 
     std::string
     to_csv_two(std::shared_ptr<View<t_ctx2>> view, std::int32_t start_row,
         std::int32_t end_row, std::int32_t start_col, std::int32_t end_col) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         return *view->to_csv(start_row, end_row, start_col, end_col);
     }
 
@@ -397,7 +405,8 @@ namespace binding {
 
     py::bytes
     get_row_delta_unit(std::shared_ptr<View<t_ctxunit>> view) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         std::shared_ptr<t_data_slice<t_ctxunit>> slice = view->get_row_delta();
         std::shared_ptr<std::string> arrow
             = view->data_slice_to_arrow(slice, false);
@@ -406,7 +415,8 @@ namespace binding {
 
     py::bytes
     get_row_delta_zero(std::shared_ptr<View<t_ctx0>> view) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         std::shared_ptr<t_data_slice<t_ctx0>> slice = view->get_row_delta();
         std::shared_ptr<std::string> arrow
             = view->data_slice_to_arrow(slice, false);
@@ -415,7 +425,8 @@ namespace binding {
 
     py::bytes
     get_row_delta_one(std::shared_ptr<View<t_ctx1>> view) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         std::shared_ptr<t_data_slice<t_ctx1>> slice = view->get_row_delta();
         std::shared_ptr<std::string> arrow
             = view->data_slice_to_arrow(slice, false);
@@ -424,7 +435,8 @@ namespace binding {
 
     py::bytes
     get_row_delta_two(std::shared_ptr<View<t_ctx2>> view) {
-        PerspectiveScopedGILRelease acquire(view->get_event_loop_thread_id());
+        PerspectiveScopedGILRelease acquire(
+            view->get_event_loop_thread_id(), view->get_lock(), true);
         std::shared_ptr<t_data_slice<t_ctx2>> slice = view->get_row_delta();
         std::shared_ptr<std::string> arrow
             = view->data_slice_to_arrow(slice, false);


### PR DESCRIPTION
This PR extends the `perspective-python` threading model to support fully thread-safe read operations, in exchange for a
"global" writer lock.  For datasets with many readers and infrequent writes, this can offer significantly better concurrency utilization.

- [x] Implement
- [ ] Measure performance under contention
- [ ] Decide whether to continue to support lock-less `async` mode 