### PR TITLE
Isolate expressions per-context and ensure memory stability

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -250,6 +250,7 @@ if (PSP_WASM_BUILD)
 			-s DISABLE_EXCEPTION_CATCHING=0 \
 			-s ASSERTIONS=2 \
 			-s DEMANGLE_SUPPORT=1 \
+			-s SAFE_HEAP=1 \
 			")
 	else()
 		set(OPT_FLAGS " \

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -501,6 +501,7 @@ set (SOURCE_FILES
 	${PSP_CPP_SRC}/src/cpp/dense_tree_context.cpp
 	${PSP_CPP_SRC}/src/cpp/dense_tree.cpp
 	${PSP_CPP_SRC}/src/cpp/dependency.cpp
+	${PSP_CPP_SRC}/src/cpp/expression_tables.cpp
 	${PSP_CPP_SRC}/src/cpp/extract_aggregate.cpp
 	${PSP_CPP_SRC}/src/cpp/filter.cpp
 	${PSP_CPP_SRC}/src/cpp/flat_traversal.cpp

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -128,8 +128,8 @@ t_computed_expression::t_computed_expression(
 
 void
 t_computed_expression::compute(
-    t_data_table* source_table,
-    t_data_table* destination_table,
+    std::shared_ptr<t_data_table> source_table,
+    std::shared_ptr<t_data_table> destination_table,
     std::shared_ptr<t_vocab> vocab) const {
     // TODO: share symtables across pre/re/compute
     exprtk::symbol_table<t_tscalar> sym_table;

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -62,17 +62,15 @@ t_computed_expression_parser::LOWER_VALIDATOR_FN = computed_function::lower(null
 computed_function::length
 t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nullptr);
 
-// Register functions in a centralized macro instead of copy-pasting the same
-// lines between compute/recompute
 #define REGISTER_COMPUTE_FUNCTIONS()                                                        \
-    computed_function::day_of_week day_of_week_fn = computed_function::day_of_week(m_expression_vocab);         \
-    computed_function::month_of_year month_of_year_fn = computed_function::month_of_year(m_expression_vocab);   \
-    computed_function::intern intern_fn = computed_function::intern(m_expression_vocab);    \
-    computed_function::concat concat_fn = computed_function::concat(m_expression_vocab);    \
-    computed_function::order order_fn = computed_function::order(m_expression_vocab);       \
-    computed_function::upper upper_fn = computed_function::upper(m_expression_vocab);       \
-    computed_function::lower lower_fn = computed_function::lower(m_expression_vocab);       \
-    computed_function::length length_fn = computed_function::length(m_expression_vocab);    \
+    computed_function::day_of_week day_of_week_fn = computed_function::day_of_week(vocab);         \
+    computed_function::month_of_year month_of_year_fn = computed_function::month_of_year(vocab);   \
+    computed_function::intern intern_fn = computed_function::intern(vocab);    \
+    computed_function::concat concat_fn = computed_function::concat(vocab);    \
+    computed_function::order order_fn = computed_function::order(vocab);       \
+    computed_function::upper upper_fn = computed_function::upper(vocab);       \
+    computed_function::lower lower_fn = computed_function::lower(vocab);       \
+    computed_function::length length_fn = computed_function::length(vocab);    \
     sym_table.add_function("today", computed_function::today);                              \
     sym_table.add_function("now", computed_function::now);                                  \
     sym_table.add_function("bucket", t_computed_expression_parser::BUCKET_FN);              \
@@ -130,7 +128,9 @@ t_computed_expression::t_computed_expression(
 
 void
 t_computed_expression::compute(
-    std::shared_ptr<t_data_table> data_table) const {
+    t_data_table* source_table,
+    t_data_table* destination_table,
+    std::shared_ptr<t_vocab> vocab) const {
     // TODO: share symtables across pre/re/compute
     exprtk::symbol_table<t_tscalar> sym_table;
     sym_table.add_constants();
@@ -148,7 +148,7 @@ t_computed_expression::compute(
     for (t_uindex cidx = 0; cidx < num_input_columns; ++cidx) {
         const std::string& column_id = m_column_ids[cidx].first;
         const std::string& column_name = m_column_ids[cidx].second;
-        columns[column_id] = data_table->get_column(column_name);
+        columns[column_id] = source_table->get_column(column_name);
 
         t_tscalar rval;
         rval.m_type = columns[column_id]->get_dtype();
@@ -171,22 +171,8 @@ t_computed_expression::compute(
     }
 
     // create or get output column using m_expression_alias
-    auto output_column = data_table->add_column_sptr(m_expression_alias, m_dtype, true);
-
-    // Stop if the column has a different dtype from m_dtype - that means
-    // this expression already exists and is a different dtype, and setting to
-    // it results in undefined behavior.
-    if (output_column->get_dtype() != m_dtype) {
-        std::stringstream ss;
-        ss << "[t_computed_expression::compute] Cannot overwrite column: `"
-            << m_expression_alias
-            << "` with an expression of a different type!"
-            << std::endl;
-
-        PSP_COMPLAIN_AND_ABORT(ss.str());
-    }
-
-    auto num_rows = data_table->size();
+    auto output_column = destination_table->add_column_sptr(m_expression_alias, m_dtype, true);
+    auto num_rows = source_table->size();
     output_column->reserve(num_rows);
 
     for (t_uindex ridx = 0; ridx < num_rows; ++ridx) {
@@ -205,168 +191,6 @@ t_computed_expression::compute(
         output_column->set_scalar(ridx, value);
     }
 };
-
-void
-t_computed_expression::recompute(
-    std::shared_ptr<t_data_table> gstate_table,
-    std::shared_ptr<t_data_table> flattened,
-    const std::vector<t_rlookup>& changed_rows) const {
-    exprtk::symbol_table<t_tscalar> sym_table;
-    sym_table.add_constants();
-
-    REGISTER_COMPUTE_FUNCTIONS()
-
-    exprtk::expression<t_tscalar> expr_definition;
-    std::vector<std::pair<std::string, t_tscalar>> values;
-
-    /**
-     * To properly recompute columns when updates have been applied, we need 
-     * to keep both the columns from flattened (the table that contains the 
-     * new round of update data) and the gstate_table (the master table that 
-     * contains the entire state of the Perspective table up to this point).
-     * 
-     * This is especially important for partial updates, where cells can be
-     * `null` or `undefined`, and we need to apply/not apply computations
-     * based on both the value in `flattened` and the `gstate_table`.
-     */
-    tsl::hopscotch_map<std::string, std::shared_ptr<t_column>> flattened_columns;
-    tsl::hopscotch_map<std::string, std::shared_ptr<t_column>> gstate_table_columns;
-
-    auto num_input_columns = m_column_ids.size();
-
-    values.resize(num_input_columns);
-    flattened_columns.reserve(num_input_columns);
-    gstate_table_columns.reserve(num_input_columns);
-
-    for (t_uindex cidx = 0; cidx < num_input_columns; ++cidx) {
-        const std::string& column_id = m_column_ids[cidx].first;
-        const std::string& column_name = m_column_ids[cidx].second;
-        flattened_columns[column_id] = flattened->get_column(column_name);
-        gstate_table_columns[column_id] = gstate_table->get_column(column_name);
-
-        t_tscalar rval;
-        rval.m_type = flattened_columns[column_id]->get_dtype();
-        values[cidx] = std::pair<std::string, t_tscalar>(column_id, rval);
-        sym_table.add_variable(column_id, values[cidx].second);
-    }
-
-    expr_definition.register_symbol_table(sym_table);
-
-    if (!t_computed_expression_parser::PARSER->compile(m_parsed_expression_string, expr_definition)) {
-        std::stringstream ss;
-        ss << "[t_computed_expression::recompute] Failed to parse expression: `"
-            << m_parsed_expression_string
-            << "`, failed with error: "
-            << t_computed_expression_parser::PARSER->error()
-            << std::endl;
-
-        PSP_COMPLAIN_AND_ABORT(ss.str());
-    }
-
-    // get or create the output column
-    auto output_column = flattened->add_column_sptr(m_expression_alias, m_dtype, true);
-
-    // Stop if the column has a different dtype from m_dtype - that means
-    // this expression already exists and is a different dtype, and setting to
-    // it results in undefined behavior.
-    if (output_column->get_dtype() != m_dtype) {
-        std::stringstream ss;
-        ss << "[t_computed_expression::recompute] Cannot overwrite column: `"
-            << m_expression_alias
-            << "` with an expression of a different type!"
-            << std::endl;
-
-        PSP_COMPLAIN_AND_ABORT(ss.str());
-    }
-
-    output_column->reserve(gstate_table->size());
-
-    t_uindex num_rows = changed_rows.size();
-
-    if (num_rows == 0) {
-        num_rows = gstate_table->size();
-    } 
-
-    for (t_uindex idx = 0; idx < num_rows; ++idx) {
-        bool row_already_exists = false;
-
-        // if changed_rows is not empty, ridx will point to a row index in
-        // the gnode state master table, whereas idx will always point to
-        // the row index in the flattened table containing the data from
-        // this update/process cycle.
-        t_uindex ridx = idx;
-
-        if (changed_rows.size() > 0) {
-            ridx = changed_rows[idx].m_idx;
-            row_already_exists = changed_rows[idx].m_exists;
-        }
-    
-        bool skip_row = false;
-
-        for (t_uindex cidx = 0; cidx < num_input_columns; ++cidx) {
-            const std::string& column_id = m_column_ids[cidx].first;
-
-            t_tscalar arg = flattened_columns[column_id]->get_scalar(idx);
-
-            if (!arg.is_valid()) {
-                /**
-                 * TODO: should these semantics change now that we don't
-                 * check or maintain intermediates?
-                 * 
-                 * If the row already exists on the gstate table and the cell
-                 * in `flattened` is `STATUS_CLEAR`, do not compute the row and
-                 * unset its value in the output column.
-                 * 
-                 * If the row does not exist, and the cell in `flattened` is
-                 * `STATUS_INVALID`, do not compute the row and unset its value
-                 * in the output column.
-                 * 
-                 * `idx` is used here instead of `ridx`, as `ridx` refers
-                 * to the row index in changed_rows, i.e. the changed row
-                 * on the gstate table, whereas idx is the row index
-                 * in the flattened table.
-                 */
-                bool should_unset = 
-                    (row_already_exists && flattened_columns[column_id]->is_cleared(idx)) ||
-                    (!row_already_exists && !flattened_columns[column_id]->is_valid(idx));
-
-                /**
-                 * Use `unset` instead of `clear`, as
-                 * `t_gstate::update_master_table` will reconcile `STATUS_CLEAR`
-                 * into `STATUS_INVALID`.
-                 */
-                if (should_unset) {
-                    output_column->unset(idx);
-                    skip_row = true;
-                    break;  
-                } else {
-                    // Get the value from the master table using `ridx`,
-                    // which points to a row in the master table that is
-                    // being overwritten in this partial update.
-                    arg = gstate_table_columns[column_id]->get_scalar(ridx);
-                }
-            }
-
-            values[cidx].second.set(arg);
-        }
-
-        if (skip_row) continue;
-
-        t_tscalar value = expr_definition.value();
-
-        if (!value.is_valid() || value.is_none()) {
-            output_column->clear(idx);
-            continue;
-        }
-        
-        output_column->set_scalar(idx, value);
-    }
-}
-
-void
-t_computed_expression::set_expression_vocab(std::shared_ptr<t_vocab> expression_vocab) {
-    m_expression_vocab = expression_vocab;
-}
 
 const std::string&
 t_computed_expression::get_expression_alias() const {

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -213,11 +213,6 @@ t_tscalar concat::operator()(t_parameter_list parameters) {
     }
 
     t_uindex interned = m_expression_vocab->get_interned(result);
-
-    // Return the sentinel with the uint64 data field set to the
-    // index of the string in the vocab. The compute() and recompute() methods
-    // will look in the uint64 field for all DTYPE_STR scalars from
-    // expression.value().
     rval.set(m_expression_vocab->unintern_c(interned));
 
     return rval;
@@ -1186,8 +1181,6 @@ t_tscalar min_fn::operator()(t_parameter_list parameters) {
         if (t_generic_type::e_scalar == gt.type) {
             t_scalar_view _temp(gt);
             t_tscalar temp = _temp();
-
-            std::cout << temp.repr() << std::endl;
 
             if (!temp.is_numeric()) {
                 rval.m_status = STATUS_CLEAR;

--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -42,8 +42,36 @@ t_ctx_grouped_pkey::init() {
     m_tree = std::make_shared<t_stree>(pivots, m_config.get_aggregates(), m_schema, m_config);
     m_tree->init();
     m_traversal = std::shared_ptr<t_traversal>(new t_traversal(m_tree));
+
+    // Initialize the vocab for expressions
+    t_lstore_recipe vlendata_args(
+        "", "__EXPRESSION_VOCAB_VLENDATA__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+
+    t_lstore_recipe extents_args(
+        "", "__EXPRESSION_VOCAB_EXTENTS__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+
+    m_expression_vocab.reset(new t_vocab(vlendata_args, extents_args));
+    m_expression_vocab->init(true);
+
+    // FIXME: without adding this value into the vocab, the first row of a
+    // complex string expression gets garbage data and is undefined behavior,
+    // see "Declare string variable" test in Javascript to see example.
+    m_expression_vocab->get_interned("__PSP_SENTINEL__");
+
+    // Each context stores its own expression columns in separate
+    // `t_data_table`s so that each context's expressions are isolated
+    // and do not affect other contexts when they are calculated.
+    const auto& expressions = m_config.get_expressions();
+    m_expression_tables = std::make_unique<t_expression_tables>(expressions);
+
     m_init = true;
 }
+
+const t_expression_tables*
+t_ctx_grouped_pkey::get_expression_tables() const {
+    return m_expression_tables.get();
+}
+
 
 t_index
 t_ctx_grouped_pkey::get_row_count() const {
@@ -149,7 +177,7 @@ t_ctx_grouped_pkey::get_data(
         if (m_has_label && ridx > 0) {
             // Get pkey
             auto iters = m_tree->get_pkeys_for_leaf(nidx);
-            tree_value.set(m_gstate->get_value(iters.first->m_pkey, grouping_label_col));
+            tree_value.set(get_value_from_gstate(grouping_label_col, iters.first->m_pkey));
         }
 
         tmpvalues[(ridx - ext.m_srow) * ncols] = tree_value;
@@ -337,44 +365,6 @@ t_ctx_grouped_pkey::get_pkeys(const std::vector<std::pair<t_uindex, t_uindex>>& 
     return rval;
 }
 
-std::vector<t_tscalar>
-t_ctx_grouped_pkey::get_cell_data(
-    const std::vector<std::pair<t_uindex, t_uindex>>& cells) const {
-    PSP_TRACE_SENTINEL();
-    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-    if (!m_traversal->validate_cells(cells)) {
-        std::vector<t_tscalar> rval;
-        return rval;
-    }
-
-    std::vector<t_tscalar> rval(cells.size());
-    t_tscalar empty = mknone();
-
-    auto aggtable = m_tree->get_aggtable();
-    auto aggcols = aggtable->get_const_columns();
-    const std::vector<t_aggspec>& aggspecs = m_config.get_aggregates();
-
-    for (t_index idx = 0, loop_end = cells.size(); idx < loop_end; ++idx) {
-        const auto& cell = cells[idx];
-        if (cell.second == 0) {
-            rval[idx].set(empty);
-            continue;
-        }
-
-        t_index rptidx = m_traversal->get_tree_index(cell.first);
-        t_uindex aggidx = cell.second - 1;
-        t_index p_rptidx = m_tree->get_parent_idx(rptidx);
-
-        t_uindex agg_ridx = m_tree->get_aggidx(rptidx);
-        t_index agg_pridx
-            = p_rptidx == INVALID_INDEX ? INVALID_INDEX : m_tree->get_aggidx(p_rptidx);
-
-        rval[idx] = extract_aggregate(aggspecs[aggidx], aggcols[aggidx], agg_ridx, agg_pridx);
-    }
-
-    return rval;
-}
-
 void
 t_ctx_grouped_pkey::set_feature_state(t_ctx_feature feature, bool state) {
     m_features[feature] = state;
@@ -423,12 +413,14 @@ t_ctx_grouped_pkey::get_cell_delta(t_index bidx, t_index eidx) const {
 }
 
 void
-t_ctx_grouped_pkey::reset() {
+t_ctx_grouped_pkey::reset(bool reset_expressions) {
     auto pivots = m_config.get_row_pivots();
     m_tree = std::make_shared<t_stree>(pivots, m_config.get_aggregates(), m_schema, m_config);
     m_tree->init();
     m_tree->set_deltas_enabled(get_feature_state(CTX_FEAT_DELTA));
     m_traversal = std::shared_ptr<t_traversal>(new t_traversal(m_tree));
+
+    if (reset_expressions) m_expression_tables->reset();
 }
 
 void
@@ -685,6 +677,91 @@ t_ctx_grouped_pkey::get_column_dtype(t_uindex idx) const {
 
     auto aggtable = m_tree->_get_aggtable();
     return aggtable->get_const_column(idx - 1)->get_dtype();
+}
+
+void
+t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
+    // Clear the transitional expression tables on the context so they are
+    // ready for the next update.
+    m_expression_tables->clear_transitional_tables();
+
+    t_data_table* master_expression_table = m_expression_tables->m_master.get();
+
+    // Set the master table to the right size.
+    master_expression_table->set_size(flattened_masked->size());
+
+    const auto& expressions = m_config.get_expressions();
+    for (const t_computed_expression& expr : expressions) {
+        // Compute the expressions on the master table.
+        expr.compute(flattened_masked.get(), master_expression_table, m_expression_vocab);
+    }
+}
+
+void
+t_ctx_grouped_pkey::compute_expressions(
+    std::shared_ptr<t_data_table> master,
+    std::shared_ptr<t_data_table> flattened,
+    std::shared_ptr<t_data_table> delta,
+    std::shared_ptr<t_data_table> prev,
+    std::shared_ptr<t_data_table> current,
+    std::shared_ptr<t_data_table> transitions,
+    std::shared_ptr<t_data_table> existed) {
+    // Clear the tables so they are ready for this round of updates
+    m_expression_tables->clear_transitional_tables();
+
+    // All tables are the same size
+    m_expression_tables->set_transitional_table_capacity(flattened->size());
+    m_expression_tables->set_transitional_table_size(flattened->size());
+
+    // Update the master expression table's capacity and size
+    m_expression_tables->m_master->set_capacity(master->get_capacity());
+    m_expression_tables->m_master->set_size(master->size());
+
+    const auto& expressions = m_config.get_expressions();
+    for (const auto& expr : expressions) {
+        // master: compute based on latest state of the gnode state table
+        expr.compute(master.get(), (m_expression_tables->m_master).get(), m_expression_vocab);
+
+        // flattened: compute based on the latest update dataset
+        expr.compute(flattened.get(), (m_expression_tables->m_flattened).get(), m_expression_vocab);
+
+        // delta: for each numerical column, the numerical delta between the
+        // previous value and the current value in the row.
+        expr.compute(delta.get(), (m_expression_tables->m_delta).get(), m_expression_vocab);
+
+        // prev: the values of the updated rows before this update was applied
+        expr.compute(prev.get(), (m_expression_tables->m_prev).get(), m_expression_vocab);
+
+        // current: the current values of the updated rows
+        expr.compute(current.get(), (m_expression_tables->m_current).get(), m_expression_vocab);
+    }
+
+    // Calculate the transitions now that the intermediate tables are computed
+    m_expression_tables->calculate_transitions(existed.get());
+}
+
+t_uindex
+t_ctx_grouped_pkey::num_expressions() const {
+    const auto& expressions = m_config.get_expressions();
+    return expressions.size();
+}
+
+bool
+t_ctx_grouped_pkey::is_expression_column(const std::string& colname) const {
+    const t_schema& schema = m_expression_tables->m_master->get_schema();
+    return schema.has_column(colname);
+}
+
+t_tscalar
+t_ctx_grouped_pkey::get_value_from_gstate(
+    const std::string& colname,
+    const t_tscalar& pkey) const {
+    if (is_expression_column(colname)) {
+        return m_gstate->get_value(*(m_expression_tables->m_master), colname, pkey);
+    } else {
+        std::shared_ptr<t_data_table> master_table = m_gstate->get_table();
+        return m_gstate->get_value(*master_table, colname, pkey);
+    }
 }
 
 std::vector<t_tscalar>

--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -43,33 +43,21 @@ t_ctx_grouped_pkey::init() {
     m_tree->init();
     m_traversal = std::shared_ptr<t_traversal>(new t_traversal(m_tree));
 
-    // Initialize the vocab for expressions
-    t_lstore_recipe vlendata_args(
-        "", "__EXPRESSION_VOCAB_VLENDATA__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
-
-    t_lstore_recipe extents_args(
-        "", "__EXPRESSION_VOCAB_EXTENTS__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
-
-    m_expression_vocab.reset(new t_vocab(vlendata_args, extents_args));
-    m_expression_vocab->init(true);
-
-    // FIXME: without adding this value into the vocab, the first row of a
-    // complex string expression gets garbage data and is undefined behavior,
-    // see "Declare string variable" test in Javascript to see example.
-    m_expression_vocab->get_interned("__PSP_SENTINEL__");
+    m_expression_vocab = std::make_shared<t_vocab>();
+    m_expression_vocab->init(false);
 
     // Each context stores its own expression columns in separate
     // `t_data_table`s so that each context's expressions are isolated
     // and do not affect other contexts when they are calculated.
     const auto& expressions = m_config.get_expressions();
-    m_expression_tables = std::make_unique<t_expression_tables>(expressions);
+    m_expression_tables = std::make_shared<t_expression_tables>(expressions);
 
     m_init = true;
 }
 
-const t_expression_tables*
+std::shared_ptr<t_expression_tables>
 t_ctx_grouped_pkey::get_expression_tables() const {
-    return m_expression_tables.get();
+    return m_expression_tables;
 }
 
 
@@ -685,7 +673,7 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> flattened_
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
 
-    t_data_table* master_expression_table = m_expression_tables->m_master.get();
+    std::shared_ptr<t_data_table> master_expression_table = m_expression_tables->m_master;
 
     // Set the master table to the right size.
     master_expression_table->set_size(flattened_masked->size());
@@ -693,7 +681,7 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> flattened_
     const auto& expressions = m_config.get_expressions();
     for (const t_computed_expression& expr : expressions) {
         // Compute the expressions on the master table.
-        expr.compute(flattened_masked.get(), master_expression_table, m_expression_vocab);
+        expr.compute(flattened_masked, master_expression_table, m_expression_vocab);
     }
 }
 
@@ -720,24 +708,24 @@ t_ctx_grouped_pkey::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr.compute(master.get(), (m_expression_tables->m_master).get(), m_expression_vocab);
+        expr.compute(master, m_expression_tables->m_master, m_expression_vocab);
 
         // flattened: compute based on the latest update dataset
-        expr.compute(flattened.get(), (m_expression_tables->m_flattened).get(), m_expression_vocab);
+        expr.compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr.compute(delta.get(), (m_expression_tables->m_delta).get(), m_expression_vocab);
+        expr.compute(delta, m_expression_tables->m_delta, m_expression_vocab);
 
         // prev: the values of the updated rows before this update was applied
-        expr.compute(prev.get(), (m_expression_tables->m_prev).get(), m_expression_vocab);
+        expr.compute(prev, m_expression_tables->m_prev, m_expression_vocab);
 
         // current: the current values of the updated rows
-        expr.compute(current.get(), (m_expression_tables->m_current).get(), m_expression_vocab);
+        expr.compute(current, m_expression_tables->m_current, m_expression_vocab);
     }
 
     // Calculate the transitions now that the intermediate tables are computed
-    m_expression_tables->calculate_transitions(existed.get());
+    m_expression_tables->calculate_transitions(existed);
 }
 
 t_uindex

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -35,26 +35,14 @@ t_ctx1::init() {
     m_tree->init();
     m_traversal = std::shared_ptr<t_traversal>(new t_traversal(m_tree));
 
-    // Initialize the vocab for expressions
-    t_lstore_recipe vlendata_args(
-        "", "__EXPRESSION_VOCAB_VLENDATA__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
-
-    t_lstore_recipe extents_args(
-        "", "__EXPRESSION_VOCAB_EXTENTS__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
-
-    m_expression_vocab.reset(new t_vocab(vlendata_args, extents_args));
-    m_expression_vocab->init(true);
-
-    // FIXME: without adding this value into the vocab, the first row of a
-    // complex string expression gets garbage data and is undefined behavior,
-    // see "Declare string variable" test in Javascript to see example.
-    m_expression_vocab->get_interned("__PSP_SENTINEL__");
+    m_expression_vocab = std::make_shared<t_vocab>();
+    m_expression_vocab->init(false);
 
     // Each context stores its own expression columns in separate
     // `t_data_table`s so that each context's expressions are isolated
     // and do not affect other contexts when they are calculated.
     const auto& expressions = m_config.get_expressions();
-    m_expression_tables = std::make_unique<t_expression_tables>(expressions);
+    m_expression_tables = std::make_shared<t_expression_tables>(expressions);
 
     m_init = true;
 }
@@ -629,7 +617,7 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
 
-    t_data_table* master_expression_table = m_expression_tables->m_master.get();
+    std::shared_ptr<t_data_table> master_expression_table = m_expression_tables->m_master;
 
     // Set the master table to the right size.
     master_expression_table->set_size(flattened_masked->size());
@@ -637,7 +625,7 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     const auto& expressions = m_config.get_expressions();
     for (const t_computed_expression& expr : expressions) {
         // Compute the expressions on the master table.
-        expr.compute(flattened_masked.get(), master_expression_table, m_expression_vocab);
+        expr.compute(flattened_masked, master_expression_table, m_expression_vocab);
     }
 }
 
@@ -664,24 +652,24 @@ t_ctx1::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr.compute(master.get(), (m_expression_tables->m_master).get(), m_expression_vocab);
+        expr.compute(master, m_expression_tables->m_master, m_expression_vocab);
 
         // flattened: compute based on the latest update dataset
-        expr.compute(flattened.get(), (m_expression_tables->m_flattened).get(), m_expression_vocab);
+        expr.compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr.compute(delta.get(), (m_expression_tables->m_delta).get(), m_expression_vocab);
+        expr.compute(delta, m_expression_tables->m_delta, m_expression_vocab);
 
         // prev: the values of the updated rows before this update was applied
-        expr.compute(prev.get(), (m_expression_tables->m_prev).get(), m_expression_vocab);
+        expr.compute(prev, m_expression_tables->m_prev, m_expression_vocab);
 
         // current: the current values of the updated rows
-        expr.compute(current.get(), (m_expression_tables->m_current).get(), m_expression_vocab);
+        expr.compute(current, m_expression_tables->m_current, m_expression_vocab);
     }
 
     // Calculate the transitions now that the intermediate tables are computed
-    m_expression_tables->calculate_transitions(existed.get());
+    m_expression_tables->calculate_transitions(existed);
 }
 
 bool
@@ -696,9 +684,9 @@ t_ctx1::num_expressions() const {
     return expressions.size();
 }
 
-const t_expression_tables*
+std::shared_ptr<t_expression_tables>
 t_ctx1::get_expression_tables() const {
-    return m_expression_tables.get();
+    return m_expression_tables;
 }
 
 std::vector<t_tscalar>

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -34,6 +34,28 @@ t_ctx1::init() {
     m_tree = std::make_shared<t_stree>(pivots, m_config.get_aggregates(), m_schema, m_config);
     m_tree->init();
     m_traversal = std::shared_ptr<t_traversal>(new t_traversal(m_tree));
+
+    // Initialize the vocab for expressions
+    t_lstore_recipe vlendata_args(
+        "", "__EXPRESSION_VOCAB_VLENDATA__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+
+    t_lstore_recipe extents_args(
+        "", "__EXPRESSION_VOCAB_EXTENTS__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+
+    m_expression_vocab.reset(new t_vocab(vlendata_args, extents_args));
+    m_expression_vocab->init(true);
+
+    // FIXME: without adding this value into the vocab, the first row of a
+    // complex string expression gets garbage data and is undefined behavior,
+    // see "Declare string variable" test in Javascript to see example.
+    m_expression_vocab->get_interned("__PSP_SENTINEL__");
+
+    // Each context stores its own expression columns in separate
+    // `t_data_table`s so that each context's expressions are isolated
+    // and do not affect other contexts when they are calculated.
+    const auto& expressions = m_config.get_expressions();
+    m_expression_tables = std::make_unique<t_expression_tables>(expressions);
+
     m_init = true;
 }
 
@@ -252,16 +274,46 @@ t_ctx1::get_data(const std::vector<t_uindex>& rows) const {
 }
 
 void
+t_ctx1::notify(const t_data_table& flattened) {
+    PSP_TRACE_SENTINEL();
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+
+    notify_sparse_tree(
+        m_tree,
+        m_traversal,
+        true,
+        m_config.get_aggregates(),
+        m_config.get_sortby_pairs(),
+        m_sortby,
+        flattened,
+        m_config,
+        *m_gstate,
+        *(m_expression_tables->m_master));
+}
+
+void
 t_ctx1::notify(const t_data_table& flattened, const t_data_table& delta,
     const t_data_table& prev, const t_data_table& current, const t_data_table& transitions,
     const t_data_table& existed) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     
-    notify_sparse_tree(m_tree, m_traversal, true, m_config.get_aggregates(),
-        m_config.get_sortby_pairs(), m_sortby, flattened, delta, prev, current, transitions,
-        existed, m_config, *m_gstate);
-    
+    notify_sparse_tree(
+        m_tree,
+        m_traversal,
+        true,
+        m_config.get_aggregates(),
+        m_config.get_sortby_pairs(),
+        m_sortby,
+        flattened,
+        delta,
+        prev,
+        current,
+        transitions,
+        existed,
+        m_config,
+        *m_gstate,
+        *(m_expression_tables->m_master));
 }
 
 void
@@ -370,43 +422,6 @@ t_ctx1::get_pkeys(const std::vector<std::pair<t_uindex, t_uindex>>& cells) const
     return rval;
 }
 
-std::vector<t_tscalar>
-t_ctx1::get_cell_data(const std::vector<std::pair<t_uindex, t_uindex>>& cells) const {
-    PSP_TRACE_SENTINEL();
-    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-    if (!m_traversal->validate_cells(cells)) {
-        std::vector<t_tscalar> rval;
-        return rval;
-    }
-
-    std::vector<t_tscalar> rval(cells.size());
-    t_tscalar empty = mknone();
-
-    auto aggtable = m_tree->get_aggtable();
-    auto aggcols = aggtable->get_const_columns();
-    const std::vector<t_aggspec>& aggspecs = m_config.get_aggregates();
-
-    for (t_index idx = 0, loop_end = cells.size(); idx < loop_end; ++idx) {
-        const auto& cell = cells[idx];
-        if (cell.second == 0) {
-            rval[idx].set(empty);
-            continue;
-        }
-
-        t_index rptidx = m_traversal->get_tree_index(cell.first);
-        t_uindex aggidx = cell.second - 1;
-
-        t_index p_rptidx = m_tree->get_parent_idx(rptidx);
-        t_uindex agg_ridx = m_tree->get_aggidx(rptidx);
-        t_index agg_pridx
-            = p_rptidx == INVALID_INDEX ? INVALID_INDEX : m_tree->get_aggidx(p_rptidx);
-
-        rval[idx] = extract_aggregate(aggspecs[aggidx], aggcols[aggidx], agg_ridx, agg_pridx);
-    }
-
-    return rval;
-}
-
 bool
 t_ctx1::get_deltas_enabled() const {
     return m_features[CTX_FEAT_DELTA];
@@ -504,12 +519,14 @@ t_ctx1::get_cell_delta(t_index bidx, t_index eidx) const {
 }
 
 void
-t_ctx1::reset() {
+t_ctx1::reset(bool reset_expressions) {
     auto pivots = m_config.get_row_pivots();
     m_tree = std::make_shared<t_stree>(pivots, m_config.get_aggregates(), m_schema, m_config);
     m_tree->init();
     m_tree->set_deltas_enabled(get_feature_state(CTX_FEAT_DELTA));
     m_traversal = std::shared_ptr<t_traversal>(new t_traversal(m_tree));
+
+    if (reset_expressions) m_expression_tables->reset();
 }
 
 void
@@ -540,14 +557,6 @@ t_ctx1::has_deltas() const {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_tree->has_deltas();
-}
-
-void
-t_ctx1::notify(const t_data_table& flattened) {
-    PSP_TRACE_SENTINEL();
-    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-    notify_sparse_tree(m_tree, m_traversal, true, m_config.get_aggregates(),
-        m_config.get_sortby_pairs(), m_sortby, flattened, m_config, *m_gstate);
 }
 
 void
@@ -612,6 +621,84 @@ t_ctx1::get_column_dtype(t_uindex idx) const {
 t_depth
 t_ctx1::get_trav_depth(t_index idx) const {
     return m_traversal->get_depth(idx);
+}
+
+void
+t_ctx1::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
+    // Clear the transitional expression tables on the context so they are
+    // ready for the next update.
+    m_expression_tables->clear_transitional_tables();
+
+    t_data_table* master_expression_table = m_expression_tables->m_master.get();
+
+    // Set the master table to the right size.
+    master_expression_table->set_size(flattened_masked->size());
+
+    const auto& expressions = m_config.get_expressions();
+    for (const t_computed_expression& expr : expressions) {
+        // Compute the expressions on the master table.
+        expr.compute(flattened_masked.get(), master_expression_table, m_expression_vocab);
+    }
+}
+
+void
+t_ctx1::compute_expressions(
+    std::shared_ptr<t_data_table> master,
+    std::shared_ptr<t_data_table> flattened,
+    std::shared_ptr<t_data_table> delta,
+    std::shared_ptr<t_data_table> prev,
+    std::shared_ptr<t_data_table> current,
+    std::shared_ptr<t_data_table> transitions,
+    std::shared_ptr<t_data_table> existed) {
+    // Clear the tables so they are ready for this round of updates
+    m_expression_tables->clear_transitional_tables();
+
+    // All tables are the same size
+    m_expression_tables->set_transitional_table_capacity(flattened->size());
+    m_expression_tables->set_transitional_table_size(flattened->size());
+
+    // Update the master expression table's capacity and size
+    m_expression_tables->m_master->set_capacity(master->get_capacity());
+    m_expression_tables->m_master->set_size(master->size());
+
+    const auto& expressions = m_config.get_expressions();
+    for (const auto& expr : expressions) {
+        // master: compute based on latest state of the gnode state table
+        expr.compute(master.get(), (m_expression_tables->m_master).get(), m_expression_vocab);
+
+        // flattened: compute based on the latest update dataset
+        expr.compute(flattened.get(), (m_expression_tables->m_flattened).get(), m_expression_vocab);
+
+        // delta: for each numerical column, the numerical delta between the
+        // previous value and the current value in the row.
+        expr.compute(delta.get(), (m_expression_tables->m_delta).get(), m_expression_vocab);
+
+        // prev: the values of the updated rows before this update was applied
+        expr.compute(prev.get(), (m_expression_tables->m_prev).get(), m_expression_vocab);
+
+        // current: the current values of the updated rows
+        expr.compute(current.get(), (m_expression_tables->m_current).get(), m_expression_vocab);
+    }
+
+    // Calculate the transitions now that the intermediate tables are computed
+    m_expression_tables->calculate_transitions(existed.get());
+}
+
+bool
+t_ctx1::is_expression_column(const std::string& colname) const {
+    const t_schema& schema = m_expression_tables->m_master->get_schema();
+    return schema.has_column(colname);
+}
+
+t_uindex
+t_ctx1::num_expressions() const {
+    const auto& expressions = m_config.get_expressions();
+    return expressions.size();
+}
+
+const t_expression_tables*
+t_ctx1::get_expression_tables() const {
+    return m_expression_tables.get();
 }
 
 std::vector<t_tscalar>

--- a/cpp/perspective/src/cpp/context_two.cpp
+++ b/cpp/perspective/src/cpp/context_two.cpp
@@ -70,26 +70,14 @@ t_ctx2::init() {
 
     m_ctraversal = std::make_shared<t_traversal>(ctree());
 
-    // Initialize the vocab for expressions
-    t_lstore_recipe vlendata_args(
-        "", "__EXPRESSION_VOCAB_VLENDATA__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
-
-    t_lstore_recipe extents_args(
-        "", "__EXPRESSION_VOCAB_EXTENTS__", DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
-
-    m_expression_vocab.reset(new t_vocab(vlendata_args, extents_args));
-    m_expression_vocab->init(true);
-
-    // FIXME: without adding this value into the vocab, the first row of a
-    // complex string expression gets garbage data and is undefined behavior,
-    // see "Declare string variable" test in Javascript to see example.
-    m_expression_vocab->get_interned("__PSP_SENTINEL__");
+    m_expression_vocab = std::make_shared<t_vocab>();
+    m_expression_vocab->init(false);
 
     // Each context stores its own expression columns in separate
     // `t_data_table`s so that each context's expressions are isolated
     // and do not affect other contexts when they are calculated.
     const auto& expressions = m_config.get_expressions();
-    m_expression_tables = std::make_unique<t_expression_tables>(expressions);
+    m_expression_tables = std::make_shared<t_expression_tables>(expressions);
 
     m_init = true;
 }
@@ -100,9 +88,9 @@ t_ctx2::num_expressions() const {
     return expressions.size();
 }
 
-const t_expression_tables*
+std::shared_ptr<t_expression_tables>
 t_ctx2::get_expression_tables() const {
-    return m_expression_tables.get();
+    return m_expression_tables;
 }
 
 void
@@ -1061,7 +1049,7 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
 
-    t_data_table* master_expression_table = m_expression_tables->m_master.get();
+    std::shared_ptr<t_data_table> master_expression_table = m_expression_tables->m_master;
 
     // Set the master table to the right size.
     master_expression_table->set_size(flattened_masked->size());
@@ -1069,7 +1057,7 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     const auto& expressions = m_config.get_expressions();
     for (const t_computed_expression& expr : expressions) {
         // Compute the expressions on the master table.
-        expr.compute(flattened_masked.get(), master_expression_table, m_expression_vocab);
+        expr.compute(flattened_masked, master_expression_table, m_expression_vocab);
     }
 }
 
@@ -1096,24 +1084,24 @@ t_ctx2::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr.compute(master.get(), (m_expression_tables->m_master).get(), m_expression_vocab);
+        expr.compute(master, m_expression_tables->m_master, m_expression_vocab);
 
         // flattened: compute based on the latest update dataset
-        expr.compute(flattened.get(), (m_expression_tables->m_flattened).get(), m_expression_vocab);
+        expr.compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr.compute(delta.get(), (m_expression_tables->m_delta).get(), m_expression_vocab);
+        expr.compute(delta, m_expression_tables->m_delta, m_expression_vocab);
 
         // prev: the values of the updated rows before this update was applied
-        expr.compute(prev.get(), (m_expression_tables->m_prev).get(), m_expression_vocab);
+        expr.compute(prev, m_expression_tables->m_prev, m_expression_vocab);
 
         // current: the current values of the updated rows
-        expr.compute(current.get(), (m_expression_tables->m_current).get(), m_expression_vocab);
+        expr.compute(current, m_expression_tables->m_current, m_expression_vocab);
     }
 
     // Calculate the transitions now that the intermediate tables are computed
-    m_expression_tables->calculate_transitions(existed.get());
+    m_expression_tables->calculate_transitions(existed);
 }
 
 bool

--- a/cpp/perspective/src/cpp/context_unit.cpp
+++ b/cpp/perspective/src/cpp/context_unit.cpp
@@ -168,6 +168,8 @@ t_ctxunit::get_data(
 
     auto none = mknone();
 
+    const t_data_table& master_table = *(m_gstate->get_table());
+
     for (t_index cidx = ext.m_scol; cidx < ext.m_ecol; ++cidx) {
         const std::string& colname = m_config.col_at(cidx);
 
@@ -175,7 +177,7 @@ t_ctxunit::get_data(
 
         // Read directly from the row indices on the table - they will
         // always correspond exactly.
-        m_gstate->read_column(colname, start_row, end_row, out_data);
+        m_gstate->read_column(master_table, colname, start_row, end_row, out_data);
 
         for (t_index ridx = ext.m_srow; ridx < ext.m_erow; ++ridx) {
             auto v = out_data[ridx - ext.m_srow];
@@ -205,9 +207,12 @@ t_ctxunit::get_data(const std::vector<t_uindex>& rows) const {
 
     auto none = mknone();
 
+    const t_data_table& master_table = *(m_gstate->get_table());
+
     for (t_uindex cidx = 0; cidx < stride; ++cidx) {
         std::vector<t_tscalar> out_data(rows.size());
-        m_gstate->read_column(m_config.col_at(cidx), rows, out_data);
+        const std::string& colname = m_config.col_at(cidx);
+        m_gstate->read_column(master_table, colname, rows, out_data);
 
         for (t_uindex ridx = 0; ridx < rows.size(); ++ridx) {
             auto v = out_data[ridx];
@@ -229,9 +234,13 @@ t_ctxunit::get_data(const std::vector<t_tscalar>& pkeys) const {
 
     auto none = mknone();
 
+    const t_data_table& master_table = *(m_gstate->get_table());
+
     for (t_uindex cidx = 0; cidx < stride; ++cidx) {
         std::vector<t_tscalar> out_data(pkeys.size());
-        m_gstate->read_column(m_config.col_at(cidx), pkeys, out_data);
+        const std::string& colname = m_config.col_at(cidx);
+
+        m_gstate->read_column(master_table, colname, pkeys, out_data);
 
         for (t_uindex ridx = 0; ridx < pkeys.size(); ++ridx) {
             auto v = out_data[ridx];
@@ -270,8 +279,8 @@ t_ctxunit::get_pkeys(const std::vector<std::pair<t_uindex, t_uindex>>& cells) co
         all_rows.insert(cells[idx].first);
     }
 
-    std::shared_ptr<const t_data_table> master_table = m_gstate->get_table();
-    std::shared_ptr<const t_column> pkey_sptr = master_table->get_const_column("psp_pkey");
+    const t_data_table& master_table = *(m_gstate->get_table());
+    std::shared_ptr<const t_column> pkey_sptr = master_table.get_const_column("psp_pkey");
 
     std::vector<t_tscalar> rval(all_rows.size());
 

--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -280,6 +280,11 @@ t_data_table::set_size(t_uindex size) {
 }
 
 void
+t_data_table::set_table_size(t_uindex size) {
+    m_size = size;
+}
+
+void
 t_data_table::reserve(t_uindex capacity) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
@@ -604,6 +609,84 @@ t_data_table::borrow(const std::vector<std::string>& columns) const {
     }
 
     rval->set_size(size());
+    return rval;
+}
+
+std::shared_ptr<t_data_table>
+t_data_table::join(std::shared_ptr<t_data_table> other_table) const {
+    PSP_TRACE_SENTINEL();
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    PSP_VERBOSE_ASSERT(size() == other_table->size(), "NOT EQUAL SIZE");
+
+    // join both schemas
+    t_schema schema = m_schema;
+    const t_schema& other_schema = other_table->get_schema();
+    std::vector<std::string> other_columns;
+
+    for (const std::string& column : other_schema.m_columns) {
+        // Only append unique columns
+        if (!schema.has_column(column)) {
+            schema.add_column(column, other_schema.get_dtype(column));
+            other_columns.push_back(column);
+        }
+    } 
+
+    std::shared_ptr<t_data_table> rval = std::make_shared<t_data_table>(
+        "", "", schema, get_capacity(), BACKING_STORE_MEMORY);
+    rval->init();
+
+    // borrow columns from the current table
+    for (const std::string& column : m_schema.m_columns) {
+        rval->set_column(column, get_column(column));
+    }
+
+    for (const std::string& column : other_columns) {
+        rval->set_column(column, other_table->get_column(column));
+    }
+
+    // don't set size on the columns - they are already of equal size, and we
+    // don't want to mutate the columns.
+    rval->set_table_size(size());
+
+    return rval;
+}
+
+std::shared_ptr<t_data_table>
+t_data_table::join(const t_data_table& other_table) const {
+    PSP_TRACE_SENTINEL();
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    PSP_VERBOSE_ASSERT(size() == other_table.size(), "NOT EQUAL SIZE");
+
+    // join both schemas
+    t_schema schema = m_schema;
+    const t_schema& other_schema = other_table.get_schema();
+    std::vector<std::string> other_columns;
+
+    for (const std::string& column : other_schema.m_columns) {
+        // Only append unique columns
+        if (!schema.has_column(column)) {
+            schema.add_column(column, other_schema.get_dtype(column));
+            other_columns.push_back(column);
+        }
+    } 
+
+    std::shared_ptr<t_data_table> rval = std::make_shared<t_data_table>(
+        "", "", schema, get_capacity(), BACKING_STORE_MEMORY);
+    rval->init();
+
+    // borrow columns from the current table
+    for (const std::string& column : m_schema.m_columns) {
+        rval->set_column(column, get_column(column));
+    }
+
+    for (const std::string& column : other_columns) {
+        rval->set_column(column, other_table.get_column(column));
+    }
+
+    // don't set size on the columns - they are already of equal size, and we
+    // don't want to mutate the columns.
+    rval->set_table_size(size());
+
     return rval;
 }
 

--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -616,7 +616,14 @@ std::shared_ptr<t_data_table>
 t_data_table::join(std::shared_ptr<t_data_table> other_table) const {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-    PSP_VERBOSE_ASSERT(size() == other_table->size(), "NOT EQUAL SIZE");
+
+    if (size() != other_table->size()) {
+        std::stringstream ss;
+        ss << "[t_data_table::join] Cannot join two tables of unequal sizes! Current size: "
+            << size() << ", size of other table: "
+            << other_table->size() << std::endl;
+        PSP_COMPLAIN_AND_ABORT(ss.str());
+    }
 
     // join both schemas
     t_schema schema = m_schema;
@@ -642,45 +649,6 @@ t_data_table::join(std::shared_ptr<t_data_table> other_table) const {
 
     for (const std::string& column : other_columns) {
         rval->set_column(column, other_table->get_column(column));
-    }
-
-    // don't set size on the columns - they are already of equal size, and we
-    // don't want to mutate the columns.
-    rval->set_table_size(size());
-
-    return rval;
-}
-
-std::shared_ptr<t_data_table>
-t_data_table::join(const t_data_table& other_table) const {
-    PSP_TRACE_SENTINEL();
-    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-    PSP_VERBOSE_ASSERT(size() == other_table.size(), "NOT EQUAL SIZE");
-
-    // join both schemas
-    t_schema schema = m_schema;
-    const t_schema& other_schema = other_table.get_schema();
-    std::vector<std::string> other_columns;
-
-    for (const std::string& column : other_schema.m_columns) {
-        // Only append unique columns
-        if (!schema.has_column(column)) {
-            schema.add_column(column, other_schema.get_dtype(column));
-            other_columns.push_back(column);
-        }
-    } 
-
-    std::shared_ptr<t_data_table> rval = std::make_shared<t_data_table>(
-        "", "", schema, get_capacity(), BACKING_STORE_MEMORY);
-    rval->init();
-
-    // borrow columns from the current table
-    for (const std::string& column : m_schema.m_columns) {
-        rval->set_column(column, get_column(column));
-    }
-
-    for (const std::string& column : other_columns) {
-        rval->set_column(column, other_table.get_column(column));
     }
 
     // don't set size on the columns - they are already of equal size, and we

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1355,7 +1355,8 @@ namespace binding {
 
     template <>
     std::shared_ptr<t_view_config>
-    make_view_config(std::shared_ptr<t_schema> schema, t_val date_parser, t_val config) {
+    make_view_config(
+        std::shared_ptr<t_schema> schema, t_val date_parser, t_val config) {
         // extract vectors from JS, where they were created
         auto row_pivots = config.call<std::vector<std::string>>("get_row_pivots");
         auto column_pivots = config.call<std::vector<std::string>>("get_column_pivots");
@@ -1487,6 +1488,8 @@ namespace binding {
     std::shared_ptr<View<CTX_T>>
     make_view(std::shared_ptr<Table> table, const std::string& name, const std::string& separator,
         t_val view_config, t_val date_parser) {
+        // Use a copy of the table schema that we can freely mutate during
+        // `make_view_config`.
         std::shared_ptr<t_schema> schema = std::make_shared<t_schema>(table->get_schema());
         std::shared_ptr<t_view_config> config = make_view_config<t_val>(schema, date_parser, view_config);
 

--- a/cpp/perspective/src/cpp/expression_tables.cpp
+++ b/cpp/perspective/src/cpp/expression_tables.cpp
@@ -1,0 +1,155 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+#include <perspective/expression_tables.h>
+
+namespace perspective {
+
+t_expression_tables::t_expression_tables() {
+    m_master = nullptr;
+    m_flattened = nullptr;
+    m_prev = nullptr;
+    m_current = nullptr;
+    m_delta = nullptr;
+    m_transitions = nullptr;
+}
+
+t_expression_tables::t_expression_tables(
+    const std::vector<t_computed_expression>& expressions) {
+    t_schema schema;
+    t_schema transitions_schema;
+
+    for (const auto& expr : expressions) {
+        const std::string& alias = expr.get_expression_alias();
+        schema.add_column(alias, expr.get_dtype());
+        transitions_schema.add_column(alias, DTYPE_UINT8);
+    }
+
+    m_master = std::make_unique<t_data_table>(
+        "", "", schema, DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+    m_flattened = std::make_unique<t_data_table>(
+        "", "", schema, DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+    m_prev = std::make_unique<t_data_table>(
+        "", "", schema, DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+    m_current = std::make_unique<t_data_table>(
+        "", "", schema, DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+    m_delta = std::make_unique<t_data_table>(
+        "", "", schema, DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+    m_transitions = std::make_unique<t_data_table>(
+        "", "", transitions_schema, DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY);
+
+    m_master->init();
+    m_flattened->init();
+    m_prev->init();
+    m_current->init();
+    m_delta->init();
+    m_transitions->init();
+}
+
+void
+t_expression_tables::calculate_transitions(t_data_table* existed) {
+    const t_schema& schema = m_master->get_schema();
+    const std::vector<std::string>& column_names = schema.m_columns;
+    auto num_cols = column_names.size();
+    const t_column& existed_column = *(existed->get_column("psp_existed"));
+
+#ifdef PSP_PARALLEL_FOR
+    tbb::parallel_for(0, int(num_cols), 1,
+        [&column_names, &existed_column, this](int cidx)
+#else
+    for (t_uindex cidx = 0; cidx < num_cols; ++cidx)
+#endif
+        {
+            const std::string& cname = column_names[cidx];
+            const t_column& prev_column = *(m_prev->get_column(cname).get());
+            const t_column& current_column = *(m_current->get_column(cname));
+            t_column& transition_column = *(m_transitions->get_column(cname));
+            
+            for (t_uindex ridx = 0; ridx < transition_column.size(); ++ridx) {
+                bool row_existed = existed_column.get_nth<bool>(ridx);
+
+                t_tscalar prev_value = prev_column.get_scalar(ridx);
+                t_tscalar curr_value = current_column.get_scalar(ridx);
+
+                bool prev_valid = prev_column.is_valid(ridx);
+                bool curr_valid = current_column.is_valid(ridx);
+                bool prev_curr_eq = prev_valid && curr_value && prev_value == curr_value;
+
+                t_value_transition transition;
+
+                // Use a small subset of `t_value_transitions` that are
+                // relevant - I have not implemented the code paths in
+                // `calc_transitions` that are not referenced elsewhere, i.e.
+                // by a context or by a tree implementation.
+                if (row_existed) {
+                    if (prev_curr_eq) {
+                        // Row existed before, and the current value is
+                        // the same as the previous value.
+                        transition = VALUE_TRANSITION_EQ_TT;
+                    } else {
+                        if (!prev_valid && curr_valid) {
+                            // Previous value was a null, new value is valid.
+                            transition = VALUE_TRANSITION_NEQ_FT;
+                        } else {
+                            // Previous value was not null, new value is
+                            // not null, and previous value != new value
+                            transition = VALUE_TRANSITION_NEQ_TT;
+                        }
+                    }
+                } else {
+                    // Row did not exist before and was added
+                    transition = VALUE_TRANSITION_NEQ_FT;
+                }
+
+                transition_column.set_nth(ridx, transition);
+            }
+        }
+#ifdef PSP_PARALLEL_FOR
+    );
+#endif
+}
+
+void
+t_expression_tables::set_transitional_table_capacity(t_uindex capacity) {
+    m_flattened->set_capacity(capacity);
+    m_prev->set_capacity(capacity);
+    m_current->set_capacity(capacity);
+    m_delta->set_capacity(capacity);
+    m_transitions->set_capacity(capacity);
+}
+
+void
+t_expression_tables::set_transitional_table_size(t_uindex size) {
+    m_flattened->set_size(size);
+    m_prev->set_size(size);
+    m_current->set_size(size);
+    m_delta->set_size(size);
+    m_transitions->set_size(size);
+}
+
+void
+t_expression_tables::clear_transitional_tables() {
+    m_flattened->clear();
+    m_prev->clear();
+    m_current->clear();
+    m_delta->clear();
+    m_transitions->clear();
+}
+
+void
+t_expression_tables::reset() {
+    m_master->reset();
+    m_flattened->reset();
+    m_prev->reset();
+    m_current->reset();
+    m_delta->reset();
+    m_transitions->reset();
+}
+
+} // end namespace perspective

--- a/cpp/perspective/src/cpp/sparse_tree.cpp
+++ b/cpp/perspective/src/cpp/sparse_tree.cpp
@@ -720,7 +720,10 @@ t_stree::mark_zero_desc() {
 }
 
 void
-t_stree::update_aggs_from_static(const t_dtree_ctx& ctx, const t_gstate& gstate) {
+t_stree::update_aggs_from_static(
+    const t_dtree_ctx& ctx,
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table) {
     const t_data_table& src_aggtable = ctx.get_aggtable();
 
     t_agg_update_info agg_update_info;
@@ -786,7 +789,13 @@ t_stree::update_aggs_from_static(const t_dtree_ctx& ctx, const t_gstate& gstate)
         }
 
         update_agg_table(
-            r.m_sptidx, agg_update_info, r.m_daggidx, r.m_saggidx, r.m_nstrands, gstate);
+            r.m_sptidx,
+            agg_update_info,
+            r.m_daggidx,
+            r.m_saggidx,
+            r.m_nstrands,
+            gstate,
+            expression_master_table);
     }
 }
 
@@ -851,8 +860,15 @@ t_stree::gen_aggidx() {
 }
 
 void
-t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_ridx,
-    t_uindex dst_ridx, t_index nstrands, const t_gstate& gstate) {
+t_stree::update_agg_table(
+    t_uindex nidx,
+    t_agg_update_info& info,
+    t_uindex src_ridx,
+    t_uindex dst_ridx,
+    t_index nstrands,
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table) {
+
     for (t_uindex idx : info.m_dst_topo_sorted) {
         const t_column* src = info.m_src[idx];
         t_column* dst = info.m_dst[idx];
@@ -874,7 +890,8 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                     // entire sum in case it is now finite
                     auto pkeys = get_pkeys(nidx);
                     std::vector<double> values;
-                    gstate.read_column(spec.get_dependencies()[0].name(), pkeys, values);
+                    read_column_from_gstate(
+                        gstate, expression_master_table, spec.get_dependencies()[0].name(), pkeys, values, true);
                     new_value.set(std::accumulate(values.begin(), values.end(), double(0)));
                 }
                 dst->set_scalar(dst_ridx, new_value);
@@ -892,7 +909,8 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 auto pkeys = get_pkeys(nidx);
                 std::vector<double> values;
 
-                gstate.read_column(spec.get_dependencies()[0].name(), pkeys, values, false);
+                read_column_from_gstate(
+                    gstate, expression_master_table, spec.get_dependencies()[0].name(), pkeys, values, false);
 
                 auto nr = std::accumulate(values.begin(), values.end(), double(0));
                 double dr = values.size();
@@ -917,8 +935,11 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 std::vector<t_tscalar> values;
                 std::vector<t_tscalar> weights;
 
-                gstate.read_column(spec.get_dependencies()[0].name(), pkeys, values);
-                gstate.read_column(spec.get_dependencies()[1].name(), pkeys, weights);
+                read_column_from_gstate(
+                    gstate, expression_master_table, spec.get_dependencies()[0].name(), pkeys, values);
+    
+                read_column_from_gstate(
+                    gstate, expression_master_table, spec.get_dependencies()[1].name(), pkeys, weights);
 
                 auto weights_it = weights.begin();
                 auto values_it = values.begin();
@@ -947,8 +968,8 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 auto pkeys = get_pkeys(nidx);
                 old_value.set(dst->get_scalar(dst_ridx));
 
-                bool is_unique
-                    = gstate.is_unique(pkeys, spec.get_dependencies()[0].name(), new_value);
+                bool is_unique = is_unique_from_gstate(
+                    gstate, expression_master_table, spec.get_dependencies()[0].name(), pkeys, new_value);
 
                 if (new_value.m_type == DTYPE_STR) {
                     if (is_unique) {
@@ -970,14 +991,21 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
             case AGGTYPE_ANY: {
                 old_value.set(dst->get_scalar(dst_ridx));
                 auto pkeys = get_pkeys(nidx);
-                gstate.apply(pkeys, spec.get_dependencies()[0].name(), new_value,
+
+                apply_from_gstate(
+                    gstate,
+                    expression_master_table,
+                    spec.get_dependencies()[0].name(),
+                    pkeys,
+                    new_value,
                     [](const t_tscalar& row_value, t_tscalar& output) {
                         if (row_value) {
                             output.set(row_value);
                             return true;
                         }
                         return false;
-                    });
+                    }
+                );
 
                 dst->set_scalar(dst_ridx, new_value);
             } break;
@@ -986,8 +1014,12 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 auto pkeys = get_pkeys(nidx);
 
                 new_value.set(
-                    gstate.reduce<std::function<t_tscalar(std::vector<t_tscalar>&)>>(pkeys,
-                        spec.get_dependencies()[0].name(), [](std::vector<t_tscalar>& values) {
+                    reduce_from_gstate<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
+                        gstate,
+                        expression_master_table,
+                        spec.get_dependencies()[0].name(),
+                        pkeys,
+                        [](std::vector<t_tscalar>& values) {
                             if (values.size() == 0) {
                                 return t_tscalar();
                             } else if (values.size() == 1) {
@@ -1000,7 +1032,9 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
 
                                 return *middle;
                             }
-                        }));
+                        }
+                    )
+                );
 
                 dst->set_scalar(dst_ridx, new_value);
             } break;
@@ -1008,8 +1042,12 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 old_value.set(dst->get_scalar(dst_ridx));
                 auto pkeys = get_pkeys(nidx);
 
-                new_value.set(gstate.reduce<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
-                    pkeys, spec.get_dependencies()[0].name(),
+                new_value.set(
+                    reduce_from_gstate<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
+                    gstate,
+                    expression_master_table,
+                    spec.get_dependencies()[0].name(),
+                    pkeys,
                     [this](std::vector<t_tscalar>& values) {
                         std::set<t_tscalar> vset;
                         for (const auto& v : values) {
@@ -1022,7 +1060,8 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                             ss << *iter << ", ";
                         }
                         return m_symtable.get_interned_tscalar(ss.str().c_str());
-                    }));
+                    })
+                );
 
                 dst->set_scalar(dst_ridx, new_value);
             } break;
@@ -1075,16 +1114,24 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 old_value.set(dst->get_scalar(dst_ridx));
                 auto pkeys = get_pkeys(nidx);
 
-                new_value.set(gstate.reduce<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
-                    pkeys, spec.get_dependencies()[0].name(),
-                    [](std::vector<t_tscalar>& values) { return get_dominant(values); }));
+                new_value.set(
+                    reduce_from_gstate<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
+                    gstate,
+                    expression_master_table,
+                    spec.get_dependencies()[0].name(),
+                    pkeys,
+                    [](std::vector<t_tscalar>& values) {
+                        return get_dominant(values);
+                    })
+                );
 
                 dst->set_scalar(dst_ridx, new_value);
             } break;
             case AGGTYPE_FIRST:
             case AGGTYPE_LAST_BY_INDEX: {
                 old_value.set(dst->get_scalar(dst_ridx));
-                new_value.set(first_last_helper(nidx, spec, gstate));
+                new_value.set(first_last_helper(
+                    nidx, spec, gstate, expression_master_table));
                 dst->set_scalar(dst_ridx, new_value);
             } break;
             case AGGTYPE_AND: {
@@ -1092,8 +1139,12 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 auto pkeys = get_pkeys(nidx);
 
                 new_value.set(
-                    gstate.reduce<std::function<t_tscalar(std::vector<t_tscalar>&)>>(pkeys,
-                        spec.get_dependencies()[0].name(), [](std::vector<t_tscalar>& values) {
+                    reduce_from_gstate<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
+                        gstate,
+                        expression_master_table,
+                        spec.get_dependencies()[0].name(),
+                        pkeys,
+                        [](std::vector<t_tscalar>& values) {
                             t_tscalar rval;
                             rval.set(true);
 
@@ -1104,7 +1155,9 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                                 }
                             }
                             return rval;
-                        }));
+                        }
+                    )
+                );
                 dst->set_scalar(dst_ridx, new_value);
             } break;
             case AGGTYPE_LAST_VALUE: {
@@ -1126,8 +1179,16 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 auto iters = m_idxpkey->get<by_idx_pkey>().equal_range(leaf);
                 if (iters.first != iters.second) {
                     t_tscalar pkey = (--iters.second)->m_pkey;
-                    std::vector<t_tscalar> values;
-                    dst->set_scalar(dst_ridx, gstate.read_by_pkey(spec.get_dependencies()[0].name(), pkey));
+
+                    dst->set_scalar(
+                        dst_ridx,
+                        read_by_pkey_from_gstate(
+                            gstate,
+                            expression_master_table,
+                            spec.get_dependencies()[0].name(),
+                            pkey
+                        )
+                    );
                 } else {
                     dst->set_scalar(dst_ridx, mknone());
                 }
@@ -1166,8 +1227,12 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 auto pkeys = get_pkeys(nidx);
 
                 new_value.set(
-                    gstate.reduce<std::function<t_tscalar(std::vector<t_tscalar>&)>>(pkeys,
-                        spec.get_dependencies()[0].name(), [](std::vector<t_tscalar>& values) {
+                    reduce_from_gstate<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
+                        gstate,
+                        expression_master_table,
+                        spec.get_dependencies()[0].name(),
+                        pkeys,
+                        [](std::vector<t_tscalar>& values) {
                             if (values.empty()) {
                                 return mknone();
                             }
@@ -1183,7 +1248,9 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                             }
 
                             return rval;
-                        }));
+                        }
+                    )
+                );
                 dst->set_scalar(dst_ridx, new_value);
             } break;
             case AGGTYPE_SUM_ABS: {
@@ -1191,8 +1258,12 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 auto pkeys = get_pkeys(nidx);
 
                 new_value.set(
-                    gstate.reduce<std::function<t_tscalar(std::vector<t_tscalar>&)>>(pkeys,
-                        spec.get_dependencies()[0].name(), [](std::vector<t_tscalar>& values) {
+                    reduce_from_gstate<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
+                        gstate,
+                        expression_master_table,
+                        spec.get_dependencies()[0].name(),
+                        pkeys,
+                        [](std::vector<t_tscalar>& values) {
                             if (values.empty()) {
                                 return mknone();
                             }
@@ -1204,15 +1275,22 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                                 rval = rval.add(v.abs());
                             }
                             return rval;
-                        }));
+                        }
+                    )
+                );
+
                 dst->set_scalar(dst_ridx, new_value);
             } break;
             case AGGTYPE_ABS_SUM: {
                 old_value.set(dst->get_scalar(dst_ridx));
                 auto pkeys = get_pkeys(nidx);
                 new_value.set(
-                    gstate.reduce<std::function<t_tscalar(std::vector<t_tscalar>&)>>(pkeys,
-                        spec.get_dependencies()[0].name(), [](std::vector<t_tscalar>& values) {
+                    reduce_from_gstate<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
+                        gstate,
+                        expression_master_table,
+                        spec.get_dependencies()[0].name(),
+                        pkeys,
+                        [](std::vector<t_tscalar>& values) {
                             if (values.empty()) {
                                 return mknone();
                             }
@@ -1223,15 +1301,21 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                                 rval = rval.add(v);
                             }
                             return rval.abs();
-                        }));                
+                        }
+                    )
+                );                
                 dst->set_scalar(dst_ridx, new_value);
              } break;
             case AGGTYPE_MUL: {
                 old_value.set(dst->get_scalar(dst_ridx));
                 auto pkeys = get_pkeys(nidx);
                 new_value.set(
-                    gstate.reduce<std::function<t_tscalar(std::vector<t_tscalar>&)>>(pkeys,
-                        spec.get_dependencies()[0].name(), [](std::vector<t_tscalar>& values) {
+                    reduce_from_gstate<std::function<t_tscalar(std::vector<t_tscalar>&)>>(
+                        gstate,
+                        expression_master_table,
+                        spec.get_dependencies()[0].name(),
+                        pkeys,
+                        [](std::vector<t_tscalar>& values) {
                             if (values.size() == 0) {
                                 return t_tscalar();
                             } else if (values.size() == 1) {
@@ -1244,7 +1328,9 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                                 }
                                 return v;
                             }
-                        }));
+                        }
+                    )
+                );
 
                 dst->set_scalar(dst_ridx, new_value);
             } break;
@@ -1253,15 +1339,21 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 auto pkeys = get_pkeys(nidx);
 
                 new_value.set(
-                    gstate.reduce<std::function<std::uint32_t(std::vector<t_tscalar>&)>>(pkeys,
-                        spec.get_dependencies()[0].name(), [](std::vector<t_tscalar>& values) {
+                    reduce_from_gstate<std::function<std::uint32_t(std::vector<t_tscalar>&)>>(
+                        gstate,
+                        expression_master_table,
+                        spec.get_dependencies()[0].name(),
+                        pkeys,
+                        [](std::vector<t_tscalar>& values) {
                             tsl::hopscotch_set<t_tscalar> vset;
                             for (const auto& v : values) {
                                 vset.insert(v);
                             }
                             std::uint32_t rv = vset.size();
                             return rv;
-                        }));
+                        }
+                    )
+                );
 
                 dst->set_scalar(dst_ridx, new_value);
             } break;
@@ -1269,8 +1361,12 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info, t_uindex src_r
                 auto pkeys = get_pkeys(nidx);
                 old_value.set(dst->get_scalar(dst_ridx));
                 bool skip = false;
-                bool is_unique
-                    = gstate.is_unique(pkeys, spec.get_dependencies()[0].name(), new_value);
+                bool is_unique = is_unique_from_gstate(
+                    gstate,
+                    expression_master_table,
+                    spec.get_dependencies()[0].name(),
+                    pkeys,
+                    new_value);
 
                 if (is_leaf(nidx) && is_unique) {
                     if (new_value.m_type == DTYPE_STR) {
@@ -1785,7 +1881,11 @@ t_stree::get_deltas() const {
 }
 
 t_tscalar
-t_stree::first_last_helper(t_uindex nidx, const t_aggspec& spec, const t_gstate& gstate) const {
+t_stree::first_last_helper(
+    t_uindex nidx,
+    const t_aggspec& spec,
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table) const {
     auto pkeys = get_pkeys(nidx);
 
     if (pkeys.empty())
@@ -1794,8 +1894,11 @@ t_stree::first_last_helper(t_uindex nidx, const t_aggspec& spec, const t_gstate&
     std::vector<t_tscalar> values;
     std::vector<t_tscalar> sort_values;
 
-    gstate.read_column(spec.get_dependencies()[0].name(), pkeys, values);
-    gstate.read_column(spec.get_dependencies()[1].name(), pkeys, sort_values);
+    read_column_from_gstate(
+        gstate, expression_master_table, spec.get_dependencies()[0].name(), pkeys, values);
+
+    read_column_from_gstate(
+        gstate, expression_master_table, spec.get_dependencies()[1].name(), pkeys, sort_values);
 
     auto minmax_idx = get_minmax_idx(sort_values, spec.get_sort_type());
 
@@ -1899,6 +2002,126 @@ t_stree::pprint() const {
             std::cout << get_aggregate(idx, aidx) << ", ";
         }
         std::cout << std::endl;
+    }
+}
+
+void
+t_stree::read_column_from_gstate(
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table,
+    const std::string& colname,
+    const std::vector<t_tscalar>& pkeys,
+    std::vector<t_tscalar>& out_data) const {
+    const t_schema& expression_schema = expression_master_table.get_schema();
+    
+    if (expression_schema.has_column(colname)) {
+        gstate.read_column(expression_master_table, colname, pkeys, out_data);
+    } else {
+        std::shared_ptr<t_data_table> gstate_master_table = gstate.get_table();
+        gstate.read_column(*gstate_master_table, colname, pkeys, out_data);
+    }
+}
+
+void
+t_stree::read_column_from_gstate(
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table,
+    const std::string& colname,
+    const std::vector<t_tscalar>& pkeys,
+    std::vector<double>& out_data,
+    bool include_none) const {
+    const t_schema& expression_schema = expression_master_table.get_schema();
+
+    if (expression_schema.has_column(colname)) {
+        gstate.read_column(
+            expression_master_table,
+            colname,
+            pkeys,
+            out_data,
+            include_none);
+    } else {
+        std::shared_ptr<t_data_table> gstate_master_table = gstate.get_table();
+        gstate.read_column(
+            *gstate_master_table,
+            colname,
+            pkeys,
+            out_data,
+            include_none);
+    }
+}
+
+t_tscalar
+t_stree::read_by_pkey_from_gstate(
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table,
+    const std::string& colname,
+    t_tscalar& pkey) const {
+    const t_schema& expression_schema = expression_master_table.get_schema();
+
+    if (expression_schema.has_column(colname)) {
+        return gstate.read_by_pkey(expression_master_table, colname, pkey);
+    } else {
+        std::shared_ptr<t_data_table> gstate_master_table = gstate.get_table();
+        return gstate.read_by_pkey(*gstate_master_table, colname, pkey);
+    }
+}
+
+bool
+t_stree::is_unique_from_gstate(
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table,
+    const std::string& colname,
+    const std::vector<t_tscalar>& pkeys,
+    t_tscalar& value) const {
+    const t_schema& expression_schema = expression_master_table.get_schema();
+
+    if (expression_schema.has_column(colname)) {
+        return gstate.is_unique(
+            expression_master_table, colname, pkeys, value);
+    } else {
+        std::shared_ptr<t_data_table> gstate_master_table = gstate.get_table();
+        return gstate.is_unique(
+            *gstate_master_table, colname, pkeys, value);
+    }
+}
+
+bool
+t_stree::apply_from_gstate(
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table,
+    const std::string& colname,
+    const std::vector<t_tscalar>& pkeys,
+    t_tscalar& value,
+    std::function<bool(const t_tscalar&, t_tscalar&)> fn) const {
+    const t_schema& expression_schema = expression_master_table.get_schema();
+
+    if (expression_schema.has_column(colname)) {
+        return gstate.apply(
+            expression_master_table, colname, pkeys, value, fn);
+    } else {
+        std::shared_ptr<t_data_table> gstate_master_table = gstate.get_table();
+        return gstate.apply(
+            *gstate_master_table, colname, pkeys, value, fn);
+    }
+}
+
+template <typename FN_T>
+typename FN_T::result_type
+t_stree::reduce_from_gstate(
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table,
+    const std::string& colname,
+    const std::vector<t_tscalar>& pkeys,
+    FN_T fn) const {
+    const t_schema& expression_schema = expression_master_table.get_schema();
+
+    if (expression_schema.has_column(colname)) {
+        return gstate.reduce(
+            expression_master_table, colname, pkeys, fn);
+    } else {
+        std::shared_ptr<t_data_table> gstate_master_table = gstate.get_table();
+        return gstate.reduce(
+            *gstate_master_table, colname, pkeys, fn);
     }
 }
 

--- a/cpp/perspective/src/cpp/tree_context_common.cpp
+++ b/cpp/perspective/src/cpp/tree_context_common.cpp
@@ -22,12 +22,17 @@
 namespace perspective {
 
 void
-notify_sparse_tree_common(std::shared_ptr<t_data_table> strands,
-    std::shared_ptr<t_data_table> strand_deltas, std::shared_ptr<t_stree> tree,
-    std::shared_ptr<t_traversal> traversal, bool process_traversal,
+notify_sparse_tree_common(
+    std::shared_ptr<t_data_table> strands,
+    std::shared_ptr<t_data_table> strand_deltas,
+    std::shared_ptr<t_stree> tree,
+    std::shared_ptr<t_traversal> traversal,
+    bool process_traversal,
     const std::vector<t_aggspec>& aggregates,
     const std::vector<std::pair<std::string, std::string>>& tree_sortby,
-    const std::vector<t_sortspec>& ctx_sortby, const t_gstate& gstate) {
+    const std::vector<t_sortspec>& ctx_sortby,
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table) {
     t_filter fltr;
     if (t_env::log_data_nsparse_strands()) {
         std::cout << "nsparse_strands" << std::endl;
@@ -73,7 +78,7 @@ notify_sparse_tree_common(std::shared_ptr<t_data_table> strands,
 
     tree->populate_leaf_index(non_zero_leaves);
 
-    tree->update_aggs_from_static(dctx, gstate);
+    tree->update_aggs_from_static(dctx, gstate, expression_master_table);
 
     std::set<t_uindex> visited;
 
@@ -128,13 +133,22 @@ notify_sparse_tree_common(std::shared_ptr<t_data_table> strands,
 }
 
 void
-notify_sparse_tree(std::shared_ptr<t_stree> tree, std::shared_ptr<t_traversal> traversal,
-    bool process_traversal, const std::vector<t_aggspec>& aggregates,
+notify_sparse_tree(
+    std::shared_ptr<t_stree> tree,
+    std::shared_ptr<t_traversal> traversal,
+    bool process_traversal,
+    const std::vector<t_aggspec>& aggregates,
     const std::vector<std::pair<std::string, std::string>>& tree_sortby,
-    const std::vector<t_sortspec>& ctx_sortby, const t_data_table& flattened,
-    const t_data_table& delta, const t_data_table& prev, const t_data_table& current,
-    const t_data_table& transitions, const t_data_table& existed, const t_config& config,
-    const t_gstate& gstate) {
+    const std::vector<t_sortspec>& ctx_sortby,
+    const t_data_table& flattened,
+    const t_data_table& delta,
+    const t_data_table& prev,
+    const t_data_table& current,
+    const t_data_table& transitions,
+    const t_data_table& existed,
+    const t_config& config,
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table) {
 
     auto strand_values = tree->build_strand_table(
         flattened, delta, prev, current, transitions, aggregates, config);
@@ -142,21 +156,27 @@ notify_sparse_tree(std::shared_ptr<t_stree> tree, std::shared_ptr<t_traversal> t
     auto strands = strand_values.first;
     auto strand_deltas = strand_values.second;
     notify_sparse_tree_common(strands, strand_deltas, tree, traversal, process_traversal,
-        aggregates, tree_sortby, ctx_sortby, gstate);
+        aggregates, tree_sortby, ctx_sortby, gstate, expression_master_table);
 }
 
 void
-notify_sparse_tree(std::shared_ptr<t_stree> tree, std::shared_ptr<t_traversal> traversal,
-    bool process_traversal, const std::vector<t_aggspec>& aggregates,
+notify_sparse_tree(
+    std::shared_ptr<t_stree> tree,
+    std::shared_ptr<t_traversal> traversal,
+    bool process_traversal,
+    const std::vector<t_aggspec>& aggregates,
     const std::vector<std::pair<std::string, std::string>>& tree_sortby,
-    const std::vector<t_sortspec>& ctx_sortby, const t_data_table& flattened,
-    const t_config& config, const t_gstate& gstate) {
+    const std::vector<t_sortspec>& ctx_sortby,
+    const t_data_table& flattened,
+    const t_config& config,
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table) {
     auto strand_values = tree->build_strand_table(flattened, aggregates, config);
 
     auto strands = strand_values.first;
     auto strand_deltas = strand_values.second;
     notify_sparse_tree_common(strands, strand_deltas, tree, traversal, process_traversal,
-        aggregates, tree_sortby, ctx_sortby, gstate);
+        aggregates, tree_sortby, ctx_sortby, gstate, expression_master_table);
 }
 
 std::vector<t_path>

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -43,24 +43,10 @@ public:
         const std::vector<std::pair<std::string, std::string>>& column_ids,
         t_dtype dtype);
 
-    /**
-     * @brief Compute this expression and add the output column to
-     * `data_table.`
-     * 
-     * @param data_table 
-     */
-    void compute(std::shared_ptr<t_data_table> data_table) const;
- 
-    /**
-     * @brief Compute this expression for the rows in `changed_rows`, and
-     * add the output column to `flattened`.
-     */
-    void recompute(
-        std::shared_ptr<t_data_table> gstate_table,
-        std::shared_ptr<t_data_table> flattened,
-        const std::vector<t_rlookup>& changed_rows) const;
-
-    void set_expression_vocab(std::shared_ptr<t_vocab> vocab);
+    void compute(
+        t_data_table* source_table,
+        t_data_table* destination_table,
+        std::shared_ptr<t_vocab> vocab) const;
 
     const std::string& get_expression_alias() const;
     const std::string& get_expression_string() const;

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -44,8 +44,8 @@ public:
         t_dtype dtype);
 
     void compute(
-        t_data_table* source_table,
-        t_data_table* destination_table,
+        std::shared_ptr<t_data_table> source_table,
+        std::shared_ptr<t_data_table> destination_table,
         std::shared_ptr<t_vocab> vocab) const;
 
     const std::string& get_expression_alias() const;

--- a/cpp/perspective/src/include/perspective/context_common_decls.h
+++ b/cpp/perspective/src/include/perspective/context_common_decls.h
@@ -87,7 +87,7 @@ bool is_expression_column(const std::string& colname) const;
 
 t_uindex num_expressions() const;
 
-const t_expression_tables* get_expression_tables() const;
+std::shared_ptr<t_expression_tables> get_expression_tables() const;
 
 // Given shared pointers to data tables from the gnode, use them to
 // compute the results of expression columns.

--- a/cpp/perspective/src/include/perspective/context_common_decls.h
+++ b/cpp/perspective/src/include/perspective/context_common_decls.h
@@ -34,7 +34,7 @@ std::string repr() const;
 
 void init();
 
-void reset();
+void reset(bool reset_expressions = true);
 
 t_index sidedness() const;
 
@@ -47,9 +47,6 @@ void set_deltas_enabled(bool enabled_state);
 void set_feature_state(t_ctx_feature feature, bool state);
 
 std::vector<t_tscalar> get_pkeys(const std::vector<std::pair<t_uindex, t_uindex>>& cells) const;
-
-std::vector<t_tscalar> get_cell_data(
-    const std::vector<std::pair<t_uindex, t_uindex>>& cells) const;
 
 t_stepdelta get_step_delta(t_index bidx, t_index eidx);
 
@@ -76,6 +73,34 @@ void pprint() const;
 t_dtype get_column_dtype(t_uindex idx) const;
 
 std::shared_ptr<t_data_table> get_table() const;
+
+/**
+ * @brief Given a column name return whether it is an expression column.
+ * Because expression columns cannot overwrite real columns, a column cannot
+ * be both an expression and a "real" column.
+ * 
+ * @param colname 
+ * @return true 
+ * @return false 
+ */
+bool is_expression_column(const std::string& colname) const;
+
+t_uindex num_expressions() const;
+
+const t_expression_tables* get_expression_tables() const;
+
+// Given shared pointers to data tables from the gnode, use them to
+// compute the results of expression columns.
+void compute_expressions(std::shared_ptr<t_data_table> flattened_masked);
+
+void compute_expressions(
+    std::shared_ptr<t_data_table> master,
+    std::shared_ptr<t_data_table> flattened,
+    std::shared_ptr<t_data_table> delta,
+    std::shared_ptr<t_data_table> prev,
+    std::shared_ptr<t_data_table> current,
+    std::shared_ptr<t_data_table> transitions,
+    std::shared_ptr<t_data_table> existed);
 
 // Unity api
 std::vector<t_tscalar> unity_get_row_data(t_uindex idx) const;

--- a/cpp/perspective/src/include/perspective/context_grouped_pkey.h
+++ b/cpp/perspective/src/include/perspective/context_grouped_pkey.h
@@ -68,7 +68,7 @@ private:
     t_depth m_depth;
     bool m_depth_set;
     std::shared_ptr<t_vocab> m_expression_vocab;
-    std::unique_ptr<t_expression_tables> m_expression_tables;
+    std::shared_ptr<t_expression_tables> m_expression_tables;
 };
 
 typedef std::shared_ptr<t_ctx_grouped_pkey> t_ctx_grouped_pkey_sptr;

--- a/cpp/perspective/src/include/perspective/context_grouped_pkey.h
+++ b/cpp/perspective/src/include/perspective/context_grouped_pkey.h
@@ -16,6 +16,7 @@
 #include <perspective/data_table.h>
 #include <perspective/path.h>
 #include <perspective/sym_table.h>
+#include <perspective/expression_tables.h>
 
 namespace perspective {
 
@@ -55,6 +56,10 @@ public:
 private:
     void rebuild();
 
+    t_tscalar get_value_from_gstate(
+        const std::string& colname,
+        const t_tscalar& pkey) const;
+
     std::shared_ptr<t_traversal> m_traversal;
     std::shared_ptr<t_stree> m_tree;
     std::vector<t_sortspec> m_sortby;
@@ -62,6 +67,8 @@ private:
     bool m_has_label;
     t_depth m_depth;
     bool m_depth_set;
+    std::shared_ptr<t_vocab> m_expression_vocab;
+    std::unique_ptr<t_expression_tables> m_expression_tables;
 };
 
 typedef std::shared_ptr<t_ctx_grouped_pkey> t_ctx_grouped_pkey_sptr;

--- a/cpp/perspective/src/include/perspective/context_one.h
+++ b/cpp/perspective/src/include/perspective/context_one.h
@@ -52,7 +52,7 @@ private:
     std::shared_ptr<t_stree> m_tree;
     std::vector<t_sortspec> m_sortby;
     std::shared_ptr<t_vocab> m_expression_vocab;
-    std::unique_ptr<t_expression_tables> m_expression_tables;
+    std::shared_ptr<t_expression_tables> m_expression_tables;
     t_depth m_depth;
     bool m_depth_set;
 };

--- a/cpp/perspective/src/include/perspective/context_one.h
+++ b/cpp/perspective/src/include/perspective/context_one.h
@@ -15,6 +15,7 @@
 #include <perspective/sort_specification.h>
 #include <perspective/traversal.h>
 #include <perspective/data_table.h>
+#include <perspective/expression_tables.h>
 
 namespace perspective {
 
@@ -50,6 +51,8 @@ private:
     std::shared_ptr<t_traversal> m_traversal;
     std::shared_ptr<t_stree> m_tree;
     std::vector<t_sortspec> m_sortby;
+    std::shared_ptr<t_vocab> m_expression_vocab;
+    std::unique_ptr<t_expression_tables> m_expression_tables;
     t_depth m_depth;
     bool m_depth_set;
 };

--- a/cpp/perspective/src/include/perspective/context_two.h
+++ b/cpp/perspective/src/include/perspective/context_two.h
@@ -86,7 +86,7 @@ private:
     t_depth m_column_depth;
     bool m_column_depth_set;
     std::shared_ptr<t_vocab> m_expression_vocab;
-    std::unique_ptr<t_expression_tables> m_expression_tables;
+    std::shared_ptr<t_expression_tables> m_expression_tables;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/context_two.h
+++ b/cpp/perspective/src/include/perspective/context_two.h
@@ -17,6 +17,7 @@
 #include <perspective/traversal_nodes.h>
 #include <perspective/traversal.h>
 #include <perspective/data_table.h>
+#include <perspective/expression_tables.h>
 
 namespace perspective {
 
@@ -84,6 +85,8 @@ private:
     bool m_row_depth_set;
     t_depth m_column_depth;
     bool m_column_depth_set;
+    std::shared_ptr<t_vocab> m_expression_vocab;
+    std::unique_ptr<t_expression_tables> m_expression_tables;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/context_zero.h
+++ b/cpp/perspective/src/include/perspective/context_zero.h
@@ -94,7 +94,7 @@ private:
     std::shared_ptr<t_zcdeltas> m_deltas;
     tsl::hopscotch_set<t_tscalar> m_delta_pkeys;
     std::shared_ptr<t_vocab> m_expression_vocab;
-    std::unique_ptr<t_expression_tables> m_expression_tables;
+    std::shared_ptr<t_expression_tables> m_expression_tables;
     t_symtable m_symtable;
     bool m_has_delta;
 };

--- a/cpp/perspective/src/include/perspective/context_zero.h
+++ b/cpp/perspective/src/include/perspective/context_zero.h
@@ -17,6 +17,7 @@
 #include <perspective/traversal.h>
 #include <perspective/flat_traversal.h>
 #include <perspective/data_table.h>
+#include <perspective/expression_tables.h>
 #include <tsl/hopscotch_set.h>
 
 namespace perspective {
@@ -74,10 +75,26 @@ protected:
 
     void add_delta_pkey(t_tscalar pkey);
 
+    /**
+     * @brief Read the specified column using the gnode's mapping - if the
+     * column is an expression column, uses the expression master table,
+     * otherwise use the gstate master table.
+     * 
+     * @param colname 
+     * @param pkeys 
+     * @param out_data 
+     */
+    void read_column_from_gstate(
+        const std::string& colname,
+        const std::vector<t_tscalar>& pkeys,
+        std::vector<t_tscalar>& out_data) const;
+
 private:
     std::shared_ptr<t_ftrav> m_traversal;
     std::shared_ptr<t_zcdeltas> m_deltas;
     tsl::hopscotch_set<t_tscalar> m_delta_pkeys;
+    std::shared_ptr<t_vocab> m_expression_vocab;
+    std::unique_ptr<t_expression_tables> m_expression_tables;
     t_symtable m_symtable;
     bool m_has_delta;
 };

--- a/cpp/perspective/src/include/perspective/data_table.h
+++ b/cpp/perspective/src/include/perspective/data_table.h
@@ -106,6 +106,13 @@ public:
 
     void set_size(t_uindex size);
 
+    /**
+     * @brief Only set `m_size` for the table without setting it for columns.
+     * 
+     * @param size 
+     */
+    void set_table_size(t_uindex size);
+
     t_column* _get_column(const std::string& colname);
 
     std::shared_ptr<t_data_table> flatten() const;
@@ -128,6 +135,26 @@ public:
     t_data_table* clone_(const t_mask& mask) const;
     std::shared_ptr<t_data_table> clone(const t_mask& mask) const;
     std::shared_ptr<t_data_table> clone() const;
+
+    /**
+     * @brief Given `other_table`, return a new `t_data_table` that references
+     * both the columns of the current table and `table` without making any
+     * copies of the underlying data.
+     * 
+     * If a column is present in both the current table and `other_table`, the
+     * column from the current table takes precedence. This method is designed
+     * for quick, temporary copies of a `t_data_table` that can be used and
+     * disposed of, which is why it returns a stack-allocated table instead
+     * of a heap-allocated pointer to a table.
+     * 
+     * @param table 
+     * @return t_data_table 
+     */
+    std::shared_ptr<t_data_table>
+    join(std::shared_ptr<t_data_table> other_table) const;
+    
+    std::shared_ptr<t_data_table>
+    join(const t_data_table& other_table) const;
 
     /**
      * @brief Create a new `t_data_table` from the specified schema. For each

--- a/cpp/perspective/src/include/perspective/data_table.h
+++ b/cpp/perspective/src/include/perspective/data_table.h
@@ -152,9 +152,6 @@ public:
      */
     std::shared_ptr<t_data_table>
     join(std::shared_ptr<t_data_table> other_table) const;
-    
-    std::shared_ptr<t_data_table>
-    join(const t_data_table& other_table) const;
 
     /**
      * @brief Create a new `t_data_table` from the specified schema. For each

--- a/cpp/perspective/src/include/perspective/expression_tables.h
+++ b/cpp/perspective/src/include/perspective/expression_tables.h
@@ -35,20 +35,20 @@ struct t_expression_tables {
     void clear_transitional_tables();
 
     // Calculate the `t_transitions` value for each row.
-    void calculate_transitions(t_data_table* existed);
+    void calculate_transitions(std::shared_ptr<t_data_table> existed);
 
     void reset();
 
     // master table is calculated from t_gstate's master table
-    std::unique_ptr<t_data_table> m_master;
+    std::shared_ptr<t_data_table> m_master;
     
     // flattened, prev, current, delta, transitions calculated from the
     // tables stored on the gnode's output ports.
-    std::unique_ptr<t_data_table> m_flattened;
-    std::unique_ptr<t_data_table> m_prev;
-    std::unique_ptr<t_data_table> m_current;
-    std::unique_ptr<t_data_table> m_delta;
-    std::unique_ptr<t_data_table> m_transitions;
+    std::shared_ptr<t_data_table> m_flattened;
+    std::shared_ptr<t_data_table> m_prev;
+    std::shared_ptr<t_data_table> m_current;
+    std::shared_ptr<t_data_table> m_delta;
+    std::shared_ptr<t_data_table> m_transitions;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/expression_tables.h
+++ b/cpp/perspective/src/include/perspective/expression_tables.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+#pragma once
+#include <perspective/first.h>
+#include <perspective/base.h>
+#include <perspective/computed_expression.h>
+#include <perspective/data_table.h>
+
+#ifdef PSP_PARALLEL_FOR
+#include <tbb/parallel_sort.h>
+#include <tbb/tbb.h>
+#endif
+
+namespace perspective {
+
+/**
+ * @brief Store expression tables for each context - by separating expression
+ * columns from the main tables managed by the context, we ensure that cleaning
+ * up a context will also clean up its expression columns and not leak memory
+ * after the lifetime of a context.
+ */
+struct t_expression_tables {
+
+    t_expression_tables();
+    t_expression_tables(const std::vector<t_computed_expression>& expressions);
+    
+    void set_transitional_table_capacity(t_uindex capacity);
+    void set_transitional_table_size(t_uindex size);
+    void clear_transitional_tables();
+
+    // Calculate the `t_transitions` value for each row.
+    void calculate_transitions(t_data_table* existed);
+
+    void reset();
+
+    // master table is calculated from t_gstate's master table
+    std::unique_ptr<t_data_table> m_master;
+    
+    // flattened, prev, current, delta, transitions calculated from the
+    // tables stored on the gnode's output ports.
+    std::unique_ptr<t_data_table> m_flattened;
+    std::unique_ptr<t_data_table> m_prev;
+    std::unique_ptr<t_data_table> m_current;
+    std::unique_ptr<t_data_table> m_delta;
+    std::unique_ptr<t_data_table> m_transitions;
+};
+
+} // end namespace perspective

--- a/cpp/perspective/src/include/perspective/flat_traversal.h
+++ b/cpp/perspective/src/include/perspective/flat_traversal.h
@@ -45,13 +45,25 @@ public:
 
     t_tscalar get_pkey(t_index idx) const;
 
-    void fill_sort_elem(std::shared_ptr<const t_gstate> gstate, const t_config& config,
-        const std::vector<t_tscalar>& row, t_mselem& out_elem) const;
+    void fill_sort_elem(
+        const t_gstate& gstate,
+        const t_data_table& expression_master_table,
+        const t_config& config,
+        t_tscalar pkey,
+        t_mselem& out_elem);
 
-    void fill_sort_elem(std::shared_ptr<const t_gstate> gstate, const t_config& config,
-        t_tscalar pkey, t_mselem& out_elem);
+    // sorting over a whole row whose data we already have, so we don't need
+    // the expression table separately.
+    void fill_sort_elem(
+        const t_gstate& gstate,
+        const t_config& config,
+        const std::vector<t_tscalar>& row,
+        t_mselem& out_elem) const;
 
-    void sort_by(std::shared_ptr<const t_gstate> gstate, const t_config& config,
+    void sort_by(
+        const t_gstate& gstate,
+        const t_data_table& expression_master_table,
+        const t_config& config,
         const std::vector<t_sortspec>& sortby);
 
     t_index size() const;
@@ -74,10 +86,17 @@ public:
 
     void step_end();
 
-    void add_row(std::shared_ptr<const t_gstate> gstate, const t_config& config, t_tscalar pkey);
+    void add_row(
+        const t_gstate& gstate, 
+        const t_data_table& expression_master_table,
+        const t_config& config,
+        t_tscalar pkey);
 
     void update_row(
-        std::shared_ptr<const t_gstate> gstate, const t_config& config, t_tscalar pkey);
+        const t_gstate& gstate,
+        const t_data_table& expression_master_table,
+        const t_config& config,
+        t_tscalar pkey);
 
     void delete_row(t_tscalar pkey);
 
@@ -86,12 +105,19 @@ public:
 
     void reset_step_state();
 
-    t_uindex lower_bound_row_idx(std::shared_ptr<const t_gstate> gstate, const t_config& config,
+    t_uindex lower_bound_row_idx(const t_gstate& gstate, const t_config& config,
         const std::vector<t_tscalar>& row) const;
 
     t_index get_row_idx(t_tscalar pkey) const;
 
 private:
+    t_tscalar get_from_gstate(
+        const t_gstate& gstate,
+        const t_data_table& expression_master_table,
+        const std::string& colname,
+        t_tscalar pkey
+    ) const;
+
     t_index m_step_deletes;
     t_index m_step_inserts;
 

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -22,6 +22,7 @@
 #include <perspective/process_state.h>
 #include <perspective/computed_expression.h>
 #include <perspective/computed_function.h>
+#include <perspective/expression_tables.h>
 #include <tsl/ordered_map.h>
 #ifdef PSP_ENABLE_PYTHON
 #include <thread>
@@ -132,8 +133,7 @@ public:
 
     /**
      * @brief Given a new context, register it with the gnode, compute and
-     * add its expression columns, and add its expressions to the
-     * `m_expression_map` managed by the gnode.
+     * add its expression columns.
      * 
      * @param name 
      * @param type 
@@ -143,7 +143,7 @@ public:
 
     /**
      * @brief Remove a context by name from the gnode, and remove its
-     * computed expression columns from `m_expression_map`.
+     * computed expression columns.
      * 
      * @param name 
      */
@@ -233,7 +233,10 @@ protected:
      * @param changed_rows 
      */
     template <typename CTX_T>
-    void update_context_from_state(CTX_T* ctx, std::shared_ptr<t_data_table> tbl);
+    void update_context_from_state(
+        CTX_T* ctx,
+        const std::string& name,
+        std::shared_ptr<t_data_table> flattened);
 
     /**
      * @brief Provide the registered `t_ctx*` with a pointer to this gnode's
@@ -247,15 +250,13 @@ protected:
     void set_ctx_state(void* ptr);
 
     bool have_context(const std::string& name) const;
-    void notify_contexts(const t_data_table& flattened);
+    void notify_contexts(std::shared_ptr<t_data_table> flattened);
 
     template <typename CTX_T>
-    void notify_context(const t_data_table& flattened, const t_ctx_handle& ctxh);
-
-    template <typename CTX_T>
-    void notify_context(CTX_T* ctx, const t_data_table& flattened, const t_data_table& delta,
-        const t_data_table& prev, const t_data_table& current, const t_data_table& transitions,
-        const t_data_table& existed);
+    void notify_context(
+        std::shared_ptr<t_data_table> flattened,
+        const t_ctx_handle& ctxh,
+        const std::string& name);
 
     /**
      * @brief Given the process state, create a `t_mask` bitset set to true for
@@ -305,29 +306,22 @@ protected:
      *
      * Expression Column Operations
      */
+
+    /**
+     * @brief Compute all expressions on each registered context using the
+     * flattened table. This method is called on the first update applied
+     * on an empty gstate master table.
+     */
+    void _compute_expressions(std::shared_ptr<t_data_table> flattened_masked);
+
+    /**
+     * @brief Compute all expressions on each registered context using all
+     * data and transition tables. This method is called on all subsequent
+     * updates applied after the first update.
+     */
     void _compute_expressions(
-        std::vector<std::shared_ptr<t_data_table>> tables);
-
-    void _recompute_expressions(
-        std::shared_ptr<t_data_table> tbl,
-        std::shared_ptr<t_data_table> flattened,
-        const std::vector<t_rlookup>& changed_rows);
-
-    /**
-     * @brief Add each expression to `m_expression_map` if it does not
-     * already exist, and register the gnode's vocab pointer with each
-     * expression.
-     * 
-     * @param expressions 
-     */
-    void _register_expressions(std::vector<t_computed_expression>& expressions);
-
-    /**
-     * @brief Remove expressions from the `m_expression_map`.
-     * 
-     * @param expressions 
-     */
-    void _unregister_expressions(const std::vector<t_computed_expression>& expressions);
+        std::shared_ptr<t_data_table> master,
+        std::shared_ptr<t_data_table> flattened);
 
 private:
     /**
@@ -350,13 +344,6 @@ private:
     // A vector of `t_schema`s for each transitional `t_data_table`.
     std::vector<t_schema> m_transitional_schemas;
 
-    // track all expressions on this gnode
-    tsl::ordered_map<std::string, t_computed_expression> m_expression_map;
-
-    // Expressions that create strings need to intern their strings so that
-    // memory leaks/errors do not happen later.
-    std::shared_ptr<t_vocab> m_expression_vocab;
-
     bool m_init;
     t_uindex m_id;
 
@@ -369,8 +356,9 @@ private:
     // Output ports stored sequentially in a vector, keyed by the
     // `t_gnode_port` enum.
     std::vector<std::shared_ptr<t_port>> m_oports;
-    std::map<std::string, t_ctx_handle> m_contexts;
+    tsl::ordered_map<std::string, t_ctx_handle> m_contexts;
     std::shared_ptr<t_gstate> m_gstate;
+
     std::chrono::high_resolution_clock::time_point m_epoch;
     std::function<void()> m_pool_cleanup;
     bool m_was_updated;
@@ -390,44 +378,56 @@ private:
  */
 template <typename CTX_T>
 void
-t_gnode::notify_context(const t_data_table& flattened, const t_ctx_handle& ctxh) {
+t_gnode::notify_context(
+    std::shared_ptr<t_data_table> flattened,
+    const t_ctx_handle& ctxh,
+    const std::string& name) {
     CTX_T* ctx = ctxh.get<CTX_T>();
-    // These tables are guaranteed to have all expression columns applied
-    // in `process_table`.
-    const t_data_table& delta = *(m_oports[PSP_PORT_DELTA]->get_table().get());
-    const t_data_table& prev = *(m_oports[PSP_PORT_PREV]->get_table().get());
-    const t_data_table& current = *(m_oports[PSP_PORT_CURRENT]->get_table().get());
-    const t_data_table& transitions = *(m_oports[PSP_PORT_TRANSITIONS]->get_table().get());
-    const t_data_table& existed = *(m_oports[PSP_PORT_EXISTED]->get_table().get());
-    notify_context<CTX_T>(ctx, flattened, delta, prev, current, transitions, existed);
-}
+    
+    // Tables from the gnode which do not have the expressions applied yet
+    std::shared_ptr<t_data_table> delta = m_oports[PSP_PORT_DELTA]->get_table();
+    std::shared_ptr<t_data_table> prev = m_oports[PSP_PORT_PREV]->get_table();
+    std::shared_ptr<t_data_table> current = m_oports[PSP_PORT_CURRENT]->get_table();
+    std::shared_ptr<t_data_table> transitions = m_oports[PSP_PORT_TRANSITIONS]->get_table();
 
-/**
- * @brief Given multiple `t_data_table`s containing the different states of the context,
- * update the context with new data.
- *
- * Called on updates and additions AFTER a view is constructed from the table/context.
- *
- * @tparam CTX_T
- * @param ctx
- * @param flattened a `t_data_table` containing the flat data for the context
- * @param delta a `t_data_table` containing the changes to the dataset
- * @param prev a `t_data_table` containing the previous state
- * @param current a `t_data_table` containing the current state
- * @param transitions a `t_data_table` containing operations to transform the context
- * @param existed
- */
-template <typename CTX_T>
-void
-t_gnode::notify_context(CTX_T* ctx, const t_data_table& flattened, const t_data_table& delta,
-    const t_data_table& prev, const t_data_table& current, const t_data_table& transitions,
-    const t_data_table& existed) {
-    auto ctx_config = ctx->get_config();
+    // Existed is special - it will never have any expression columns and can
+    // be used as-is from the gnode.
+    const t_data_table& existed = *(m_oports[PSP_PORT_EXISTED]->get_table().get());
 
     ctx->step_begin();
-    // Flattened has the expressions at this point, as it has
-    // passed through the body of `process_table`.
-    ctx->notify(flattened, delta, prev, current, transitions, existed);
+
+    if (ctx->num_expressions() > 0) {
+        // Join expression tables on the context with gnode tables and pass those
+        // into the context so there is no distinction between expression and real
+        // columns for the context.
+        const t_expression_tables* ctx_expression_tables = ctx->get_expression_tables();
+
+        auto joined_flattened = ctx_expression_tables->m_flattened->join(flattened);
+        auto joined_delta = ctx_expression_tables->m_delta->join(delta);
+        auto joined_prev = ctx_expression_tables->m_prev->join(prev);
+        auto joined_current = ctx_expression_tables->m_current->join(current);
+        auto joined_transitions = ctx_expression_tables->m_transitions->join(transitions);
+
+        // pass the tables as const references - the destructors for all of the
+        // joined tables will be called after this function finishes executing,
+        // as the contexts do not retain a reference to these tables.
+        ctx->notify(
+            *(joined_flattened.get()),
+            *(joined_delta.get()),
+            *(joined_prev.get()),
+            *(joined_current.get()),
+            *(joined_transitions.get()),
+            existed);
+    } else {
+        ctx->notify(
+            *(flattened.get()),
+            *(delta.get()),
+            *(prev.get()),
+            *(current.get()),
+            *(transitions.get()),
+            existed);
+    }
+
     ctx->step_end();
 }
 
@@ -443,22 +443,39 @@ t_gnode::notify_context(CTX_T* ctx, const t_data_table& flattened, const t_data_
 template <typename CTX_T>
 void
 t_gnode::update_context_from_state(
-    CTX_T* ctx, std::shared_ptr<t_data_table> flattened) {
+    CTX_T* ctx,
+    const std::string& name,
+    std::shared_ptr<t_data_table> flattened) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     PSP_VERBOSE_ASSERT(
         m_mode == NODE_PROCESSING_SIMPLE_DATAFLOW, "Only simple dataflows supported currently")
 
-    if (flattened->size() == 0)
-        return;
-
-    // Need to cast shared ptr to a const reference before passing to notify,
-    // reference is valid as `notify` is not async
-    const t_data_table& const_flattened = 
-        const_cast<const t_data_table&>(*flattened);
+    if (flattened->size() == 0) return;
 
     ctx->step_begin();
-    ctx->notify(const_flattened);
+
+    // This method is called in two places:
+    //
+    // 1. when a new context is created and it needs to get the current state
+    //  of the gstate master table in order to calculate aggregates, etc.
+    //
+    // 2. when a table created from schema (0 rows) gets data and now needs
+    //  to update its registered contexts with the new data.
+    if (ctx->num_expressions() > 0) {
+        // If the context has expression columns, it has already been computed
+        // in `process_table` and we can join the "real" and expression columns
+        // together and pass it to the context.
+        const t_expression_tables* ctx_expression_tables = ctx->get_expression_tables();
+        const t_data_table* master_expression_table = ctx_expression_tables->m_master.get();
+        std::shared_ptr<t_data_table> joined_flattened = master_expression_table->join(flattened);
+
+        ctx->notify(*(joined_flattened.get()));
+    } else {
+        // Just use the table from the gnode
+        ctx->notify(*(flattened.get()));
+    }
+
     ctx->step_end();
 }
 

--- a/cpp/perspective/src/include/perspective/tree_context_common.h
+++ b/cpp/perspective/src/include/perspective/tree_context_common.h
@@ -16,28 +16,46 @@
 
 namespace perspective {
 
-PERSPECTIVE_EXPORT void notify_sparse_tree_common(std::shared_ptr<t_data_table> strands,
-    std::shared_ptr<t_data_table> strand_deltas, std::shared_ptr<t_stree> tree,
-    std::shared_ptr<t_traversal> traversal, bool process_traversal,
+PERSPECTIVE_EXPORT void notify_sparse_tree_common(
+    std::shared_ptr<t_data_table> strands,
+    std::shared_ptr<t_data_table> strand_deltas,
+    std::shared_ptr<t_stree> tree,
+    std::shared_ptr<t_traversal> traversal,
+    bool process_traversal,
     const std::vector<t_aggspec>& aggregates,
     const std::vector<std::pair<std::string, std::string>>& tree_sortby,
-    const std::vector<t_sortspec>& ctx_sortby, const t_gstate& gstate);
+    const std::vector<t_sortspec>& ctx_sortby,
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table);
 
-PERSPECTIVE_EXPORT void notify_sparse_tree(std::shared_ptr<t_stree> tree,
-    std::shared_ptr<t_traversal> traversal, bool process_traversal,
+PERSPECTIVE_EXPORT void notify_sparse_tree(
+    std::shared_ptr<t_stree> tree,
+    std::shared_ptr<t_traversal> traversal,
+    bool process_traversal,
     const std::vector<t_aggspec>& aggregates,
     const std::vector<std::pair<std::string, std::string>>& tree_sortby,
-    const std::vector<t_sortspec>& ctx_sortby, const t_data_table& flattened,
-    const t_data_table& delta, const t_data_table& prev, const t_data_table& current,
-    const t_data_table& transitions, const t_data_table& existed, const t_config& config,
-    const t_gstate& gstate);
+    const std::vector<t_sortspec>& ctx_sortby,
+    const t_data_table& flattened,
+    const t_data_table& delta,
+    const t_data_table& prev,
+    const t_data_table& current,
+    const t_data_table& transitions,
+    const t_data_table& existed,
+    const t_config& config,
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table);
 
-PERSPECTIVE_EXPORT void notify_sparse_tree(std::shared_ptr<t_stree> tree,
-    std::shared_ptr<t_traversal> traversal, bool process_traversal,
+PERSPECTIVE_EXPORT void notify_sparse_tree(
+    std::shared_ptr<t_stree> tree,
+    std::shared_ptr<t_traversal> traversal,
+    bool process_traversal,
     const std::vector<t_aggspec>& aggregates,
     const std::vector<std::pair<std::string, std::string>>& tree_sortby,
-    const std::vector<t_sortspec>& ctx_sortby, const t_data_table& flattened,
-    const t_config& config, const t_gstate& gstate);
+    const std::vector<t_sortspec>& ctx_sortby,
+    const t_data_table& flattened,
+    const t_config& config,
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table);
 
 template <typename CONTEXT_T>
 void

--- a/docs/md/view.md
+++ b/docs/md/view.md
@@ -291,30 +291,33 @@ Use the `filters` attribute on `<perspective-viewer>` instead of `filter`.
 </perspective-viewer>
 </div>
 
-## Computed Columns
+## Expressions
 
-The `computed-columns` property defines calculations over the Table's columns,
-allowing you to create new columns using values from existing ones.  Computed
-columns are added using the `New Column` button in
-the bottom left of `<perspective-viewer>`, which opens the expression editor.
-This allows you to create computed columns from arbitary expressions, which are
-type and syntax-checked and allow for aliasing, nesting, and evaluation in the
-correct order.  To add computed columns in via the API, pass in an array of
-Objects:
+The `expressions` attribute specifies _new_ columns in Perspective that are
+created using existing column values or arbitary scalar values defined within
+the expression. In `<perspective-viewer>`, expressions are added using the
+"New Column" button in the side panel. 
+
+A custom name can be added to an expression by making the first line a
+comment:
+
+```javascript
+// new column
+("Sales" * "Profit") - 15
+```
+
+To add expressions using the API:
 #### Example
-
-`<perspective-viewer>`'s `computed-column` attribute can be set using an
-array of expressions.
 
 ```html
 <perspective-viewer
-    columns='["(Sales + ((Profit * Quantity) / sqrt(Sales)))"]'
-    computed-columns='["\"Sales\" + \"Profit\" * \"Quantity\" / sqrt(\"Sales\")")]'>
+    columns='["new expression"]'
+    expressions='["//new expression\n"\"Sales\" + \"Profit\" * 50 / sqrt(\"Sales\")"]'>
 </perspective-viewer>
 ```
 
 <div>
-<perspective-viewer columns='["(Sales + ((Profit * Quantity) / sqrt(Sales)))"]' computed-columns='["\"Sales\" + \"Profit\" * \"Quantity\" / sqrt(\"Sales\")"]'>
+<perspective-viewer columns='["new expression"]' expressions='["//new expression\n"\"Sales\" + \"Profit\" * 50 / sqrt(\"Sales\")"]'>
 </perspective-viewer>
 </div>
 

--- a/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
+++ b/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
@@ -390,7 +390,7 @@ function get_rule(regular, tag, def) {
 export async function createModel(regular, table, view, extend = {}) {
     const config = await view.get_config();
 
-    // Extract just the expression strings from the expressions array, which
+    // Extract just the expression aliases from the expressions array, which
     // contains more metadata than we need.
     const expressions = config.expressions.map(expr => expr[0]);
 

--- a/packages/perspective/test/js/clear.js
+++ b/packages/perspective/test/js/clear.js
@@ -20,6 +20,20 @@ module.exports = perspective => {
             view.delete();
             table.delete();
         });
+
+        it("to_columns output is empty", async function() {
+            const table = await perspective.table([{x: 1}]);
+            const view = await table.view();
+            let result = await view.to_columns();
+            expect(result).toEqual({
+                x: [1]
+            });
+            table.clear();
+            result = await view.to_columns();
+            expect(result).toEqual({});
+            view.delete();
+            table.delete();
+        });
     });
 
     describe("Replace", function() {

--- a/packages/perspective/test/js/expressions.js
+++ b/packages/perspective/test/js/expressions.js
@@ -14,6 +14,7 @@ const datetime = require("./expressions/datetime");
 const updates = require("./expressions/updates");
 const deltas = require("./expressions/deltas");
 const invariant = require("./expressions/invariant");
+const multiple_views = require("./expressions/multiple_views");
 
 module.exports = perspective => {
     functionality(perspective);
@@ -23,4 +24,5 @@ module.exports = perspective => {
     updates(perspective);
     deltas(perspective);
     invariant(perspective);
+    multiple_views(perspective);
 };

--- a/packages/perspective/test/js/expressions/multiple_views.js
+++ b/packages/perspective/test/js/expressions/multiple_views.js
@@ -1,0 +1,579 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const expressions_common = require("./common.js");
+
+/**
+ * Tests the functionality of `View`-based expressions, specifically that
+ * existing column/view semantics (pivots, aggregates, columns, sorts, filters)
+ * continue to be functional on expressions.
+ */
+module.exports = perspective => {
+    const validate_delta = async (colname, delta, expected) => {
+        const t = await perspective.table(delta.slice());
+        const v = await t.view();
+        const data = await v.to_columns();
+        expect(data[colname]).toEqual(expected);
+        await v.delete();
+        await t.delete();
+    };
+
+    describe("Expressions with multiple views", () => {
+        it("Multiple views with the same expression alias should not conflict", async () => {
+            const now = new Date();
+            const bucketed = new Date(now.getUTCFullYear(), 0, 1).getTime();
+            const table = await perspective.table({
+                x: [1, 2, 3, 4],
+                y: ["a", "b", "c", "d"],
+                z: [now, now, now, now]
+            });
+
+            const v1 = await table.view({
+                columns: ["column", "column2"],
+                expressions: [`// column \n"x" + 10`, `// column2 \n concat('a', 'b', 'c')`]
+            });
+            const v2 = await table.view({
+                columns: ["column2", "column"],
+                expressions: [`// column \n upper("y")`, `// column2 \n bucket("z", 'Y')`]
+            });
+
+            expect(await v1.expression_schema()).toEqual({
+                column: "float",
+                column2: "string"
+            });
+
+            expect(await v2.expression_schema()).toEqual({
+                column: "string",
+                column2: "date"
+            });
+
+            const result = await v1.to_columns();
+            const result2 = await v2.to_columns();
+
+            expect(result["column"]).toEqual([11, 12, 13, 14]);
+            expect(result["column2"]).toEqual(Array(4).fill("abc"));
+            expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+            expect(result2["column2"]).toEqual(Array(4).fill(bucketed));
+
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        it("Multiple views with the same expression alias should not conflict, to_arrow", async () => {
+            const table = await perspective.table(expressions_common.data);
+
+            const v1 = await table.view({
+                expressions: [`// column \n"x" + 10`]
+            });
+            const v2 = await table.view({
+                expressions: [`// column \n upper("y")`]
+            });
+
+            let result = await v1.to_columns();
+            let result2 = await v2.to_columns();
+
+            expect(result["column"]).toEqual([11, 12, 13, 14]);
+            expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+            const t1 = await perspective.table(await v1.to_arrow());
+            const t2 = await perspective.table(await v2.to_arrow());
+
+            const new_v1 = await t1.view();
+            const new_v2 = await t2.view();
+
+            result = await new_v1.to_columns();
+            result2 = await new_v2.to_columns();
+
+            expect(result["column"]).toEqual([11, 12, 13, 14]);
+            expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+            await new_v2.delete();
+            await new_v1.delete();
+            await t2.delete();
+            await t1.delete();
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        it("Multiple views with the same expression alias should not conflict, filtered", async () => {
+            const table = await perspective.table(expressions_common.data);
+
+            const v1 = await table.view({
+                expressions: [`// column \n"x" + 10`],
+                filter: [["column", "==", 12]]
+            });
+            const v2 = await table.view({
+                expressions: [`// column \n upper("y")`],
+                filter: [["column", "==", "D"]]
+            });
+
+            const result = await v1.to_columns();
+            const result2 = await v2.to_columns();
+
+            expect(result["column"]).toEqual([12]);
+            expect(result2["column"]).toEqual(["D"]);
+
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        it("Multiple pivoted views with the same expression alias should not conflict", async () => {
+            const table = await perspective.table(expressions_common.data);
+
+            const v1 = await table.view({
+                row_pivots: ["y"],
+                column_pivots: ["x"],
+                expressions: [`// column \n"x" + 10`]
+            });
+            const v2 = await table.view({
+                row_pivots: ["x"],
+                column_pivots: ["y"],
+                expressions: [`// column \n upper("y")`],
+                aggregates: {
+                    column: "last"
+                }
+            });
+
+            const result = await v1.to_columns();
+            const result2 = await v2.to_columns();
+
+            expect(result["1|column"]).toEqual([11, 11, null, null, null]);
+            expect(result["2|column"]).toEqual([12, null, 12, null, null]);
+            expect(result["3|column"]).toEqual([13, null, null, 13, null]);
+            expect(result["4|column"]).toEqual([14, null, null, null, 14]);
+
+            expect(result2["a|column"]).toEqual(["A", "A", null, null, null]);
+            expect(result2["b|column"]).toEqual(["B", null, "B", null, null]);
+            expect(result2["c|column"]).toEqual(["C", null, null, "C", null]);
+            expect(result2["d|column"]).toEqual(["D", null, null, null, "D"]);
+
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        it("Multiple pivoted views with the same expression alias and different aggregates should not conflict", async () => {
+            const table = await perspective.table({
+                x: [10, 10, 20, 20],
+                y: ["A", "B", "C", "D"],
+                z: [1.5, 2.5, 3.5, 4.5]
+            });
+
+            const v1 = await table.view({
+                row_pivots: ["x"],
+                expressions: [`// column \n"z" + 10`],
+                aggregates: {
+                    column: "avg"
+                }
+            });
+
+            const v2 = await table.view({
+                row_pivots: ["x"],
+                expressions: [`// column \n upper("y")`],
+                aggregates: {
+                    column: "last"
+                }
+            });
+
+            const v3 = await table.view({
+                row_pivots: ["x"],
+                expressions: [`// column \n 2"z"`],
+                aggregates: {
+                    column: ["weighted mean", "z"]
+                }
+            });
+
+            const result = await v1.to_columns();
+            const result2 = await v2.to_columns();
+            const result3 = await v3.to_columns();
+
+            expect(result["column"]).toEqual([13, 12, 14]);
+            expect(result2["column"]).toEqual(["D", "B", "D"]);
+            expect(result3["column"]).toEqual([6.833333333333333, 4.25, 8.125]);
+
+            await v3.delete();
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+
+        describe("Multiple views with updates", () => {
+            it("Appends", async () => {
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" + 10`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                table.update(expressions_common.data);
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14, 11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D", "A", "B", "C", "D"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Append in sequence", async () => {
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper(concat("y", 'bcd'))`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([2, 4, 6, 8]);
+                expect(result2["column"]).toEqual(["ABCD", "BBCD", "CBCD", "DBCD"]);
+
+                const expected = [2, 4, 6, 8];
+                const expected2 = ["ABCD", "BBCD", "CBCD", "DBCD"];
+
+                for (let i = 0; i < 10; i++) {
+                    table.update({
+                        x: [i + 4],
+                        y: [`${i + 4}`]
+                    });
+
+                    result = await v1.to_columns();
+                    result2 = await v2.to_columns();
+
+                    expected.push((i + 4) * 2);
+                    expected2.push(`${i + 4}BCD`);
+
+                    expect(result["column"]).toEqual(expected);
+                    expect(result2["column"]).toEqual(expected2);
+                }
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Append in sequence, sorted", async () => {
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper(concat("y", 'bcd'))`],
+                    sort: [["column", "asc"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                const expected = [8, 6, 4, 2];
+                const expected2 = ["ABCD", "BBCD", "CBCD", "DBCD"];
+
+                expect(result["column"]).toEqual(expected);
+                expect(result2["column"]).toEqual(expected2);
+
+                let idx = 0;
+                for (let i = 5; i < 9; i++) {
+                    table.update({
+                        x: [i],
+                        y: [`${i}`]
+                    });
+
+                    result = await v1.to_columns();
+                    result2 = await v2.to_columns();
+
+                    expected.unshift(i * 2);
+                    expected2.splice(idx, 0, `${i}BCD`);
+
+                    expect(result["column"]).toEqual(expected);
+                    expect(result2["column"]).toEqual(expected2);
+                    idx++;
+                }
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update", async () => {
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([2, 4, 6, 8]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([null, 2, 4, 6, 8, 20]);
+                expect(result2["column"]).toEqual(["DEF", "A", "X", "Z", "Y", "ABC"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update, sorted", async () => {
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`],
+                    sort: [["column", "desc"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([8, 6, 4, 2]);
+                expect(result2["column"]).toEqual(["D", "C", "B", "A"]);
+
+                console.log("before update");
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+                console.log("after update");
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
+                expect(result2["column"]).toEqual(["Z", "Y", "X", "DEF", "ABC", "A"]);
+
+                console.log("before update2");
+                table.update({
+                    x: [2, 10],
+                    y: ["XYZ", "DEF"]
+                });
+                console.log("after update2");
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
+                expect(result2["x"]).toEqual([3, 4, 2, null, 10, 1]);
+                expect(result2["column"]).toEqual(["Z", "Y", "XYZ", "DEF", "DEF", "A"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Limit", async () => {
+                const table = await perspective.table(expressions_common.data, {limit: 2});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([6, 8]);
+                expect(result2["column"]).toEqual(["C", "D"]);
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([null, 20]);
+                expect(result2["column"]).toEqual(["DEF", "ABC"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Appends delta", async done => {
+                expect.assertions(6);
+
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" + 10`]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                const result = await v1.to_columns();
+                const result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                v1.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, [11, 12, 13, 14]);
+                        const result = await v1.to_columns();
+                        expect(result["column"]).toEqual([11, 12, 13, 14, 11, 12, 13, 14]);
+                    },
+                    {mode: "row"}
+                );
+
+                v2.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, ["A", "B", "C", "D"]);
+                        const result2 = await v2.to_columns();
+                        expect(result2["column"]).toEqual(["A", "B", "C", "D", "A", "B", "C", "D"]);
+                        await v2.delete();
+                        await v1.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update(expressions_common.data);
+            });
+
+            it("Partial update delta", async done => {
+                expect.assertions(6);
+
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                const result = await v1.to_columns();
+                const result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([2, 4, 6, 8]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                v1.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, [null, 4, 6, 8, 20]);
+                        const result = await v1.to_columns();
+                        expect(result["column"]).toEqual([null, 2, 4, 6, 8, 20]);
+                    },
+                    {mode: "row"}
+                );
+
+                v2.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, ["DEF", "X", "Z", "Y", "ABC"]);
+                        const result = await v2.to_columns();
+                        expect(result["column"]).toEqual(["DEF", "A", "X", "Z", "Y", "ABC"]);
+                        await v2.delete();
+                        await v1.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+            });
+
+            it("Partial update, sorted delta", async done => {
+                expect.assertions(6);
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`],
+                    sort: [["column", "desc"]]
+                });
+
+                const result = await v1.to_columns();
+                const result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([8, 6, 4, 2]);
+                expect(result2["column"]).toEqual(["D", "C", "B", "A"]);
+
+                v1.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, [20, 8, 6, 4, null]);
+                        const result = await v1.to_columns();
+                        expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
+                    },
+                    {mode: "row"}
+                );
+
+                v2.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, ["Z", "Y", "X", "DEF", "ABC"]);
+                        const result2 = await v2.to_columns();
+                        expect(result2["column"]).toEqual(["Z", "Y", "X", "DEF", "ABC", "A"]);
+                        await v2.delete();
+                        await v1.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+            });
+        });
+    });
+};

--- a/packages/perspective/test/js/expressions/multiple_views.js
+++ b/packages/perspective/test/js/expressions/multiple_views.js
@@ -25,6 +25,975 @@ module.exports = perspective => {
     };
 
     describe("Expressions with multiple views", () => {
+        describe("Schema then update", () => {
+            it("Appends", async () => {
+                const table = await perspective.table({
+                    x: "integer",
+                    y: "string",
+                    z: "boolean"
+                });
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" + 10`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result).toEqual({});
+                expect(result2).toEqual({});
+
+                table.update(expressions_common.data);
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Append in sequence", async () => {
+                const table = await perspective.table({
+                    x: "integer",
+                    y: "string",
+                    z: "boolean"
+                });
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper(concat("y", 'bcd'))`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result).toEqual({});
+                expect(result2).toEqual({});
+
+                const expected = [];
+                const expected2 = [];
+
+                for (let i = 1; i < 10; i++) {
+                    table.update({
+                        x: [i],
+                        y: [`${i}`]
+                    });
+
+                    result = await v1.to_columns();
+                    result2 = await v2.to_columns();
+
+                    expected.push(i * 2);
+                    expected2.push(`${i}BCD`);
+
+                    expect(result["column"]).toEqual(expected);
+                    expect(result2["column"]).toEqual(expected2);
+                }
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Append in sequence, filtered", async () => {
+                const table = await perspective.table({
+                    x: "integer",
+                    y: "string",
+                    z: "boolean"
+                });
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    filter: [["column", ">", 5]]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper(concat("y", 'bcd'))`],
+                    filter: [["column", "contains", "A"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result).toEqual({});
+                expect(result2).toEqual({});
+
+                const expected = [];
+                const expected2 = [];
+
+                for (let i = 1; i < 10; i++) {
+                    table.update({
+                        x: [i],
+                        y: [`A${i}`]
+                    });
+
+                    result = await v1.to_columns();
+                    result2 = await v2.to_columns();
+
+                    if (i * 2 > 5) {
+                        expected.push(i * 2);
+                        expect(result["column"]).toEqual(expected);
+                    } else {
+                        expect(result).toEqual({});
+                    }
+
+                    expected2.push(`A${i}BCD`);
+                    expect(result2["column"]).toEqual(expected2);
+                }
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Append in sequence, sorted", async () => {
+                const table = await perspective.table({
+                    x: "integer",
+                    y: "string",
+                    z: "boolean"
+                });
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper(concat("y", 'bcd'))`],
+                    sort: [["column", "asc"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result).toEqual({});
+                expect(result2).toEqual({});
+
+                const expected = [];
+                const expected2 = [];
+
+                let idx = 0;
+                for (let i = 5; i < 9; i++) {
+                    table.update({
+                        x: [i],
+                        y: [`${i}`]
+                    });
+
+                    result = await v1.to_columns();
+                    result2 = await v2.to_columns();
+
+                    expected.unshift(i * 2);
+                    expected2.splice(idx, 0, `${i}BCD`);
+
+                    expect(result["column"]).toEqual(expected);
+                    expect(result2["column"]).toEqual(expected2);
+                    idx++;
+                }
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update", async () => {
+                const table = await perspective.table(
+                    {
+                        x: "integer",
+                        y: "string",
+                        z: "boolean"
+                    },
+                    {index: "x"}
+                );
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result).toEqual({});
+                expect(result2).toEqual({});
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([null, 4, 6, 8, 20]);
+                expect(result2["column"]).toEqual(["DEF", "X", "Z", "Y", "ABC"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update, filtered", async () => {
+                const table = await perspective.table(
+                    {
+                        x: "integer",
+                        y: "string",
+                        z: "boolean"
+                    },
+                    {index: "x"}
+                );
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    filter: [["column", "==", 8]]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`],
+                    filter: [["column", "==", "Z"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result).toEqual({});
+                expect(result2).toEqual({});
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([8]);
+                expect(result2["column"]).toEqual(["Z"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update, sorted", async () => {
+                const table = await perspective.table(
+                    {
+                        x: "integer",
+                        y: "string",
+                        z: "boolean"
+                    },
+                    {index: "x"}
+                );
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`],
+                    sort: [["column", "desc"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result).toEqual({});
+                expect(result2).toEqual({});
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([20, 8, 6, 4, null]);
+                expect(result2["column"]).toEqual(["Z", "Y", "X", "DEF", "ABC"]);
+
+                table.update({
+                    x: [2, 10],
+                    y: ["XYZ", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([20, 8, 6, 4, null]);
+                expect(result2["x"]).toEqual([3, 4, 2, null, 10]);
+                expect(result2["column"]).toEqual(["Z", "Y", "XYZ", "DEF", "DEF"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Limit", async () => {
+                const table = await perspective.table(
+                    {
+                        x: "integer",
+                        y: "string",
+                        z: "boolean"
+                    },
+                    {limit: 2}
+                );
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result).toEqual({});
+                expect(result2).toEqual({});
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([null, 20]);
+                expect(result2["column"]).toEqual(["DEF", "ABC"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+        });
+
+        describe("Data then update", () => {
+            it("Appends", async () => {
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" + 10`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                table.update(expressions_common.data);
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14, 11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D", "A", "B", "C", "D"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Append in sequence", async () => {
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper(concat("y", 'bcd'))`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([2, 4, 6, 8]);
+                expect(result2["column"]).toEqual(["ABCD", "BBCD", "CBCD", "DBCD"]);
+
+                const expected = [2, 4, 6, 8];
+                const expected2 = ["ABCD", "BBCD", "CBCD", "DBCD"];
+
+                for (let i = 0; i < 10; i++) {
+                    table.update({
+                        x: [i + 4],
+                        y: [`${i + 4}`]
+                    });
+
+                    result = await v1.to_columns();
+                    result2 = await v2.to_columns();
+
+                    expected.push((i + 4) * 2);
+                    expected2.push(`${i + 4}BCD`);
+
+                    expect(result["column"]).toEqual(expected);
+                    expect(result2["column"]).toEqual(expected2);
+                }
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Append in sequence, filtered", async () => {
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    filter: [["column", ">", 5]]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper(concat("y", 'bcd'))`],
+                    filter: [["column", "contains", "A"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([6, 8]);
+                expect(result2["column"]).toEqual(["ABCD"]);
+
+                const expected = [6, 8];
+
+                for (let i = 0; i < 10; i++) {
+                    table.update({
+                        x: [i + 4],
+                        y: [`${i + 4}`]
+                    });
+
+                    result = await v1.to_columns();
+                    result2 = await v2.to_columns();
+
+                    expected.push((i + 4) * 2);
+
+                    expect(result["column"]).toEqual(expected);
+                    expect(result2["column"]).toEqual(["ABCD"]);
+                }
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Append in sequence, sorted", async () => {
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper(concat("y", 'bcd'))`],
+                    sort: [["column", "asc"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                const expected = [8, 6, 4, 2];
+                const expected2 = ["ABCD", "BBCD", "CBCD", "DBCD"];
+
+                expect(result["column"]).toEqual(expected);
+                expect(result2["column"]).toEqual(expected2);
+
+                let idx = 0;
+                for (let i = 5; i < 9; i++) {
+                    table.update({
+                        x: [i],
+                        y: [`${i}`]
+                    });
+
+                    result = await v1.to_columns();
+                    result2 = await v2.to_columns();
+
+                    expected.unshift(i * 2);
+                    expected2.splice(idx, 0, `${i}BCD`);
+
+                    expect(result["column"]).toEqual(expected);
+                    expect(result2["column"]).toEqual(expected2);
+                    idx++;
+                }
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update", async () => {
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([2, 4, 6, 8]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([null, 2, 4, 6, 8, 20]);
+                expect(result2["column"]).toEqual(["DEF", "A", "X", "Z", "Y", "ABC"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update, filtered", async () => {
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    filter: [["column", "==", 8]]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`],
+                    filter: [["column", "==", "B"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([8]);
+                expect(result2["column"]).toEqual(["B"]);
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                console.log(result, result2);
+
+                expect(result["column"]).toEqual([8]);
+                expect(result2).toEqual({});
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Partial update, sorted", async () => {
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`],
+                    sort: [["column", "desc"]]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([8, 6, 4, 2]);
+                expect(result2["column"]).toEqual(["D", "C", "B", "A"]);
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
+                expect(result2["column"]).toEqual(["Z", "Y", "X", "DEF", "ABC", "A"]);
+
+                table.update({
+                    x: [2, 10],
+                    y: ["XYZ", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
+                expect(result2["x"]).toEqual([3, 4, 2, null, 10, 1]);
+                expect(result2["column"]).toEqual(["Z", "Y", "XYZ", "DEF", "DEF", "A"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Limit", async () => {
+                const table = await perspective.table(expressions_common.data, {limit: 2});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([6, 8]);
+                expect(result2["column"]).toEqual(["C", "D"]);
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([null, 20]);
+                expect(result2["column"]).toEqual(["DEF", "ABC"]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+        });
+
+        describe("Deltas", () => {
+            it("Appends delta", async done => {
+                expect.assertions(6);
+
+                const table = await perspective.table(expressions_common.data);
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" + 10`]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                const result = await v1.to_columns();
+                const result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                v1.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, [11, 12, 13, 14]);
+                        const result = await v1.to_columns();
+                        expect(result["column"]).toEqual([11, 12, 13, 14, 11, 12, 13, 14]);
+                    },
+                    {mode: "row"}
+                );
+
+                v2.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, ["A", "B", "C", "D"]);
+                        const result2 = await v2.to_columns();
+                        expect(result2["column"]).toEqual(["A", "B", "C", "D", "A", "B", "C", "D"]);
+                        await v2.delete();
+                        await v1.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update(expressions_common.data);
+            });
+
+            it("Partial update delta", async done => {
+                expect.assertions(6);
+
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`]
+                });
+
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`]
+                });
+
+                const result = await v1.to_columns();
+                const result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([2, 4, 6, 8]);
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+
+                v1.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, [null, 4, 6, 8, 20]);
+                        const result = await v1.to_columns();
+                        expect(result["column"]).toEqual([null, 2, 4, 6, 8, 20]);
+                    },
+                    {mode: "row"}
+                );
+
+                v2.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, ["DEF", "X", "Z", "Y", "ABC"]);
+                        const result = await v2.to_columns();
+                        expect(result["column"]).toEqual(["DEF", "A", "X", "Z", "Y", "ABC"]);
+                        await v2.delete();
+                        await v1.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+            });
+
+            it("Partial update, sorted delta", async done => {
+                expect.assertions(6);
+                const table = await perspective.table(expressions_common.data, {index: "x"});
+
+                const v1 = await table.view({
+                    expressions: [`// column \n"x" * 2`],
+                    sort: [["column", "desc"]]
+                });
+                const v2 = await table.view({
+                    expressions: [`// column \n upper("y")`],
+                    sort: [["column", "desc"]]
+                });
+
+                const result = await v1.to_columns();
+                const result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([8, 6, 4, 2]);
+                expect(result2["column"]).toEqual(["D", "C", "B", "A"]);
+
+                v1.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, [20, 8, 6, 4, null]);
+                        const result = await v1.to_columns();
+                        expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
+                    },
+                    {mode: "row"}
+                );
+
+                v2.on_update(
+                    async updated => {
+                        await validate_delta("column", updated.delta, ["Z", "Y", "X", "DEF", "ABC"]);
+                        const result2 = await v2.to_columns();
+                        expect(result2["column"]).toEqual(["Z", "Y", "X", "DEF", "ABC", "A"]);
+                        await v2.delete();
+                        await v1.delete();
+                        await table.delete();
+                        done();
+                    },
+                    {mode: "row"}
+                );
+
+                table.update({
+                    x: [2, 4, 3, 10, null],
+                    y: ["X", "Y", "Z", "ABC", "DEF"]
+                });
+            });
+        });
+
+        describe("Clear/Replace", () => {
+            it("Rows should clear() when called", async () => {
+                const now = new Date();
+                const bucketed = new Date(now.getUTCFullYear(), 0, 1).getTime();
+                const table = await perspective.table({
+                    x: [1, 2, 3, 4],
+                    y: ["a", "b", "c", "d"],
+                    z: [now, now, now, now]
+                });
+
+                const v1 = await table.view({
+                    columns: ["column", "column2"],
+                    expressions: [`// column \n"x" + 10`, `// column2 \n concat('a', 'b', 'c')`]
+                });
+                const v2 = await table.view({
+                    columns: ["column2", "column"],
+                    expressions: [`// column \n upper("y")`, `// column2 \n bucket("z", 'Y')`]
+                });
+
+                expect(await v1.expression_schema()).toEqual({
+                    column: "float",
+                    column2: "string"
+                });
+
+                expect(await v2.expression_schema()).toEqual({
+                    column: "string",
+                    column2: "date"
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result["column2"]).toEqual(Array(4).fill("abc"));
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+                expect(result2["column2"]).toEqual(Array(4).fill(bucketed));
+
+                await table.clear();
+
+                expect(await v1.num_rows()).toEqual(0);
+                expect(await v2.num_rows()).toEqual(0);
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result).toEqual({});
+                expect(result2).toEqual({});
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+
+            it("Rows should replace() when called", async () => {
+                const now = new Date();
+                const bucketed = new Date(now.getUTCFullYear(), 0, 1).getTime();
+                const table = await perspective.table({
+                    x: [1, 2, 3, 4],
+                    y: ["a", "b", "c", "d"],
+                    z: [now, now, now, now]
+                });
+
+                const v1 = await table.view({
+                    columns: ["column", "column2"],
+                    expressions: [`// column \n"x" + 10`, `// column2 \n concat('a', 'b', 'c')`]
+                });
+                const v2 = await table.view({
+                    columns: ["column2", "column"],
+                    expressions: [`// column \n upper("y")`, `// column2 \n bucket("z", 'Y')`]
+                });
+
+                expect(await v1.expression_schema()).toEqual({
+                    column: "float",
+                    column2: "string"
+                });
+
+                expect(await v2.expression_schema()).toEqual({
+                    column: "string",
+                    column2: "date"
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result["column2"]).toEqual(Array(4).fill("abc"));
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+                expect(result2["column2"]).toEqual(Array(4).fill(bucketed));
+
+                await table.replace({
+                    x: [100, 300],
+                    y: ["x", "y"],
+                    z: [now, now]
+                });
+
+                expect(await v1.num_rows()).toEqual(2);
+                expect(await v2.num_rows()).toEqual(2);
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([110, 310]);
+                expect(result["column2"]).toEqual(["abc", "abc"]);
+                expect(result2["column"]).toEqual(["X", "Y"]);
+                expect(result2["column2"]).toEqual([bucketed, bucketed]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+        });
+
+        describe("Remove", () => {
+            it("Rows should remove() when called", async () => {
+                const now = new Date();
+                const bucketed = new Date(now.getUTCFullYear(), 0, 1).getTime();
+                const table = await perspective.table(
+                    {
+                        x: [1, 2, 3, 4],
+                        y: ["a", "b", "c", "d"],
+                        z: [now, now, now, now]
+                    },
+                    {index: "x"}
+                );
+
+                const v1 = await table.view({
+                    columns: ["column", "column2"],
+                    expressions: [`// column \n"x" + 10`, `// column2 \n concat('a', 'b', 'c')`]
+                });
+                const v2 = await table.view({
+                    columns: ["column2", "column"],
+                    expressions: [`// column \n upper("y")`, `// column2 \n bucket("z", 'Y')`]
+                });
+
+                expect(await v1.expression_schema()).toEqual({
+                    column: "float",
+                    column2: "string"
+                });
+
+                expect(await v2.expression_schema()).toEqual({
+                    column: "string",
+                    column2: "date"
+                });
+
+                let result = await v1.to_columns();
+                let result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 12, 13, 14]);
+                expect(result["column2"]).toEqual(Array(4).fill("abc"));
+                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
+                expect(result2["column2"]).toEqual(Array(4).fill(bucketed));
+
+                await table.remove([2, 3]);
+
+                // FIXME: size() and num_rows() do not respond correctly to
+                // remove() calls.
+                // expect(await v1.num_rows()).toEqual(2);
+                // expect(await v2.num_rows()).toEqual(2);
+
+                result = await v1.to_columns();
+                result2 = await v2.to_columns();
+
+                expect(result["column"]).toEqual([11, 14]);
+                expect(result["column2"]).toEqual(["abc", "abc"]);
+                expect(result2["column"]).toEqual(["A", "D"]);
+                expect(result2["column2"]).toEqual([bucketed, bucketed]);
+
+                await v2.delete();
+                await v1.delete();
+                await table.delete();
+            });
+        });
+
         it("Multiple views with the same expression alias should not conflict", async () => {
             const now = new Date();
             const bucketed = new Date(now.getUTCFullYear(), 0, 1).getTime();
@@ -206,374 +1175,106 @@ module.exports = perspective => {
             await table.delete();
         });
 
-        describe("Multiple views with updates", () => {
-            it("Appends", async () => {
-                const table = await perspective.table(expressions_common.data);
-
-                const v1 = await table.view({
-                    expressions: [`// column \n"x" + 10`]
-                });
-                const v2 = await table.view({
-                    expressions: [`// column \n upper("y")`]
-                });
-
-                let result = await v1.to_columns();
-                let result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([11, 12, 13, 14]);
-                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
-
-                table.update(expressions_common.data);
-
-                result = await v1.to_columns();
-                result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([11, 12, 13, 14, 11, 12, 13, 14]);
-                expect(result2["column"]).toEqual(["A", "B", "C", "D", "A", "B", "C", "D"]);
-
-                await v2.delete();
-                await v1.delete();
-                await table.delete();
+        it("Multiple 2-sided pivoted views with the same expression alias and different aggregates should not conflict", async () => {
+            const table = await perspective.table({
+                x: [10, 10, 20, 20],
+                y: ["A", "B", "C", "D"],
+                z: [1.5, 2.5, 3.5, 4.5]
             });
 
-            it("Append in sequence", async () => {
-                const table = await perspective.table(expressions_common.data);
-
-                const v1 = await table.view({
-                    expressions: [`// column \n"x" * 2`]
-                });
-
-                const v2 = await table.view({
-                    expressions: [`// column \n upper(concat("y", 'bcd'))`]
-                });
-
-                let result = await v1.to_columns();
-                let result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([2, 4, 6, 8]);
-                expect(result2["column"]).toEqual(["ABCD", "BBCD", "CBCD", "DBCD"]);
-
-                const expected = [2, 4, 6, 8];
-                const expected2 = ["ABCD", "BBCD", "CBCD", "DBCD"];
-
-                for (let i = 0; i < 10; i++) {
-                    table.update({
-                        x: [i + 4],
-                        y: [`${i + 4}`]
-                    });
-
-                    result = await v1.to_columns();
-                    result2 = await v2.to_columns();
-
-                    expected.push((i + 4) * 2);
-                    expected2.push(`${i + 4}BCD`);
-
-                    expect(result["column"]).toEqual(expected);
-                    expect(result2["column"]).toEqual(expected2);
+            const v1 = await table.view({
+                row_pivots: ["x"],
+                column_pivots: ["y"],
+                expressions: [`// column \n"z" + 10`],
+                aggregates: {
+                    column: "avg"
                 }
-
-                await v2.delete();
-                await v1.delete();
-                await table.delete();
             });
 
-            it("Append in sequence, sorted", async () => {
-                const table = await perspective.table(expressions_common.data);
-
-                const v1 = await table.view({
-                    expressions: [`// column \n"x" * 2`],
-                    sort: [["column", "desc"]]
-                });
-
-                const v2 = await table.view({
-                    expressions: [`// column \n upper(concat("y", 'bcd'))`],
-                    sort: [["column", "asc"]]
-                });
-
-                let result = await v1.to_columns();
-                let result2 = await v2.to_columns();
-
-                const expected = [8, 6, 4, 2];
-                const expected2 = ["ABCD", "BBCD", "CBCD", "DBCD"];
-
-                expect(result["column"]).toEqual(expected);
-                expect(result2["column"]).toEqual(expected2);
-
-                let idx = 0;
-                for (let i = 5; i < 9; i++) {
-                    table.update({
-                        x: [i],
-                        y: [`${i}`]
-                    });
-
-                    result = await v1.to_columns();
-                    result2 = await v2.to_columns();
-
-                    expected.unshift(i * 2);
-                    expected2.splice(idx, 0, `${i}BCD`);
-
-                    expect(result["column"]).toEqual(expected);
-                    expect(result2["column"]).toEqual(expected2);
-                    idx++;
+            const v2 = await table.view({
+                row_pivots: ["x"],
+                column_pivots: ["y"],
+                expressions: [`// column \n upper("y")`],
+                aggregates: {
+                    column: "last"
                 }
-
-                await v2.delete();
-                await v1.delete();
-                await table.delete();
             });
 
-            it("Partial update", async () => {
-                const table = await perspective.table(expressions_common.data, {index: "x"});
-
-                const v1 = await table.view({
-                    expressions: [`// column \n"x" * 2`]
-                });
-                const v2 = await table.view({
-                    expressions: [`// column \n upper("y")`]
-                });
-
-                let result = await v1.to_columns();
-                let result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([2, 4, 6, 8]);
-                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
-
-                table.update({
-                    x: [2, 4, 3, 10, null],
-                    y: ["X", "Y", "Z", "ABC", "DEF"]
-                });
-
-                result = await v1.to_columns();
-                result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([null, 2, 4, 6, 8, 20]);
-                expect(result2["column"]).toEqual(["DEF", "A", "X", "Z", "Y", "ABC"]);
-
-                await v2.delete();
-                await v1.delete();
-                await table.delete();
+            const v3 = await table.view({
+                row_pivots: ["x"],
+                column_pivots: ["y"],
+                expressions: [`// column \n 2"z"`],
+                aggregates: {
+                    column: ["weighted mean", "z"]
+                }
             });
 
-            it("Partial update, sorted", async () => {
-                const table = await perspective.table(expressions_common.data, {index: "x"});
+            const result = await v1.to_columns();
+            const result2 = await v2.to_columns();
+            const result3 = await v3.to_columns();
 
-                const v1 = await table.view({
-                    expressions: [`// column \n"x" * 2`],
-                    sort: [["column", "desc"]]
-                });
-                const v2 = await table.view({
-                    expressions: [`// column \n upper("y")`],
-                    sort: [["column", "desc"]]
-                });
-
-                let result = await v1.to_columns();
-                let result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([8, 6, 4, 2]);
-                expect(result2["column"]).toEqual(["D", "C", "B", "A"]);
-
-                console.log("before update");
-
-                table.update({
-                    x: [2, 4, 3, 10, null],
-                    y: ["X", "Y", "Z", "ABC", "DEF"]
-                });
-                console.log("after update");
-
-                result = await v1.to_columns();
-                result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
-                expect(result2["column"]).toEqual(["Z", "Y", "X", "DEF", "ABC", "A"]);
-
-                console.log("before update2");
-                table.update({
-                    x: [2, 10],
-                    y: ["XYZ", "DEF"]
-                });
-                console.log("after update2");
-
-                result = await v1.to_columns();
-                result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
-                expect(result2["x"]).toEqual([3, 4, 2, null, 10, 1]);
-                expect(result2["column"]).toEqual(["Z", "Y", "XYZ", "DEF", "DEF", "A"]);
-
-                await v2.delete();
-                await v1.delete();
-                await table.delete();
+            expect(result).toEqual({
+                __ROW_PATH__: [[], [10], [20]],
+                "A|x": [10, 10, null],
+                "A|y": [1, 1, null],
+                "A|z": [1.5, 1.5, null],
+                "A|column": [11.5, 11.5, null],
+                "B|x": [10, 10, null],
+                "B|y": [1, 1, null],
+                "B|z": [2.5, 2.5, null],
+                "B|column": [12.5, 12.5, null],
+                "C|x": [20, null, 20],
+                "C|y": [1, null, 1],
+                "C|z": [3.5, null, 3.5],
+                "C|column": [13.5, null, 13.5],
+                "D|x": [20, null, 20],
+                "D|y": [1, null, 1],
+                "D|z": [4.5, null, 4.5],
+                "D|column": [14.5, null, 14.5]
+            });
+            expect(result2).toEqual({
+                __ROW_PATH__: [[], [10], [20]],
+                "A|x": [10, 10, null],
+                "A|y": [1, 1, null],
+                "A|z": [1.5, 1.5, null],
+                "A|column": ["A", "A", null],
+                "B|x": [10, 10, null],
+                "B|y": [1, 1, null],
+                "B|z": [2.5, 2.5, null],
+                "B|column": ["B", "B", null],
+                "C|x": [20, null, 20],
+                "C|y": [1, null, 1],
+                "C|z": [3.5, null, 3.5],
+                "C|column": ["C", null, "C"],
+                "D|x": [20, null, 20],
+                "D|y": [1, null, 1],
+                "D|z": [4.5, null, 4.5],
+                "D|column": ["D", null, "D"]
+            });
+            expect(result3).toEqual({
+                __ROW_PATH__: [[], [10], [20]],
+                "A|x": [10, 10, null],
+                "A|y": [1, 1, null],
+                "A|z": [1.5, 1.5, null],
+                "A|column": [3, 3, null],
+                "B|x": [10, 10, null],
+                "B|y": [1, 1, null],
+                "B|z": [2.5, 2.5, null],
+                "B|column": [5, 5, null],
+                "C|x": [20, null, 20],
+                "C|y": [1, null, 1],
+                "C|z": [3.5, null, 3.5],
+                "C|column": [7, null, 7],
+                "D|x": [20, null, 20],
+                "D|y": [1, null, 1],
+                "D|z": [4.5, null, 4.5],
+                "D|column": [9, null, 9]
             });
 
-            it("Limit", async () => {
-                const table = await perspective.table(expressions_common.data, {limit: 2});
-
-                const v1 = await table.view({
-                    expressions: [`// column \n"x" * 2`]
-                });
-                const v2 = await table.view({
-                    expressions: [`// column \n upper("y")`]
-                });
-
-                let result = await v1.to_columns();
-                let result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([6, 8]);
-                expect(result2["column"]).toEqual(["C", "D"]);
-
-                table.update({
-                    x: [2, 4, 3, 10, null],
-                    y: ["X", "Y", "Z", "ABC", "DEF"]
-                });
-
-                result = await v1.to_columns();
-                result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([null, 20]);
-                expect(result2["column"]).toEqual(["DEF", "ABC"]);
-
-                await v2.delete();
-                await v1.delete();
-                await table.delete();
-            });
-
-            it("Appends delta", async done => {
-                expect.assertions(6);
-
-                const table = await perspective.table(expressions_common.data);
-
-                const v1 = await table.view({
-                    expressions: [`// column \n"x" + 10`]
-                });
-
-                const v2 = await table.view({
-                    expressions: [`// column \n upper("y")`]
-                });
-
-                const result = await v1.to_columns();
-                const result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([11, 12, 13, 14]);
-                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
-
-                v1.on_update(
-                    async updated => {
-                        await validate_delta("column", updated.delta, [11, 12, 13, 14]);
-                        const result = await v1.to_columns();
-                        expect(result["column"]).toEqual([11, 12, 13, 14, 11, 12, 13, 14]);
-                    },
-                    {mode: "row"}
-                );
-
-                v2.on_update(
-                    async updated => {
-                        await validate_delta("column", updated.delta, ["A", "B", "C", "D"]);
-                        const result2 = await v2.to_columns();
-                        expect(result2["column"]).toEqual(["A", "B", "C", "D", "A", "B", "C", "D"]);
-                        await v2.delete();
-                        await v1.delete();
-                        await table.delete();
-                        done();
-                    },
-                    {mode: "row"}
-                );
-
-                table.update(expressions_common.data);
-            });
-
-            it("Partial update delta", async done => {
-                expect.assertions(6);
-
-                const table = await perspective.table(expressions_common.data, {index: "x"});
-
-                const v1 = await table.view({
-                    expressions: [`// column \n"x" * 2`]
-                });
-
-                const v2 = await table.view({
-                    expressions: [`// column \n upper("y")`]
-                });
-
-                const result = await v1.to_columns();
-                const result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([2, 4, 6, 8]);
-                expect(result2["column"]).toEqual(["A", "B", "C", "D"]);
-
-                v1.on_update(
-                    async updated => {
-                        await validate_delta("column", updated.delta, [null, 4, 6, 8, 20]);
-                        const result = await v1.to_columns();
-                        expect(result["column"]).toEqual([null, 2, 4, 6, 8, 20]);
-                    },
-                    {mode: "row"}
-                );
-
-                v2.on_update(
-                    async updated => {
-                        await validate_delta("column", updated.delta, ["DEF", "X", "Z", "Y", "ABC"]);
-                        const result = await v2.to_columns();
-                        expect(result["column"]).toEqual(["DEF", "A", "X", "Z", "Y", "ABC"]);
-                        await v2.delete();
-                        await v1.delete();
-                        await table.delete();
-                        done();
-                    },
-                    {mode: "row"}
-                );
-
-                table.update({
-                    x: [2, 4, 3, 10, null],
-                    y: ["X", "Y", "Z", "ABC", "DEF"]
-                });
-            });
-
-            it("Partial update, sorted delta", async done => {
-                expect.assertions(6);
-                const table = await perspective.table(expressions_common.data, {index: "x"});
-
-                const v1 = await table.view({
-                    expressions: [`// column \n"x" * 2`],
-                    sort: [["column", "desc"]]
-                });
-                const v2 = await table.view({
-                    expressions: [`// column \n upper("y")`],
-                    sort: [["column", "desc"]]
-                });
-
-                const result = await v1.to_columns();
-                const result2 = await v2.to_columns();
-
-                expect(result["column"]).toEqual([8, 6, 4, 2]);
-                expect(result2["column"]).toEqual(["D", "C", "B", "A"]);
-
-                v1.on_update(
-                    async updated => {
-                        await validate_delta("column", updated.delta, [20, 8, 6, 4, null]);
-                        const result = await v1.to_columns();
-                        expect(result["column"]).toEqual([20, 8, 6, 4, 2, null]);
-                    },
-                    {mode: "row"}
-                );
-
-                v2.on_update(
-                    async updated => {
-                        await validate_delta("column", updated.delta, ["Z", "Y", "X", "DEF", "ABC"]);
-                        const result2 = await v2.to_columns();
-                        expect(result2["column"]).toEqual(["Z", "Y", "X", "DEF", "ABC", "A"]);
-                        await v2.delete();
-                        await v1.delete();
-                        await table.delete();
-                        done();
-                    },
-                    {mode: "row"}
-                );
-
-                table.update({
-                    x: [2, 4, 3, 10, null],
-                    y: ["X", "Y", "Z", "ABC", "DEF"]
-                });
-            });
+            await v3.delete();
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
         });
     });
 };

--- a/packages/perspective/test/js/expressions/string.js
+++ b/packages/perspective/test/js/expressions/string.js
@@ -13,6 +13,48 @@
  */
 module.exports = perspective => {
     describe("String functions", function() {
+        it("Pivoted", async function() {
+            const table = await perspective.table({
+                a: ["abc", "deeeeef", "fg", "hhs", "abcdefghijk"],
+                b: ["ABC", "DEF", "EfG", "HIjK", "lMNoP"],
+                c: [2, 2, 4, 4]
+            });
+            const view = await table.view({
+                aggregates: {column: "last"},
+                row_pivots: ["column"],
+                expressions: [`//column\nconcat("a", ', ', 'here is a long string, ', "b")`]
+            });
+            let result = await view.to_columns();
+
+            expect(result["column"]).toEqual([
+                "hhs, here is a long string, HIjK",
+                "abc, here is a long string, ABC",
+                "abcdefghijk, here is a long string, lMNoP",
+                "deeeeef, here is a long string, DEF",
+                "fg, here is a long string, EfG",
+                "hhs, here is a long string, HIjK"
+            ]);
+
+            view.delete();
+            table.delete();
+        });
+
+        it("Filtered", async function() {
+            const table = await perspective.table({
+                a: ["abc", "deeeeef", "fg", "hhs", "abcdefghijk"],
+                b: ["ABC", "DEF", "EfG", "HIjK", "lMNoP"],
+                c: [2, 2, 4, 4]
+            });
+            const view = await table.view({
+                filter: [["column", "==", "hhs, here is a long string, HIjK"]],
+                expressions: [`//column\nconcat("a", ', ', 'here is a long string, ', "b")`]
+            });
+            let result = await view.to_columns();
+            expect(result["column"]).toEqual(["hhs, here is a long string, HIjK"]);
+            view.delete();
+            table.delete();
+        });
+
         it("Length", async function() {
             const table = await perspective.table({
                 a: ["abc", "deeeeef", "fg", "hhs", "abcdefghijk"]

--- a/python/perspective/perspective/include/perspective/python/view.h
+++ b/python/perspective/perspective/include/perspective/python/view.h
@@ -35,7 +35,8 @@ std::tuple<std::string, std::string, std::vector<t_tscalar>>
 make_filter_term(t_dtype column_type, t_val date_parser, const std::string& column_name, const std::string& filter_op_str, t_val filter_term);
 
 template <>
-std::shared_ptr<t_view_config> make_view_config(std::shared_ptr<t_schema> schema, t_val date_parser, t_val config);
+std::shared_ptr<t_view_config> make_view_config(
+    std::shared_ptr<t_schema> schema, t_val date_parser, t_val config);
 
 template <typename CTX_T>
 std::shared_ptr<View<CTX_T>> make_view(std::shared_ptr<Table> table, const std::string& name, const std::string& separator, t_val view_config, t_val date_parser);

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -105,7 +105,8 @@ make_filter_term(t_dtype column_type, t_val date_parser, const std::string& colu
 
 template <>
 std::shared_ptr<t_view_config>
-make_view_config(std::shared_ptr<t_schema> schema, t_val date_parser, t_val config) {
+make_view_config(
+    std::shared_ptr<t_schema> schema, t_val date_parser, t_val config) {
     auto row_pivots = config.attr("get_row_pivots")().cast<std::vector<std::string>>();
     auto column_pivots = config.attr("get_column_pivots")().cast<std::vector<std::string>>();
     auto columns = config.attr("get_columns")().cast<std::vector<std::string>>();
@@ -239,6 +240,8 @@ template <typename CTX_T>
 std::shared_ptr<View<CTX_T>>
 make_view(std::shared_ptr<Table> table, const std::string& name, const std::string& separator,
     t_val view_config, t_val date_parser) {
+    // Use a copy of the table schema that we can freely mutate during
+    // `make_view_config`.
     std::shared_ptr<t_schema> schema = std::make_shared<t_schema>(table->get_schema());
     std::shared_ptr<t_view_config> config = make_view_config<t_val>(schema, date_parser, view_config);
     {

--- a/python/perspective/perspective/table/_utils.py
+++ b/python/perspective/perspective/table/_utils.py
@@ -6,7 +6,6 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
-import logging
 import re
 from datetime import date, datetime
 from functools import partial
@@ -149,7 +148,7 @@ def _parse_expression_strings(expressions):
        names, which will be used by the engine.
     """
     validated_expressions = []
-    alias_set = set()
+    alias_map = {}
 
     for expression in expressions:
         if '""' in expression:
@@ -160,22 +159,15 @@ def _parse_expression_strings(expressions):
 
         alias_match = re.match(ALIAS_REGEX, expression)
 
+        # initialize `parsed` here so we keep `expression` unedited as the
+        # user typed it into Perspective
+        parsed = expression
+
         if alias_match:
             alias = alias_match.group(1).strip()
 
-            # Don't allow for duplicate aliases
-            if alias in alias_set:
-                logging.warn(
-                    "Skipping expression `{}` as it reuses alias `{}`!".format(
-                        expression, alias
-                    )
-                )
-                continue
-
-            alias_set.add(alias)
-
             # Remove the alias from the expression
-            expression = re.sub(ALIAS_REGEX, "", expression)
+            parsed = re.sub(ALIAS_REGEX, "", expression)
         else:
             # Expression itself is the alias
             alias = expression
@@ -191,7 +183,7 @@ def _parse_expression_strings(expressions):
             running_cidx,
         )
 
-        parsed = re.sub(EXPRESSION_COLUMN_NAME_REGEX, replacer_fn, expression)
+        parsed = re.sub(EXPRESSION_COLUMN_NAME_REGEX, replacer_fn, parsed)
         parsed = re.sub(
             STRING_LITERAL_REGEX,
             lambda match: "intern({0})".format(match.group(0)),
@@ -201,6 +193,13 @@ def _parse_expression_strings(expressions):
         # remove the `intern()` in bucket - TODO: this is messy
         parsed = re.sub(BUCKET_LITERAL_REGEX, _replace_bucket_unit, parsed)
 
-        validated_expressions.append([alias, expression, parsed, column_id_map])
+        validated = [alias, expression, parsed, column_id_map]
+
+        if alias_map.get(alias) is not None:
+            idx = alias_map[alias]
+            validated_expressions[idx] = validated
+        else:
+            validated_expressions.append(validated)
+            alias_map[alias] = len(validated_expressions) - 1
 
     return validated_expressions

--- a/scripts/test_python.js
+++ b/scripts/test_python.js
@@ -41,11 +41,11 @@ const pytest_client_mode = IS_DOCKER => {
     if (IS_DOCKER) {
         return bash`${docker(IMAGE)} bash -c "cd \
             python/perspective && TZ=UTC ${PYTHON} -m pytest \
-            ${VERBOSE ? "-vv" : ""} --noconftest 
+            ${VERBOSE ? "-vv --full-trace" : ""} --noconftest 
             perspective/tests/client_mode"`;
     } else {
         return bash`cd ${python_path} && ${PYTHON} -m pytest \
-            ${VERBOSE ? "-vv" : ""} --noconftest 
+            ${VERBOSE ? "-vv --full-trace" : ""} --noconftest 
             perspective/tests/client_mode`;
     }
 };
@@ -57,12 +57,12 @@ const pytest = IS_DOCKER => {
     if (IS_DOCKER) {
         return bash`${docker(IMAGE)} bash -c "cd \
             python/perspective && TZ=UTC ${PYTHON} -m pytest \
-            ${VERBOSE ? "-vv" : ""} perspective \
+            ${VERBOSE ? "-vv --full-trace" : ""} perspective \
             --ignore=perspective/tests/client_mode \
             --cov=perspective"`;
     } else {
         return bash`cd ${python_path} && ${PYTHON} -m pytest \
-            ${VERBOSE ? "-vv" : ""} perspective \
+            ${VERBOSE ? "-vv --full-trace" : ""} perspective \
             --ignore=perspective/tests/client_mode \
             ${COVERAGE ? "--cov=perspective" : ""}`;
     }


### PR DESCRIPTION
This PR refactors the way that expressions are handled and stored in Perspective - previously, expressions columns were calculated and stored on the main table inside `t_gstate` and its intermediate tables (prev, current, delta, transitions, etc.). By having all expressions on the gnode's tables, expressions were "real" columns to the engine, and it guaranteed that all the features available to real columns (pivot, filter, etc.) were available to expression columns without having to do large refactors to the code that generated aggregates, pivots etc.

However, this meant that expressions were not "isolated" to the `View` they were created in - a user could not create a new expression named `new column` of `float` type, and then replace it immediately with an expression that returns a `string`, as the main table schema had already recorded `new column` as a `float` column and could not overwrite it.

Now, expression columns are stored _per-context_ on data tables that only contain the expression columns belonging to the `View`. This means that each `View` can create expression columns that use the same aliases as other `Views`, and they can be of any type:

```javascript
const v1 = await table.view({
  expressions: [`// new column\n "ask" - "bid"`]
});

const v2 = await table.view({
  expressions: [`// new column\n upper("client")`]
});
```
And now, expression columns are guaranteed to be deleted when `view.delete()` is called - when the context is deleted, the data tables that contain their expressions are cleaned up from the heap.

To implement this, I added a `join` function to `t_data_table` - given two data tables, it creates a new data table that references the columns from the source tables using their shared pointers without copying any of the underlying memory or allocating new data stores on the heap.  When the context receives data from the gnode during `notify`, it is provided a `t_data_table` that contains the "real" columns _joined_ with the expression columns from the context being notified. This means that the context will continue to treat expression columns as "real" columns so there is no loss of functionality.

Some work remains on the UI to allow for duplicate expression aliases to be created - right now, `perspective-viewer` does not allow aliases to be reused. Because #1426 changes the expressions UI "bigly", this PR does not contain any UI changes, and those changes will be added on in a new PR before the Perspective 0.9.0 release.

### Changelog

- Store expressions per-context using the `t_expression_tables` struct
- `t_vocab` for string expressions are now per-context, instead of a static global vocab for all expressions
- Added tests using multiple views with identical expression aliases
- Added tests to assert that there are no memory leaks or excess allocations when views with expressions are created and deleted
- Updated the `View` documentation to reflect the expressions API