### PR TITLE
Enable editing to mime renderer in JupyterLab

### DIFF
--- a/docs/md/python.md
+++ b/docs/md/python.md
@@ -481,6 +481,10 @@ PerspectiveWidget(table)
 PerspectiveWidget(None)
 ```
 
+## `PerspectiveRenderer`
+
+Perspective also exposes a JS-only `mimerender-extension`. This lets you view `csv`, `json`, and `arrow` files directly from the file browser. You can see this by right clicking one of these files and `Open With->CSVPerspective` (or `JSONPerspective` or `ArrowPerspective`). Perspetive will also install itself as the default handler for opening `.arrow` files.
+
 ## `PerspectiveTornadoHandler`
 
 Perspective ships with a pre-built Tornado handler that makes integration with

--- a/docs/md/python.md
+++ b/docs/md/python.md
@@ -483,7 +483,7 @@ PerspectiveWidget(None)
 
 ## `PerspectiveRenderer`
 
-Perspective also exposes a JS-only `mimerender-extension`. This lets you view `csv`, `json`, and `arrow` files directly from the file browser. You can see this by right clicking one of these files and `Open With->CSVPerspective` (or `JSONPerspective` or `ArrowPerspective`). Perspetive will also install itself as the default handler for opening `.arrow` files.
+Perspective also exposes a JS-only `mimerender-extension`. This lets you view `csv`, `json`, and `arrow` files directly from the file browser. You can see this by right clicking one of these files and `Open With->CSVPerspective` (or `JSONPerspective` or `ArrowPerspective`). Perspective will also install itself as the default handler for opening `.arrow` files.
 
 ## `PerspectiveTornadoHandler`
 

--- a/packages/perspective-jupyterlab/src/ts/psp_widget.ts
+++ b/packages/perspective-jupyterlab/src/ts/psp_widget.ts
@@ -31,6 +31,7 @@ export interface PerspectiveWidgetOptions extends PerspectiveViewerOptions {
     column_pivots?: Pivots;
     row_pivots?: Pivots;
     computed_columns?: ComputedColumns;
+    editable?: boolean;
 }
 
 /**
@@ -56,7 +57,7 @@ export class PerspectiveWidget extends Widget {
      *
      * @param options
      */
-    _set_attributes(options: PerspectiveWidgetOptions): void {
+    _set_attributes(options: PerspectiveViewerOptions & PerspectiveWidgetOptions): void {
         const plugin: string = options.plugin || "datagrid";
         const columns: Columns = options.columns || [];
         const row_pivots: Pivots = options.row_pivots || options["row-pivots"] || [];

--- a/packages/perspective-jupyterlab/src/ts/renderer.ts
+++ b/packages/perspective-jupyterlab/src/ts/renderer.ts
@@ -92,7 +92,7 @@ export class PerspectiveDocumentWidget extends DocumentWidget<PerspectiveWidget>
 
                 // create a flat view
                 const view = await table.view();
-                view.on_update(() => {
+                view.on_update(async () => {
                     if (this._type === "csv") {
                         const result: string = await view.to_csv();
                         this.context.model.fromString(result);

--- a/packages/perspective-jupyterlab/src/ts/renderer.ts
+++ b/packages/perspective-jupyterlab/src/ts/renderer.ts
@@ -94,21 +94,18 @@ export class PerspectiveDocumentWidget extends DocumentWidget<PerspectiveWidget>
                 const view = await table.view();
                 view.on_update(() => {
                     if (this._type === "csv") {
-                        view.to_csv().then((result: string) => {
-                            this.context.model.fromString(result);
-                            this.context.save();
-                        });
+                        const result: string = await view.to_csv();
+                        this.context.model.fromString(result);
+                        this.context.save();
                     } else if (this._type === "arrow") {
-                        view.to_arrow().then((result: ArrayBuffer) => {
-                            const resultAsB64 = btoa(new Uint8Array(result).reduce((acc, i) => (acc += String.fromCharCode.apply(null, [i])), ""));
-                            this.context.model.fromString(resultAsB64);
-                            this.context.save();
-                        });
+                        const result: ArrayBuffer = await view.to_arrow();
+                        const resultAsB64 = btoa(new Uint8Array(result).reduce((acc, i) => (acc += String.fromCharCode.apply(null, [i])), ""));
+                        this.context.model.fromString(resultAsB64);
+                        this.context.save();
                     } else if (this._type === "json") {
-                        view.to_json().then((result: any) => {
-                            this.context.model.fromJSON(result);
-                            this.context.save();
-                        });
+                        const result: any = await view.to_json();
+                        this.context.model.fromJSON(result);
+                        this.context.save();
                     }
                 });
             } else {


### PR DESCRIPTION
This is a simple modification that turns on editing for our JupyterLab mime renderer plugin (the thing that lets you right click on a `csv`, `json`, or `arrow` and visualize in perspective). As a result, we now have a pivotable, sortable, filterable, **editable** csv/json/arrow viewer.

![tmp](https://user-images.githubusercontent.com/3105306/112087878-285be180-8b65-11eb-8fc4-4dbcebc467a8.gif)


- [x] add mime renderer to jlab readme and usage page
- [x] fix arrow saving