### PR TITLE
Reproduce #1312 - broken US date string parsing

### DIFF
--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -982,7 +982,7 @@ module.exports = perspective => {
             table.delete();
         });
 
-        it.skip("Handles datetime strings in US locale string", async function() {
+        it("Handles datetime strings in US locale string", async function() {
             // FIXME: 1/1/2020, 12:30:45 PM = 1/1/2020, 7:30:45 AM UTC, but
             // because C++ strptime in Emscripten parses the time as 12:30:45AM,
             // the output is 12/31/2019 19:30:45 PM UTC. This is clearly wrong.
@@ -1008,7 +1008,7 @@ module.exports = perspective => {
             table.delete();
         });
 
-        it("Handles datetime strings in US locale string", async function() {
+        it.skip("Handles datetime strings in US locale string", async function() {
             const data = {
                 x: ["1/1/2020, 05:30:45 AM", "03/15/2020, 11:30:45 AM", "06/30/2020, 01:30:45 AM", "12/31/2020, 11:59:59 PM"]
             };


### PR DESCRIPTION
In order for US locale strings to be treated as valid by the filter validator, the locale string format must be added to the parser format definition in `arrow_csv.cpp`. This has the side effect of parsing US locale strings as part of the dataset, where I found an issue with strptime in the C STL - when given the US locale string format ("%m/%d/%Y, %I:%M:%S %p"), it parses "12:00:00 AM" as "12:00:00 PM", which is incorrect. 

This seems to be an issue with strptime when compiled in Emscripten; the Python library does not have the same issue. Users should pass in date values as Date() objects, but there can be cases where strings are being passed in and this parsing error occurs. The solution here looks to be to add a custom parser for US locale strings, similar to the custom ISO format parser added by @texodus.