### PR TITLE
Replace `emsdk-npm` with simple script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ rust/perspective-vieux/pkg
 
 rust/perspective-vieux/target
 rust/perspective-vieux/target2
+.emsdk

--- a/cpp/perspective/package.json
+++ b/cpp/perspective/package.json
@@ -10,7 +10,7 @@
         "dist/cjs/**/*"
     ],
     "scripts": {
-        "build": "yarn emsdk-run node ./build.js",
+        "build": "node ../../scripts/run_emsdk.js node ./build.js",
         "clean": "rimraf dist/cpp/build",
         "test": ":",
         "test:run": ":",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
         "cssnano": "^4.1.10",
         "cssnano-preset-lite": "^1.0.1",
         "dotenv": "^8.1.0",
-        "emsdk-npm": "https://github.com/texodus/emsdk-npm.git#bash-sub-fix",
         "eslint": "^6.6.0",
         "eslint-config-prettier": "^3.0.1",
         "eslint-plugin-markdown": "^1.0.2",

--- a/scripts/install_emsdk.js
+++ b/scripts/install_emsdk.js
@@ -9,23 +9,45 @@
 
 require("dotenv").config({path: "./.perspectiverc"});
 
-const {execute, execute_throw} = require("./script_utils.js");
+const {execute_throw} = require("./script_utils.js");
 const {emscripten} = require("../package.json");
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+
+function base() {
+    return path.join(__dirname, "..", ".emsdk");
+}
+
+function emsdk_checkout() {
+    function git(args) {
+        execute_throw`git ${args.join(" ")}`;
+    }
+
+    git(["clone", "https://github.com/emscripten-core/emsdk.git", base()]);
+}
+
+function emsdk(...args) {
+    const basedir = base();
+    const suffix = os.type() == "Windows_NT" ? ".bat" : "";
+    const emsdk = path.join(basedir, "emsdk" + suffix);
+    execute_throw`${emsdk} ${args.join(" ")}`;
+}
 
 function upgrade() {
     console.log(`-- Emscripten not found, installing ${emscripten}`);
-    execute`yarn emsdk-checkout`;
-    execute`yarn emsdk install ${emscripten}`;
-    execute`yarn emsdk activate ${emscripten}`;
+    emsdk_checkout();
+    emsdk("install", emscripten);
+    emsdk("activate", emscripten);
     console.log(`-- Emscripten ${emscripten} installed`);
 }
 
 function check() {
     try {
-        execute_throw`yarn emsdk-run command -v emcc`;
+        execute_throw`emcc --version`;
         return true;
     } catch (e) {
-        return false;
+        return fs.existsSync(path.join(__dirname, "..", ".emsdk"));
     }
 }
 

--- a/scripts/run_emsdk.js
+++ b/scripts/run_emsdk.js
@@ -1,0 +1,21 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const {execute_throw} = require("./script_utils.js");
+const path = require("path");
+
+try {
+    const cwd = process.cwd();
+    const cmd = process.argv.slice(2).join(" ");
+    const emsdkdir = path.join(__dirname, "..", ".emsdk");
+    execute_throw`cd ${emsdkdir} && . ./emsdk_env.sh && cd ${cwd} && ${cmd}`;
+} catch (e) {
+    console.log(e.message);
+    process.exit(1);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7105,10 +7105,6 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-"emsdk-npm@https://github.com/texodus/emsdk-npm.git#bash-sub-fix":
-  version "0.2.2"
-  resolved "https://github.com/texodus/emsdk-npm.git#19ecbaa3fb2572bd00a87173273815cf5e382fef"
-
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"


### PR DESCRIPTION
This PR replaces `emsdk-npm` fork with an inlined script of the same nature, only this one installs Emscripten under the Project root's `.emsdk` directory, rather than deep within `node_modules` where it is removed on every install.  It also conveniently fixes a regression in this module, which even surreptitious amendment to the already-forked `emsdk-npm` failed to fix due to ... mystery reasons.  Azure reports the [cache miss](https://dev.azure.com/finosfoundation/perspective/_build/results?buildId=2176&view=logs&j=430750e5-873f-5cdb-f7d1-334fffa69fc8&t=57225e1f-43e2-5ff6-cc86-707b9e1bb780), but then continues using the [removed flag](https://dev.azure.com/finosfoundation/perspective/_build/results?buildId=2176&view=logs&j=430750e5-873f-5cdb-f7d1-334fffa69fc8&t=d698da02-2f77-5ae1-6a6a-8574f52eb49f&l=60), and frankly I've just lost the will to determine why.