### PR TITLE
Generate flattened row paths from to_arrow

### DIFF
--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -274,6 +274,15 @@ t_ctx1::get_row_path(t_index idx) const {
     return ctx_get_path(m_tree, m_traversal, idx);
 }
 
+std::vector<std::vector<t_tscalar>>
+t_ctx1::get_row_paths_by_pivots() const {
+    PSP_TRACE_SENTINEL();
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    t_index num_rows = get_row_count();
+    if (num_rows == 0) return {};
+    return m_tree->get_paths_by_pivots(num_rows);
+}
+
 void
 t_ctx1::reset_sortby() {
     PSP_TRACE_SENTINEL();

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -282,12 +282,6 @@ t_ctx1::get_row_paths(t_index start_row, t_index end_row) const {
     auto ext = sanitize_get_data_extents(
         get_row_count(), get_column_count(), start_row, end_row, 0, 1);
 
-    // Cannot start at row 0 - it is the total row, and will cause undefined
-    // behavior if we try to lookup.
-    if (ext.m_srow == 0) {
-        ext.m_srow++;
-    }
-
     t_index num_rows = ext.m_erow - ext.m_srow;
 
     if (num_rows == 0) return {};
@@ -308,7 +302,7 @@ t_ctx1::get_row_paths(t_index start_row, t_index end_row) const {
 }
 
 std::vector<std::vector<t_tscalar>>
-t_ctx1::get_row_paths_by_pivots() const {
+t_ctx1::get_all_row_paths() const {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     t_index num_rows = get_row_count();

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -275,6 +275,39 @@ t_ctx1::get_row_path(t_index idx) const {
 }
 
 std::vector<std::vector<t_tscalar>>
+t_ctx1::get_row_paths(t_index start_row, t_index end_row) const {
+    PSP_TRACE_SENTINEL();
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+
+    auto ext = sanitize_get_data_extents(
+        get_row_count(), get_column_count(), start_row, end_row, 0, 1);
+
+    // Cannot start at row 0 - it is the total row, and will cause undefined
+    // behavior if we try to lookup.
+    if (ext.m_srow == 0) {
+        ext.m_srow++;
+    }
+
+    t_index num_rows = ext.m_erow - ext.m_srow;
+
+    if (num_rows == 0) return {};
+
+    std::vector<t_index> row_indices;
+    row_indices.resize(num_rows);
+
+    t_index counter = 0;
+
+    for (auto ridx = ext.m_srow; ridx < ext.m_erow; ++ridx) {
+        // translate node indices into their index on the sparse tree - when
+        // a context is sorted, etc., the order of row path indices change.
+        row_indices[counter] = m_traversal->get_tree_index(ridx);
+        counter++;
+    }
+
+    return m_tree->get_paths(row_indices);
+}
+
+std::vector<std::vector<t_tscalar>>
 t_ctx1::get_row_paths_by_pivots() const {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");

--- a/cpp/perspective/src/cpp/sparse_tree.cpp
+++ b/cpp/perspective/src/cpp/sparse_tree.cpp
@@ -1440,6 +1440,11 @@ t_stree::get_paths(const std::vector<t_index>& row_indices) const {
     t_index counter = 0;
 
     for (auto ridx : row_indices) {
+        if (ridx == 0) {
+            // 0 is total row, need to always skip.
+            continue;
+        }
+
         iter_by_idx iter = m_nodes->get<by_idx>().find(ridx);
 
         // find the number of treenodes between the node and the root, i.e.

--- a/cpp/perspective/src/cpp/sparse_tree.cpp
+++ b/cpp/perspective/src/cpp/sparse_tree.cpp
@@ -1420,12 +1420,45 @@ t_stree::get_path(t_uindex idx, std::vector<t_tscalar>& rval) const {
 }
 
 std::vector<std::vector<t_tscalar>>
+t_stree::get_paths(const std::vector<t_index>& row_indices) const {
+    std::vector<std::vector<t_tscalar>> rval;
+    auto num_pivots = m_pivots.size();
+
+    if (num_pivots == 0) return rval;
+
+    rval.resize(num_pivots);
+
+    auto num_rows = row_indices.size();
+
+    // each pivot column needs its own path vector.
+    for (auto i = 0; i < num_pivots; ++i) {
+        std::vector<t_tscalar> path;
+        path.resize(num_rows);
+        rval[i] = path;
+    }
+
+    t_index counter = 0;
+
+    for (auto ridx : row_indices) {
+        iter_by_idx iter = m_nodes->get<by_idx>().find(ridx);
+
+        // find the number of treenodes between the node and the root, i.e.
+        // what level is this row pivoted to?
+        auto path_count = get_ancestry_count(iter->m_pidx);
+        rval[path_count][counter] = iter->m_value;
+
+        counter++;
+    }
+
+    return rval;
+}
+
+std::vector<std::vector<t_tscalar>>
 t_stree::get_paths_by_pivots(t_index num_rows) const {
     std::vector<std::vector<t_tscalar>> rval;
     auto num_pivots = m_pivots.size();
 
     if (num_pivots == 0) return rval;
-    rval.reserve(num_pivots);
     rval.resize(num_pivots);
 
     // each pivot column needs its own path vector.

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -547,12 +547,16 @@ View<CTX_T>::data_slice_to_arrow(
         vectors.reserve(num_columns);
     }
 
+    // auto paths = data_slice->get_row_path();
+
+    // std::cout << paths << std::endl;
+
     for (auto cidx = start_col; cidx < end_col; ++cidx) {
         std::vector<t_tscalar> col_path = names.at(cidx);
         t_dtype dtype = get_column_dtype(cidx);
         std::string name;
 
-        // TODO: 1. emit __INDEX__ (this should be pretty easy)
+        // TODO: 1. emit __INDEX__: need some sort of homogenous list type 
         // TODO: 2 .emit __ID__
         // TODO: 3. emit row_path as arrow array
         if (sides() > 1) {

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -542,17 +542,20 @@ View<CTX_T>::data_slice_to_arrow(
     std::vector<std::shared_ptr<arrow::Field>> fields;
 
     std::int32_t num_columns = end_col - start_col;
+    fields.reserve(num_columns);
+    vectors.reserve(num_columns);
 
-    std::vector<std::vector<t_tscalar>> row_paths;
+    // std::vector<std::vector<t_tscalar>> row_paths;
 
-    if (sides() == 1) {
-        row_paths = get_row_paths_by_pivots();
-        fields.reserve(num_columns + row_paths.size());
-        vectors.reserve(num_columns + row_paths.size());
-    } else {
-        fields.reserve(num_columns);
-        vectors.reserve(num_columns);
-    }
+    // if (sides() == 1) {
+    //     row_paths = get_row_paths_by_pivots();
+    //     fields.reserve(num_columns + row_paths.size());
+    //     vectors.reserve(num_columns + row_paths.size());
+
+    //     // generate row_path columns
+    // } else {
+        
+    // }
 
     for (std::int32_t cidx = start_col; cidx < end_col; ++cidx) {
         std::vector<t_tscalar> col_path = names.at(cidx);

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -524,8 +524,12 @@ View<CTX_T>::data_slice_to_arrow(
     std::shared_ptr<t_data_slice<CTX_T>> data_slice) const {
     // From the data slice, get all the metadata we need
     t_get_data_extents extents = data_slice->get_data_extents();
+
     std::int32_t start_col = extents.m_scol;
     std::int32_t end_col = extents.m_ecol;
+    
+    // TODO: col_offset needs to be removed in order for __ROW_PATH__ to be
+    // implemented.
     std::int32_t col_offset = data_slice->get_col_offset();
     start_col += col_offset;
 
@@ -548,8 +552,23 @@ View<CTX_T>::data_slice_to_arrow(
         t_dtype dtype = get_column_dtype(cidx);
         std::string name;
 
+        // TODO: 1. emit __INDEX__ (this should be pretty easy)
+        // TODO: 2 .emit __ID__
+        // TODO: 3. emit row_path as arrow array
         if (sides() > 1) {
             name = join_column_names(col_path, m_separator);
+            // if (name == "__ROW_PATH__") {
+                /**
+                 * TODO: this needs to be a list type with content of mixed
+                 * types, which isn't actually allowed in arrow. We can pass
+                 * back a list of strings, but this defeats formatting and a
+                 * host of other things that depend on the __ROW_PATH__ being
+                 * objects with concrete types.
+                 * 
+                 * FIXME: figure out an alternative encoding for row_path that
+                 * can be communicated via arrow.
+                 */
+            // }
         } else {
             name = col_path.at(col_path.size() - 1).to_string();
         }

--- a/cpp/perspective/src/include/perspective/arrow_writer.h
+++ b/cpp/perspective/src/include/perspective/arrow_writer.h
@@ -44,7 +44,8 @@ namespace apachearrow {
     /**
      * @brief Retrieve the correct index into the data slice for the given
      * column and row. This is a redefinition of the method in `t_data_slice`,
-     * except it does not rely on any instance variables.
+     * except it does not rely on any instance variables as we don't use the
+     * `t_data_slice` instance, instead accessing the its data vector directly.
      * 
      * @param cidx 
      * @param ridx 
@@ -61,9 +62,14 @@ namespace apachearrow {
     /**
      * @brief Build an `arrow::Array` from a column typed as `DTYPE_BOOL.`
      * 
-     * @param data 
-     * @param offset 
-     * @param stride 
+     * @param data a vector of scalars to write into an arrow array.
+     * @param cidx the index of the column in the dataset, used to calculate
+     *      the physical offset of the column's data in `data`, a tightly packed
+     *      vector containing the dataset for the entire data slice.
+     * @param stride the number of columns present in the data slice, used to
+     *      calculate the data's physical offset.
+     * @param extents the start/end rows and columns of the data slice, used
+     *      to calculate the data's physical offset.
      */
     std::shared_ptr<arrow::Array>
     boolean_col_to_array(
@@ -78,9 +84,14 @@ namespace apachearrow {
      * `uint32_t` that needs to be written into the `arrow::Array` as an
      * `int32_t`.
      *
-     * @param data 
-     * @param offset 
-     * @param stride 
+     * @param data a vector of scalars to write into an arrow array.
+     * @param cidx the index of the column in the dataset, used to calculate
+     *      the physical offset of the column's data in `data`, a tightly packed
+     *      vector containing the dataset for the entire data slice.
+     * @param stride the number of columns present in the data slice, used to
+     *      calculate the data's physical offset.
+     * @param extents the start/end rows and columns of the data slice, used
+     *      to calculate the data's physical offset.
      */
     std::shared_ptr<arrow::Array>
     date_col_to_array(
@@ -94,9 +105,14 @@ namespace apachearrow {
      * Separated out from the main templated `col_to_array` as
      * `arrow::timestamp()` has parameters that need to be filled.
      *
-     * @param data 
-     * @param offset 
-     * @param stride 
+     * @param data a vector of scalars to write into an arrow array.
+     * @param cidx the index of the column in the dataset, used to calculate
+     *      the physical offset of the column's data in `data`, a tightly packed
+     *      vector containing the dataset for the entire data slice.
+     * @param stride the number of columns present in the data slice, used to
+     *      calculate the data's physical offset.
+     * @param extents the start/end rows and columns of the data slice, used
+     *      to calculate the data's physical offset.
      */
     std::shared_ptr<arrow::Array>
     timestamp_col_to_array(
@@ -108,11 +124,15 @@ namespace apachearrow {
     /**
      * @brief Build an `arrow::Array` from a column typed as `DTYPE_STR`, using
      * arrow's `DictionaryArray` constructors.
-     * 
-     * @param data 
-     * @param offset 
-     * @param stride 
-     * @return std::shared_ptr<arrow::Array> 
+     *
+     * @param data a vector of scalars to write into an arrow array.
+     * @param cidx the index of the column in the dataset, used to calculate
+     *      the physical offset of the column's data in `data`, a tightly packed
+     *      vector containing the dataset for the entire data slice.
+     * @param stride the number of columns present in the data slice, used to
+     *      calculate the data's physical offset.
+     * @param extents the start/end rows and columns of the data slice, used
+     *      to calculate the data's physical offset.
      */
     std::shared_ptr<arrow::Array>
     string_col_to_dictionary_array(
@@ -127,11 +147,17 @@ namespace apachearrow {
      * slice, as `t_data_slice` is templated on the context type and we'd like
      * to avoid template hell.
      *
-     * @tparam ArrowDataType
-     * @param data 
-     * @param offset 
-     * @param stride 
-     * @return std::shared_ptr<arrow::Array> 
+     * @tparam ArrowDataType 
+     * @tparam ArrowValueType
+     *
+     * @param data a vector of scalars to write into an arrow array.
+     * @param cidx the index of the column in the dataset, used to calculate
+     *      the physical offset of the column's data in `data`, a tightly packed
+     *      vector containing the dataset for the entire data slice.
+     * @param stride the number of columns present in the data slice, used to
+     *      calculate the data's physical offset.
+     * @param extents the start/end rows and columns of the data slice, used
+     *      to calculate the data's physical offset.
      */
     template <typename ArrowDataType, typename ArrowValueType>
     std::shared_ptr<arrow::Array>

--- a/cpp/perspective/src/include/perspective/context_one.h
+++ b/cpp/perspective/src/include/perspective/context_one.h
@@ -58,7 +58,7 @@ public:
      * 
      * @return std::vector<std::vector<t_tscalar>> 
      */
-    std::vector<std::vector<t_tscalar>> get_row_paths_by_pivots() const;
+    std::vector<std::vector<t_tscalar>> get_all_row_paths() const;
 
     void set_depth(t_depth depth);
 

--- a/cpp/perspective/src/include/perspective/context_one.h
+++ b/cpp/perspective/src/include/perspective/context_one.h
@@ -38,6 +38,19 @@ public:
     std::vector<t_tscalar> get_row_path(t_index idx) const;
 
     /**
+     * @brief Returns flattened, null-padded row paths for the given start
+     * and end rows. Thus, row pivots of ["Region", "State", "City"] returns
+     * [
+     *  ["South", null, null],
+     *  [null, "Texas", null],
+     *  [null, null, "Houston"]
+     * ]
+     * 
+     */
+    std::vector<std::vector<t_tscalar>> get_row_paths(
+        t_index start_row, t_index end_row) const;
+
+    /**
      * @brief Returns a vector of scalar vectors which represent the flattened
      * row paths for each column in the pivot in order, i.e. row pivots of
      * ["Region", "State", "City"] returns

--- a/cpp/perspective/src/include/perspective/context_one.h
+++ b/cpp/perspective/src/include/perspective/context_one.h
@@ -36,6 +36,17 @@ public:
     t_tscalar get_aggregate_name(t_uindex idx) const;
     std::vector<t_aggspec> get_aggregates() const;
     std::vector<t_tscalar> get_row_path(t_index idx) const;
+
+    /**
+     * @brief Returns a vector of scalar vectors which represent the flattened
+     * row paths for each column in the pivot in order, i.e. row pivots of
+     * ["Region", "State", "City"] returns
+     * vector(["East", ...], ["Texas", ...], ["Houston", ...]).
+     * 
+     * @return std::vector<std::vector<t_tscalar>> 
+     */
+    std::vector<std::vector<t_tscalar>> get_row_paths_by_pivots() const;
+
     void set_depth(t_depth depth);
 
     t_index get_row_idx(const std::vector<t_tscalar>& path) const;

--- a/cpp/perspective/src/include/perspective/sparse_tree.h
+++ b/cpp/perspective/src/include/perspective/sparse_tree.h
@@ -195,7 +195,17 @@ public:
         const std::set<t_uindex>& ptiset, const std::vector<t_uindex>& zero_strands) const;
 
     t_uindex get_parent_idx(t_uindex idx) const;
+
     std::vector<t_uindex> get_ancestry(t_uindex idx) const;
+
+    /**
+     * @brief Given a node index on the tree, return how many nodes it has
+     * between itself and its root parent.
+     * 
+     * @param idx 
+     * @return t_uindex 
+     */
+    t_uindex get_ancestry_count(t_uindex idx) const;
 
     t_index get_sibling_idx(t_index p_ptidx, t_index p_nchild, t_uindex c_ptidx) const;
     t_uindex get_aggidx(t_uindex idx) const;
@@ -207,6 +217,9 @@ public:
     t_tnode get_node(t_uindex idx) const;
 
     void get_path(t_uindex idx, std::vector<t_tscalar>& path) const;
+
+    std::vector<std::vector<t_tscalar>> get_paths_by_pivots(t_index num_rows) const;
+
     void get_sortby_path(t_uindex idx, std::vector<t_tscalar>& path) const;
 
     t_uindex resolve_child(t_uindex root, const t_tscalar& datum) const;

--- a/cpp/perspective/src/include/perspective/sparse_tree.h
+++ b/cpp/perspective/src/include/perspective/sparse_tree.h
@@ -218,6 +218,19 @@ public:
 
     void get_path(t_uindex idx, std::vector<t_tscalar>& path) const;
 
+    /**
+     * @brief Returns flattened, null-padded row paths for the given vector of
+     * row indices. Thus, row pivots of ["Region", "State", "City"] returns
+     * [
+     *  ["South", null, null],
+     *  [null, "Texas", null],
+     *  [null, null, "Houston"]
+     * ]
+     * 
+     * @param row_indices
+     */
+    std::vector<std::vector<t_tscalar>> get_paths(const std::vector<t_index>& row_indices) const;
+
     std::vector<std::vector<t_tscalar>> get_paths_by_pivots(t_index num_rows) const;
 
     void get_sortby_path(t_uindex idx, std::vector<t_tscalar>& path) const;

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -19,6 +19,7 @@
 #include <perspective/data_slice.h>
 #include <perspective/table.h>
 #include <perspective/view_config.h>
+#include <perspective/arrow_writer.h>
 #include <cstddef>
 #include <memory>
 #include <map>
@@ -169,6 +170,30 @@ public:
     data_slice_to_arrow(
         std::shared_ptr<t_data_slice<CTX_T>> data_slice) const;
 
+    /**
+     * @brief Convert a `t_column` to an arrow array, and push it into the
+     * `arrow_vectors` and `arrow_fields` vectors.
+     * 
+     * @param arrow_vectors 
+     * @param arrow_fields 
+     * @param data_slice 
+     * @param column_name 
+     * @param column_dtype 
+     * @param cidx 
+     * @param stride 
+     * @param extents 
+     */
+    void
+    column_to_arrow(
+        std::vector<std::shared_ptr<arrow::Array>>& arrow_vectors,
+        std::vector<std::shared_ptr<arrow::Field>>& arrow_fields,
+        const std::vector<t_tscalar>& slice,
+        const std::string& column_name,
+        t_dtype column_dtype,
+        t_uindex cidx,
+        t_uindex stride,
+        t_get_data_extents extents) const;
+
     // Delta calculation
     bool _get_deltas_enabled() const;
     void _set_deltas_enabled(bool enabled_state);
@@ -225,6 +250,7 @@ public:
     std::vector<t_sortspec> get_sort() const;
     std::vector<t_computed_column_definition> get_computed_columns() const;
     std::vector<t_tscalar> get_row_path(t_uindex idx) const;
+    std::vector<std::vector<t_tscalar>> get_row_paths_by_pivots() const;
     t_stepdelta get_step_delta(t_index bidx, t_index eidx) const;
     t_dtype get_column_dtype(t_uindex idx) const;
     bool is_column_only() const;

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -173,7 +173,7 @@ public:
     /**
      * @brief Convert a `t_column` to an arrow array, and push it into the
      * `arrow_vectors` and `arrow_fields` vectors.
-     * 
+     *
      * @param arrow_vectors 
      * @param arrow_fields 
      * @param data_slice 
@@ -181,7 +181,7 @@ public:
      * @param column_dtype 
      * @param cidx 
      * @param stride 
-     * @param extents 
+     * @param extents
      */
     void
     column_to_arrow(
@@ -241,6 +241,19 @@ public:
      */
     std::shared_ptr<t_data_slice<CTX_T>> get_row_delta() const;
 
+    /**
+     * @brief Returns flattened, null-padded row paths for the given start
+     * and end rows. i.e. row pivots of ["Region", "State", "City"] returns
+     * [
+     *  ["South", null, null],
+     *  [null, "Texas", null],
+     *  [null, null, "Houston"]
+     * ]
+     * 
+     */
+    std::vector<std::vector<t_tscalar>> get_row_paths(
+        std::int32_t start_row, std::int32_t end_row) const;
+
     // Getters
     std::shared_ptr<CTX_T> get_context() const;
     std::vector<std::string> get_row_pivots() const;
@@ -250,7 +263,6 @@ public:
     std::vector<t_sortspec> get_sort() const;
     std::vector<t_computed_column_definition> get_computed_columns() const;
     std::vector<t_tscalar> get_row_path(t_uindex idx) const;
-    std::vector<std::vector<t_tscalar>> get_row_paths_by_pivots() const;
     t_stepdelta get_step_delta(t_index bidx, t_index eidx) const;
     t_dtype get_column_dtype(t_uindex idx) const;
     bool is_column_only() const;

--- a/packages/perspective/test/js/perspective.spec.js
+++ b/packages/perspective/test/js/perspective.spec.js
@@ -21,6 +21,7 @@ const update_tests = require("./updates.js");
 const filter_tests = require("./filters.js");
 const internal_tests = require("./internal.js");
 const toformat_tests = require("./to_format.js");
+const to_arrow_tests = require("./to_arrow.js");
 const sort_tests = require("./sort.js");
 const multiple_tests = require("./multiple.js");
 const pivot_nulls = require("./pivot_nulls.js");
@@ -38,6 +39,7 @@ describe("perspective.js", function() {
             update_tests(RUNTIMES[mode]);
             filter_tests(RUNTIMES[mode]);
             toformat_tests(RUNTIMES[mode]);
+            to_arrow_tests(RUNTIMES[mode]);
             internal_tests(RUNTIMES[mode], mode);
             sort_tests(RUNTIMES[mode], mode);
             multiple_tests(RUNTIMES[mode], mode);

--- a/packages/perspective/test/js/to_arrow.js
+++ b/packages/perspective/test/js/to_arrow.js
@@ -1,0 +1,37 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+const jsc = require("jsverify");
+
+const replicate = (n, g) => jsc.tuple(new Array(n).fill(g));
+
+const generator = function(length = 100, has_zero = true) {
+    const min = has_zero ? 0 : 1;
+    return jsc.record({
+        a: replicate(length, jsc.number(min, 1000000)),
+        b: replicate(length, jsc.number(min, 1000000)),
+        c: replicate(length, jsc.string),
+        d: replicate(length, jsc.datetime),
+        e: replicate(length, jsc.bool)
+    });
+};
+
+module.exports = perspective => {
+    describe("to_arrow invariance", () => {
+        describe("1-sided", () => {
+            // TODO: add invariant test suite for flattened row paths.
+            jsc.property("reconstruct row paths", generator(), async data => {
+                const table = perspective.table(data);
+                const view = table.view();
+                view.delete();
+                table.delete();
+                return true;
+            });
+        });
+    });
+};

--- a/python/perspective/perspective/table/_accessor.py
+++ b/python/perspective/perspective/table/_accessor.py
@@ -234,7 +234,8 @@ class _PerspectiveAccessor(object):
             return None
 
         elif isinstance(val, list) and len(val) == 1:
-            # strip out values encased lists
+            # strip out values encased in lists, like `__INDEX__` or for
+            # object types.
             val = val[0]
 
         elif dtype == t_dtype.DTYPE_STR:

--- a/python/perspective/perspective/tests/table/test_to_format.py
+++ b/python/perspective/perspective/tests/table/test_to_format.py
@@ -1121,6 +1121,25 @@ class TestToFormat(object):
             "b": [2.5, 4.5]
         }
 
+    def test_to_format_implicit_index_with_index_records(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data, index="a")
+        view = tbl.view()
+        assert view.to_records(index=True) == [
+            {"__INDEX__": [1.5], "a": 1.5, "b": 2.5},
+            {"__INDEX__": [3.5], "a": 3.5, "b": 4.5}
+        ]
+
+    def test_to_format_implicit_index_with_index_dict(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data, index="a")
+        view = tbl.view()
+        assert view.to_dict(index=True) == {
+            "__INDEX__": [[1.5], [3.5]],
+            "a": [1.5, 3.5],
+            "b": [2.5, 4.5]
+        }
+
     def test_to_format_implicit_id_records(self):
         data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
         tbl = Table(data)
@@ -1140,20 +1159,50 @@ class TestToFormat(object):
             "b": [2.5, 4.5]
         }
 
-    def test_to_format_implicit_index_two_dict(self):
+    def test_to_format_implicit_id_pivoted_records(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view(row_pivots=["a"])
+        assert view.to_records(id=True) == [
+            {"__ROW_PATH__": [], "__ID__": [], "a": 5, "b": 7},
+            {"__ROW_PATH__": [1.5], "__ID__": [1.5], "a": 1.5, "b": 2.5},
+            {"__ROW_PATH__": [3.5], "__ID__": [3.5], "a": 3.5, "b": 4.5}
+        ]
+
+    def test_to_format_implicit_id_pivoted_dict(self):
+        data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
+        tbl = Table(data)
+        view = tbl.view(row_pivots=["a"])
+        assert view.to_dict(id=True) == {
+            "__ROW_PATH__": [[], [1.5], [3.5]],
+            "__ID__": [[], [1.5], [3.5]],
+            "a": [5, 1.5, 3.5],
+            "b": [7, 2.5, 4.5]
+        }
+
+    def test_to_format_implicit_id_multi_pivoted_dict(self):
+        data = [{"a": 1.5, "b": 2.5, "c": "a"}, {"a": 3.5, "b": 4.5, "c": "b"}]
+        tbl = Table(data)
+        view = tbl.view(row_pivots=["a", "c"])
+        assert view.to_dict(id=True) == {
+            "__ROW_PATH__": [[], [1.5], [1.5, "a"], [3.5], [3.5, "b"]],
+            "__ID__": [[], [1.5], [1.5, "a"], [3.5], [3.5, "b"]],
+            "a": [5, 1.5, 1.5, 3.5, 3.5],
+            "b": [7, 2.5, 2.5, 4.5, 4.5],
+            "c": [2, 1, 1, 1, 1]
+        }
+
+    def test_to_format_implicit_id_two_records(self):
         data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
         tbl = Table(data)
         view = tbl.view(row_pivots=["a"], column_pivots=["b"])
-        assert view.to_dict(index=True) == {
-            '2.5|a': [1.5, 1.5, None],
-            '2.5|b': [2.5, 2.5, None],
-            '4.5|a': [3.5, None, 3.5],
-            '4.5|b': [4.5, None, 4.5],
-            '__INDEX__': [[], [], []],  # index needs to be the same length as each column
-            '__ROW_PATH__': [[], [1.5], [3.5]]
-        }
+        assert view.to_records(id=True) == [
+            {"2.5|a": 1.5, "2.5|b": 2.5, "4.5|a": 3.5, "4.5|b": 4.5, "__ID__": [], "__ROW_PATH__": []},
+            {"2.5|a": 1.5, "2.5|b": 2.5, "4.5|a": None, "4.5|b": None, "__ID__": [1.5], "__ROW_PATH__": [1.5]},
+            {"2.5|a": None, "2.5|b": None, "4.5|a": 3.5, "4.5|b": 4.5, "__ID__": [3.5], "__ROW_PATH__": [3.5]},
+        ]
 
-    def test_to_format_implicit_index_two_dict(self):
+    def test_to_format_implicit_id_two_dict(self):
         data = [{"a": 1.5, "b": 2.5}, {"a": 3.5, "b": 4.5}]
         tbl = Table(data)
         view = tbl.view(row_pivots=["a"], column_pivots=["b"])


### PR DESCRIPTION
This PR enables Perspective to generate row paths from its `to_arrow` method, allowing for more efficient transport of serialized data from pivoted views. Currently, only arrows from un-pivoted views are accurate representations of the table's data (in that you can take the arrow and create a new table from it, and the data from the new table `==` the data from the old table).

Because Perspective stores row paths (an array of category headers from each pivot column, which indicates the categories a given aggregate row belongs to) as an array per row, which can be of mixed type, there is no good way to serialize the row path to Arrow in a mono-typed array without transformation. This PR transforms the row path structure into flattened, mono-typed arrow arrays so that they can be loaded into Perspective and re-constructed:

![Screen Shot 2021-01-13 at 5 58 35 PM](https://user-images.githubusercontent.com/13220267/104520454-26a3f980-55c9-11eb-904b-a426471a2852.png)

And pivoted to match the original view (with nulls removed, as the flattened serialization format uses nulls to help map out the row path tree structure).

![Screen Shot 2021-01-13 at 5 59 46 PM](https://user-images.githubusercontent.com/13220267/104520485-36bbd900-55c9-11eb-98ba-f51832a5532b.png)

The overall goal of this improvement is to allow the Rust Arrow Accessor defined in #1261 to be used for all views, in not only the datagrid but the charting plugins as well. For that to happen, we need full feature parity between `to_arrow` and the other to_format methods across all contexts.

### TODO:
- [ ] Implement row and column path handling for 2-sided views
- [ ] Implement `__INDEX__` and `__ID__` for `to_arrow`
- [ ] Implement `leaves_only` for `to_arrow`
- [ ] Add invariant test suite for arrow outputs - we want to know that the row path transformation process creates an arrow dataset that can be put into a table, and re-pivoted back to match the original pivoted view.