### PR TITLE
Fix styling bugs from CSS minification

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/plugin/template.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/template.js
@@ -110,7 +110,7 @@ class D3FCChartElement extends HTMLElement {
 
             const oldValues = [oldSettings.crossValues, oldSettings.mainValues, oldSettings.splitValues, oldSettings.realValues];
             const newValues = [newSettings.crossValues, newSettings.mainValues, newSettings.splitValues, newSettings.realValues];
-            if (areArraysEqualSimple(oldValues, newValues)) return {...oldSettings, data: newSettings.data, colorStyles: null};
+            if (areArraysEqualSimple(oldValues, newValues)) return {...oldSettings, data: newSettings.data, agg_paths: newSettings.agg_paths, colorStyles: null};
         }
         this.remove();
         return newSettings;

--- a/packages/perspective-viewer-datagrid/src/less/regular_table.less
+++ b/packages/perspective-viewer-datagrid/src/less/regular_table.less
@@ -128,12 +128,14 @@ regular-table thead tr:last-child th {
 regular-table table {
     user-select: none;
     color: #161616;
+    border-collapse: separate;
 
     th {
         font-weight: 400;
     }
 
     td, th {
+        border-color: #eaedef;
         height: 23px;
     }
 
@@ -142,7 +144,8 @@ regular-table table {
     }
 
     td, th.psp-tree-label, th.psp-tree-label, th.psp-tree-leaf, tbody tr:first-child th {
-        border: 0px solid #eaedef;
+        border-style: solid;
+        border-width: 0px;
         border-top-width: 1px;
     }
 

--- a/packages/perspective-viewer/src/themes/material.dark.less
+++ b/packages/perspective-viewer/src/themes/material.dark.less
@@ -86,33 +86,33 @@ perspective-viewer, .perspective-viewer-material-dark {
     --d3fc-tooltip--border-color: @grey800;
     --d3fc-legend--background: rgba(42,44,47,0.8);
 
-    --d3fc-series: rgb(71, 120, 194) !important;
-    --d3fc-series-1: rgb(71, 120, 194) !important;
-    --d3fc-series-2: rgb(204, 120, 48) !important;
-    --d3fc-series-3: rgb(158, 84, 192) !important;
-    --d3fc-series-4: rgb(51, 150, 153) !important;
-    --d3fc-series-5: rgb(102, 114, 143) !important;
-    --d3fc-series-6: rgb(211, 103, 189) !important;
-    --d3fc-series-7: rgb(109, 124, 77) !important;
-    --d3fc-series-8: rgb(221, 99, 103) !important;
-    --d3fc-series-9: rgb(120, 104, 206) !important;
-    --d3fc-series-10: rgb(23, 166, 123) !important;
+    --d3fc-series: rgb(71, 120, 194);
+    --d3fc-series-1: rgb(71, 120, 194);
+    --d3fc-series-2: rgb(204, 120, 48);
+    --d3fc-series-3: rgb(158, 84, 192);
+    --d3fc-series-4: rgb(51, 150, 153);
+    --d3fc-series-5: rgb(102, 114, 143);
+    --d3fc-series-6: rgb(211, 103, 189);
+    --d3fc-series-7: rgb(109, 124, 77);
+    --d3fc-series-8: rgb(221, 99, 103);
+    --d3fc-series-9: rgb(120, 104, 206);
+    --d3fc-series-10: rgb(23, 166, 123);
   
     --d3fc-full--gradient: linear-gradient(
-        rgb(221, 99, 103) 0%,
-        @grey800 50%,
-        rgb(50, 137, 200) 100%
-    ) !important;
+        #dd6367 0%,
+        #242526 50%,
+        #3289c8 100%
+    );
   
     --d3fc-positive--gradient: linear-gradient(
-        @grey800 0%,
-        rgb(50, 137, 200) 100%
-    ) !important;
+        #242526 0%,
+        #3289c8 100%
+    );
   
     --d3fc-negative--gradient: linear-gradient(
-        @grey800 100%,
-        rgb(221, 99, 103) 0%
-    ) !important;
+        #dd6367 0%,
+        #242526 100%
+    );
 
     --warning--color: #333;
 


### PR DESCRIPTION
* Fix non-leaf aggregate cache bug in d3fc which caused sunburst charts to render incorrect parent values.
* Fix strange chrome border rendering glitch in datagrid, which caused Gridcell elemenets with non-matching rowspan (or colspan) to miscalculate shared border widths.