### PR TITLE
Parse date locale strings, autocomplete filtering for date/datetime columns

### DIFF
--- a/cpp/perspective/src/cpp/arrow_csv.cpp
+++ b/cpp/perspective/src/cpp/arrow_csv.cpp
@@ -144,6 +144,8 @@ namespace apachearrow {
     std::vector<std::shared_ptr<arrow::TimestampParser>> DATE_PARSERS{
         std::make_shared<CustomISO8601Parser>(),
         arrow::TimestampParser::MakeStrptime("%Y-%m-%d\\D%H:%M:%S.%f"),
+        arrow::TimestampParser::MakeStrptime("%m/%d/%Y, %I:%M:%S %p"), // US locale string
+        arrow::TimestampParser::MakeStrptime("%d/%m/%Y, %H:%M:%S"), // UK locale string
         arrow::TimestampParser::MakeStrptime("%m-%d-%Y"),
         arrow::TimestampParser::MakeStrptime("%m/%d/%Y"),
         arrow::TimestampParser::MakeStrptime("%d %m %Y"),
@@ -153,6 +155,8 @@ namespace apachearrow {
         std::make_shared<UnixTimestampParser>(),
         std::make_shared<CustomISO8601Parser>(),
         arrow::TimestampParser::MakeStrptime("%Y-%m-%d\\D%H:%M:%S.%f"),
+        arrow::TimestampParser::MakeStrptime("%m/%d/%Y, %I:%M:%S %p"), // US locale string
+        arrow::TimestampParser::MakeStrptime("%d/%m/%Y, %H:%M:%S"), // UK locale string
         arrow::TimestampParser::MakeStrptime("%m-%d-%Y"),
         arrow::TimestampParser::MakeStrptime("%m/%d/%Y"),
         arrow::TimestampParser::MakeStrptime("%d %m %Y"),
@@ -160,10 +164,17 @@ namespace apachearrow {
 
     int64_t
     parseAsArrowTimestamp(const std::string& input) {
+        std::cout << "parsing: " << input << std::endl;
         for (auto candidate : DATE_PARSERS) {
             int64_t datetime;
             if (candidate->operator()(
                     input.c_str(), input.size(), arrow::TimeUnit::MILLI, &datetime)) {
+                std::tm res;
+                char* ret = strptime(input.c_str(), "%m/%d/%Y, %I:%M:%S %p", &res);
+                if (ret != NULLPTR) {
+                    std::cout << "strptime: " << res.tm_year + 1900 << "/" << res.tm_mon + 1 << "/" << res.tm_mday << " " << res.tm_hour << ":" << res.tm_min << ":" << res.tm_sec << std::endl;
+                }
+                std::cout << "parsed: " << datetime << std::endl;
                 return datetime;
             }
         }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -61,7 +61,7 @@ namespace binding {
         std::string datetime_string;
 
         if (filter_term.instanceof(t_val::global("Date"))) {
-            datetime_string = filter_term.call<t_val>("toLocaleString").as<std::string>();
+            datetime_string = filter_term.call<t_val>("toISOString").as<std::string>();
         } else {
             datetime_string = filter_term.as<std::string>();
         }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -57,7 +57,17 @@ namespace binding {
 
     t_val
     is_valid_datetime(t_val filter_term) {
-        return t_val(apachearrow::parseAsArrowTimestamp(filter_term.as<std::string>()) != -1);
+        // Convert `Date()` values to string before parsing
+        std::string datetime_string;
+
+        if (filter_term.instanceof(t_val::global("Date"))) {
+            datetime_string = filter_term.call<t_val>("toLocaleString").as<std::string>();
+        } else {
+            datetime_string = filter_term.as<std::string>();
+        }
+
+        std::cout << datetime_string << std::endl;
+        return t_val(apachearrow::parseAsArrowTimestamp(datetime_string) != -1);
     }
 
     bool val_to_date(t_val& item, t_date* out) {

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1118,6 +1118,14 @@ namespace binding {
         apachearrow::ArrowLoader arrow_loader;
         std::uintptr_t ptr;
 
+        std::tm res;
+        char* ret = strptime("3/1/2020, 12:30:55 AM", "%m/%d/%Y, %I:%M:%S %p", &res);
+        if (ret != NULLPTR) {
+            // parses to 2020/3/1 12:30:55, which is incorrect
+            // should parse to 2020/3/1 00:30:55
+            std::cout << "SSSSstrptime: " << res.tm_year + 1900 << "/" << res.tm_mon + 1 << "/" << res.tm_mday << " " << res.tm_hour << ":" << res.tm_min << ":" << res.tm_sec << std::endl;
+        }
+
         // Determine metadata
         bool is_delete = op == OP_DELETE;
 

--- a/packages/perspective-viewer/src/js/viewer/dom_element.js
+++ b/packages/perspective-viewer/src/js/viewer/dom_element.js
@@ -94,11 +94,11 @@ export class DomElement extends PerspectiveElement {
         if (filter) {
             row.setAttribute("filter", filter);
 
-            if (type === "string") {
+            if (type === "string" || type === "date" || type === "datetime") {
                 // Get all unique values for the column
                 const view = this._table.view({row_pivots: [name], columns: []});
                 view.to_json().then(json => {
-                    row.choices(this._autocomplete_choices(json));
+                    row.choices(this._autocomplete_choices(json, type));
                 });
                 view.delete();
             }
@@ -504,12 +504,16 @@ export class DomElement extends PerspectiveElement {
         render(options(current_renderers), this._vis_selector);
     }
 
-    _autocomplete_choices(json) {
+    _autocomplete_choices(json, type) {
         const choices = [];
         for (let i = 1; i < json.length; i++) {
             const row_path = json[i].__ROW_PATH__;
             if (Array.isArray(row_path) && row_path.length > 0 && row_path[0]) {
-                choices.push(row_path[0]);
+                let choice = row_path[0];
+                if (type === "date" || type === "datetime") {
+                    choice = new Date(choice).toLocaleString();
+                }
+                choices.push(choice);
             }
         }
         return choices;

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -989,6 +989,52 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("Handles datetime strings in US locale string", async function() {
+            const data = {
+                x: ["1/1/2020 12:30:45 PM", "03/15/2020 11:30:45 AM", "06/30/2020 01:30:45 AM", "12/31/2020 11:59:59 PM"]
+            };
+            const table = perspective.table(data);
+            const schema = await table.schema();
+
+            expect(schema).toEqual({
+                x: "datetime"
+            });
+
+            const view = table.view();
+            const result = await view.to_columns();
+
+            const expected = {
+                x: ["1/1/2020 12:30:45 PM", "03/15/2020 11:30:45 AM", "06/30/2020 01:30:45 AM", "12/31/2020 11:59:59 PM"].map(v => new Date(v).getTime())
+            };
+
+            expect(result).toEqual(expected);
+            view.delete();
+            table.delete();
+        });
+
+        it("Handles datetime strings in UK locale string", async function() {
+            const data = {
+                x: ["1/1/2020 12:30:45", "3/3/2020 19:30:45", "15/6/2020 01:30:45", "31/12/2020 23:59:59"]
+            };
+            const table = perspective.table(data);
+            const schema = await table.schema();
+
+            expect(schema).toEqual({
+                x: "datetime"
+            });
+
+            const view = table.view();
+            const result = await view.to_columns();
+
+            const expected = {
+                x: ["1/1/2020 12:30:45", "3/3/2020 19:30:45", "15/6/2020 01:30:45", "31/12/2020 23:59:59"].map(v => new Date(v).getTime())
+            };
+
+            expect(result).toEqual(expected);
+            view.delete();
+            table.delete();
+        });
+
         it("Reads datetime values in local time", async function() {
             const table = perspective.table(datetime_range_data);
             const view = table.view();

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -137,84 +137,107 @@ module.exports = perspective => {
 
                 it("w == datetime with time as string", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", "==", "2020/12/01 23:30:55"]];
+                    const filter = [["w", "==", "2020-12-01 23:30:55"]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual(datetime_range_data[0]);
+                    expect(json).toEqual([{w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}]);
                     view.delete();
                     table.delete();
                 });
 
                 it("w > datetime with time as string", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", ">", "2020/10/01 23:30:55"]];
+                    const filter = [["w", ">", "2020-10-01 23:30:55"]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 10, 1, 19, 30, 55), x: 3, y: "c", z: true},
+                        {w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });
 
                 it("w < datetime with time as string", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", "<", "2020/10/01 23:30:55"]];
+                    const filter = [["w", "<", "2020-10-01 23:30:55"]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     let json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 2, 1, 12, 30, 55), x: 1, y: "a", z: true},
+                        {w: +new Date(2020, 9, 1, 15, 30, 55), x: 2, y: "b", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });
 
-                it("w == datetime with time as toLocaleString", async function() {
+                it("w == datetime with time as toISOString", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", "==", new Date(2020, 2, 1, 12, 30, 55).toLocaleString()]];
+                    const filter = [["w", "==", new Date(2020, 2, 1, 12, 30, 55).toISOString()]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual(datetime_range_data[0]);
+                    expect(json).toEqual([
+                        {
+                            w: +new Date(2020, 2, 1, 12, 30, 55),
+                            x: 1,
+                            y: "a",
+                            z: true
+                        }
+                    ]);
                     view.delete();
                     table.delete();
                 });
 
-                it("w > datetime with time as toLocaleString", async function() {
+                it("w > datetime with time as toISOString", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", ">", new Date(2020, 9, 1, 15, 30, 55).toLocaleString()]];
+                    const filter = [["w", ">", new Date(2020, 9, 1, 15, 30, 55).toISOString()]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 10, 1, 19, 30, 55), x: 3, y: "c", z: true},
+                        {w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });
 
-                it("w < datetime with time as toLocaleString", async function() {
+                it("w < datetime with time as toISOString", async function() {
                     const table = perspective.table(datetime_range_data);
-                    const filter = [["w", "<", new Date(2020, 9, 1, 15, 30, 55).toLocaleString()]];
+                    const filter = [["w", "<", new Date(2020, 9, 1, 15, 30, 55).toISOString()]];
                     const valid = await table.is_valid_filter(filter[0]);
                     expect(valid).toEqual(true);
                     const view = table.view({
                         filter
                     });
                     let json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {
+                            w: +new Date(2020, 2, 1, 12, 30, 55),
+                            x: 1,
+                            y: "a",
+                            z: true
+                        }
+                    ]);
                     view.delete();
                     table.delete();
                 });
@@ -228,7 +251,14 @@ module.exports = perspective => {
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual(datetime_range_data[0]);
+                    expect(json).toEqual([
+                        {
+                            w: +new Date(2020, 2, 1, 12, 30, 55),
+                            x: 1,
+                            y: "a",
+                            z: true
+                        }
+                    ]);
                     view.delete();
                     table.delete();
                 });
@@ -242,7 +272,10 @@ module.exports = perspective => {
                         filter
                     });
                     const json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 10, 1, 19, 30, 55), x: 3, y: "c", z: true},
+                        {w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });
@@ -256,7 +289,77 @@ module.exports = perspective => {
                         filter
                     });
                     let json = await view.to_json();
-                    expect(json).toEqual([datetime_range_data[0]]);
+                    expect(json).toEqual([
+                        {
+                            w: +new Date(2020, 2, 1, 12, 30, 55),
+                            x: 1,
+                            y: "a",
+                            z: true
+                        }
+                    ]);
+                    view.delete();
+                    table.delete();
+                });
+            });
+
+            describe("Filter on datetime column in EST", () => {
+                beforeAll(() => {
+                    process.env.TZ = "US/Eastern";
+                });
+
+                afterAll(() => {
+                    process.env.TZ = "UTC";
+                });
+
+                it("w == datetime with time as string", async function() {
+                    expect(process.env.TZ).toEqual("US/Eastern");
+                    const table = perspective.table(datetime_range_data);
+                    const filter = [["w", "==", "2020-12-01 23:30:55"]];
+                    const valid = await table.is_valid_filter(filter[0]);
+                    expect(valid).toEqual(true);
+                    const view = table.view({
+                        filter
+                    });
+                    const json = await view.to_json();
+                    expect(json).toEqual([{w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}]);
+                    view.delete();
+                    table.delete();
+                });
+
+                it("w > datetime with time as string", async function() {
+                    expect(process.env.TZ).toEqual("US/Eastern");
+                    const table = perspective.table(datetime_range_data);
+                    const filter = [["w", ">", "2020-10-01 23:30:55"]];
+                    const valid = await table.is_valid_filter(filter[0]);
+                    expect(valid).toEqual(true);
+                    const view = table.view({
+                        filter
+                    });
+
+                    console.log(new Date("2020-10-01 23:30:55").toLocaleString());
+                    const json = await view.to_json();
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 10, 1, 19, 30, 55), x: 3, y: "c", z: true},
+                        {w: +new Date(2020, 11, 1, 23, 30, 55), x: 4, y: "d", z: false}
+                    ]);
+                    view.delete();
+                    table.delete();
+                });
+
+                it("w < datetime with time as string", async function() {
+                    expect(process.env.TZ).toEqual("US/Eastern");
+                    const table = perspective.table(datetime_range_data);
+                    const filter = [["w", "<", "2020-10-01 23:30:55"]];
+                    const valid = await table.is_valid_filter(filter[0]);
+                    expect(valid).toEqual(true);
+                    const view = table.view({
+                        filter
+                    });
+                    let json = await view.to_json();
+                    expect(json).toEqual([
+                        {w: +new Date(2020, 2, 1, 12, 30, 55), x: 1, y: "a", z: true},
+                        {w: +new Date(2020, 9, 1, 15, 30, 55), x: 2, y: "b", z: false}
+                    ]);
                     view.delete();
                     table.delete();
                 });


### PR DESCRIPTION
This PR takes over from #1274, and tries to fix some of the issues in #1242. Datetime filters are currently heavily format dependent - though the formats are the same as the date string formats supported by Perspective, this is not well-documented, and more specifically locale strings are not accepted in either the dataset nor the filters, but dates/datetimes are *displayed* as locale strings. This leads to a disconnect in the user experience, as the most obvious date format—the one displayed on the grid—is considered "invalid".

This PR adds in parsing support for US and UK locale strings, as well as enables autocomplete on date/datetime columns, which will display a list of the unique dates/datetimes as locale strings in the filter column. This should improve the user experience of datetime filters.

One unique issue right now pertains to `strptime` in the C STL - when given the US locale string format ("%m/%d/%Y, %I:%M:%S %p"), it parses "12:00:00 AM" as "12:00:00 PM", which is incorrect. I've added in some print statements in the C++ for now to try to figure out where this issue is happening—this is coming from strptime, and not arrow's date parser (which internally uses strptime). This issue does not affect Perspective at present, since the current parser simply does not parse 12-hour US locale strings.

UK locale strings seem to work fine in the same situation though :)