### PR TITLE
Fix cross-origin webpack defaults

### DIFF
--- a/packages/perspective-webpack-plugin/index.js
+++ b/packages/perspective-webpack-plugin/index.js
@@ -9,6 +9,7 @@
 
 const {get_config} = require("@finos/perspective/dist/esm/config");
 const path = require("path");
+const webpack = require("webpack");
 
 class PerspectiveWebpackPlugin {
     constructor(options = {}) {
@@ -84,6 +85,9 @@ class PerspectiveWebpackPlugin {
                 ]
             });
         }
+
+        const plugin_replace = new webpack.NormalModuleReplacementPlugin(/@finos\/perspective$/, "@finos/perspective/dist/esm/perspective.parallel.js");
+        plugin_replace.apply(compiler);
 
         moduleOptions.rules = (moduleOptions.rules || []).concat(rules);
     }

--- a/packages/perspective/src/config/common.config.js
+++ b/packages/perspective/src/config/common.config.js
@@ -70,11 +70,9 @@ function common({no_minify, inline} = {}) {
                     test: /perspective\.worker\.js$/,
                     type: "javascript/auto",
                     loader: "worker-loader",
-                    options: inline
-                        ? {
-                              inline: "no-fallback"
-                          }
-                        : undefined
+                    options: {
+                        inline: "no-fallback"
+                    }
                 }
             ]
         },
@@ -82,9 +80,6 @@ function common({no_minify, inline} = {}) {
             fallback: {
                 crypto: false
             }
-        },
-        experiments: {
-            syncWebAssembly: true
         },
         devtool: "source-map",
         performance: {

--- a/packages/perspective/src/config/perspective.inline.config.js
+++ b/packages/perspective/src/config/perspective.inline.config.js
@@ -4,6 +4,7 @@ const common = require("./common.config.js");
 module.exports = common({inline: true}, config =>
     Object.assign(config, {
         entry: "./dist/esm/perspective.parallel.js",
+        devtool: undefined,
         output: {
             filename: "perspective.inline.js",
             library: "perspective",


### PR DESCRIPTION
Fixes asset cross-origin loading to work correctly with new rust-based wasm packages.