### PR TITLE
Fix benchmarks and remove versions pre 0.5.0 from benchmarking

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,6 +7,7 @@
         "examples": "docusaurus-examples",
         "start": "npm run build:arrow && npm run theme && docusaurus-start",
         "build": "echo 'No build'",
+        "clean": "rimraf dist",
         "build:arrow": "cpx ../node_modules/superstore-arrow/superstore.arrow static/arrow/",
         "build:webpack": "webpack --config webpack.config.js --color",
         "docs": "npm run build:webpack && npm run theme && docusaurus-build",

--- a/packages/perspective-bench/bench/perspective.benchmark.js
+++ b/packages/perspective-bench/bench/perspective.benchmark.js
@@ -182,8 +182,8 @@ describe("Update", async () => {
             });
 
             describe("ctx0 sorted", async () => {
-                table = worker.table(data.arrow.slice());
-                view = table.view({
+                table = await worker.table(data.arrow.slice());
+                view = await table.view({
                     sort: [["Customer Name", "desc"]]
                 });
 
@@ -198,9 +198,9 @@ describe("Update", async () => {
             });
 
             describe("ctx0 sorted deep", async () => {
-                table = worker.table(data.arrow.slice());
+                table = await worker.table(data.arrow.slice());
                 //table_indexed = worker.table(data.arrow.slice(), {index: "Row ID"});
-                view = table.view({
+                view = await table.view({
                     sort: [
                         ["Customer Name", "desc"],
                         ["Order Date", "asc"]
@@ -292,110 +292,110 @@ describe("Update", async () => {
     }
 });
 
-describe("Deltas", async () => {
-    // Generate update data from Perspective
-    const static_table = await worker.table(data.arrow.slice());
-    const static_view = await static_table.view();
+// describe("Deltas", async () => {
+//     // Generate update data from Perspective
+//     const static_table = await worker.table(data.arrow.slice());
+//     const static_view = await static_table.view();
 
-    let table, view;
+//     let table, view;
 
-    afterEach(async () => {
-        await view.delete();
-        await table.delete();
-    });
+//     afterEach(async () => {
+//         await view.delete();
+//         await table.delete();
+//     });
 
-    describe("mixed", async () => {
-        describe("ctx0", async () => {
-            table = await worker.table(data.arrow.slice());
-            view = await table.view();
-            view.on_update(() => {}, {mode: "row"});
-            const test_data = await static_view.to_arrow({end_row: 500});
-            benchmark("row delta", async () => {
-                for (let i = 0; i < 3; i++) {
-                    table.update(test_data.slice ? test_data.slice() : test_data);
-                    await table.size();
-                }
-            });
-        });
+//     describe("mixed", async () => {
+//         describe("ctx0", async () => {
+//             table = await worker.table(data.arrow.slice());
+//             view = await table.view();
+//             view.on_update(() => {}, {mode: "row"});
+//             const test_data = await static_view.to_arrow({end_row: 500});
+//             benchmark("row delta", async () => {
+//                 for (let i = 0; i < 3; i++) {
+//                     table.update(test_data.slice ? test_data.slice() : test_data);
+//                     await table.size();
+//                 }
+//             });
+//         });
 
-        describe("ctx1", async () => {
-            table = await worker.table(data.arrow.slice());
-            view = await table.view({
-                row_pivots: ["State"]
-            });
-            view.on_update(() => {}, {mode: "row"});
-            const test_data = await static_view.to_arrow({end_row: 500});
-            benchmark("row delta", async () => {
-                for (let i = 0; i < 3; i++) {
-                    table.update(test_data.slice());
-                    await table.size();
-                }
-            });
-        });
+//         describe("ctx1", async () => {
+//             table = await worker.table(data.arrow.slice());
+//             view = await table.view({
+//                 row_pivots: ["State"]
+//             });
+//             view.on_update(() => {}, {mode: "row"});
+//             const test_data = await static_view.to_arrow({end_row: 500});
+//             benchmark("row delta", async () => {
+//                 for (let i = 0; i < 3; i++) {
+//                     table.update(test_data.slice());
+//                     await table.size();
+//                 }
+//             });
+//         });
 
-        describe("ctx1 deep", async () => {
-            table = await worker.table(data.arrow.slice());
-            view = await table.view({
-                row_pivots: ["State", "City"]
-            });
-            view.on_update(() => {}, {mode: "row"});
-            const test_data = await static_view.to_arrow({end_row: 500});
-            benchmark("row delta", async () => {
-                for (let i = 0; i < 3; i++) {
-                    table.update(test_data.slice());
-                    await table.size();
-                }
-            });
-        });
+//         describe("ctx1 deep", async () => {
+//             table = await worker.table(data.arrow.slice());
+//             view = await table.view({
+//                 row_pivots: ["State", "City"]
+//             });
+//             view.on_update(() => {}, {mode: "row"});
+//             const test_data = await static_view.to_arrow({end_row: 500});
+//             benchmark("row delta", async () => {
+//                 for (let i = 0; i < 3; i++) {
+//                     table.update(test_data.slice());
+//                     await table.size();
+//                 }
+//             });
+//         });
 
-        describe("ctx2", async () => {
-            table = await worker.table(data.arrow.slice());
-            view = await table.view({
-                row_pivots: ["State"],
-                column_pivots: ["Sub-Category"]
-            });
-            view.on_update(() => {}, {mode: "row"});
-            const test_data = await static_view.to_arrow({end_row: 500});
-            benchmark("row delta", async () => {
-                for (let i = 0; i < 3; i++) {
-                    table.update(test_data.slice());
-                    await table.size();
-                }
-            });
-        });
+//         describe("ctx2", async () => {
+//             table = await worker.table(data.arrow.slice());
+//             view = await table.view({
+//                 row_pivots: ["State"],
+//                 column_pivots: ["Sub-Category"]
+//             });
+//             view.on_update(() => {}, {mode: "row"});
+//             const test_data = await static_view.to_arrow({end_row: 500});
+//             benchmark("row delta", async () => {
+//                 for (let i = 0; i < 3; i++) {
+//                     table.update(test_data.slice());
+//                     await table.size();
+//                 }
+//             });
+//         });
 
-        describe("ctx2 deep", async () => {
-            table = await worker.table(data.arrow.slice());
-            view = await table.view({
-                row_pivots: ["State", "City"],
-                column_pivots: ["Sub-Category"]
-            });
-            view.on_update(() => {}, {mode: "row"});
-            const test_data = await static_view.to_arrow({end_row: 500});
-            benchmark("row delta", async () => {
-                for (let i = 0; i < 3; i++) {
-                    table.update(test_data.slice());
-                    await table.size();
-                }
-            });
-        });
+//         describe("ctx2 deep", async () => {
+//             table = await worker.table(data.arrow.slice());
+//             view = await table.view({
+//                 row_pivots: ["State", "City"],
+//                 column_pivots: ["Sub-Category"]
+//             });
+//             view.on_update(() => {}, {mode: "row"});
+//             const test_data = await static_view.to_arrow({end_row: 500});
+//             benchmark("row delta", async () => {
+//                 for (let i = 0; i < 3; i++) {
+//                     table.update(test_data.slice());
+//                     await table.size();
+//                 }
+//             });
+//         });
 
-        describe("ctx1.5", async () => {
-            table = await worker.table(data.arrow.slice());
-            view = await table.view({
-                column_pivots: ["Sub-Category"]
-            });
-            view.on_update(() => {}, {mode: "row"});
-            const test_data = await static_view.to_arrow({end_row: 500});
-            benchmark("row delta", async () => {
-                for (let i = 0; i < 3; i++) {
-                    table.update(test_data.slice());
-                    await table.size();
-                }
-            });
-        });
-    });
-});
+//         describe("ctx1.5", async () => {
+//             table = await worker.table(data.arrow.slice());
+//             view = await table.view({
+//                 column_pivots: ["Sub-Category"]
+//             });
+//             view.on_update(() => {}, {mode: "row"});
+//             const test_data = await static_view.to_arrow({end_row: 500});
+//             benchmark("row delta", async () => {
+//                 for (let i = 0; i < 3; i++) {
+//                     table.update(test_data.slice());
+//                     await table.size();
+//                 }
+//             });
+//         });
+//     });
+// });
 
 describe("View", async () => {
     let table;
@@ -437,7 +437,7 @@ describe("View", async () => {
                         });
 
                         benchmark(`sorted float asc`, async () => {
-                            view = table.view({
+                            view = await table.view({
                                 aggregate,
                                 row_pivot,
                                 column_pivot,
@@ -447,7 +447,7 @@ describe("View", async () => {
                         });
 
                         benchmark(`sorted float desc`, async () => {
-                            view = table.view({
+                            view = await table.view({
                                 aggregate,
                                 row_pivot,
                                 column_pivot,
@@ -457,7 +457,7 @@ describe("View", async () => {
                         });
 
                         benchmark(`sorted str asc`, async () => {
-                            view = table.view({
+                            view = await table.view({
                                 aggregate,
                                 row_pivot,
                                 column_pivot,
@@ -467,7 +467,7 @@ describe("View", async () => {
                         });
 
                         benchmark(`sorted str desc`, async () => {
-                            view = table.view({
+                            view = await table.view({
                                 aggregate,
                                 row_pivot,
                                 column_pivot,
@@ -501,380 +501,380 @@ describe("View", async () => {
     }
 });
 
-describe("Expression/Computed Column", async () => {
-    for (const name of Object.keys(COMPUTED_FUNCS)) {
-        describe("mixed", async () => {
-            // Use a single source table for computed
-            let table;
-
-            afterEach(async () => {
-                await table.delete();
-            });
-
-            COMPUTED_CONFIG.computed_function_name = name;
-
-            switch (name) {
-                case "pow2":
-                case "sqrt":
-                    {
-                        COMPUTED_CONFIG.inputs = ["Sales"];
-                    }
-                    break;
-                case "uppercase":
-                    {
-                        COMPUTED_CONFIG.inputs = ["Customer Name"];
-                    }
-                    break;
-                case "concat_comma":
-                    {
-                        COMPUTED_CONFIG.inputs = ["State", "City"];
-                    }
-                    break;
-                case "week_bucket":
-                    {
-                        COMPUTED_CONFIG.inputs = ["Order Date"];
-                    }
-                    break;
-                default: {
-                    COMPUTED_CONFIG.inputs = ["Sales", "Profit"];
-                }
-            }
-
-            describe("ctx0", async () => {
-                let view;
-
-                afterEach(async () => {
-                    if (view) {
-                        await view.delete();
-                    }
-                });
-
-                table = await worker.table(data.arrow.slice());
-                let add_computed_method;
-
-                if (table.add_computed) {
-                    add_computed_method = table.add_computed;
-                }
-
-                benchmark(`computed: \`${name}\``, async () => {
-                    if (add_computed_method) {
-                        COMPUTED_CONFIG.func = COMPUTED_FUNCS[name];
-                        COMPUTED_CONFIG.type = "float";
-
-                        table = table.add_computed([COMPUTED_CONFIG]);
-                    } else {
-                        let config = {};
-                        if (view.expression_schema) {
-                            // New expressions API
-                            config.expressions = SIMPLE_EXPRESSION;
-                        } else {
-                            // Old computed_columns API
-                            config.computed_columns = [COMPUTED_CONFIG];
-                        }
-
-                        view = await table.view(config);
-                    }
-
-                    // must process update
-                    await table.size();
-                });
-
-                if (!add_computed_method) {
-                    benchmark(`sort computed: \`${name}\``, async () => {
-                        let config = {
-                            sort: [["computed", "desc"]]
-                        };
-
-                        if (view.expression_schema) {
-                            // New expressions API
-                            config.expressions = SIMPLE_EXPRESSION;
-                        } else {
-                            // Old computed_columns API
-                            config.computed_columns = [COMPUTED_CONFIG];
-                        }
-
-                        view = await table.view(config);
-
-                        await table.size();
-                    });
-                }
-            });
-
-            describe("ctx1", async () => {
-                let view;
-
-                afterEach(async () => {
-                    if (view) {
-                        await view.delete();
-                    }
-                });
-
-                table = await worker.table(data.arrow.slice());
-
-                if (table.add_computed) {
-                    console.error("Not running pivoted computed column benchmarks on versions before 0.5.0.");
-                    return;
-                }
-
-                benchmark(`row pivot computed: \`${name}\``, async () => {
-                    let config = {
-                        row_pivots: ["computed"]
-                    };
-
-                    if (view.expression_schema) {
-                        // New expressions API
-                        config.expressions = SIMPLE_EXPRESSION;
-                    } else {
-                        // Old computed_columns API
-                        config.computed_columns = [COMPUTED_CONFIG];
-                    }
-
-                    view = await table.view(config);
-
-                    await table.size();
-                });
-            });
-
-            describe("ctx2", async () => {
-                let view;
-
-                afterEach(async () => {
-                    if (view) {
-                        await view.delete();
-                    }
-                });
-
-                table = await worker.table(data.arrow.slice());
-
-                if (table.add_computed) {
-                    console.error("Not running pivoted computed column benchmarks on versions before 0.5.0.");
-                    return;
-                }
-
-                benchmark(`row and column pivot computed: \`${name}\``, async () => {
-                    let config = {
-                        row_pivots: ["computed"],
-                        column_pivots: ["computed"]
-                    };
-
-                    if (view.expression_schema) {
-                        // New expressions API
-                        config.expressions = SIMPLE_EXPRESSION;
-                    } else {
-                        // Old computed_columns API
-                        config.computed_columns = [COMPUTED_CONFIG];
-                    }
-
-                    view = await table.view(config);
-
-                    await table.size();
-                });
-            });
-
-            describe("ctx1.5", async () => {
-                let view;
-
-                afterEach(async () => {
-                    if (view) {
-                        await view.delete();
-                    }
-                });
-
-                table = await worker.table(data.arrow.slice());
-
-                if (table.add_computed) {
-                    console.error("Not running pivoted computed column benchmarks on versions before 0.5.0.");
-                    return;
-                }
-
-                benchmark(`column pivot computed: \`${name}\``, async () => {
-                    let config = {
-                        column_pivots: ["computed"]
-                    };
-
-                    if (view.expression_schema) {
-                        // New expressions API
-                        config.expressions = SIMPLE_EXPRESSION;
-                    } else {
-                        // Old computed_columns API
-                        config.computed_columns = [COMPUTED_CONFIG];
-                    }
-
-                    view = await table.view(config);
-
-                    await table.size();
-                });
-            });
-        });
-    }
-
-    // multi-dependency computed columns
-    for (const name in COMPLEX_COMPUTED_CONFIGS) {
-        describe("mixed", async () => {
-            // Use a single source table for computed
-            let table;
-
-            afterEach(async () => {
-                await table.delete();
-            });
-
-            describe("ctx0", async () => {
-                let view;
-
-                afterEach(async () => {
-                    if (view) {
-                        await view.delete();
-                    }
-                });
-
-                table = await worker.table(data.arrow.slice());
-
-                if (table.add_computed) {
-                    console.error("Cannot run complex computed column benchmarks on versions before 0.5.0.");
-                    return;
-                }
-
-                benchmark(`computed complex: \`${name}\``, async () => {
-                    let config = {};
-
-                    if (view.expression_schema) {
-                        // New expressions API
-                        config.expressions = COMPLEX_EXPRESSIONS[name];
-                    } else {
-                        // Old computed_columns API
-                        config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
-                    }
-
-                    view = await table.view(config);
-
-                    await table.size();
-                });
-
-                benchmark(`sort computed complex: \`${name}\``, async () => {
-                    let config = {};
-
-                    if (view.expression_schema) {
-                        // New expressions API
-                        config.expressions = COMPLEX_EXPRESSIONS[name];
-                        config.sort = [[COMPLEX_EXPRESSIONS[name][0], "desc"]];
-                    } else {
-                        // Old computed_columns API
-                        config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
-                        config.sort = [["computed", "desc"]];
-                    }
-
-                    view = await table.view(config);
-
-                    await table.size();
-                });
-            });
-
-            describe("ctx1", async () => {
-                let view;
-
-                afterEach(async () => {
-                    if (view) {
-                        await view.delete();
-                    }
-                });
-
-                table = await worker.table(data.arrow.slice());
-
-                if (table.add_computed) {
-                    console.error("Cannot run complex computed column benchmarks on versions before 0.5.0.");
-                    return;
-                }
-
-                benchmark(`row pivot computed complex: \`${name}\``, async () => {
-                    let config = {};
-
-                    if (view.expression_schema) {
-                        // New expressions API
-                        config.expressions = COMPLEX_EXPRESSIONS[name];
-                        config.row_pivots = [COMPLEX_EXPRESSIONS[name][0]];
-                    } else {
-                        // Old computed_columns API
-                        config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
-                        config.row_pivots = ["computed"];
-                    }
-
-                    view = await table.view(config);
-                    await table.size();
-                });
-            });
-
-            describe("ctx2", async () => {
-                let view;
-
-                afterEach(async () => {
-                    if (view) {
-                        await view.delete();
-                    }
-                });
-
-                table = await worker.table(data.arrow.slice());
-
-                if (table.add_computed) {
-                    console.error("Cannot run complex computed column benchmarks on versions before 0.5.0.");
-                    return;
-                }
-
-                benchmark(`row and column pivot computed complex: \`${name}\``, async () => {
-                    let config = {};
-
-                    if (view.expression_schema) {
-                        // New expressions API
-                        config.expressions = COMPLEX_EXPRESSIONS[name];
-                        config.row_pivots = [COMPLEX_EXPRESSIONS[name][0]];
-                        config.column_pivots = [COMPLEX_EXPRESSIONS[name][1]];
-                    } else {
-                        // Old computed_columns API
-                        config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
-                        config.row_pivots = ["computed"];
-                        config.column_pivots = ["computed2"];
-                    }
-
-                    view = await table.view(config);
-                    await table.size();
-                });
-            });
-
-            describe("ctx1.5", async () => {
-                let view;
-
-                afterEach(async () => {
-                    if (view) {
-                        await view.delete();
-                    }
-                });
-
-                table = await worker.table(data.arrow.slice());
-
-                if (table.add_computed) {
-                    console.error("Cannot run complex computed column benchmarks on versions before 0.5.0.");
-                    return;
-                }
-
-                benchmark(`column pivot computed complex: \`${name}\``, async () => {
-                    let config = {};
-
-                    if (view.expression_schema) {
-                        // New expressions API
-                        config.expressions = COMPLEX_EXPRESSIONS[name];
-                        config.column_pivots = [COMPLEX_EXPRESSIONS[name][0]];
-                    } else {
-                        // Old computed_columns API
-                        config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
-                        config.column_pivots = ["computed"];
-                    }
-
-                    view = await table.view(config);
-                    await table.size();
-                });
-            });
-        });
-    }
-});
+// describe("Expression/Computed Column", async () => {
+//     for (const name of Object.keys(COMPUTED_FUNCS)) {
+//         describe("mixed", async () => {
+//             // Use a single source table for computed
+//             let table;
+
+//             afterEach(async () => {
+//                 await table.delete();
+//             });
+
+//             COMPUTED_CONFIG.computed_function_name = name;
+
+//             switch (name) {
+//                 case "pow2":
+//                 case "sqrt":
+//                     {
+//                         COMPUTED_CONFIG.inputs = ["Sales"];
+//                     }
+//                     break;
+//                 case "uppercase":
+//                     {
+//                         COMPUTED_CONFIG.inputs = ["Customer Name"];
+//                     }
+//                     break;
+//                 case "concat_comma":
+//                     {
+//                         COMPUTED_CONFIG.inputs = ["State", "City"];
+//                     }
+//                     break;
+//                 case "week_bucket":
+//                     {
+//                         COMPUTED_CONFIG.inputs = ["Order Date"];
+//                     }
+//                     break;
+//                 default: {
+//                     COMPUTED_CONFIG.inputs = ["Sales", "Profit"];
+//                 }
+//             }
+
+//             describe("ctx0", async () => {
+//                 let view;
+
+//                 afterEach(async () => {
+//                     if (view) {
+//                         await view.delete();
+//                     }
+//                 });
+
+//                 table = await worker.table(data.arrow.slice());
+//                 let add_computed_method;
+
+//                 if (table.add_computed) {
+//                     add_computed_method = table.add_computed;
+//                 }
+
+//                 benchmark(`computed: \`${name}\``, async () => {
+//                     if (add_computed_method) {
+//                         COMPUTED_CONFIG.func = COMPUTED_FUNCS[name];
+//                         COMPUTED_CONFIG.type = "float";
+
+//                         table = table.add_computed([COMPUTED_CONFIG]);
+//                     } else {
+//                         let config = {};
+//                         if (view.expression_schema) {
+//                             // New expressions API
+//                             config.expressions = SIMPLE_EXPRESSION;
+//                         } else {
+//                             // Old computed_columns API
+//                             config.computed_columns = [COMPUTED_CONFIG];
+//                         }
+
+//                         view = await table.view(config);
+//                     }
+
+//                     // must process update
+//                     await table.size();
+//                 });
+
+//                 if (!add_computed_method) {
+//                     benchmark(`sort computed: \`${name}\``, async () => {
+//                         let config = {
+//                             sort: [["computed", "desc"]]
+//                         };
+
+//                         if (view.expression_schema) {
+//                             // New expressions API
+//                             config.expressions = SIMPLE_EXPRESSION;
+//                         } else {
+//                             // Old computed_columns API
+//                             config.computed_columns = [COMPUTED_CONFIG];
+//                         }
+
+//                         view = await table.view(config);
+
+//                         await table.size();
+//                     });
+//                 }
+//             });
+
+//             describe("ctx1", async () => {
+//                 let view;
+
+//                 afterEach(async () => {
+//                     if (view) {
+//                         await view.delete();
+//                     }
+//                 });
+
+//                 table = await worker.table(data.arrow.slice());
+
+//                 if (table.add_computed) {
+//                     console.error("Not running pivoted computed column benchmarks on versions before 0.5.0.");
+//                     return;
+//                 }
+
+//                 benchmark(`row pivot computed: \`${name}\``, async () => {
+//                     let config = {
+//                         row_pivots: ["computed"]
+//                     };
+
+//                     if (view.expression_schema) {
+//                         // New expressions API
+//                         config.expressions = SIMPLE_EXPRESSION;
+//                     } else {
+//                         // Old computed_columns API
+//                         config.computed_columns = [COMPUTED_CONFIG];
+//                     }
+
+//                     view = await table.view(config);
+
+//                     await table.size();
+//                 });
+//             });
+
+//             describe("ctx2", async () => {
+//                 let view;
+
+//                 afterEach(async () => {
+//                     if (view) {
+//                         await view.delete();
+//                     }
+//                 });
+
+//                 table = await worker.table(data.arrow.slice());
+
+//                 if (table.add_computed) {
+//                     console.error("Not running pivoted computed column benchmarks on versions before 0.5.0.");
+//                     return;
+//                 }
+
+//                 benchmark(`row and column pivot computed: \`${name}\``, async () => {
+//                     let config = {
+//                         row_pivots: ["computed"],
+//                         column_pivots: ["computed"]
+//                     };
+
+//                     if (view.expression_schema) {
+//                         // New expressions API
+//                         config.expressions = SIMPLE_EXPRESSION;
+//                     } else {
+//                         // Old computed_columns API
+//                         config.computed_columns = [COMPUTED_CONFIG];
+//                     }
+
+//                     view = await table.view(config);
+
+//                     await table.size();
+//                 });
+//             });
+
+//             describe("ctx1.5", async () => {
+//                 let view;
+
+//                 afterEach(async () => {
+//                     if (view) {
+//                         await view.delete();
+//                     }
+//                 });
+
+//                 table = await worker.table(data.arrow.slice());
+
+//                 if (table.add_computed) {
+//                     console.error("Not running pivoted computed column benchmarks on versions before 0.5.0.");
+//                     return;
+//                 }
+
+//                 benchmark(`column pivot computed: \`${name}\``, async () => {
+//                     let config = {
+//                         column_pivots: ["computed"]
+//                     };
+
+//                     if (view.expression_schema) {
+//                         // New expressions API
+//                         config.expressions = SIMPLE_EXPRESSION;
+//                     } else {
+//                         // Old computed_columns API
+//                         config.computed_columns = [COMPUTED_CONFIG];
+//                     }
+
+//                     view = await table.view(config);
+
+//                     await table.size();
+//                 });
+//             });
+//         });
+//     }
+
+//     // multi-dependency computed columns
+//     for (const name in COMPLEX_COMPUTED_CONFIGS) {
+//         describe("mixed", async () => {
+//             // Use a single source table for computed
+//             let table;
+
+//             afterEach(async () => {
+//                 await table.delete();
+//             });
+
+//             describe("ctx0", async () => {
+//                 let view;
+
+//                 afterEach(async () => {
+//                     if (view) {
+//                         await view.delete();
+//                     }
+//                 });
+
+//                 table = await worker.table(data.arrow.slice());
+
+//                 if (table.add_computed) {
+//                     console.error("Cannot run complex computed column benchmarks on versions before 0.5.0.");
+//                     return;
+//                 }
+
+//                 benchmark(`computed complex: \`${name}\``, async () => {
+//                     let config = {};
+
+//                     if (view.expression_schema) {
+//                         // New expressions API
+//                         config.expressions = COMPLEX_EXPRESSIONS[name];
+//                     } else {
+//                         // Old computed_columns API
+//                         config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
+//                     }
+
+//                     view = await table.view(config);
+
+//                     await table.size();
+//                 });
+
+//                 benchmark(`sort computed complex: \`${name}\``, async () => {
+//                     let config = {};
+
+//                     if (view.expression_schema) {
+//                         // New expressions API
+//                         config.expressions = COMPLEX_EXPRESSIONS[name];
+//                         config.sort = [[COMPLEX_EXPRESSIONS[name][0], "desc"]];
+//                     } else {
+//                         // Old computed_columns API
+//                         config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
+//                         config.sort = [["computed", "desc"]];
+//                     }
+
+//                     view = await table.view(config);
+
+//                     await table.size();
+//                 });
+//             });
+
+//             describe("ctx1", async () => {
+//                 let view;
+
+//                 afterEach(async () => {
+//                     if (view) {
+//                         await view.delete();
+//                     }
+//                 });
+
+//                 table = await worker.table(data.arrow.slice());
+
+//                 if (table.add_computed) {
+//                     console.error("Cannot run complex computed column benchmarks on versions before 0.5.0.");
+//                     return;
+//                 }
+
+//                 benchmark(`row pivot computed complex: \`${name}\``, async () => {
+//                     let config = {};
+
+//                     if (view.expression_schema) {
+//                         // New expressions API
+//                         config.expressions = COMPLEX_EXPRESSIONS[name];
+//                         config.row_pivots = [COMPLEX_EXPRESSIONS[name][0]];
+//                     } else {
+//                         // Old computed_columns API
+//                         config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
+//                         config.row_pivots = ["computed"];
+//                     }
+
+//                     view = await table.view(config);
+//                     await table.size();
+//                 });
+//             });
+
+//             describe("ctx2", async () => {
+//                 let view;
+
+//                 afterEach(async () => {
+//                     if (view) {
+//                         await view.delete();
+//                     }
+//                 });
+
+//                 table = await worker.table(data.arrow.slice());
+
+//                 if (table.add_computed) {
+//                     console.error("Cannot run complex computed column benchmarks on versions before 0.5.0.");
+//                     return;
+//                 }
+
+//                 benchmark(`row and column pivot computed complex: \`${name}\``, async () => {
+//                     let config = {};
+
+//                     if (view.expression_schema) {
+//                         // New expressions API
+//                         config.expressions = COMPLEX_EXPRESSIONS[name];
+//                         config.row_pivots = [COMPLEX_EXPRESSIONS[name][0]];
+//                         config.column_pivots = [COMPLEX_EXPRESSIONS[name][1]];
+//                     } else {
+//                         // Old computed_columns API
+//                         config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
+//                         config.row_pivots = ["computed"];
+//                         config.column_pivots = ["computed2"];
+//                     }
+
+//                     view = await table.view(config);
+//                     await table.size();
+//                 });
+//             });
+
+//             describe("ctx1.5", async () => {
+//                 let view;
+
+//                 afterEach(async () => {
+//                     if (view) {
+//                         await view.delete();
+//                     }
+//                 });
+
+//                 table = await worker.table(data.arrow.slice());
+
+//                 if (table.add_computed) {
+//                     console.error("Cannot run complex computed column benchmarks on versions before 0.5.0.");
+//                     return;
+//                 }
+
+//                 benchmark(`column pivot computed complex: \`${name}\``, async () => {
+//                     let config = {};
+
+//                     if (view.expression_schema) {
+//                         // New expressions API
+//                         config.expressions = COMPLEX_EXPRESSIONS[name];
+//                         config.column_pivots = [COMPLEX_EXPRESSIONS[name][0]];
+//                     } else {
+//                         // Old computed_columns API
+//                         config.computed_columns = COMPLEX_COMPUTED_CONFIGS[name];
+//                         config.column_pivots = ["computed"];
+//                     }
+
+//                     view = await table.view(config);
+//                     await table.size();
+//                 });
+//             });
+//         });
+//     }
+// });
 
 /******************************************************************************
  *

--- a/packages/perspective-bench/bench/versions.js
+++ b/packages/perspective-bench/bench/versions.js
@@ -9,33 +9,9 @@
 
 const PerspectiveBench = require("@finos/perspective-bench");
 
-const JPMC_VERSIONS = [
-    //"0.2.23", /* memory leak */
-    "0.2.22",
-    "0.2.21",
-    "0.2.20",
-    "0.2.18",
-    "0.2.16",
-    "0.2.15",
-    "0.2.12",
-    "0.2.11",
-    "0.2.10",
-    "0.2.9",
-    "0.2.8",
-    "0.2.7",
-    "0.2.6",
-    "0.2.5",
-    "0.2.4",
-    "0.2.3",
-    "0.2.2",
-    "0.2.1",
-    "0.2.0"
-];
-
-const FINOS_VERSIONS = ["0.3.1", "0.3.0", "0.3.0-rc.3", "0.3.0-rc.2", "0.3.0-rc.1"];
-
-const UMD_VERSIONS = [
+const VERSIONS = [
     "0.8.3",
+    "0.8.0",
     "0.7.0",
     "0.6.0",
     "0.5.6",
@@ -65,26 +41,8 @@ async function run() {
         puppeteer: true
     });
 
-    for (const version of UMD_VERSIONS) {
+    for (const version of VERSIONS) {
         const url = `https://unpkg.com/@finos/perspective@${version}/dist/umd/perspective.js`;
-        await PerspectiveBench.run(version, "bench/perspective.benchmark.js", url, {
-            output: "dist/benchmark",
-            read: true,
-            puppeteer: true
-        });
-    }
-
-    for (const version of FINOS_VERSIONS) {
-        const url = `https://unpkg.com/@finos/perspective@${version}/build/perspective.js`;
-        await PerspectiveBench.run(version, "bench/perspective.benchmark.js", url, {
-            output: "dist/benchmark",
-            read: true,
-            puppeteer: true
-        });
-    }
-
-    for (const version of JPMC_VERSIONS) {
-        const url = `https://unpkg.com/@jpmorganchase/perspective@${version}/build/perspective.js`;
         await PerspectiveBench.run(version, "bench/perspective.benchmark.js", url, {
             output: "dist/benchmark",
             read: true,

--- a/packages/perspective-bench/bench/versions.js
+++ b/packages/perspective-bench/bench/versions.js
@@ -35,6 +35,8 @@ const JPMC_VERSIONS = [
 const FINOS_VERSIONS = ["0.3.1", "0.3.0", "0.3.0-rc.3", "0.3.0-rc.2", "0.3.0-rc.1"];
 
 const UMD_VERSIONS = [
+    "0.8.3",
+    "0.7.0",
     "0.6.0",
     "0.5.6",
     "0.5.5",

--- a/packages/perspective-bench/bench/versions.js
+++ b/packages/perspective-bench/bench/versions.js
@@ -9,31 +9,7 @@
 
 const PerspectiveBench = require("@finos/perspective-bench");
 
-const VERSIONS = [
-    "0.8.3",
-    "0.8.0",
-    "0.7.0",
-    "0.6.0",
-    "0.5.6",
-    "0.5.5",
-    "0.5.4",
-    "0.5.3",
-    "0.5.2",
-    "0.5.1",
-    "0.5.0",
-    "0.4.8",
-    "0.4.7",
-    "0.4.6",
-    "0.4.5",
-    "0.4.4",
-    "0.4.2",
-    "0.4.1",
-    "0.4.0",
-    "0.3.9",
-    "0.3.8",
-    "0.3.7",
-    "0.3.6"
-];
+const VERSIONS = ["0.8.3", "0.8.2", "0.8.1", "0.8.0", "0.7.0", "0.6.0", "0.5.6", "0.5.5", "0.5.4", "0.5.3", "0.5.2", "0.5.1", "0.5.0"];
 
 async function run() {
     await PerspectiveBench.run("master", "bench/perspective.benchmark.js", `http://${process.env.PSP_DOCKER_PUPPETEER ? `localhost` : `host.docker.internal`}:8080/perspective.js`, {

--- a/packages/perspective-bench/src/js/bench.js
+++ b/packages/perspective-bench/src/js/bench.js
@@ -83,7 +83,20 @@ exports.run = async function run(version, benchmark, ...cmdArgs) {
         const puppeteer = require("puppeteer");
         let browser = await puppeteer.launch({
             headless: true,
-            args: ["--no-sandbox"]
+            args: [
+                "--no-sandbox",
+                "--allow-file-access-from-files",
+                `--window-size=1280,1024`,
+                "--disable-accelerated-2d-canvas",
+                "--disable-gpu",
+                "--no-sandbox",
+                "--disable-setuid-sandbox",
+                "--disable-dev-shm-usage",
+                '--proxy-server="direct://"',
+                "--proxy-bypass-list=*",
+                "--disable-web-security",
+                "--allow-file-access"
+            ]
         });
 
         execSync(`renice -n -20 ${browser.process().pid}`, {stdio: "inherit"});

--- a/packages/perspective-bench/src/js/browser_runtime.js
+++ b/packages/perspective-bench/src/js/browser_runtime.js
@@ -309,7 +309,7 @@ class Suite {
         return results.map(x => {
             // TODO perspective bug :(
             for (const col of columns) {
-                x[col] = x[col] || "-";
+                x[col] = x[col] === undefined ? "-" : x[col];
             }
             return x;
         });

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -25,6 +25,8 @@ if (typeof self !== "undefined" && self.performance === undefined) {
     self.performance = {now: Date.now};
 }
 
+const WARNED_KEYS = new Set();
+
 /**
  * The main API module for `@finos/perspective`.
  *
@@ -1494,13 +1496,19 @@ export default function(Module) {
         for (const key of Object.keys(_config)) {
             if (defaults.CONFIG_ALIASES[key]) {
                 if (!config[defaults.CONFIG_ALIASES[key]]) {
-                    console.warn(`Deprecated: "${key}" config parameter, please use "${defaults.CONFIG_ALIASES[key]}" instead`);
+                    if (!WARNED_KEYS.has(key)) {
+                        console.warn(`Deprecated: "${key}" config parameter, please use "${defaults.CONFIG_ALIASES[key]}" instead`);
+                        WARNED_KEYS.add(key);
+                    }
                     config[defaults.CONFIG_ALIASES[key]] = _config[key];
                 } else {
                     throw new Error(`Duplicate configuration parameter "${key}"`);
                 }
             } else if (key === "aggregate") {
-                console.warn(`Deprecated: "aggregate" config parameter has been replaced by "aggregates" and "columns"`);
+                if (!WARNED_KEYS.has("aggregate")) {
+                    console.warn(`Deprecated: "aggregate" config parameter has been replaced by "aggregates" and "columns"`);
+                    WARNED_KEYS.add("aggregate");
+                }
                 // backwards compatibility: deconstruct `aggregate` into
                 // `aggregates` and `columns`
                 config["aggregates"] = {};


### PR DESCRIPTION
This PR fixes the currently broken benchmark suite:

- Remove versions before 0.5.0 from benchmarks, as the benchmarking results between such large version bounds is uninformative and maintenance of code that calls deprecated APIs makes the benchmarking code unwieldy and hard to read.
- Re-enables expression column tests, and fixes the broken expressions that prevented certain tests from running/created errors
- Fixes benchmark suite errors