### PR TITLE
Remove webpack as a peerDependency for the webpack plugin

### DIFF
--- a/packages/perspective-webpack-plugin/package.json
+++ b/packages/perspective-webpack-plugin/package.json
@@ -24,7 +24,6 @@
         "worker-loader": "^3.0.7"
     },
     "peerDependencies": {
-        "@finos/perspective": "^0.6.0",
-        "webpack": "^5.14.0"
+        "@finos/perspective": "^0.6.0"
     }
 }


### PR DESCRIPTION
This PR removes webpack as a peerDependency for `@finos/perspective-webpack-plugin`

IMO, a peer dependency (or dependency) should only be included if it's actually required by the source code. (For the same reason, `file-loader` and `worker-loader` _should_ be included because they're implicitly required.) Keeping this peerDependency makes it so that the consuming package has to declare webpack as a dependency, even if they're only passing the plugin to a tool that transitively uses webpack.