### PR TITLE
Fix #1244: make test_wheels script use python -m pip

### DIFF
--- a/python/perspective/scripts/test_wheels.sh
+++ b/python/perspective/scripts/test_wheels.sh
@@ -78,6 +78,10 @@ source ./bin/activate
 echo "${PYTHON_INTERPRETER} virtualenv activated"
 cd ..
 
+echo "Upgrading pip for ${PYTHON_INTERPRETER}..."
+${PYTHON_INTERPRETER} -m pip install --upgrade pip
+
+echo "Looking for wheels..."
 cd ${HERE}/../wheelhouse
 
 # Look for wheels based on Python version/platform
@@ -89,12 +93,14 @@ IFS=${SAVEIFS}
 
 for wheel in ${WHEELS_LIST}; do
     echo "Installing ${wheel}..."
-    pip install --force-reinstall ${wheel}
+    ${PYTHON_INTERPRETER} -m pip install --force-reinstall ${wheel}
 
     echo "-----------------------"
     echo "Testing ${wheel}"
 
     IS_LIBPSP=$(${PYTHON_INTERPRETER} -c "import perspective;print(perspective.is_libpsp())")
+
+    echo "-----------------------"
 
     if [ "${IS_LIBPSP}" != "True" ]; then
         echo "${wheel} failed to import with error: ${IS_LIBPSP}"


### PR DESCRIPTION
This PR fixes #1244.

The `test_wheels` script now uses the correct version of pip according to the Python interpreter rather than the `pip` defined in `$PATH`. This caused a [failure] on the 0.6.0 mega-build; even though pip was upgraded, the test script called the wrong version of `pip` and caused the wheel import to fail.