### PR TITLE
Add `call_loop` and `get_table_names`

### DIFF
--- a/docs/md/python.md
+++ b/docs/md/python.md
@@ -247,10 +247,10 @@ using a websocket API.
 By default, `perspective` will run with a synchronous interface.  Using the
 `PerspectiveManager.set_loop_callback()` method, `perspective` can be configured
 to defer the application of side-effectful calls like `update()` to an event
-loop, such as `asyncio`.  When running in Async mode, Perspective will release
-the GIL for some operations, enabling better parallelism and overall better
-server performance.  There are a few important differences when running
-`PerspectiveManager` in this mode:
+loop, such as `tornado.ioloop.IOLoop`.  When running in Async mode, Perspective
+will release the GIL for some operations, enabling better parallelism and
+overall better server performance.  There are a few important differences when
+running `PerspectiveManager` in this mode:
 
   * Calls to methods like `update()` will return immediately, and the reciprocal 
     `on_update()` callbacks will be invoked on an event later scheduled.  Calls

--- a/python/perspective/perspective/tests/manager/test_manager.py
+++ b/python/perspective/perspective/tests/manager/test_manager.py
@@ -46,6 +46,14 @@ class TestPerspectiveManager(object):
         with raises(PerspectiveError):
             manager.host({})
 
+    def test_manager_host(self):
+        manager = PerspectiveManager()
+        table = Table(data)
+        manager.host(table)
+        table.update({"a": [4, 5, 6], "b": ["d", "e", "f"]})
+        names = manager.get_table_names()
+        assert manager.get_table(names[0]).size() == 6
+
     def test_manager_host_table_transitive(self):
         manager = PerspectiveManager()
         table = Table(data)


### PR DESCRIPTION
This PR adds two methods to the `PerspectiveManager` API:

`call_loop(fn, *args, **kwargs)`: calls `fn` on the `loop_callback` of the manager, or raises a `PerspectiveError` if the loop callback is not set.

This allows users to make calls on the Perspective thread without having to deal with the `_loop_callback` property of the manager, which is ostensibly private but (until now) lacked a public API.

`get_table_names()`: Returns a list of the tables hosted on the manager by name.

A common use case is to query the managers' private `_tables` and `_views` dictionaries for users to find out which Tables/Views are hosted on a server, which is especially useful in a server-client context where the consumers of the Perspective server may be different than the author of the server. `get_table_names()` offers a public API that can be called without having to query private properties of `PerspectiveManager`.