### PR TITLE
Parse aggregates in column order

### DIFF
--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -15,6 +15,7 @@
 #include <perspective/scalar.h>
 #include <perspective/computed_expression.h>
 #include <tsl/ordered_map.h>
+#include <tsl/hopscotch_set.h>
 #include <unordered_set>
 #include <tuple>
 
@@ -153,6 +154,8 @@ private:
      * @return t_index
      */
     t_index get_aggregate_index(const std::string& column) const;
+
+    void make_aggspec(const std::string& column, const std::vector<std::string>& aggregate, t_dtype dtype);
 
     // containers for primitive data that does not need transformation into abstractions
     std::vector<std::string> m_row_pivots;

--- a/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
+++ b/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
@@ -390,9 +390,10 @@ function get_rule(regular, tag, def) {
 export async function createModel(regular, table, view, extend = {}) {
     const config = await view.get_config();
 
-    // Extract just the expression aliases from the expressions array, which
-    // contains more metadata than we need.
-    const expressions = config.expressions.map(expr => expr[0]);
+    // Extract the entire expression string as typed by the user, so we can
+    // feed it into `validate_expressions` and get back the data types for
+    // each column without it being affected by a pivot.
+    const expressions = config.expressions.map(expr => expr[1]);
 
     const [table_schema, validated_expressions, num_rows, schema, expression_schema, column_paths] = await Promise.all([
         table.schema(),

--- a/packages/perspective-viewer-datagrid/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-datagrid/test/js/superstore.spec.js
@@ -101,6 +101,18 @@ utils.with_server({}, () => {
                     }
                 });
             });
+
+            test.capture("expression columns have the right row pivot headers", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(async () => await document.querySelector("perspective-viewer").toggleConfig());
+
+                // create expression columns with aliases
+                await page.evaluate(element => element.setAttribute("expressions", JSON.stringify([`// abc\n upper("State")`, `// def \n bucket("Order Date", 'M')`])), viewer);
+                await page.evaluate(element => element.setAttribute("row-pivots", '["abc"]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.evaluate(element => element.setAttribute("columns", '["abc", "def"]'), viewer);
+            });
         },
         {reload_page: false, root: path.join(__dirname, "..", "..")}
     );

--- a/packages/perspective-viewer-datagrid/test/results/linux.docker.json
+++ b/packages/perspective-viewer-datagrid/test/results/linux.docker.json
@@ -16,5 +16,6 @@
     "superstore_resets_viewable_area_when_the_physical_size_expands_": "47e5c98779867ac53408640280b38023",
     "superstore_perspective_dispatches_perspective-click_event_with_correct_details": "47e5c98779867ac53408640280b38023",
     "superstore_perspective_dispatches_perspective-click_event_with_correct_details_when_filter_is_set": "d478d32c14d60a8af0a56b32b4e8a2dc",
-    "__GIT_COMMIT__": "455eea35adcda4ab55f4c778a9f4b16c1a019f46"
+    "__GIT_COMMIT__": "8833873645e5b0594a5680a95a8bbc6a72fcd5ea",
+    "superstore_expression_columns_have_the_right_row_pivot_headers": "bc96fbfaad89c88b87980b251d30d5f5"
 }

--- a/packages/perspective/src/js/config/constants.js
+++ b/packages/perspective/src/js/config/constants.js
@@ -56,7 +56,7 @@ const NUMBER_AGGREGATES = [
 
 const STRING_AGGREGATES = ["any", "count", "distinct count", "distinct leaf", "dominant", "first by index", "last by index", "last", "unique"];
 
-const BOOLEAN_AGGREGATES = ["any", "count", "distinct count", "distinct leaf", "dominant", "first by index", "last by index", "last", "unique", "and", "or"];
+const BOOLEAN_AGGREGATES = ["any", "count", "distinct count", "distinct leaf", "dominant", "first by index", "last by index", "last", "unique"];
 
 export const SORT_ORDERS = ["none", "asc", "desc", "col asc", "col desc", "asc abs", "desc abs", "col asc abs", "col desc abs"];
 

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -60,6 +60,51 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("Aggregates are processed in the order of the columns array", async function() {
+            const table = await perspective.table(data);
+            const view = await table.view({
+                row_pivots: ["z"],
+                columns: ["y", "z"],
+                aggregates: {
+                    z: "last",
+                    y: "last"
+                }
+            });
+            const paths = await view.column_paths();
+            expect(paths).toEqual(["__ROW_PATH__", "y", "z"]);
+            const answer = [
+                {__ROW_PATH__: [], y: "c", z: true},
+                {__ROW_PATH__: [false], y: "d", z: false},
+                {__ROW_PATH__: [true], y: "c", z: true}
+            ];
+            const result = await view.to_json();
+            expect(result).toEqual(answer);
+            view.delete();
+            table.delete();
+        });
+
+        it("Aggregates are not in columns are ignored", async function() {
+            const table = await perspective.table(data);
+            const view = await table.view({
+                row_pivots: ["z"],
+                columns: ["y", "z"],
+                aggregates: {
+                    x: "count"
+                }
+            });
+            const paths = await view.column_paths();
+            expect(paths).toEqual(["__ROW_PATH__", "y", "z"]);
+            const answer = [
+                {__ROW_PATH__: [], y: 4, z: 4},
+                {__ROW_PATH__: [false], y: 2, z: 2},
+                {__ROW_PATH__: [true], y: 2, z: 2}
+            ];
+            const result = await view.to_json();
+            expect(result).toEqual(answer);
+            view.delete();
+            table.delete();
+        });
+
         it("['z'], sum", async function() {
             var table = await perspective.table(data);
             var view = await table.view({
@@ -1286,6 +1331,33 @@ module.exports = perspective => {
             });
             const paths = await view.column_paths();
             expect(paths).toEqual(["__ROW_PATH__", "x", "y", "z"]);
+            view.delete();
+            table.delete();
+        });
+
+        it("Should return numerical column names in the correct order, 1-sided view", async function() {
+            const table = await perspective.table({
+                "2345": [0, 1, 2, 3],
+                "1.23456789": [0, 1, 2, 3],
+                "1234": [1, 2, 3, 4],
+                x: [5, 6, 7, 8]
+            });
+
+            // Previously, we iterated through the aggregates map using the
+            // order given in Object.keys() which meant that column names that
+            // were parsable as numbers automatically ended up at the front of
+            // the map. This test makes sure that column orders are respected
+            // by the engine for all column names.
+            const view = await table.view({
+                row_pivots: ["x"],
+                columns: ["2345", "1234", "x", "1.23456789"],
+                aggregates: {
+                    x: "sum",
+                    "1234": "sum"
+                }
+            });
+            const paths = await view.column_paths();
+            expect(paths).toEqual(["__ROW_PATH__", "2345", "1234", "x", "1.23456789"]);
             view.delete();
             table.delete();
         });

--- a/packages/perspective/test/js/sort.js
+++ b/packages/perspective/test/js/sort.js
@@ -569,6 +569,65 @@ module.exports = perspective => {
                 table.delete();
             });
 
+            it("column pivot and hidden sort ['y'] with aggregates specified", async function() {
+                const table = await perspective.table({
+                    x: [1, 2, 3, 4],
+                    y: ["a", "a", "a", "b"]
+                });
+
+                // Aggregate for hidden sort should be ignored in column-only,
+                // so just make sure we stick to that.
+                const view = await table.view({
+                    columns: ["x"],
+                    column_pivots: ["y"],
+                    sort: [["y", "desc"]],
+                    aggregates: {
+                        y: "count"
+                    }
+                });
+
+                const paths = await view.column_paths();
+                // regular non-col sort should not change order of column paths
+                expect(paths).toEqual(["a|x", "b|x"]);
+
+                const result = await view.to_columns();
+                expect(result).toEqual({
+                    "a|x": [null, 1, 2, 3],
+                    "b|x": [4, null, null, null]
+                });
+                view.delete();
+                table.delete();
+            });
+
+            it("column pivot and hidden col sort ['y'] with aggregates specified", async function() {
+                const table = await perspective.table({
+                    x: [1, 2, 3, 4],
+                    y: ["a", "a", "a", "b"]
+                });
+
+                // Aggregate for hidden sort should be ignored in column-only,
+                // so just make sure we stick to that.
+                const view = await table.view({
+                    columns: ["x"],
+                    column_pivots: ["y"],
+                    sort: [["y", "col desc"]],
+                    aggregates: {
+                        y: "count"
+                    }
+                });
+
+                const paths = await view.column_paths();
+                expect(paths).toEqual(["b|x", "a|x"]);
+
+                const result = await view.to_columns();
+                expect(result).toEqual({
+                    "b|x": [null, null, null, 4],
+                    "a|x": [1, 2, 3, null]
+                });
+                view.delete();
+                table.delete();
+            });
+
             it("column pivot ['y'] with overridden aggregates", async function() {
                 const table = await perspective.table({
                     x: [1, 2, 3, 4],


### PR DESCRIPTION
This PR fixes a bug where column names that could be parsed as numbers (like the expression `1234`) did not respond correctly to column ordering and would be the first column in a pivoted view:

<img width="586" alt="Screen Shot 2021-05-27 at 3 03 32 PM 2" src="https://user-images.githubusercontent.com/13220267/119845750-1ec37100-bf3c-11eb-92e5-19cec4a2f9db.png">

This was due to the way that aggregates were parsed in the C++, which happened in three separate iterations:

1. Iterate through the `columns` array, and generate default aggregates for all columns _not_ in the aggregate map
2. Iterate through the `aggregate` map (using the order generated by `Object.keys()`), and apply specified aggregates for all aggregate columns _in_ the columns array
3. Generate aggregates for hidden sort columns.

I'm not sure exactly _why_ I wrote the parsing logic the way that I did (in 2019, IIRC), but the issue it causes is simple: by ignore the column order when parsing the aggregates map, it assumes that the aggregates map can be iterated in the same order as columns.

However, in Javascript, in an object with a `string` key that is parsable as an integer (like "1234"), when iterating through the object using `Object.keys()`, the integer-parsable key is automatically moved to the front of the iteration order, and multiple integer-parsable keys are ordered in ascending order. More details [here](https://stackoverflow.com/a/23202095).

An example of this behavior is as follows:

<img width="603" alt="Screen Shot 2021-05-27 at 10 32 28 PM" src="https://user-images.githubusercontent.com/13220267/119845206-a78ddd00-bf3b-11eb-9bae-62f0bd384884.png">

This behavior does not seem to happen when the keys are parsable as floats ("4.5" and "5.55555", for example, remain in insertion order). Thus, the assumption that the aggregates map is ordered properly is broken, and so goes the column order. The fix is to rewrite the aggregate parsing logic to use the column order while iterating, and access the aggregates map through the column order instead of the order given by `Object.keys()`.

I also removed the unimplemented `and` and `or` filters for boolean columns from the UI - though boolean columns are less common, selecting those would have caused an `abort()`.