### PR TITLE
Fix missing return in ctx0::notify

### DIFF
--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -131,6 +131,8 @@ t_ctx0::notify(const t_data_table& flattened, const t_data_table& delta,
             add_delta_pkey(pkey);
         }
         m_has_delta = m_deltas->size() > 0 || m_delta_pkeys.size() > 0 || delete_encountered;
+
+        return;
     }
 
     // Context does not have filters applied

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -196,6 +196,33 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("x == 1, rolling updates", async function() {
+                var table = perspective.table(data);
+                var view = table.view({
+                    columns: ["x"],
+                    filter: [["x", "==", 1]]
+                });
+                let json = await view.to_json();
+                expect(json).toEqual([{x: 1}]);
+
+                for (let i = 0; i < 5; i++) {
+                    table.update([{x: 1}]);
+                }
+
+                expect(await view.to_columns()).toEqual({
+                    x: [1, 1, 1, 1, 1, 1]
+                });
+
+                table.update([{x: 2}]);
+
+                expect(await view.to_columns()).toEqual({
+                    x: [1, 1, 1, 1, 1, 1]
+                });
+
+                view.delete();
+                table.delete();
+            });
+
             it("x == 5", async function() {
                 var table = perspective.table(data);
                 var view = table.view({


### PR DESCRIPTION
This puts back a return statement that was erroneously removed in t_ctx0::notify, which caused filtered contexts to fail when updates were read out. I've added a test for this issue and verified the breakage before the fix was applied.