### PR TITLE
Fix timezone tests to take DST into account

### DIFF
--- a/packages/perspective/test/js/timezone/timezone.spec.js
+++ b/packages/perspective/test/js/timezone/timezone.spec.js
@@ -64,7 +64,17 @@ const check_datetime = (output, expected) => {
 describe("Timezone Tests", () => {
     beforeAll(() => {
         expect(process.env.TZ).toBe("America/New_York");
-        expect(new Date().getTimezoneOffset()).toBe(300);
+        const now = new Date();
+
+        // offset is 240 during DST and 300 during non-DST, since we manually
+        // set the timezone here just assert the timezone string
+
+        if (now.toString().includes("GMT-0400") || now.toString().includes("Eastern Daylight Time")) {
+            expect(new Date().getTimezoneOffset()).toBe(240);
+        } else {
+            expect(new Date().getTimezoneOffset()).toBe(300);
+        }
+
         console.log("Timezone set to", process.env.TZ);
     });
 


### PR DESCRIPTION
In our suite of timezone tests, we set the timezone manually and assert that `getTimezoneOffset` is 300 (for EST). However, during Daylight Savings time (which started on Sunday, March 14th) the timezone offset is 240, and our tests did not take that into account. This PR fixes the issue and now should work for both DST and non-DST times.