### PR TITLE
Install Boost from JFrog, fix outdated docs from #1409

### DIFF
--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -17,7 +17,7 @@ RUN python3.7 -m pip install numpy pandas
 
 RUN ls -al /usr/local/lib/python3.7/site-packages/numpy
 
-RUN wget https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.gz >/dev/null 2>&1  || echo "wget failed"
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz >/dev/null 2>&1  || echo "wget failed"
 RUN tar xfz boost_1_67_0.tar.gz
 RUN cd boost_1_67_0 && CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/local/include/python3.7m" C_INCLUDE_PATH="$C_INCLUDE_PATH:/usr/local/include/python3.7m" ./bootstrap.sh --with-python=/usr/local/bin/python3.7  || echo "boostrap failed"
 RUN cd boost_1_67_0 && CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/local/include/python3.7m" C_INCLUDE_PATH="$C_INCLUDE_PATH:/usr/local/include/python3.7m" ./b2 -j4 install || echo "build boost failed" 

--- a/docker/python/manylinux2010/Dockerfile
+++ b/docker/python/manylinux2010/Dockerfile
@@ -54,7 +54,7 @@ RUN python3.8 -m pip install --ignore-installed auditwheel
 RUN python3.9 -m pip install --ignore-installed auditwheel
 
 # install boost
-RUN wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz --no-check-certificate >/dev/null 2>&1
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz --no-check-certificate >/dev/null 2>&1
 RUN tar xfz boost_1_71_0.tar.gz
 # https://github.com/boostorg/build/issues/468
 RUN cd boost_1_71_0 && ./bootstrap.sh

--- a/docker/python/manylinux2014/Dockerfile
+++ b/docker/python/manylinux2014/Dockerfile
@@ -50,7 +50,7 @@ RUN python3.8 -m pip install --ignore-installed auditwheel
 RUN python3.9 -m pip install --ignore-installed auditwheel
 
 # install boost
-RUN wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz --no-check-certificate >/dev/null 2>&1
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz --no-check-certificate >/dev/null 2>&1
 RUN tar xfz boost_1_71_0.tar.gz
 # https://github.com/boostorg/build/issues/468
 RUN cd boost_1_71_0 && ./bootstrap.sh

--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -63,10 +63,10 @@ which loads a dataset stored in the Apache Arrow format using the `Fetch` API.
 Add these scripts to your `.html`'s `<head>` section:
 
 ```html
-<script src="https://unpkg.com/@finos/perspective"></script>
-<script src="https://unpkg.com/@finos/perspective-viewer"></script>
-<script src="https://unpkg.com/@finos/perspective-viewer-datagrid"></script>
-<script src="https://unpkg.com/@finos/perspective-viewer-d3fc"></script>
+<script src="https://unpkg.com/@finos/perspective/dist/umd/perspective.js"></script>
+<script src="https://unpkg.com/@finos/perspective-viewer/dist/umd/perspective-viewer.js"></script>
+<script src="https://unpkg.com/@finos/perspective-viewer-datagrid/dist/umd/perspective-viewer-datagrid.js"></script>
+<script src="https://unpkg.com/@finos/perspective-viewer-d3fc/dist/umd/perspective-viewer-d3fc.js"></script>
 ```
 
 Once added to your page, you can access the Javascript API through the

--- a/docs/md/js.md
+++ b/docs/md/js.md
@@ -99,10 +99,10 @@ which loads a dataset stored in the Apache Arrow format using the `Fetch` API.
 Add these scripts to your `.html`'s `<head>` section:
 
 ```html
-<script src="https://unpkg.com/@finos/perspective"></script>
-<script src="https://unpkg.com/@finos/perspective-viewer"></script>
-<script src="https://unpkg.com/@finos/perspective-viewer-datagrid"></script>
-<script src="https://unpkg.com/@finos/perspective-viewer-d3fc"></script>
+<script src="https://unpkg.com/@finos/perspective/dist/umd/perspective.js"></script>
+<script src="https://unpkg.com/@finos/perspective-viewer/dist/umd/perspective-viewer.js"></script>
+<script src="https://unpkg.com/@finos/perspective-viewer-datagrid/dist/umd/perspective-viewer-datagrid.js"></script>
+<script src="https://unpkg.com/@finos/perspective-viewer-d3fc/dist/umd/perspective-viewer-d3fc.js"></script>
 ```
 
 Once added to your page, you can access the Javascript API through the

--- a/scripts/install_tools.js
+++ b/scripts/install_tools.js
@@ -12,7 +12,7 @@ const {execute} = require("./script_utils.js");
 try {
     if (process.platform === "linux") {
         console.log("-- Installing Boost 1.71.0");
-        execute`wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz >/dev/null 2>&1`;
+        execute`wget https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz >/dev/null 2>&1`;
         execute`tar xfz boost_1_71_0.tar.gz`;
         process.chdir("boost_1_71_0");
         execute`./bootstrap.sh`;


### PR DESCRIPTION
As of May 1, Bintray has been [sunset](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) which causes our `install_tools.js` to fail when trying to install Boost.

This PR removes all Bintray links and replaces them with a link to the Boost artefact in JFrog, from the link provided on the Boost [website](https://www.boost.org/users/history/version_1_71_0.html). Dockerfiles have also been updated to use the JFrog link to prevent any build issues.

Additionally, it fixes the outdated docs mentioned in #1409 by removing Unpkg alias links and replacing them with direct links to the /dist/umd folder.