### PR TITLE
Remove webcomponentsjs

### DIFF
--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -83,7 +83,7 @@ Or create a `<perspective-viewer>` in HTML:
 ```html
 <perspective-viewer columns="['Sales', 'Profit']">`
   <script>
-    document.addEventListener("WebComponentsReady", function() {
+    document.addEventListener("DOMContentLoaded", function() {
       const data = {
         Sales: [500, 1000, 1500],
         Profit: [100.25, 200.5, 300.75]
@@ -96,10 +96,8 @@ Or create a `<perspective-viewer>` in HTML:
 </perspective-viewer>
 ```
 
-You must wait for the document `WebComponentsReady` event to fire,
-which indicates that the provided
-[webcomponents.js polyfill](https://github.com/webcomponents/webcomponentsjs)
-has loaded.
+You may choose to wait for the document's `DOMContentLoaded` event to fire,
+which indicates that all page DOM content is available.
 
 This makes it extremely easy to spin up Perspective locally without depending
 on a build chain or other tooling. For production usage, you should incorporate

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -119,7 +119,7 @@ Or create a `<perspective-viewer>` in HTML:
 ```html
 <perspective-viewer columns="['Sales', 'Profit']">`
   <script>
-    document.addEventListener("WebComponentsReady", async function() {
+    document.addEventListener("DOMContentLoaded", async function() {
       const data = {
         Sales: [500, 1000, 1500],
         Profit: [100.25, 200.5, 300.75]
@@ -616,7 +616,7 @@ _*index.html*_
 <perspective-viewer id="viewer" editable></perspective-viewer>
 
 <script>
-  window.addEventListener("WebComponentsReady", async function () {
+  window.addEventListener("DOMContentLoaded", async function () {
     // Create a client that expects a Perspective server
     // to accept connections at the specified URL.
     const websocket = perspective.websocket("ws://localhost:8888/websocket");

--- a/docs/md/python.md
+++ b/docs/md/python.md
@@ -378,7 +378,7 @@ _*index.html*_
 <perspective-viewer id="viewer" editable></perspective-viewer>
 
 <script>
-  window.addEventListener("WebComponentsReady", async function () {
+  window.addEventListener("DOMContentLoaded", async function () {
     // Create a client that expects a Perspective server
     // to accept connections at the specified URL.
     const websocket = perspective.websocket("ws://localhost:8888/websocket");

--- a/docs/static/js/animation.js
+++ b/docs/static/js/animation.js
@@ -132,7 +132,7 @@ function get_arrow(callback) {
     xhr.send(null);
 }
 
-window.addEventListener("WebComponentsReady", async function() {
+window.addEventListener("DOMContentLoaded", async function() {
     var data = [];
     for (var x = 0; x < 100; x++) {
         data.push(newRow());

--- a/examples/blocks/src/csv/csv.js
+++ b/examples/blocks/src/csv/csv.js
@@ -1,4 +1,4 @@
-window.addEventListener("WebComponentsReady", function() {
+window.addEventListener("DOMContentLoaded", function() {
     const worker = window.perspective.worker();
 
     // Get `dropArea` element from the DOM.

--- a/examples/blocks/src/dataset/index.html
+++ b/examples/blocks/src/dataset/index.html
@@ -237,7 +237,7 @@
 
         // Main
 
-        window.addEventListener("WebComponentsReady", async function() {
+        window.addEventListener("DOMContentLoaded", async function () {
             run.addEventListener("click", make_run_click_callback({}));
             run.dispatchEvent(new Event("click"));
         });

--- a/examples/blocks/src/editable/index.html
+++ b/examples/blocks/src/editable/index.html
@@ -50,7 +50,7 @@
             });
         }
 
-        window.addEventListener('WebComponentsReady', function() {
+        window.addEventListener('DOMContentLoaded', function () {
             var xhr = new XMLHttpRequest();
             xhr.open('GET', '/node_modules/superstore-arrow/superstore.arrow', true);
             xhr.responseType = "arraybuffer"

--- a/examples/blocks/src/iex/index.js
+++ b/examples/blocks/src/iex/index.js
@@ -35,7 +35,7 @@ async function get_layout() {
     return json;
 }
 
-window.addEventListener("WebComponentsReady", async function() {
+window.addEventListener("DOMContentLoaded", async function() {
     const workspace = document.getElementsByTagName("perspective-workspace")[0];
     const input = document.getElementById("ticker");
 

--- a/examples/blocks/src/mandelbrot/index.html
+++ b/examples/blocks/src/mandelbrot/index.html
@@ -327,7 +327,7 @@
 
         // Main
 
-        window.addEventListener("WebComponentsReady", async function() {
+        window.addEventListener("DOMContentLoaded", async function () {
             make_range(xmin, xmax, xrange, "X");
             make_range(ymin, ymax, yrange, "Y");
 

--- a/examples/blocks/src/ohlc/index.html
+++ b/examples/blocks/src/ohlc/index.html
@@ -38,7 +38,7 @@
     </div>
 
     <script>
-        window.addEventListener("WebComponentsReady", function () {
+        window.addEventListener("DOMContentLoaded", function () {
             var url = './FTSE100.csv';
             var xhr = new XMLHttpRequest();
             xhr.open('GET', url, true);

--- a/examples/blocks/src/streaming/streaming.js
+++ b/examples/blocks/src/streaming/streaming.js
@@ -19,7 +19,7 @@ function newRows() {
     return rows;
 }
 
-window.addEventListener("WebComponentsReady", async function() {
+window.addEventListener("DOMContentLoaded", async function() {
     // Get element from the DOM.
     var elem = document.getElementsByTagName("perspective-viewer")[0];
 

--- a/examples/blocks/src/workspace/workspace.js
+++ b/examples/blocks/src/workspace/workspace.js
@@ -14,7 +14,7 @@ const datasource = async () => {
     return await worker.table(buffer);
 };
 
-window.addEventListener("WebComponentsReady", async function() {
+window.addEventListener("DOMContentLoaded", async function() {
     const workspace = document.getElementsByTagName("perspective-workspace")[0];
     workspace.addTable("superstore", await datasource());
 

--- a/examples/git-history/chained.html
+++ b/examples/git-history/chained.html
@@ -38,7 +38,7 @@
     </perspective-viewer>
 
     <script>
-        window.addEventListener('WebComponentsReady', async function() {
+        window.addEventListener('DOMContentLoaded', async function () {
             var elem = document.getElementById('view1');
             var client = perspective.websocket();
             let table = client.open_table('data_source');

--- a/examples/git-history/index.html
+++ b/examples/git-history/index.html
@@ -38,7 +38,7 @@
     </perspective-viewer>
 
     <script>
-        window.addEventListener('WebComponentsReady', function() {
+        window.addEventListener('DOMContentLoaded', function () {
             var elem = document.getElementById('view1');
             var client = perspective.websocket();
             elem.load(client.open_table('data_source_one'));

--- a/examples/remote-express-typescript/assets/index.html
+++ b/examples/remote-express-typescript/assets/index.html
@@ -38,7 +38,7 @@
 
     <script>
 
-        window.addEventListener('WebComponentsReady', async function() {
+        window.addEventListener('DOMContentLoaded', async function () {
 
             // Create two perspective interfaces, one remotely via WebSocket, 
             // and one local via WebWorker.

--- a/examples/remote-express/index.html
+++ b/examples/remote-express/index.html
@@ -38,7 +38,7 @@
 
     <script>
 
-        window.addEventListener('WebComponentsReady', async function() {
+        window.addEventListener('DOMContentLoaded', async function () {
 
             // Create two perspective interfaces, one remotely via WebSocket, 
             // and one local via WebWorker.

--- a/examples/tornado-python/client_server_editing.html
+++ b/examples/tornado-python/client_server_editing.html
@@ -48,7 +48,7 @@
          * For a simple example of distributed mode without editing, see
          * `index.html`.
          */
-        window.addEventListener('WebComponentsReady', async function() {
+        window.addEventListener('DOMContentLoaded', async function () {
             const viewer = document.getElementById('viewer');
 
             // Connect to the websocket and create a new webworker

--- a/examples/tornado-python/index.html
+++ b/examples/tornado-python/index.html
@@ -35,7 +35,7 @@
 
     <script>
 
-        window.addEventListener('WebComponentsReady', async function() {
+        window.addEventListener('DOMContentLoaded', async function () {
 
             /**
              * `perspective.websocket` connects to a remote Perspective server

--- a/examples/tornado-python/server_mode.html
+++ b/examples/tornado-python/server_mode.html
@@ -36,7 +36,7 @@
 
     <script>
 
-        window.addEventListener('WebComponentsReady', async function() {
+        window.addEventListener('DOMContentLoaded', async function () {
             // Create a client that expects a Perspective server to accept
             // Websocket connections at the specified URL.
             const websocket = perspective.websocket("ws://localhost:8080/websocket");

--- a/examples/tornado-streaming-python/index.html
+++ b/examples/tornado-streaming-python/index.html
@@ -44,7 +44,7 @@
 
     <script>
 
-        window.addEventListener('WebComponentsReady', async function() {
+        window.addEventListener('DOMContentLoaded', async function () {
             const viewer = document.getElementById('viewer');
 
             // Create a client that expects a Perspective server to accept

--- a/examples/webpack-cross-origin/src/index.js
+++ b/examples/webpack-cross-origin/src/index.js
@@ -13,7 +13,7 @@ import "@finos/perspective-viewer";
 import "@finos/perspective-viewer-datagrid";
 import "@finos/perspective-viewer-d3fc";
 
-window.addEventListener("WebComponentsReady", async () => {
+window.addEventListener("DOMContentLoaded", async () => {
     const worker = perspective.worker();
     const table = await worker.table([
         {x: 1, y: 2},

--- a/packages/perspective-bench/src/html/benchmark.html
+++ b/packages/perspective-bench/src/html/benchmark.html
@@ -38,7 +38,7 @@
     <perspective-viewer></perspective-viewer>
 
     <script>
-        window.addEventListener('WebComponentsReady', async () => {
+        window.addEventListener('DOMContentLoaded', async () => {
             const el = document.getElementsByTagName('perspective-viewer')[0];
             el.addEventListener("perspective-config-update", () => localStorage.setItem("layout", JSON.stringify(el.save())));
             el.restore(JSON.parse(localStorage.getItem("layout")));

--- a/packages/perspective-cli/src/html/index.html
+++ b/packages/perspective-cli/src/html/index.html
@@ -47,7 +47,7 @@
 <body>
     <perspective-viewer id="view1"></perspective-viewer>
     <script>
-        window.addEventListener('WebComponentsReady', function() {
+        window.addEventListener('DOMContentLoaded', function () {
             var elem = document.getElementById('view1');
             var worker = perspective.websocket();
             elem.load(worker.open_table('data_source_one'));

--- a/packages/perspective-viewer-datagrid/package.json
+++ b/packages/perspective-viewer-datagrid/package.json
@@ -40,7 +40,7 @@
     "dependencies": {
         "@finos/perspective": "^0.6.2",
         "@finos/perspective-viewer": "^0.6.2",
-        "regular-table": "=0.3.2"
+        "regular-table": "=0.3.3"
     },
     "devDependencies": {
         "@finos/perspective-test": "^0.6.2"

--- a/packages/perspective-viewer/package.json
+++ b/packages/perspective-viewer/package.json
@@ -55,8 +55,6 @@
         "@babel/runtime": "^7.8.4",
         "@finos/perspective": "^0.6.2",
         "@types/react": "^16.8.6",
-        "@webcomponents/shadycss": "^1.5.2",
-        "@webcomponents/webcomponentsjs": "~2.0.4",
         "awesomplete": "^1.1.2",
         "chevrotain": "^6.5.0",
         "core-js": "^3.6.4",

--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -7,7 +7,6 @@
  *
  */
 
-import "@webcomponents/webcomponentsjs";
 import {wasm} from "../../dist/esm/@finos/perspective-vieux";
 import "./polyfill.js";
 

--- a/packages/perspective/src/js/perspective.node.js
+++ b/packages/perspective/src/js/perspective.node.js
@@ -105,7 +105,7 @@ function perspective_assets(assets, host_psp) {
                 if (typeof content !== "undefined") {
                     console.log(`200 ${url}`);
                     response.writeHead(200, {"Content-Type": contentType});
-                    response.end(content, extname === ".arrow" ? "user-defined" : "utf-8");
+                    response.end(content, extname === ".arrow" ? undefined : "utf-8");
                     return;
                 }
             }
@@ -119,7 +119,7 @@ function perspective_assets(assets, host_psp) {
                         if (typeof content !== "undefined") {
                             console.log(`200 ${url}`);
                             response.writeHead(200, {"Content-Type": contentType});
-                            response.end(content, extname === ".arrow" ? "user-defined" : "utf-8");
+                            response.end(content, extname === ".arrow" ? undefined : "utf-8");
                             return;
                         }
                     } catch (e) {}

--- a/python/perspective/bench/runtime/benchmark_hosted.html
+++ b/python/perspective/bench/runtime/benchmark_hosted.html
@@ -41,7 +41,7 @@
 
     <script>
 
-        window.addEventListener('WebComponentsReady', async function() {
+        window.addEventListener('DOMContentLoaded', async function () {
             const websocket = perspective.websocket("ws://localhost:8888/websocket");
             const table = websocket.open_table('benchmark_results');
             document.getElementById('viewer').load(table);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3457,16 +3457,6 @@
     "@webassemblyjs/ast" "1.11.0"
     "@xtuc/long" "4.2.2"
 
-"@webcomponents/shadycss@^1.5.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.10.2.tgz#40e03cab6dc5e12f199949ba2b79e02f183d1e7b"
-  integrity sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A==
-
-"@webcomponents/webcomponentsjs@~2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.4.tgz#fe18c288f99b7103e9ae7a766020f9702cedcc08"
-  integrity sha512-wzPSTmwjAd/0oKW36Yi+cB/BmDrHhcHqGlbqqMjrbPIFkt5Mw7wtvEZQouCrQyBNnRquUhRnSWIBrRijHNBBKg==
-
 "@webpack-cli/info@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.2.1.tgz#af98311f983d0b9fce7284cfcf1acaf1e9f4879c"


### PR DESCRIPTION
Removes `webcomponentsjs`, as there is little possibility there still exists a browser which both supports WebAssembly and not Web Components.  This saves ~100k overall on `perspective-workspace`, but if necessary projects may import this manually still to replicate previous behavior:

```javascript
import "@webcomponents/webcompoentsjs";
```

This change however deprecates all examples which used the `WebComponentsReady` event, which is no longer fired if the polyfill is not imported, causing this PR to be a breaking change.  Instead of `WebComponentsReady`, you may use the `DOMContentLoaded` event.

