### PR TITLE
Improve expressions engine

### DIFF
--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -170,23 +170,10 @@ t_computed_expression::compute(
         PSP_COMPLAIN_AND_ABORT(ss.str());
     }
 
-    // create or get output column using m_expression_alias
-    auto output_column = data_table->add_column_sptr(m_expression_alias, m_dtype, true);
-
-    // Stop if the column has a different dtype from m_dtype - that means
-    // this expression already exists and is a different dtype, and setting to
-    // it results in undefined behavior.
-    if (output_column->get_dtype() != m_dtype) {
-        std::stringstream ss;
-        ss << "[t_computed_expression::compute] Cannot overwrite column: `"
-            << m_expression_alias
-            << "` with an expression of a different type!"
-            << std::endl;
-
-        PSP_COMPLAIN_AND_ABORT(ss.str());
-    }
-
+    // Store the expression column under the entire string as typed by the user
+    auto output_column = data_table->add_column_sptr(m_expression_string, m_dtype, true);
     auto num_rows = data_table->size();
+
     output_column->reserve(num_rows);
 
     for (t_uindex ridx = 0; ridx < num_rows; ++ridx) {
@@ -264,21 +251,7 @@ t_computed_expression::recompute(
     }
 
     // get or create the output column
-    auto output_column = flattened->add_column_sptr(m_expression_alias, m_dtype, true);
-
-    // Stop if the column has a different dtype from m_dtype - that means
-    // this expression already exists and is a different dtype, and setting to
-    // it results in undefined behavior.
-    if (output_column->get_dtype() != m_dtype) {
-        std::stringstream ss;
-        ss << "[t_computed_expression::recompute] Cannot overwrite column: `"
-            << m_expression_alias
-            << "` with an expression of a different type!"
-            << std::endl;
-
-        PSP_COMPLAIN_AND_ABORT(ss.str());
-    }
-
+    auto output_column = flattened->add_column_sptr(m_expression_string, m_dtype, true);
     output_column->reserve(gstate_table->size());
 
     t_uindex num_rows = changed_rows.size();

--- a/cpp/perspective/src/cpp/config.cpp
+++ b/cpp/perspective/src/cpp/config.cpp
@@ -82,18 +82,7 @@ t_config::t_config() {}
 
 void
 t_config::init() {
-    const auto& expressions = get_expressions();
-
-    for (const auto& expression : expressions) {
-        m_expression_alias_map[expression.get_expression_alias()] = expression.get_expression_string();
-    }
-
     for (auto i = 0; i < m_detail_columns.size(); ++i) {
-        // const std::string& column = detail_columns[i];
-        // if (m_expression_alias_map.count(column) != 0) {
-        //     detail_columns[i] = m_expression_alias_map.at(column);
-        // }
-
         m_detail_colmap[m_detail_columns[i]] = i;
     }
 
@@ -299,11 +288,6 @@ t_config::get_fterms() const {
 const std::vector<t_computed_expression>&
 t_config::get_expressions() const {
     return m_expressions;
-}
-
-const tsl::hopscotch_map<std::string, std::string>&
-t_config::get_expression_alias_map() const {
-    return m_expression_alias_map;
 }
 
 t_filter_op

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1381,7 +1381,7 @@ namespace binding {
             std::vector<std::pair<std::string, std::string>> column_ids;
 
             // Don't allow overwriting of "real" table columns.
-            if (schema->has_column(expression_alias)) {
+            if (schema->has_column(expression_alias) || schema->has_column(expression_string)) {
                 std::stringstream ss;
                 ss << "View creation failed: cannot create expression column '"
                 << expression_alias

--- a/cpp/perspective/src/cpp/gnode.cpp
+++ b/cpp/perspective/src/cpp/gnode.cpp
@@ -890,7 +890,7 @@ t_gnode::_register_context(const std::string& name, t_ctx_type type, std::int64_
 
     for (const auto& expr : expressions) {
         gstate_table->add_column_sptr(
-            expr.get_expression_alias(),
+            expr.get_expression_string(),
             expr.get_dtype(),
             true);
     }
@@ -1013,19 +1013,19 @@ t_gnode::_recompute_expressions(
 void
 t_gnode::_register_expressions(std::vector<t_computed_expression>& expressions) {
     for (auto& expr : expressions) {
-        const std::string& expression_alias = expr.get_expression_alias();
+        const std::string& expression_string = expr.get_expression_string();
         expr.set_expression_vocab(m_expression_vocab);
-        m_expression_map[expression_alias] = expr;
+        m_expression_map[expression_string] = expr;
     }
 }
 
 void
 t_gnode::_unregister_expressions(const std::vector<t_computed_expression>& expressions) {
     for (const auto& expr : expressions) {
-        const std::string& expression_alias = expr.get_expression_alias();
+        const std::string& expression_string = expr.get_expression_string();
 
-        if (m_expression_map.count(expression_alias) == 1) {
-            m_expression_map.erase(expression_alias);
+        if (m_expression_map.count(expression_string) == 1) {
+            m_expression_map.erase(expression_string);
         }
     }
 }

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -40,7 +40,6 @@ void
 t_view_config::init(std::shared_ptr<t_schema> schema) {
     // Build the reverse expression-to-alias mapping
     for (const auto& items : m_expression_alias_map) {
-        std::cout << "alias: " << items.first << ", expr: " << items.second << std::endl;
         m_expression_alias_reverse_map[items.second] = items.first;
     }
 

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -19,6 +19,7 @@ t_view_config::t_view_config(
         const std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>>& filter,
         const std::vector<std::vector<std::string>>& sort,
         const std::vector<t_computed_expression>& expressions,
+        const tsl::hopscotch_map<std::string, std::string>& expression_alias_map,
         const std::string& filter_op,
         bool column_only)
     : m_init(false)
@@ -29,6 +30,7 @@ t_view_config::t_view_config(
     , m_filter(filter)
     , m_sort(sort)
     , m_expressions(expressions)
+    , m_expression_alias_map(expression_alias_map)
     , m_row_pivot_depth(-1)
     , m_column_pivot_depth(-1)
     , m_filter_op(filter_op)
@@ -36,6 +38,12 @@ t_view_config::t_view_config(
 
 void
 t_view_config::init(std::shared_ptr<t_schema> schema) {
+    // Build the reverse expression-to-alias mapping
+    for (const auto& items : m_expression_alias_map) {
+        std::cout << "alias: " << items.first << ", expr: " << items.second << std::endl;
+        m_expression_alias_reverse_map[items.second] = items.first;
+    }
+
     validate(schema);
     fill_aggspecs(schema);
     fill_fterm();
@@ -46,15 +54,8 @@ t_view_config::init(std::shared_ptr<t_schema> schema) {
 
 void
 t_view_config::validate(std::shared_ptr<t_schema> schema) {
-    std::unordered_set<std::string> expression_aliases;
-    expression_aliases.reserve(m_expressions.size());
-
-    for (const auto& expr : m_expressions) {
-        expression_aliases.insert(expr.get_expression_alias());
-    }
-
     for (const std::string& col : m_columns) {
-        if (!schema->has_column(col) && expression_aliases.count(col) == 0) {
+        if (!schema->has_column(col) && m_expression_alias_reverse_map.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View columns." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -63,7 +64,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
 
     for (const auto& agg : m_aggregates) {
         const std::string& col = agg.first;
-        if (!schema->has_column(col) && expression_aliases.count(col) == 0) {
+        if (!schema->has_column(col) && m_expression_alias_reverse_map.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View aggregates." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -71,7 +72,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
     }
 
     for (const std::string& col : m_row_pivots) {
-        if (!schema->has_column(col) && expression_aliases.count(col) == 0) {
+        if (!schema->has_column(col) && m_expression_alias_reverse_map.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View row_pivots." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -79,7 +80,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
     }
 
     for (const std::string& col : m_column_pivots) {
-        if (!schema->has_column(col) && expression_aliases.count(col) == 0) {
+        if (!schema->has_column(col) && m_expression_alias_reverse_map.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View column_pivots." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -88,7 +89,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
 
     for (const auto& filter : m_filter) {
         const std::string& col = std::get<0>(filter);
-        if (!schema->has_column(col) && expression_aliases.count(col) == 0) {
+        if (!schema->has_column(col) && m_expression_alias_reverse_map.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View filters." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -97,7 +98,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
 
     for (const auto& sort : m_sort) {
         const std::string& col = sort[0];
-        if (!schema->has_column(col) && expression_aliases.count(col) == 0) {
+        if (!schema->has_column(col) && m_expression_alias_reverse_map.count(col) == 0) {
             std::stringstream ss;
             ss << "Invalid column '" << col << "' found in View sorts." << std::endl;
             PSP_COMPLAIN_AND_ABORT(ss.str());
@@ -124,54 +125,65 @@ t_view_config::set_column_pivot_depth(std::int32_t depth) {
     m_column_pivot_depth = depth;
 }
 
-std::vector<std::string>
+const std::vector<std::string>&
 t_view_config::get_row_pivots() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_row_pivots;
 }
 
-std::vector<std::string>
+const std::vector<std::string>&
 t_view_config::get_column_pivots() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_column_pivots;
 }
 
-std::vector<t_aggspec>
+const std::vector<t_aggspec>&
 t_view_config::get_aggspecs() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_aggspecs;
 }
 
-std::vector<std::string>
+const std::vector<std::string>&
 t_view_config::get_columns() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_columns;
 }
 
-std::vector<t_fterm>
+const std::vector<t_fterm>&
 t_view_config::get_fterm() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_fterm;
 }
 
-std::vector<t_sortspec>
+const std::vector<t_sortspec>&
 t_view_config::get_sortspec() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_sortspec;
 }
 
-std::vector<t_sortspec>
+const std::vector<t_sortspec>&
 t_view_config::get_col_sortspec() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_col_sortspec;
 }
 
-std::vector<t_computed_expression>
+const std::vector<t_computed_expression>&
 t_view_config::get_expressions() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_expressions;
 }
 
+const tsl::hopscotch_map<std::string, std::string>&
+t_view_config::get_expression_alias_map() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    return m_expression_alias_map;
+}
+
+const tsl::hopscotch_map<std::string, std::string>&
+t_view_config::get_expression_alias_reverse_map() const {
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    return m_expression_alias_reverse_map;
+}
 
 t_filter_op
 t_view_config::get_filter_op() const {

--- a/cpp/perspective/src/include/perspective/config.h
+++ b/cpp/perspective/src/include/perspective/config.h
@@ -128,9 +128,6 @@ public:
     const std::vector<t_computed_expression>&
     get_expressions() const;
 
-    const tsl::hopscotch_map<std::string, std::string>&
-    get_expression_alias_map() const;
-
     t_totals get_totals() const;
 
     t_filter_op get_combiner() const;
@@ -166,11 +163,6 @@ private:
     std::vector<t_computed_expression> m_expressions;
     t_filter_op m_combiner;
     bool m_column_only;
-
-    // A map of expression aliases to expression strings as typed by the
-    // user. This allows for multiple views to simultaneously exist with
-    // the same expression alias that resolve to different columns.
-    tsl::hopscotch_map<std::string, std::string> m_expression_alias_map;
 
     // Internal
     t_totals m_totals;

--- a/cpp/perspective/src/include/perspective/config.h
+++ b/cpp/perspective/src/include/perspective/config.h
@@ -87,43 +87,7 @@ public:
     // An empty config, used for the unit context.
     t_config();
 
-    // Constructors used for C++ tests, not exposed to other parts of the engine
-    t_config(const std::vector<std::string>& row_pivots,
-        const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates);
-
-    t_config(const std::vector<std::string>& row_pivots,
-        const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates,
-        const t_totals totals, t_filter_op combiner, const std::vector<t_fterm>& fterms);
-
-    t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_aggspec>& aggregates);
-
-    t_config(
-        const std::vector<std::string>& row_pivots, const std::vector<t_aggspec>& aggregates);
-
-    t_config(const std::vector<std::string>& row_pivots, const t_aggspec& agg);
-    
-    /**
-     * @brief For each column in the config's `detail_columns` (i.e. visible
-     * columns), add it to the internal map tracking column indices.
-     * 
-     * @param detail_columns 
-     */
-    void setup(const std::vector<std::string>& detail_columns);
-
-    void setup(const std::vector<std::string>& detail_columns,
-        const std::vector<std::string>& sort_pivot,
-        const std::vector<std::string>& sort_pivot_by);
-
-    /**
-     * @brief A t_config is trivial if it does not have any pivots, sorts,
-     * filter terms, or expressions. This allows a context_zero to
-     * skip creating a traversal and simply read from its gnode state for
-     * a performance boost.
-     * 
-     * @return true 
-     * @return false 
-     */
-    bool is_trivial_config();
+    void init();
 
     t_index get_colidx(const std::string& colname) const;
 
@@ -161,8 +125,11 @@ public:
 
     const std::vector<t_fterm>& get_fterms() const;
 
-    std::vector<t_computed_expression>
+    const std::vector<t_computed_expression>&
     get_expressions() const;
+
+    const tsl::hopscotch_map<std::string, std::string>&
+    get_expression_alias_map() const;
 
     t_totals get_totals() const;
 
@@ -200,9 +167,10 @@ private:
     t_filter_op m_combiner;
     bool m_column_only;
 
-    // A trivial config exists if there are no pivots, sorts, filters, or
-    // expression columns.
-    bool m_is_trivial_config;
+    // A map of expression aliases to expression strings as typed by the
+    // user. This allows for multiple views to simultaneously exist with
+    // the same expression alias that resolve to different columns.
+    tsl::hopscotch_map<std::string, std::string> m_expression_alias_map;
 
     // Internal
     t_totals m_totals;

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -260,6 +260,10 @@ private:
 
     void _find_hidden_sort(const std::vector<t_sortspec>& sort);
 
+    std::string
+    _join_column_names(
+        const std::vector<t_tscalar>& names, const std::string& separator) const;
+
     std::shared_ptr<Table> m_table;
     std::shared_ptr<CTX_T> m_ctx;
     std::string m_name;
@@ -273,6 +277,8 @@ private:
     std::vector<t_sortspec> m_sort;
     std::vector<std::string> m_hidden_sort;
     std::vector<t_computed_expression> m_expressions;
+    tsl::hopscotch_map<std::string, std::string> m_expression_alias_map;
+    tsl::hopscotch_map<std::string, std::string> m_expression_alias_reverse_map;
     bool m_column_only;
     t_uindex m_row_offset;
     t_uindex m_col_offset;

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -46,6 +46,7 @@ public:
         const std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>>& filter,
         const std::vector<std::vector<std::string>>& sort,
         const std::vector<t_computed_expression>& expressions,
+        const tsl::hopscotch_map<std::string, std::string>& expression_alias_map,
         const std::string& filter_op,
         bool column_only);
 
@@ -81,21 +82,27 @@ public:
     void set_row_pivot_depth(std::int32_t depth);
     void set_column_pivot_depth(std::int32_t depth);
 
-    std::vector<std::string> get_row_pivots() const;
+    const std::vector<std::string>& get_row_pivots() const;
 
-    std::vector<std::string> get_column_pivots() const;
+    const std::vector<std::string>& get_column_pivots() const;
 
-    std::vector<t_aggspec> get_aggspecs() const;
+    const std::vector<t_aggspec>& get_aggspecs() const;
 
-    std::vector<std::string> get_columns() const;
+    const std::vector<std::string>& get_columns() const;
 
-    std::vector<t_fterm> get_fterm() const;
+    const std::vector<t_fterm>& get_fterm() const;
 
-    std::vector<t_sortspec> get_sortspec() const;
+    const std::vector<t_sortspec>& get_sortspec() const;
 
-    std::vector<t_sortspec> get_col_sortspec() const;
+    const std::vector<t_sortspec>& get_col_sortspec() const;
 
-    std::vector<t_computed_expression> get_expressions() const;
+    const std::vector<t_computed_expression>& get_expressions() const;
+
+    const tsl::hopscotch_map<std::string, std::string>&
+    get_expression_alias_map() const;
+
+    const tsl::hopscotch_map<std::string, std::string>&
+    get_expression_alias_reverse_map() const;
 
     t_filter_op get_filter_op() const;
 
@@ -162,6 +169,15 @@ private:
     std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> m_filter;
     std::vector<std::vector<std::string>> m_sort;
     std::vector<t_computed_expression> m_expressions;
+
+    // A map of expression aliases to expression strings as typed by the
+    // user. This allows for multiple views to simultaneously exist with
+    // the same expression alias that resolve to different columns.
+    tsl::hopscotch_map<std::string, std::string> m_expression_alias_map;
+
+    // A map of expression strings to expression aliases - when the view
+    // or view config is queried, use this to define the output to the user.
+    tsl::hopscotch_map<std::string, std::string> m_expression_alias_reverse_map;
 
     /**
      * @brief The ordered list of aggregate columns:

--- a/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
+++ b/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
@@ -390,9 +390,8 @@ function get_rule(regular, tag, def) {
 export async function createModel(regular, table, view, extend = {}) {
     const config = await view.get_config();
 
-    // Extract just the expression strings from the expressions array, which
-    // contains more metadata than we need.
-    const expressions = config.expressions.map(expr => expr[0]);
+    // Extract just the expression strings from the expressions array.
+    const expressions = config.expressions.map(expr => expr[1]);
 
     const [table_schema, validated_expressions, num_rows, schema, expression_schema, column_paths] = await Promise.all([
         table.schema(),

--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -277,6 +277,8 @@ class PerspectiveViewer extends ActionElement {
                     this.setAttribute("expressions", null);
                 }
 
+                expressions = validated_expressions;
+
                 // Need to remove old expressions from the viewer DOM and
                 // config so they don't mess up state. To do this, we need
                 // to get the expression columns that are currently in the DOM,
@@ -290,13 +292,12 @@ class PerspectiveViewer extends ActionElement {
                     .map(x => x.getAttribute("expression"));
 
                 const old_expressions = active_expressions.concat(inactive_expressions);
+                console.log(active_expressions, inactive_expressions, old_expressions, expressions);
                 const to_remove = this._diff_expressions(old_expressions, expressions);
 
                 if (to_remove.length > 0) {
                     this._reset_expressions_view(to_remove);
                 }
-
-                expressions = validated_expressions;
             } else {
                 console.warn(`Applying unvalidated expressions: ${expressions} because the viewer does not have a Table attached!`);
             }

--- a/packages/perspective-viewer/src/js/viewer/action_element.js
+++ b/packages/perspective-viewer/src/js/viewer/action_element.js
@@ -9,7 +9,6 @@
 
 import {dragend, column_dragend, column_dragleave, column_dragover, column_drop, drop, dragenter, dragover, dragleave} from "./dragdrop.js";
 import {DomElement} from "./dom_element.js";
-import {findExpressionByAlias} from "../utils.js";
 
 export class ActionElement extends DomElement {
     async _toggle_config(event) {
@@ -99,15 +98,8 @@ export class ActionElement extends DomElement {
      * @param {*} event
      */
     _save_expression(event) {
-        const {expression, alias} = event.detail;
+        const {expression} = event.detail;
         const expressions = this._get_view_expressions();
-        const is_duplicate = findExpressionByAlias(alias, expressions);
-
-        if (expressions.includes(expression) || is_duplicate) {
-            console.warn(`"${expression}" was not applied because it already exists.`);
-            return;
-        }
-
         expressions.push(expression);
 
         // Will be validated in the attribute callback
@@ -115,20 +107,7 @@ export class ActionElement extends DomElement {
     }
 
     async _type_check_expression(event) {
-        const {expression, alias} = event.detail;
-        const expressions = this._get_view_expressions();
-        const is_duplicate = findExpressionByAlias(alias, expressions);
-
-        if (expressions.includes(expression) || is_duplicate) {
-            console.warn(`Cannot apply duplicate expression: "${expression}"`);
-            const result = {
-                expression_schema: {},
-                errors: {}
-            };
-            result.errors[alias] = "Value Error - Cannot apply duplicate expression.";
-            this._expression_editor.type_check_expression(result);
-            return;
-        }
+        const {expression} = event.detail;
 
         if (!expression || expression.length === 0) {
             this._expression_editor.type_check_expression({});

--- a/packages/perspective-viewer/src/js/viewer/dom_element.js
+++ b/packages/perspective-viewer/src/js/viewer/dom_element.js
@@ -212,6 +212,10 @@ export class DomElement extends PerspectiveElement {
 
         const attr = JSON.parse(this.getAttribute("columns")) || [];
         let reset_columns_attr = false;
+        console.log(expression_schema);
+
+        // TODO: find all expression columns on the dom and if it already
+        // exists, re-render if the types are different.
 
         for (const expr of expressions) {
             // All expressions are guaranteed to have alias at this point. If
@@ -223,7 +227,6 @@ export class DomElement extends PerspectiveElement {
                 continue;
             }
 
-            //
             // Check for whether the expression is in the attribute but
             // NOT in the DOM - occurs when restore is called and a race
             // condition between `expressions` and `columns` occurs.

--- a/packages/perspective-viewer/src/js/viewer/state_element.js
+++ b/packages/perspective-viewer/src/js/viewer/state_element.js
@@ -42,16 +42,12 @@ export class StateElement extends HTMLElement {
         return Array.prototype.slice.call(this.shadowRoot.querySelectorAll("#inactive_columns perspective-row"));
     }
 
-    _get_view_all_column_names() {
+    _get_view_inactive_column_names() {
         return this._get_view_inactive_columns().map(x => x.getAttribute("name"));
     }
 
     _get_view_active_column_names() {
         return this._get_view_active_columns().map(x => x.getAttribute("name"));
-    }
-
-    _get_view_all_valid_column_names() {
-        return this._get_view_all_column_names().filter(x => x);
     }
 
     _get_view_active_valid_column_names() {

--- a/packages/perspective-viewer/test/js/expressions.spec.js
+++ b/packages/perspective-viewer/test/js/expressions.spec.js
@@ -179,7 +179,7 @@ utils.with_server({}, () => {
                 await page.waitForSelector("perspective-viewer:not([updating])");
             });
 
-            test.capture("Should prevent saving a duplicate expression alias", async page => {
+            test.skip("Should prevent saving a duplicate expression alias", async page => {
                 await page.evaluate(async () => await document.querySelector("perspective-viewer").toggleConfig());
                 await add_expression(page, '// new column \n "Sales" / "Profit"');
                 await page.waitForSelector("perspective-viewer:not([updating])");
@@ -195,7 +195,7 @@ utils.with_server({}, () => {
                 await page.shadow_type("//new column 1 \n 123 + 345", "perspective-viewer", "perspective-expression-editor", "#psp-expression-editor__edit_area");
             });
 
-            test.capture("Should prevent saving a duplicate expression", async page => {
+            test.skip("Should prevent saving a duplicate expression", async page => {
                 await page.evaluate(async () => await document.querySelector("perspective-viewer").toggleConfig());
                 await add_expression(page, '"Sales" / "Profit"');
                 await page.waitForSelector("perspective-viewer:not([updating])");

--- a/packages/perspective/test/js/expressions.js
+++ b/packages/perspective/test/js/expressions.js
@@ -14,6 +14,7 @@ const datetime = require("./expressions/datetime");
 const updates = require("./expressions/updates");
 const deltas = require("./expressions/deltas");
 const invariant = require("./expressions/invariant");
+const multiple_views = require("./expressions/multiple_views");
 
 module.exports = perspective => {
     functionality(perspective);
@@ -23,4 +24,5 @@ module.exports = perspective => {
     updates(perspective);
     deltas(perspective);
     invariant(perspective);
+    multiple_views(perspective);
 };

--- a/packages/perspective/test/js/expressions/multiple_views.js
+++ b/packages/perspective/test/js/expressions/multiple_views.js
@@ -1,0 +1,476 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const expressions_common = require("./common.js");
+
+/**
+ * Tests the functionality of `View`-based expressions, specifically that
+ * existing column/view semantics (pivots, aggregates, columns, sorts, filters)
+ * continue to be functional on expressions.
+ */
+module.exports = perspective => {
+    const validate_delta = async (colname, delta, expected) => {
+        const t = await perspective.table(delta.slice());
+        const v = await t.view();
+        const data = await v.to_columns();
+        expect(data[colname]).toEqual(expected);
+        await v.delete();
+        await t.delete();
+    };
+
+    describe("Expressions with multiple views", () => {
+        it("Multiple views with the same expression alias should not conflict", async () => {
+            const now = new Date();
+            const bucketed = new Date(now.getUTCFullYear(), 0, 1).getTime();
+            const table = await perspective.table({
+                x: [1, 2, 3, 4],
+                y: ["a", "b", "c", "d"],
+                z: [now, now, now, now]
+            });
+
+            const v1 = await table.view({
+                columns: ["column", "column2"],
+                expressions: [`// column \n"x" + 10`, `// column2 \n concat('a', 'b', 'c')`]
+            });
+            const v2 = await table.view({
+                columns: ["column2", "column"],
+                expressions: [`// column \n upper("y")`, `// column2 \n bucket("z", 'Y')`]
+            });
+
+            expect(await v1.expression_schema()).toEqual({
+                column: "float",
+                column2: "string"
+            });
+
+            expect(await v2.expression_schema()).toEqual({
+                column: "string",
+                column2: "date"
+            });
+
+            const result = await v1.to_columns();
+            const result2 = await v2.to_columns();
+
+            expect(result["column"]).toEqual([11, 12, 13, 14]);
+            expect(result["column2"]).toEqual(Array(4).fill("abc"));
+            expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+            expect(result2["column2"]).toEqual(Array(4).fill(bucketed));
+
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        it("Multiple views with the same expression alias should not conflict, to_arrow", async () => {
+            const table = await perspective.table(expressions_common.data);
+
+            const v1 = await table.view({
+                expressions: [`// column \n"x" + 10`]
+            });
+            const v2 = await table.view({
+                expressions: [`// column \n upper("y")`]
+            });
+
+            let result = await v1.to_columns();
+            let result2 = await v2.to_columns();
+
+            expect(result["column"]).toEqual([11, 12, 13, 14]);
+            expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+            const t1 = await perspective.table(await v1.to_arrow());
+            const t2 = await perspective.table(await v2.to_arrow());
+
+            const new_v1 = await t1.view();
+            const new_v2 = await t2.view();
+
+            result = await new_v1.to_columns();
+            result2 = await new_v2.to_columns();
+
+            expect(result["column"]).toEqual([11, 12, 13, 14]);
+            expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+            await new_v2.delete();
+            await new_v1.delete();
+            await t2.delete();
+            await t1.delete();
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        it("Multiple views with the same expression alias should not conflict, filtered", async () => {
+            const table = await perspective.table(expressions_common.data);
+
+            const v1 = await table.view({
+                expressions: [`// column \n"x" + 10`],
+                filter: [["column", "==", 12]]
+            });
+            const v2 = await table.view({
+                expressions: [`// column \n upper("y")`],
+                filter: [["column", "==", "D"]]
+            });
+
+            const result = await v1.to_columns();
+            const result2 = await v2.to_columns();
+
+            expect(result["column"]).toEqual([12]);
+            expect(result2["column"]).toEqual(["D"]);
+
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        it("Multiple pivoted views with the same expression alias should not conflict", async () => {
+            const table = await perspective.table(expressions_common.data);
+
+            const v1 = await table.view({
+                row_pivots: ["y"],
+                column_pivots: ["x"],
+                expressions: [`// column \n"x" + 10`]
+            });
+            const v2 = await table.view({
+                row_pivots: ["x"],
+                column_pivots: ["y"],
+                expressions: [`// column \n upper("y")`],
+                aggregates: {
+                    column: "last"
+                }
+            });
+
+            const result = await v1.to_columns();
+            const result2 = await v2.to_columns();
+
+            expect(result["1|column"]).toEqual([11, 11, null, null, null]);
+            expect(result["2|column"]).toEqual([12, null, 12, null, null]);
+            expect(result["3|column"]).toEqual([13, null, null, 13, null]);
+            expect(result["4|column"]).toEqual([14, null, null, null, 14]);
+
+            expect(result2["a|column"]).toEqual(["A", "A", null, null, null]);
+            expect(result2["b|column"]).toEqual(["B", null, "B", null, null]);
+            expect(result2["c|column"]).toEqual(["C", null, null, "C", null]);
+            expect(result2["d|column"]).toEqual(["D", null, null, null, "D"]);
+
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        it("Multiple pivoted views with the same expression alias and different aggregates should not conflict", async () => {
+            const table = await perspective.table({
+                x: [10, 10, 20, 20],
+                y: ["A", "B", "C", "D"],
+                z: [1.5, 2.5, 3.5, 4.5]
+            });
+
+            const v1 = await table.view({
+                row_pivots: ["x"],
+                expressions: [`// column \n"z" + 10`],
+                aggregates: {
+                    column: "avg"
+                }
+            });
+
+            const v2 = await table.view({
+                row_pivots: ["x"],
+                expressions: [`// column \n upper("y")`],
+                aggregates: {
+                    column: "last"
+                }
+            });
+
+            const v3 = await table.view({
+                row_pivots: ["x"],
+                expressions: [`// column \n 2"z"`],
+                aggregates: {
+                    column: ["weighted mean", "z"]
+                }
+            });
+
+            const result = await v1.to_columns();
+            const result2 = await v2.to_columns();
+            const result3 = await v3.to_columns();
+
+            expect(result["column"]).toEqual([13, 12, 14]);
+            expect(result2["column"]).toEqual(["D", "B", "D"]);
+            expect(result3["column"]).toEqual([6.833333333333333, 4.25, 8.125]);
+
+            await v3.delete();
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        describe("Multiple views with updates", () => {
+            it("Appends", async () => {
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" + 10`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                table.update(expressions_common.data);
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14, 11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D", "A", "B", "C", "D"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update", async () => {
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([2, 4, 6, 8]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([null, 2, 4, 6, 8, 20]);
+                expect(result2["column"]).toEqual(["DEF", "A", "X", "Z", "Y", "ABC"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update, sorted", async () => {
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`],
+                    sort: [["column", "desc"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([8, 6, 4, 2]);
+                expect(result2["column"]).toEqual(["D", "C", "B", "A"]);
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
+                expect(result2["column"]).toEqual(["Z", "Y", "X", "DEF", "ABC", "A"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Limit", async () => {
+                const table = await perspective.table(expressions_common.data, {limit: 2});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([6, 8]);
+                expect(result2["column"]).toEqual(["C", "D"]);
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([null, 20]);
+                expect(result2["column"]).toEqual(["DEF", "ABC"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Appends delta", async done => {
+                expect.assertions(6);
+
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" + 10`]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                const result = await v1.to_columns();
+                const result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                v1.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, [11, 12, 13, 14]);
+                        const result = await v1.to_columns();
+                        expect(result["column"]).toEqual([11, 12, 13, 14, 11, 12, 13, 14]);
+                    },
+                    {mode: "row"}
+                );
+
+                v2.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, ["A", "B", "C", "D"]);
+                        const result2 = await v2.to_columns();
+                        expect(result2["column"]).toEqual(["A", "B", "C", "D", "A", "B", "C", "D"]);
+                        await v2.delete();
+                        await v1.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update(expressions_common.data);
+            });
+
+            it("Partial update delta", async done => {
+                expect.assertions(6);
+
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                const result = await v1.to_columns();
+                const result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([2, 4, 6, 8]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                v1.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, [null, 4, 6, 8, 20]);
+                        const result = await v1.to_columns();
+                        expect(result["column"]).toEqual([null, 2, 4, 6, 8, 20]);
+                    },
+                    {mode: "row"}
+                );
+
+                v2.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, ["DEF", "X", "Z", "Y", "ABC"]);
+                        const result = await v2.to_columns();
+                        expect(result["column"]).toEqual(["DEF", "A", "X", "Z", "Y", "ABC"]);
+                        await v2.delete();
+                        await v1.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+            });
+
+            it("Partial update, sorted delta", async done => {
+                expect.assertions(6);
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`],
+                    sort: [["column", "desc"]]
+                });
+
+                const result = await v1.to_columns();
+                const result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([8, 6, 4, 2]);
+                expect(result2["column"]).toEqual(["D", "C", "B", "A"]);
+
+                v1.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, [20, 8, 6, 4, null]);
+                        const result = await v1.to_columns();
+                        expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
+                    },
+                    {mode: "row"}
+                );
+
+                v2.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, ["Z", "Y", "X", "DEF", "ABC"]);
+                        const result2 = await v2.to_columns();
+                        expect(result2["column"]).toEqual(["Z", "Y", "X", "DEF", "ABC", "A"]);
+                        await v2.delete();
+                        await v1.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+            });
+        });
+    });
+};

--- a/packages/perspective/test/js/get_min_max.spec.js
+++ b/packages/perspective/test/js/get_min_max.spec.js
@@ -44,6 +44,43 @@ describe("get_min_max", function() {
             view.delete();
             table.delete();
         });
+
+        it("float expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                expressions: ['// column\n"w" * 10']
+            });
+            const range = await view.get_min_max("column");
+            expect(range).toEqual([-95, 85]);
+            view.delete();
+            table.delete();
+        });
+
+        it("int expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                expressions: ["// column\n100 * 20", '//column2\n"x" + 5']
+            });
+            const range = await view.get_min_max("column");
+            expect(range).toEqual([2000, 2000]);
+            const range2 = await view.get_min_max("column2");
+            expect(range2).toEqual([6, 9]);
+            view.delete();
+            table.delete();
+        });
+
+        it("string expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                expressions: ["'abcd'", 'upper("y")']
+            });
+            const range = await view.get_min_max("'abcd'");
+            expect(range).toEqual(["abcd", "abcd"]);
+            const range2 = await view.get_min_max('upper("y")');
+            expect(range2).toEqual(["A", "D"]);
+            view.delete();
+            table.delete();
+        });
     });
 
     describe("1 sided", function() {
@@ -76,6 +113,42 @@ describe("get_min_max", function() {
             });
             const cols = await view.get_min_max("y");
             expect(cols).toEqual([4, 4]);
+            view.delete();
+            table.delete();
+        });
+
+        it("float expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                row_pivots: ["y"],
+                expressions: ['// column\n"w" * 10']
+            });
+            const range = await view.get_min_max("column");
+            expect(range).toEqual([-40, 10]);
+            view.delete();
+            table.delete();
+        });
+
+        it("int expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                row_pivots: ["y"],
+                expressions: ['//column\n"x" + 5']
+            });
+            const range = await view.get_min_max("column");
+            expect(range).toEqual([28, 32]);
+            view.delete();
+            table.delete();
+        });
+
+        it("string expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                row_pivots: ["y"],
+                expressions: ["'abcdefghijk'"]
+            });
+            const range = await view.get_min_max("'abcdefghijk'");
+            expect(range).toEqual([4, 4]);
             view.delete();
             table.delete();
         });
@@ -117,6 +190,45 @@ describe("get_min_max", function() {
             view.delete();
             table.delete();
         });
+
+        it("float expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                row_pivots: ["y"],
+                column_pivots: ["z"],
+                expressions: ['// column\n"w" * 10']
+            });
+            const range = await view.get_min_max("column");
+            expect(range).toEqual([-95, 95]);
+            view.delete();
+            table.delete();
+        });
+
+        it("int expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                row_pivots: ["y"],
+                column_pivots: ["z"],
+                expressions: ['//column2\n"x" + 5']
+            });
+            const range = await view.get_min_max("column2");
+            expect(range).toEqual([6, 23]);
+            view.delete();
+            table.delete();
+        });
+
+        it("string expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                row_pivots: ["y"],
+                column_pivots: ["z"],
+                expressions: ['upper("y")']
+            });
+            const range = await view.get_min_max('upper("y")');
+            expect(range).toEqual([1, 3]);
+            view.delete();
+            table.delete();
+        });
     });
 
     describe("column only", function() {
@@ -149,6 +261,42 @@ describe("get_min_max", function() {
             });
             const cols = await view.get_min_max("y");
             expect(cols).toEqual(["a", "d"]);
+            view.delete();
+            table.delete();
+        });
+
+        it("float expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                column_pivots: ["z"],
+                expressions: ['// column\n"w" * 10']
+            });
+            const range = await view.get_min_max("column");
+            expect(range).toEqual([-95, 85]);
+            view.delete();
+            table.delete();
+        });
+
+        it("int expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                column_pivots: ["z"],
+                expressions: ['//column\n"x" + 5']
+            });
+            const range = await view.get_min_max("column");
+            expect(range).toEqual([6, 9]);
+            view.delete();
+            table.delete();
+        });
+
+        it("string expression column", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                column_pivots: ["z"],
+                expressions: ['upper("y")']
+            });
+            const range = await view.get_min_max('upper("y")');
+            expect(range).toEqual(["A", "D"]);
             view.delete();
             table.delete();
         });

--- a/python/perspective/perspective/include/perspective/python.h
+++ b/python/perspective/perspective/include/perspective/python.h
@@ -203,6 +203,7 @@ PYBIND11_MODULE(libbinding, m)
             const std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>>&,
             const std::vector<std::vector<std::string>>&,
             const std::vector<t_computed_expression>&,
+            const tsl::hopscotch_map<std::string, std::string>&,
             const std::string,
             bool>())
         .def("add_filter_term", &t_view_config::add_filter_term);

--- a/python/perspective/perspective/table/_utils.py
+++ b/python/perspective/perspective/table/_utils.py
@@ -6,7 +6,6 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
-import logging
 import re
 from datetime import date, datetime
 from functools import partial
@@ -162,16 +161,6 @@ def _parse_expression_strings(expressions):
 
         if alias_match:
             alias = alias_match.group(1).strip()
-
-            # Don't allow for duplicate aliases
-            if alias in alias_set:
-                logging.warn(
-                    "Skipping expression `{}` as it reuses alias `{}`!".format(
-                        expression, alias
-                    )
-                )
-                continue
-
             alias_set.add(alias)
 
             # Remove the alias from the expression

--- a/python/perspective/perspective/tests/table/test_view_expression.py
+++ b/python/perspective/perspective/tests/table/test_view_expression.py
@@ -53,13 +53,13 @@ class TestViewExpression(object):
             == "View creation failed: cannot create expression column 'a' that overwrites a column that already exists.\n"
         )
 
-    def test_view_expression_should_skip_duplicate(self):
+    def test_view_expression_should_resolve_to_last_alias(self):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
         view = table.view(
             columns=["abc"],
             expressions=['// abc \n "a" + "b"', '// abc \n "a" - "b"'],
         )
-        assert view.to_columns() == {"abc": [6, 8, 10, 12]}
+        assert view.to_columns() == {"abc": [-4, -4, -4, -4]}
 
     def test_view_expression_multiple_alias(
         self,
@@ -88,6 +88,133 @@ class TestViewExpression(object):
             "computed3": float,
             "computed4": float,
         }
+
+    def test_view_expression_multiple_views_with_the_same_alias_should_not_overwrite(
+        self,
+    ):
+        table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+
+        view = table.view(
+            expressions=['// computed \n "a" + "b"']
+        )
+
+        view2 = table.view(
+            expressions=['// computed \n "a" * "b"']
+        )
+
+        assert view.expression_schema() == {
+            "computed": float
+        }
+
+        assert view2.expression_schema() == {
+            "computed": float,
+        }
+
+        assert view.to_dict()["computed"] == [6, 8, 10, 12]
+        assert view2.to_dict()["computed"] == [5, 12, 21, 32]
+
+    def test_view_expression_multiple_views_with_the_same_alias_pivoted(
+        self,
+    ):
+        table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+
+        view = table.view(
+            row_pivots=["computed"],
+            aggregates={
+                "computed": ["weighted mean", "b"]
+            },
+            expressions=['// computed \n "a" + "b"']
+        )
+
+        view2 = table.view(
+            row_pivots=["computed"],
+            aggregates={
+                "computed": "last"
+            },
+            expressions=['// computed \nconcat(\'abc\', \' \', \'def\')']
+        )
+
+        assert view.expression_schema() == {
+            "computed": float
+        }
+
+        assert view2.expression_schema() == {
+            "computed": str,
+        }
+
+        result = view.to_dict()
+        result2 = view2.to_dict()
+
+        assert result["__ROW_PATH__"] == [[], [6], [8], [10], [12]]
+        assert result2["__ROW_PATH__"] == [[], ["abc def"]]
+
+        assert result["computed"] == [9.384615384615385, 6, 8, 10, 12]
+        assert result2["computed"] == ["abc def", "abc def"]
+
+
+    def test_view_expression_multiple_views_with_the_same_alias_all_types(
+        self,
+    ):
+        now = datetime.now()
+        today = date.today()
+
+        month_bucketed = datetime(today.year, today.month, 1)
+        minute_bucketed = datetime(now.year, now.month, now.day, now.hour, now.minute, 0, 0)
+
+        table = Table({
+            "a": [1, 2, 3, 4],
+            "b": [5.5, 6.5, 7.5, 8.5],
+            "c": [datetime.now() for _ in range(4)],
+            "d": [date.today() for _ in range(4)],
+            "e": [True, False, True, False],
+            "f": ["a", "b", "c", "d"]
+        })
+
+        view = table.view(
+            expressions=[
+                '// computed \n "a" + "b"',
+                '// computed2 \n bucket("c", \'M\')',
+                '// computed3 \n concat(\'a\', \'b\', \'c\')',
+                '// computed4 \n \'new string\'',
+            ]
+        )
+
+        view2 = table.view(
+            expressions=[
+                '// computed \n upper("f")',
+                '// computed2 \n 20 + ("b" * "a")',
+                '// computed4 \n bucket("c", \'m\')',
+            ]
+        )
+
+        assert view.expression_schema() == {
+            "computed": float,
+            "computed2": date,
+            "computed3": str,
+            "computed4": str,
+        }
+
+        assert view2.expression_schema() == {
+            "computed": str,
+            "computed2": float,
+            "computed4": datetime,
+        }
+
+        result = view.to_dict()
+        result2 = view2.to_dict()
+
+        assert result["computed"] == [6.5, 8.5, 10.5, 12.5]
+        assert result2["computed"] == ["A", "B", "C", "D"]
+        
+        assert result["computed2"] == [month_bucketed for _ in range(4)]
+        assert result2["computed2"] == [25.5, 33, 42.5, 54]
+
+        assert result["computed3"] == ["abc", "abc", "abc", "abc"]
+        assert "computed3" not in result2
+
+        assert result["computed4"] == ["new string" for _ in range(4)]
+        assert result2["computed4"] == [minute_bucketed for _ in range(4)]
+
 
     def test_view_expression_create_no_columns(self):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})


### PR DESCRIPTION
### Changelog

- Multiple views can now create expressions using the same alias, but of different output types.
  * Previously, expression columns were stored on the tables provided by the `gnode` using their alias, so multiple views could overwrite each other's columns as long as they were the same type. 
  * Now, expression columns are stored using the full expression string as typed by the user, and the `View` keeps track of a mapping of expression aliases to expression strings. During view construction, references to an expression alias are removed and replaced with the expression string, and whenever a view API method is called, expression strings are replaced with the expression alias before the result is returned. Thus, multiple views can share the same alias and create columns of arbitrary types using the same alias.
- Small UI fixes to allow for replacing expressions - when an expression is replaced with one of a different type, it is `reset` and removed from columns, filters, sorts etc. - this is a stopgap measure and should be replaced wholly with a better UI for editing and creating expression columns.