### PR TITLE
Include throttle attribute in types

### DIFF
--- a/packages/perspective-viewer/index.d.ts
+++ b/packages/perspective-viewer/index.d.ts
@@ -58,6 +58,7 @@ interface PerspectiveViewerHTMLAttributes extends Pick<PerspectiveViewerOptions,
     filters?: string;
     sort?: string;
     columns?: string;
+    throttle?: string | number;
 }
 
 interface ReactPerspectiveViewerHTMLAttributes<T> extends PerspectiveViewerHTMLAttributes, React.HTMLAttributes<T> {}


### PR DESCRIPTION
Update Perspective Viewer types to include the throttle attribute, per docs. This currently works if using @ts-ignore to ignore the typescript error when using throttle in a TS project, but should work out of the box.