### PR TITLE
Backwards compatibility for table() and view()

### DIFF
--- a/packages/perspective/src/js/api/server.js
+++ b/packages/perspective/src/js/api/server.js
@@ -40,6 +40,7 @@ export class Server {
     }
 
     /**
+     * Return an initialization message to the client for confirmation.
      * `Server` must be extended and the `post` method implemented before the
      * server can successfully be initialized.
      */
@@ -47,6 +48,16 @@ export class Server {
         if (msg.config) {
             override_config(msg.config);
         }
+
+        // The client will wait for a response message on table() and
+        // view(). If this flag is not set, the table() and view()
+        // constructors will resolve automatically and errors from the
+        // server will not be caught in those constructors. This allows
+        // for backwards compatibility between newer frontends (those
+        // with async table/view constructors) and older servers (which
+        // do not send the response message to the client).
+        msg.data = ["wait_for_response"];
+
         this.post(msg);
     }
 

--- a/packages/perspective/src/js/api/table_api.js
+++ b/packages/perspective/src/js/api/table_api.js
@@ -67,6 +67,10 @@ export function table(worker, data, options) {
                 reject
             );
         }
+
+        if (this._worker._initialized === true && !this._worker._features?.wait_for_response) {
+            resolve(this);
+        }
     });
 }
 

--- a/packages/perspective/src/js/api/view_api.js
+++ b/packages/perspective/src/js/api/view_api.js
@@ -40,6 +40,10 @@ export function view(worker, table_name, config) {
             },
             reject
         );
+
+        if (this._worker._initialized === true && !this._worker._features?.wait_for_response) {
+            resolve(this);
+        }
     });
 }
 

--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -122,8 +122,14 @@ class _PerspectiveManagerInternal(object):
 
         try:
             if cmd == "init":
-                # return empty response
-                message = self._make_message(msg["id"], None)
+                # The client should wait for the return message on table()
+                # and view() to confirm successful creation.
+                flags = ["wait_for_response"]
+
+                # Return a message to the client to confirm initialization with
+                # a list of feature flags that the client will use to enable
+                # or disable behavior depending on its version.
+                message = self._make_message(msg["id"], flags)
                 post_callback(self._message_to_json(msg["id"], message))
             elif cmd == "table":
                 try:


### PR DESCRIPTION
#1289 was a breaking change for the Perspective API, as it made Table and View constructors `async` by returning a `Promise` to the Table or View instance instead of the instance itself. Internally, the constructors would wait on the server (across the websocket or a web worker) to return a message that signaled successful Table/View creation. However, when running a Perspective client that is newer than the Perspective server, older versions of the server (i.e. all released versions right now, as the async table/view changes are not in a tagged release yet) will not return the acknowledgement message and thus Table and View constructors will block forever.

To maintain backwards compatibility, this PR adds a simple feature flag implementation on both the client and server, which allows newer versions of Perspective to run against older versions on the server. In the `init` message used to begin client/server communication, the server returns an array of strings that represent enabled features, and the client will use those flags to determine its behaviour.

Currently, only one flag (`wait_for_response`) is implemented - if the flag is present, then the Table and View constructors will wait for an acknowledgement message from the server. If the flag is not present, or if there are no feature flags at all, then the constructors will `resolve()` immediately, thus preserving compatible behaviour between different versions.