### PR TITLE
Fix partial updates in Python using dicts

### DIFF
--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -1576,7 +1576,7 @@ module.exports = perspective => {
     });
 
     describe("implicit index", function() {
-        it("should apply single partial update on unindexed table using row id from '__INDEX__'", async function() {
+        it("should partial update on unindexed table", async function() {
             let table = perspective.table(data);
             table.update([
                 {
@@ -1591,6 +1591,73 @@ module.exports = perspective => {
             expected[2]["y"] = "new_string";
 
             expect(result).toEqual(expected);
+            view.delete();
+            table.delete();
+        });
+
+        it("should partial update on unindexed table, column dataset", async function() {
+            let table = perspective.table(data);
+            table.update({
+                __INDEX__: [2],
+                y: ["new_string"]
+            });
+
+            let view = table.view();
+            let result = await view.to_json();
+
+            // does not unset any values
+            expect(result).toEqual([
+                {x: 1, y: "a", z: true},
+                {x: 2, y: "b", z: false},
+                {x: 3, y: "new_string", z: true},
+                {x: 4, y: "d", z: false}
+            ]);
+            view.delete();
+            table.delete();
+        });
+
+        it("should partial update and unset on unindexed table", async function() {
+            let table = perspective.table(data);
+            table.update([
+                {
+                    __INDEX__: 2,
+                    y: "new_string",
+                    z: null
+                }
+            ]);
+
+            let view = table.view();
+            let result = await view.to_json();
+
+            // does not unset any values
+            expect(result).toEqual([
+                {x: 1, y: "a", z: true},
+                {x: 2, y: "b", z: false},
+                {x: 3, y: "new_string", z: null},
+                {x: 4, y: "d", z: false}
+            ]);
+            view.delete();
+            table.delete();
+        });
+
+        it("should partial update and unset on unindexed table, column dataset", async function() {
+            let table = perspective.table(data);
+            table.update({
+                __INDEX__: [0, 2],
+                y: [undefined, "new_string"],
+                z: [null, undefined]
+            });
+
+            let view = table.view();
+            let result = await view.to_json();
+
+            // does not unset any values
+            expect(result).toEqual([
+                {x: 1, y: "a", z: null},
+                {x: 2, y: "b", z: false},
+                {x: 3, y: "new_string", z: true},
+                {x: 4, y: "d", z: false}
+            ]);
             view.delete();
             table.delete();
         });

--- a/python/perspective/perspective/tests/table/test_update_arrow.py
+++ b/python/perspective/perspective/tests/table/test_update_arrow.py
@@ -95,16 +95,21 @@ class TestUpdateArrow(object):
     @mark.skip
     def test_update_arrow_updates_dict_partial_file(self):
         tbl = None
+        v = None
 
         with open(DICT_ARROW, mode='rb') as src:
             tbl = Table(src.read(), index="a")
-            tbl.update(src.read())
-            assert tbl.size() == 2
+            v = tbl.view()
+            assert v.num_rows() == 2
+            assert v.to_dict() == {
+                "a": ["abc", "def"],
+                "b": ["klm", "hij"]
+            }
 
         with open(DICT_UPDATE_ARROW, mode='rb') as partial:
             tbl.update(partial.read())
-            assert tbl.size() == 4
-            assert tbl.view().to_dict() == {
+            v.num_rows() == 4
+            assert v.to_dict() == {
                 "a": ["abc", "def", "update1", "update2"],
                 "b": ["klm", "hij", None, "update4"]
             }


### PR DESCRIPTION
Fixes #1268 by refactoring the data loading path for dict-shaped datasets.

There are some inconsistencies between how `None` values are handled in JS and in Python. In JS, `null` and `undefined` in a dataset mean different things in a partial update:

```javascript
table = perspective.table({a: [1, 2, 3, 4], b: ["a", "b", "c", "d"], c: [10, 20, 30, 40]}, {index: "a"})
table.update({a: [3], c: [100]}) // "b" is `undefined` here, so values in `b` are not modified.
```

`undefined` resolves to a no-op, so values that are `undefined` will not be modified or overwritten. However, if the value is replaced with null:

```javascript
table.update({a: [3], b: [null], c: [100]}) // "b" is explicitly "null", which will unset the value at "b" for pkey `3` and set it to null.
```

To remedy this, the Python library uses a method called `_has_column`, which ascertains whether a given row contains a given column name. If the column name does not exist, it is a no-op similar to `undefined`, but if the column name exists then it will be overwritten with the new value.

Thus, a row-oriented update of `[{a: undefined}]` that would work as a no-op update in Javascript _does not_ work in Python. In the column-oriented case, #1268 illustrates the issue where a missing column in a columnar dataset would be treated as an _overwrite_, and not a no-op. This PR fixes the behavior by treating missing columns in columnar datasets as no-ops, and has been tested. This behavior is now equivalent between JS and Python.

There will always remain Python-specific idiosyncrasies around partial updates. For example, this update works in JS:

```javascript
table.update({
  a: [2, 3, 4],
  b: [null, undefined, null] // delete, no-op, delete
})
```

but it would not work in Python, because one cannot satisfy the "all columns must have the same # of rows" requirement _AND_ mark a `column[row]` as a no-op, and there is no way to reconcile this behavior:

```python
table.update({
  "a": [2, 3, 4],
  "b": [None, None, None] # delete, delete, delete
})
```