### PR TITLE
Fix D3FC label font bug

### DIFF
--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -240,11 +240,13 @@
         }
 
         & .y-label-container .splitter-label::after {
-            content: "\1f847";
+            font-family: var(--d3fc-y1-label--font-family, inherit);
+            content: var(--d3fc-y1-label--content, "\1f847");
         }
 
         & .y2-label-container .splitter-label::after {
-            content: "\1f845";
+            font-family: var(--d3fc-y2-label--font-family, inherit);
+            content: var(--d3fc-y2-label--content, "\1f845");
         }
 
         &.d3_y_bar .y-axis path,

--- a/packages/perspective-viewer/src/themes/material.less
+++ b/packages/perspective-viewer/src/themes/material.less
@@ -87,4 +87,10 @@ perspective-viewer, .perspective-viewer-material {
     --top-panel-row--display: inline-flex;
    
     --d3fc-treedata-axis--lines: none;
+
+    --d3fc-y1-label--font-family: "Material Icons";
+    --d3fc-y1-label--content: "arrow_upward";
+
+    --d3fc-y2-label--font-family: "Material Icons";
+    --d3fc-y2-label--content: "arrow_downward";
 }


### PR DESCRIPTION
Fixes a CSS issue with `@finos/perspective-viewer-d3fc` which causes terser to generate malformed unicode (I think ..) in the Y label for multi-Y-axis charts.  Regardless of the cause, these should not be unicode in the Material Theme which is all that Perspective has now, so this PR parameterizes these values  with  `--d3fc-y1-label--*` custom CSS rules.

EDIT

`cssnano` is the cluprit, not `terser` ... _this_ _time_ ...

<img width="174" alt="Screen Shot 2021-03-04 at 5 37 11 PM" src="https://user-images.githubusercontent.com/60666/110040322-9ce2f380-7d10-11eb-8084-58dee3573504.png">

