### PR TITLE
Remove cross module boundary imports

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {registerPlugin} from "@finos/perspective-viewer/dist/esm/utils.js";
+import {registerPlugin} from "@finos/perspective-viewer";
 import charts from "../charts/charts";
 import "./polyfills/index";
 import "./template";

--- a/packages/perspective-viewer-d3fc/src/js/plugin/template.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/template.js
@@ -13,7 +13,7 @@ import template from "../../html/d3fc-chart.html";
 import {areArraysEqualSimple} from "../utils/utils";
 import {initialiseStyles} from "../series/colorStyles";
 
-import {bindTemplate} from "@finos/perspective-viewer/dist/esm/utils";
+import {bindTemplate} from "@finos/perspective-viewer";
 
 const styleWithD3FC = `${style}${getD3FCStyles()}`;
 const EXCLUDED_SETTINGS = ["crossValues", "mainValues", "splitValues", "filter", "data", "size", "colorStyles"];

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/generateHTML.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/generateHTML.js
@@ -8,7 +8,7 @@
  */
 import {select} from "d3";
 import {getGroupValues, getSplitValues, getDataValues} from "./selectionData";
-import {get_type_config} from "@finos/perspective/dist/esm/config";
+import {get_type_config} from "@finos/perspective";
 
 export function generateHtml(tooltipDiv, data, settings) {
     const tooltipValues = getGroupValues(data, settings)

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
@@ -6,7 +6,7 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
-import {get_type_config} from "@finos/perspective/dist/esm/config";
+import {get_type_config} from "@finos/perspective";
 
 export function toValue(type, value) {
     switch (type) {

--- a/packages/perspective-viewer-datagrid/src/js/plugin.js
+++ b/packages/perspective-viewer-datagrid/src/js/plugin.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {registerPlugin} from "@finos/perspective-viewer/dist/esm/utils.js";
+import {registerPlugin} from "@finos/perspective-viewer";
 
 import "regular-table";
 import {createModel, configureRegularTable, formatters} from "regular-table/dist/examples/perspective.js";

--- a/packages/perspective-viewer/src/js/custom_styles.js
+++ b/packages/perspective-viewer/src/js/custom_styles.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {get_type_config, get_types} from "@finos/perspective/dist/esm/config";
+import {get_type_config, get_types} from "@finos/perspective";
 
 export function get_style(elem, name) {
     let value;

--- a/packages/perspective-viewer/src/js/row.js
+++ b/packages/perspective-viewer/src/js/row.js
@@ -14,8 +14,7 @@ import awesomplete_style from "!!css-loader!awesomplete/awesomplete.css";
 
 import {bindTemplate} from "./utils.js";
 
-import * as perspective from "@finos/perspective/dist/esm/config/constants.js";
-import {get_type_config} from "@finos/perspective/dist/esm/config";
+import perspective, { get_type_config } from "@finos/perspective";
 import template from "../html/row.html";
 
 import style from "../less/row.less";

--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -10,7 +10,7 @@
 import "@webcomponents/webcomponentsjs";
 import "./polyfill.js";
 
-import {bindTemplate, json_attribute, array_attribute, copy_to_clipboard, invertPromise, throttlePromise} from "./utils.js";
+import {registerTemplate, bindTemplate, json_attribute, array_attribute, copy_to_clipboard, invertPromise, throttlePromise} from "./utils.js";
 import {renderers, register_debug_plugin} from "./viewer/renderers.js";
 import "./row.js";
 import "./autocomplete_widget.js";
@@ -596,7 +596,7 @@ class PerspectiveViewer extends ActionElement {
     @throttlePromise
     async notifyResize(immediate) {
         const resized = await this._check_responsive_layout();
-        if (!resized && !document.hidden && this.offsetParent) {
+        if (!resized && !document.hidden && this.offsetParent && this._plugin) {
             await this._plugin.resize.call(this, immediate);
         }
     }
@@ -848,3 +848,8 @@ class PerspectiveViewer extends ActionElement {
  * @event module:perspective_viewer~PerspectiveViewer#perspective-view-update
  * @type {String}
  */
+
+export { 
+    bindTemplate,
+    registerTemplate
+}

--- a/packages/perspective-viewer/src/js/viewer/dom_element.js
+++ b/packages/perspective-viewer/src/js/viewer/dom_element.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {get_type_config} from "@finos/perspective/dist/esm/config";
+import {get_type_config} from "@finos/perspective";
 import {dragend} from "./dragdrop.js";
 import {renderers} from "./renderers.js";
 

--- a/packages/perspective-viewer/src/js/viewer/perspective_element.js
+++ b/packages/perspective-viewer/src/js/viewer/perspective_element.js
@@ -11,8 +11,7 @@ import debounce from "lodash/debounce";
 import isEqual from "lodash/isEqual";
 import {html, render} from "lit-html";
 
-import * as perspective from "@finos/perspective/dist/esm/config/constants.js";
-import {get_type_config} from "@finos/perspective/dist/esm/config";
+import perspective, {get_type_config} from "@finos/perspective";
 import {CancelTask} from "./cancel_task.js";
 
 import {StateElement} from "./state_element.js";

--- a/packages/perspective-workspace/src/js/index.js
+++ b/packages/perspective-workspace/src/js/index.js
@@ -9,7 +9,7 @@
 
 import style from "../less/workspace.less";
 import template from "../html/workspace.html";
-import {bindTemplate} from "@finos/perspective-viewer/dist/esm/utils";
+import {bindTemplate} from "@finos/perspective-viewer";
 import {PerspectiveWorkspace, SIDE} from "./workspace";
 import {MessageLoop} from "@lumino/messaging";
 import {Widget} from "@lumino/widgets";

--- a/packages/perspective/src/js/perspective.node.js
+++ b/packages/perspective/src/js/perspective.node.js
@@ -191,3 +191,5 @@ module.exports.websocket = websocket;
 module.exports.perspective_assets = perspective_assets;
 module.exports.WebSocketServer = WebSocketServer;
 module.exports.WebSocketManager = WebSocketManager;
+module.exports.get_type_config = require("./config").get_type_config;
+module.exports.get_types = require("./config").get_types;

--- a/packages/perspective/src/js/perspective.parallel.js
+++ b/packages/perspective/src/js/perspective.parallel.js
@@ -8,13 +8,12 @@
  */
 
 import * as defaults from "./config/constants.js";
-import {get_config} from "./config";
+import {override_config, get_config, get_type_config, get_types} from "./config";
 import {Client} from "./api/client.js";
 const {WebSocketClient} = require("./websocket/client");
 
 import wasm_worker from "./perspective.wasm.js";
 import wasm from "./psp.async.wasm.js";
-import {override_config} from "../../dist/esm/config/index.js";
 
 // eslint-disable-next-line max-len
 const INLINE_WARNING = `Perspective has been compiled in INLINE mode.  While Perspective's runtime performance is not affected, you may see smaller assets size and faster engine initial load time using "@finos/perspective-webpack-plugin" to build your application.
@@ -182,3 +181,7 @@ for (let prop of Object.keys(defaults)) {
 }
 
 export default mod;
+export {
+    get_type_config,
+    get_types
+}


### PR DESCRIPTION
I was going to raise an issue for this but I thought it was simple enough to propose a fix instead... 

I noticed that when running in a commonjs only environment (i.e. `jest`) that imports of `@finos/perspective-viewer-.*` reach across the module boundary into the `esm` build of `@finos/perspective` even though the `cjs` build of the files is already being used. This causes issues without further transpilation, but will also cause builds to duplicate these modules. 

I fixed this issue locally by simply refactoring imports to use the top level module import which allows the resolution process to resolve the correct relative filenames. 