### PR TITLE
Expose `join` aggregate

### DIFF
--- a/cpp/perspective/src/cpp/sparse_tree.cpp
+++ b/cpp/perspective/src/cpp/sparse_tree.cpp
@@ -31,6 +31,9 @@
 
 namespace perspective {
 
+// Tweet length
+const t_uindex MAX_JOIN_SIZE = 280; 
+
 t_tscalar
 get_dominant(std::vector<t_tscalar>& values) {
     if (values.empty())
@@ -1055,9 +1058,19 @@ t_stree::update_agg_table(
                         }
 
                         std::stringstream ss;
+                        t_uindex str_size = 0, idx = 0;
                         for (std::set<t_tscalar>::const_iterator iter = vset.begin();
                              iter != vset.end(); ++iter) {
-                            ss << *iter << ", ";
+                            str_size += strlen(iter->get_char_ptr()) + 2;
+                            if (str_size > MAX_JOIN_SIZE) {
+                                break;
+                            }
+
+                            if (iter != vset.begin()) {
+                                ss << ", ";
+                            }
+
+                            ss << *iter;
                         }
                         return m_symtable.get_interned_tscalar(ss.str().c_str());
                     })

--- a/packages/perspective/src/js/config/constants.js
+++ b/packages/perspective/src/js/config/constants.js
@@ -43,6 +43,7 @@ const NUMBER_AGGREGATES = [
     "last by index",
     "last",
     "high",
+    "join",
     "low",
     "mean",
     "median",
@@ -54,7 +55,7 @@ const NUMBER_AGGREGATES = [
     "unique"
 ];
 
-const STRING_AGGREGATES = ["any", "count", "distinct count", "distinct leaf", "dominant", "first by index", "last by index", "last", "unique"];
+const STRING_AGGREGATES = ["any", "count", "distinct count", "distinct leaf", "dominant", "first by index", "join", "last by index", "last", "unique"];
 
 const BOOLEAN_AGGREGATES = ["any", "count", "distinct count", "distinct leaf", "dominant", "first by index", "last by index", "last", "unique"];
 

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -228,6 +228,24 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("['z'], join", async function() {
+            var table = await perspective.table(data);
+            var view = await table.view({
+                row_pivots: ["z"],
+                columns: ["x"],
+                aggregates: {x: "join"}
+            });
+            var answer = [
+                {__ROW_PATH__: [], x: "1, 2, 3, 4, "},
+                {__ROW_PATH__: [false], x: "2, 4, "},
+                {__ROW_PATH__: [true], x: "1, 3, "}
+            ];
+            let result = await view.to_json();
+            expect(result).toEqual(answer);
+            view.delete();
+            table.delete();
+        });
+
         it("['z'], first by index with appends", async function() {
             var table = await perspective.table(data, {index: "y"});
             var view = await table.view({

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -236,9 +236,29 @@ module.exports = perspective => {
                 aggregates: {x: "join"}
             });
             var answer = [
-                {__ROW_PATH__: [], x: "1, 2, 3, 4, "},
-                {__ROW_PATH__: [false], x: "2, 4, "},
-                {__ROW_PATH__: [true], x: "1, 3, "}
+                {__ROW_PATH__: [], x: "1, 2, 3, 4"},
+                {__ROW_PATH__: [false], x: "2, 4"},
+                {__ROW_PATH__: [true], x: "1, 3"}
+            ];
+            let result = await view.to_json();
+            expect(result).toEqual(answer);
+            view.delete();
+            table.delete();
+        });
+
+        it("['z'], join exceeds max join size", async function() {
+            let data2 = JSON.parse(JSON.stringify(data));
+            data2.push({x: 5, y: "abcdefghijklmnopqrstuvwxyz".repeat(12), z: false});
+            var table = await perspective.table(data2);
+            var view = await table.view({
+                row_pivots: ["z"],
+                columns: ["y"],
+                aggregates: {y: "join"}
+            });
+            var answer = [
+                {__ROW_PATH__: [], y: "a"},
+                {__ROW_PATH__: [false], y: ""},
+                {__ROW_PATH__: [true], y: "a, c"}
             ];
             let result = await view.to_json();
             expect(result).toEqual(answer);

--- a/python/perspective/perspective/core/aggregate.py
+++ b/python/perspective/perspective/core/aggregate.py
@@ -28,6 +28,7 @@ class Aggregate(Enum):
     LAST_BY_INDEX = "last by index"
     LAST = "last"
     HIGH = "high"
+    JOIN = "join"
     LOW = "low"
     MEAN = "mean"
     MEDIAN = "median"


### PR DESCRIPTION
Updated fork of #1394

Currently uses `strlen` but this should really use the `t_vocab` extents to calculate length, however this is difficult to access currently from `sparse_tree`.

I've also removed the trailing `", "` semantically.