### PR TITLE
Remove python2 build support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,11 +73,6 @@ jobs:
 
   strategy:
     matrix:
-      Python27ManyLinux2010:
-        python.version: '2.7'
-        python_flag: '--python2'
-        manylinux_flag: '--manylinux2010'
-        artifact_name: 'cp27-cp27m-manylinux2010_x86_64'
       Python37ManyLinux2010:
         python.version: '3.7'
         python_flag: ''

--- a/docker/python/manylinux2010/Dockerfile
+++ b/docker/python/manylinux2010/Dockerfile
@@ -21,14 +21,12 @@ RUN ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 RUN ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest
 
 # Remove auditwheel for reinstall
-RUN rm -rf /opt/python/cp27-cp27m/bin/auditwheel
 RUN rm -rf /opt/python/cp36-cp36m/bin/auditwheel
 RUN rm -rf /opt/python/cp37-cp37m/bin/auditwheel
 RUN rm -rf /opt/python/cp38-cp38/bin/auditwheel
 
 
 # Copy assets
-RUN cp -arf /opt/python/cp27-cp27m/* /usr/local/
 RUN cp -arf /opt/python/cp36-cp36m/* /usr/local/
 RUN cp -arf /opt/python/cp37-cp37m/* /usr/local/
 RUN cp -arf /opt/python/cp38-cp38/* /usr/local/
@@ -36,12 +34,11 @@ RUN cp -arf /opt/python/cp38-cp38/* /usr/local/
 ENV PATH=/usr/local/bin:$PATH
 
 # Install dependencies
-RUN python2.7 -m pip install numpy scipy pybind11 cython codecov mock pytest pytest-cov traitlets ipywidgets faker psutil
 RUN python3.6 -m pip install numpy scipy pybind11 cython codecov mock black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
 RUN python3.7 -m pip install numpy scipy pybind11 cython codecov mock black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
 RUN python3.8 -m pip install numpy scipy pybind11 cython codecov mock black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
 
-# Install Auditwheel - not available on Python 2
+# Install Auditwheel
 RUN python3.6 -m pip install --ignore-installed auditwheel
 RUN python3.7 -m pip install --ignore-installed auditwheel
 RUN python3.8 -m pip install --ignore-installed auditwheel

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -21,22 +21,9 @@ import sys
 import subprocess
 
 
-try:
-    from shutil import which
+from shutil import which
 
-    CPU_COUNT = os.cpu_count()
-except ImportError:
-    # Python2
-    try:
-        from backports.shutil_which import which
-    except ImportError:
-        # just rely on path
-        def which(x):
-            return x
-
-    import multiprocessing
-
-    CPU_COUNT = multiprocessing.cpu_count()
+CPU_COUNT = os.cpu_count()
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -54,17 +41,14 @@ requires = [
     "traitlets>=4.3.2",
 ]
 
-if sys.version_info.major < 3:
-    requires += ["backports.shutil-which"]
-
-if (sys.version_info.major == 2 and sys.version_info.minor < 7) or (
-    sys.version_info.major == 3 and sys.version_info.minor < 6
-):
+if (sys.version_info.major <= 3 or sys.version_info.minor < 6):
     raise Exception("Requires Python 2.7/3.6 or later")
 
-requires_dev_py2 = [
+requires_dev = [
+    "black==20.8b1",
     "Faker>=1.0.0",
     "flake8>=3.7.8",
+    "flake8-black>=0.2.0",
     "mock",
     "pybind11>=2.4.0",
     "pyarrow>=0.16.0",
@@ -76,11 +60,6 @@ requires_dev_py2 = [
     "Sphinx>=1.8.4",
     "sphinx-markdown-builder>=0.5.2",
 ] + requires
-
-requires_dev = [
-    "flake8-black>=0.2.0",
-    "black==20.8b1",
-] + requires_dev_py2  # for development, remember to install black and flake8-black
 
 
 def get_version(file, name="__version__"):
@@ -258,7 +237,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=requires,
-    extras_require={"dev": requires_dev, "devpy2": requires_dev_py2},
+    extras_require={"dev": requires_dev},
     ext_modules=[PSPExtension("perspective")],
     cmdclass=dict(build_ext=PSPBuild, sdist=PSPCheckSDist),
 )

--- a/scripts/build_python.js
+++ b/scripts/build_python.js
@@ -10,19 +10,17 @@
 const {execute, execute_throw, docker, resolve, getarg, bash, python_image} = require("./script_utils.js");
 const fs = require("fs-extra");
 
-const IS_PY2 = getarg("--python2");
-
-let PYTHON = IS_PY2 ? "python2" : getarg("--python38") ? "python3.8" : getarg("--python36") ? "python3.6" : "python3.7";
+const PYTHON = getarg("--python39") ? "python3.9" : getarg("--python38") ? "python3.8" : getarg("--python36") ? "python3.6" : "python3.7";
 let IMAGE = "manylinux2010";
 const IS_DOCKER = process.env.PSP_DOCKER;
 
 if (IS_DOCKER) {
     // defaults to 2010
     let MANYLINUX_VERSION = "manylinux2010";
-    if (!IS_PY2) {
-        // switch to 2014 only on python3
-        (MANYLINUX_VERSION = getarg("--manylinux2010") ? "manylinux2010" : getarg("--manylinux2014") ? "manylinux2014" : "manylinux2010"), PYTHON;
-    }
+
+    // switch to 2014 only on python3
+    (MANYLINUX_VERSION = getarg("--manylinux2010") ? "manylinux2010" : getarg("--manylinux2014") ? "manylinux2014" : "manylinux2010"), PYTHON;
+
     IMAGE = python_image(MANYLINUX_VERSION, PYTHON);
 }
 
@@ -60,12 +58,7 @@ try {
 
     let cmd;
     if (IS_CI) {
-        if (IS_PY2) {
-            // shutil_which is required in setup.py
-            cmd = bash`${PYTHON} -m pip install backports.shutil_which && ${PYTHON} -m pip install -e .[devpy2] --no-clean &&`;
-        } else {
-            cmd = bash`${PYTHON} -m pip install -e .[dev] --no-clean &&`;
-        }
+        cmd = bash`${PYTHON} -m pip install -e .[dev] --no-clean &&`;
 
         // pip install in-place with --no-clean so that pep-518 assets stick
         // around for later wheel build (so cmake cache can stay in place)

--- a/scripts/lint_python.js
+++ b/scripts/lint_python.js
@@ -9,18 +9,17 @@
 const {execute, docker, resolve, getarg, python_image} = require("./script_utils.js");
 
 const IS_DOCKER = process.env.PSP_DOCKER;
-const IS_PY2 = getarg("--python2");
-const PYTHON = IS_PY2 ? "python2" : getarg("--python38") ? "python3.8" : getarg("--python36") ? "python3.6" : "python3.7";
+const PYTHON = getarg("--python39") ? "python3.9" : getarg("--python38") ? "python3.8" : getarg("--python36") ? "python3.6" : "python3.7";
 
 let IMAGE = "manylinux2014";
 
 if (IS_DOCKER) {
     // defaults to 2010
     let MANYLINUX_VERSION = "manylinux2010";
-    if (!IS_PY2) {
-        // switch to 2014 only on python3
-        MANYLINUX_VERSION = getarg("--manylinux2010") ? "manylinux2010" : getarg("--manylinux2014") ? "manylinux2014" : "manylinux2014";
-    }
+
+    // switch to 2014 only on python3
+    MANYLINUX_VERSION = getarg("--manylinux2010") ? "manylinux2010" : getarg("--manylinux2014") ? "manylinux2014" : "manylinux2014";
+
     IMAGE = python_image(MANYLINUX_VERSION, PYTHON);
 }
 

--- a/scripts/test_python.js
+++ b/scripts/test_python.js
@@ -8,7 +8,7 @@
  */
 const {bash, execute, execute_throw, docker, resolve, getarg, python_image} = require("./script_utils.js");
 
-let PYTHON = getarg("--python2") ? "python2" : getarg("--python38") ? "python3.8" : "python3.7";
+const PYTHON = getarg("--python39") ? "python3.9" : getarg("--python38") ? "python3.8" : getarg("--python36") ? "python3.6" : "python3.7";
 
 const COVERAGE = getarg("--coverage");
 const VERBOSE = getarg("--debug");


### PR DESCRIPTION
Refactored from #1336.

Deprecates [Python2](https://www.youtube.com/watch?v=IVXJmfd3cmg).  While official support will be removed in `v0.7.0` already, this PR removes the build script and library specializations that remain for supporting python2 builds.