### PR TITLE
Color-by-string for Treemap/Sunburst

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/sunburst.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/sunburst.js
@@ -14,6 +14,7 @@ import {sunburstSeries} from "../series/sunburst/sunburstSeries";
 import {tooltip} from "../tooltip/tooltip";
 import {gridLayoutMultiChart} from "../layout/gridLayoutMultiChart";
 import {colorRangeLegend} from "../legend/colorRangeLegend";
+import {colorLegend} from "../legend/legend";
 
 function sunburst(container, settings) {
     if (settings.crossValues.length === 0) {
@@ -22,17 +23,22 @@ function sunburst(container, settings) {
     }
 
     const data = treeData(settings);
-    const color = treeColor(
-        settings,
-        data.map(d => d.extents)
-    );
+    const color = treeColor(settings, data);
     const sunburstGrid = gridLayoutMultiChart().elementsPrefix("sunburst");
 
     container.datum(data).call(sunburstGrid);
 
     if (color) {
-        const legend = colorRangeLegend().scale(color);
-        container.call(legend);
+        const color_column = settings.realValues[1];
+        if (settings.mainValues.find(x => x.name === color_column)?.type === "string") {
+            const legend = colorLegend()
+                .settings(settings)
+                .scale(color);
+            container.call(legend);
+        } else {
+            const legend = colorRangeLegend().scale(color);
+            container.call(legend);
+        }
     }
 
     const sunburstContainer = sunburstGrid.chartContainer();
@@ -59,7 +65,7 @@ function sunburst(container, settings) {
             const svgNode = this.parentNode;
             const {width, height} = svgNode.getBoundingClientRect();
 
-            const radius = (Math.min(width, height) - 120) / 6;
+            const radius = (Math.min(width, height) - 24) / (settings.crossValues.length * 2);
             sunburstSeries()
                 .settings(settings)
                 .split(split)

--- a/packages/perspective-viewer-d3fc/src/js/charts/treemap.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/treemap.js
@@ -37,7 +37,7 @@ function treemap(container, settings) {
     container.datum(data).call(treemapGrid);
     if (color) {
         const color_column = settings.realValues[1];
-        if (settings.mainValues.find(x => x.name === color_column).type === "string") {
+        if (settings.mainValues.find(x => x.name === color_column)?.type === "string") {
             const legend = colorLegend()
                 .settings(settings)
                 .scale(color);

--- a/packages/perspective-viewer-d3fc/src/js/charts/treemap.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/treemap.js
@@ -14,6 +14,7 @@ import {treemapSeries} from "../series/treemap/treemapSeries";
 import {tooltip} from "../tooltip/tooltip";
 import {gridLayoutMultiChart} from "../layout/gridLayoutMultiChart";
 import {colorRangeLegend} from "../legend/colorRangeLegend";
+import {colorLegend} from "../legend/legend";
 
 function treemap(container, settings) {
     if (settings.crossValues.length === 0) {
@@ -34,10 +35,17 @@ function treemap(container, settings) {
 
     const treemapGrid = gridLayoutMultiChart().elementsPrefix("treemap");
     container.datum(data).call(treemapGrid);
-
     if (color) {
-        const legend = colorRangeLegend().scale(color);
-        container.call(legend);
+        const color_column = settings.realValues[1];
+        if (settings.mainValues.find(x => x.name === color_column).type === "string") {
+            const legend = colorLegend()
+                .settings(settings)
+                .scale(color);
+            container.call(legend);
+        } else {
+            const legend = colorRangeLegend().scale(color);
+            container.call(legend);
+        }
     }
 
     const treemapEnter = treemapGrid.chartEnter();

--- a/packages/perspective-viewer-d3fc/src/js/data/treeData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/treeData.js
@@ -30,7 +30,7 @@ export function treeData(settings) {
                 }
                 if (settings.realValues.length > 1 && settings.realValues[1] !== null) {
                     const colorValue = getDataValue(d, settings.mainValues[1], split);
-                    element.color = element.color ? element.color + colorValue : colorValue;
+                    element.color = colorValue;
                 }
                 if (settings.realValues.length > 2 && settings.realValues[2] !== null) {
                     element.tooltip = [];

--- a/packages/perspective-viewer-d3fc/src/js/data/treeData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/treeData.js
@@ -13,7 +13,7 @@ import {toValue} from "../tooltip/selectionData";
 export function treeData(settings) {
     const sets = {};
     const real_aggs = settings.realValues.map(x => (x === null ? null : settings.mainValues.find(y => y.name === x)));
-    settings.data.forEach(d => {
+    settings.data.forEach((d, j) => {
         const groups = d.__ROW_PATH__;
         const splits = getSplitNames(d);
         splits.forEach(split => {
@@ -29,8 +29,11 @@ export function treeData(settings) {
                     currentLevel.push(element);
                 }
                 if (settings.realValues.length > 1 && settings.realValues[1] !== null) {
-                    const colorValue = getDataValue(d, settings.mainValues[1], split);
-                    element.color = colorValue;
+                    const is_leaf = i === groups.length - 1;
+                    const colorValue = is_leaf ? getDataValue(d, settings.mainValues[1], split) : getDataValue(settings.agg_paths[j][i + 1] || d, settings.mainValues[1], split);
+                    if (colorValue) {
+                        element.color = colorValue;
+                    }
                 }
                 if (settings.realValues.length > 2 && settings.realValues[2] !== null) {
                     element.tooltip = [];
@@ -59,7 +62,7 @@ export function treeData(settings) {
             d.mainValues =
                 settings.realValues.length === 1 || (settings.realValues[1] === null && settings.realValues[2] === null)
                     ? d.value
-                    : [d.value, d.data.color].concat(d.data.tooltip || []).filter(x => x !== null);
+                    : [d.value, d.data.color].concat(d.data.tooltip || []).filter(x => x !== undefined);
             d.crossValue = d
                 .ancestors()
                 .slice(0, -1)

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
@@ -17,6 +17,14 @@ export function seriesColors(settings) {
         .domain(domain)();
 }
 
+export function seriesColorsFromDistinct(settings, data) {
+    // const col = settings.data && settings.data.length > 0 ? settings.data[0] : {};
+    let domain = Array.from(new Set(data));
+    return colorScale()
+        .settings(settings)
+        .domain(domain)();
+}
+
 export function seriesColorsFromGroups(settings) {
     const col = settings.data && settings.data.length > 0 ? settings.data[0] : {};
     const domain = [];

--- a/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstArc.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstArc.js
@@ -15,7 +15,7 @@ export const drawArc = radius =>
         .endAngle(d => d.x1)
         .padAngle(d => Math.min((d.x1 - d.x0) / 2, 0.005))
         .padRadius(radius)
-        .innerRadius(d => d.y0 * radius)
-        .outerRadius(d => Math.max(d.y0 * radius, d.y1 * radius - 1));
+        .innerRadius(d => Math.max(1, (d.y0 - 1) * radius))
+        .outerRadius(d => Math.max((d.y0 - 1) * radius, (d.y1 - 1) * radius - 1));
 
-export const arcVisible = d => d.y1 <= 3 && d.y0 >= 1 && d.x1 > d.x0;
+export const arcVisible = d => d.y0 >= 1 && d.x1 > d.x0;

--- a/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstColor.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstColor.js
@@ -9,9 +9,26 @@
 
 import {flattenExtent} from "../../axis/flatten";
 import {seriesColorRange} from "../seriesRange";
+import {seriesColorsFromDistinct} from "../seriesColors";
 
-export function treeColor(settings, extents) {
+export function treeColor(settings, data) {
     if (settings.realValues.length > 1 && settings.realValues[1] !== null) {
-        return seriesColorRange(settings, null, null, flattenExtent(extents));
+        const color_column = settings.realValues[1];
+        if (settings.mainValues.find(x => x.name === color_column)?.type === "string") {
+            const colors = data
+                .map(d => d.data)
+                .filter(x => x.height > 0)
+                .map(x => getColors(x))
+                .reduce((a, b) => a.concat(b));
+            return seriesColorsFromDistinct(settings, colors);
+        } else {
+            return seriesColorRange(settings, null, null, flattenExtent(data.map(d => d.extents)));
+        }
     }
+}
+
+// only get the colors from the bottom level (e.g. nodes with no children)
+function getColors(nodes, colors = []) {
+    nodes.children && nodes.children.length > 0 ? nodes.children.forEach(child => colors.concat(getColors(child, colors))) : nodes.data.color && colors.push(nodes.data.color);
+    return colors;
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstLabel.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/sunburst/sunburstLabel.js
@@ -13,7 +13,7 @@ export const labelVisible = d => d.y1 <= 3 && d.y0 >= 1 && (d.y1 - d.y0) * (d.x1
 
 export function labelTransform(d, radius) {
     const x = (((d.x0 + d.x1) / 2) * 180) / Math.PI;
-    const y = ((d.y0 + d.y1) / 2) * radius;
+    const y = ((d.y0 - 1 + (d.y1 - 1)) / 2) * radius;
     return `rotate(${x - 90}) translate(${y},0) rotate(${x < 180 ? 0 : 180})`;
 }
 

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapColor.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapColor.js
@@ -17,7 +17,7 @@ export function treeColor(settings, data) {
         .filter(x => x.height > 0)
         .map(x => getColors(x))
         .reduce((a, b) => a.concat(b));
-    if (settings.mainValues.find(x => x.name === color_column).type === "string") {
+    if (settings.mainValues.find(x => x.name === color_column)?.type === "string") {
         return seriesColorsFromDistinct(settings, colors);
     } else {
         let min = Math.min(...colors);

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapColor.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapColor.js
@@ -8,20 +8,26 @@
  */
 
 import {seriesColorRange} from "../seriesRange";
+import {seriesColorsFromDistinct} from "../seriesColors";
 
 export function treeColor(settings, data) {
     if (settings.realValues.length < 1 || settings.realValues[1] === null) return;
+    const color_column = settings.realValues[1];
     const colors = data
         .filter(x => x.height > 0)
         .map(x => getColors(x))
         .reduce((a, b) => a.concat(b));
-    let min = Math.min(...colors);
-    let max = Math.max(...colors);
-    return seriesColorRange(settings, null, null, [min, max]);
+    if (settings.mainValues.find(x => x.name === color_column).type === "string") {
+        return seriesColorsFromDistinct(settings, colors);
+    } else {
+        let min = Math.min(...colors);
+        let max = Math.max(...colors);
+        return seriesColorRange(settings, null, null, [min, max]);
+    }
 }
 
 // only get the colors from the bottom level (e.g. nodes with no children)
 function getColors(nodes, colors = []) {
-    nodes.children && nodes.children.length > 0 ? nodes.children.forEach(child => colors.concat(getColors(child, colors))) : colors.push(nodes.data.color);
+    nodes.children && nodes.children.length > 0 ? nodes.children.forEach(child => colors.concat(getColors(child, colors))) : nodes.data.color && colors.push(nodes.data.color);
     return colors;
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapSeries.js
@@ -56,7 +56,13 @@ export function treemapSeries() {
             .style("y", d => d.y0)
             .style("width", d => calcWidth(d))
             .style("height", d => calcHeight(d));
-        color && rects.style("fill", d => color(d.data.color));
+
+        color &&
+            rects.style("fill", d => {
+                if (d.data.color) {
+                    return color(d.data.color);
+                }
+            });
 
         const labels = nodesMerge
             .filter(d => d.value !== 0)

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -60,10 +60,13 @@
                     overflow: hidden;
                 }
 
+                .sunburst-container:not(:only-child) svg {
+                    transform: translate(0, -27px);
+                }
+
                 & svg {
                     width: 100%;
                     height: 100%;
-                    transform: translate(0, -27px);
                 }
 
                 & path {

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -414,6 +414,10 @@
         height: 200px;
     }
 
+    .d3_treemap .legend-container:not(.legend-color) {
+        width: 100px;
+    }
+
     .zoom-controls {
         position: absolute;
         top: 10px;

--- a/packages/perspective-viewer-d3fc/test/js/unit/data/testTreeData.js
+++ b/packages/perspective-viewer-d3fc/test/js/unit/data/testTreeData.js
@@ -21,6 +21,20 @@ export const data = [
     }
 ];
 
+const item = {
+    __ROW_PATH__: ["East"],
+    Quantity: 4156
+};
+
+export const agg_paths = [
+    [item, item, item],
+    [item, item, item],
+    [item, item, item],
+    [item, item, item],
+    [item, item, item],
+    [item, item, item]
+];
+
 export const splitData = [
     {
         __ROW_PATH__: ["Central", "Furniture"],
@@ -101,16 +115,7 @@ export const mainValues = [
     }
 ];
 
-export const realValues = [
-    {
-        name: "Sales",
-        type: "float"
-    },
-    {
-        name: "Quantity",
-        type: "integer"
-    }
-];
+export const realValues = ["Sales", "Quantity"];
 
 export const crossValues = [
     {

--- a/packages/perspective-viewer-d3fc/test/js/unit/data/treeData.spec.js
+++ b/packages/perspective-viewer-d3fc/test/js/unit/data/treeData.spec.js
@@ -8,21 +8,21 @@
  */
 
 import {treeData} from "../../../../src/js/data/treeData";
-import {data, splitData, mainValues, crossValues, realValues} from "./testTreeData";
+import {data, splitData, mainValues, crossValues, realValues, agg_paths} from "./testTreeData";
 
 describe("treeData should", () => {
     test("create a structure with the right number of levels", () => {
-        const {data: result} = treeData({data, mainValues, crossValues, realValues})[0];
+        const {data: result} = treeData({data, agg_paths, mainValues, crossValues, realValues})[0];
         expect(result.height).toEqual(2);
     });
 
     test("calculate the correct color extents", () => {
-        const {extents} = treeData({data, mainValues, crossValues, realValues})[0];
+        const {extents} = treeData({data, agg_paths, mainValues, crossValues, realValues})[0];
         expect(extents).toEqual([1544, 4156]);
     });
 
     test("produce tree data for each split", () => {
-        const result = treeData({data: splitData, mainValues, crossValues, realValues});
+        const result = treeData({data: splitData, agg_paths, mainValues, crossValues, realValues});
         expect(result.length).toEqual(4);
     });
 });

--- a/packages/perspective-viewer-d3fc/test/js/unit/tooltip/generateHTML.spec.js
+++ b/packages/perspective-viewer-d3fc/test/js/unit/tooltip/generateHTML.spec.js
@@ -23,7 +23,8 @@ describe("tooltip generateHTML should", () => {
         settings = {
             crossValues: [],
             splitValues: [],
-            mainValues: [{name: "main-1", type: "integer"}]
+            mainValues: [{name: "main-1", type: "integer"}],
+            realValues: ["main-1"]
         };
     });
     afterEach(() => {
@@ -48,6 +49,7 @@ describe("tooltip generateHTML should", () => {
 
     test("show multiple mainValues", () => {
         settings.mainValues.push({name: "main-2", type: "float"});
+        settings.realValues.push("main-2");
         const data = {
             mainValues: [101, 202.22]
         };


### PR DESCRIPTION
This PR adds support for `"string"` typed columns in the `Color` position in "Treemap" and "Sunburst" D3FC plugins, assigning each unique string in the column color from the series palette.

![category_colors](https://user-images.githubusercontent.com/60666/117564724-7710fc80-b07b-11eb-97b0-3ec66a671ab5.gif)

In addition, the `Sunburst" chart type has been re-vamped:
* Re-styled to a more _pie_-like appearance (as opposed to donut), without a center cutout.
* Radius calculation has been changed to take up the full width of the panel (as opposed to constant)
* Pivot depth limit of 2 has been removed.
* Parent sunburst levels are now pulled from aggregate rows (as opposed to spontaneously re-calculated).

![whie_chart](https://user-images.githubusercontent.com/60666/117564806-e7b81900-b07b-11eb-9337-a70cca6474bc.gif)

