### PR TITLE
Add integer, float, string, date, and datetime conversion functions

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -250,7 +250,6 @@ if (PSP_WASM_BUILD)
 			-s DISABLE_EXCEPTION_CATCHING=0 \
 			-s ASSERTIONS=2 \
 			-s DEMANGLE_SUPPORT=1 \
-			-s SAFE_HEAP=1 \
 			")
 	else()
 		set(OPT_FLAGS " \

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -74,6 +74,9 @@ t_computed_expression_parser::LOWER_VALIDATOR_FN = computed_function::lower(null
 computed_function::length
 t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nullptr);
 
+computed_function::to_string
+t_computed_expression_parser::TO_STRING_VALIDATOR_FN = computed_function::to_string(nullptr);
+
 #define REGISTER_COMPUTE_FUNCTIONS(vocab)                                                        \
     computed_function::day_of_week day_of_week_fn = computed_function::day_of_week(vocab);         \
     computed_function::month_of_year month_of_year_fn = computed_function::month_of_year(vocab);   \
@@ -83,6 +86,7 @@ t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nu
     computed_function::upper upper_fn = computed_function::upper(vocab);       \
     computed_function::lower lower_fn = computed_function::lower(vocab);       \
     computed_function::length length_fn = computed_function::length(vocab);    \
+    computed_function::to_string to_string_fn = computed_function::to_string(vocab);        \
     sym_table.add_function("today", computed_function::today);                              \
     sym_table.add_function("now", computed_function::now);                                  \
     sym_table.add_function("bucket", t_computed_expression_parser::BUCKET_FN);              \
@@ -95,6 +99,7 @@ t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nu
     sym_table.add_function("upper", upper_fn);                                              \
     sym_table.add_function("lower", lower_fn);                                              \
     sym_table.add_function("length", length_fn);                                            \
+    sym_table.add_function("string", to_string_fn);                                         \
     sym_table.add_reserved_function("min", t_computed_expression_parser::MIN_FN);           \
     sym_table.add_reserved_function("max", t_computed_expression_parser::MAX_FN);           \
     sym_table.add_function("percent_of", t_computed_expression_parser::PERCENT_OF_FN);      \
@@ -123,6 +128,7 @@ t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nu
     sym_table.add_function("percent_of", t_computed_expression_parser::PERCENT_OF_FN);      \
     sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);            \
     sym_table.add_function("is_not_null", t_computed_expression_parser::IS_NOT_NULL_FN);    \
+    sym_table.add_function("string", t_computed_expression_parser::TO_STRING_VALIDATOR_FN); \
     sym_table.add_function("integer", t_computed_expression_parser::TO_INTEGER_FN);         \
     sym_table.add_function("float", t_computed_expression_parser::TO_FLOAT_FN);             \
     sym_table.add_function("date", t_computed_expression_parser::MAKE_DATE_FN);             \

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -39,6 +39,12 @@ t_computed_expression_parser::IS_NOT_NULL_FN = computed_function::is_not_null();
 computed_function::make_date
 t_computed_expression_parser::MAKE_DATE_FN = computed_function::make_date();
 
+computed_function::to_integer
+t_computed_expression_parser::TO_INTEGER_FN = computed_function::to_integer();
+
+computed_function::to_float
+t_computed_expression_parser::TO_FLOAT_FN = computed_function::to_float();
+
 computed_function::make_datetime
 t_computed_expression_parser::MAKE_DATETIME_FN = computed_function::make_datetime();
 
@@ -94,6 +100,8 @@ t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nu
     sym_table.add_function("percent_of", t_computed_expression_parser::PERCENT_OF_FN);      \
     sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);            \
     sym_table.add_function("is_not_null", t_computed_expression_parser::IS_NOT_NULL_FN);    \
+    sym_table.add_function("integer", t_computed_expression_parser::TO_INTEGER_FN);         \
+    sym_table.add_function("float", t_computed_expression_parser::TO_FLOAT_FN);             \
     sym_table.add_function("date", t_computed_expression_parser::MAKE_DATE_FN);             \
     sym_table.add_function("datetime", t_computed_expression_parser::MAKE_DATETIME_FN);     \
 
@@ -115,6 +123,8 @@ t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nu
     sym_table.add_function("percent_of", t_computed_expression_parser::PERCENT_OF_FN);      \
     sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);            \
     sym_table.add_function("is_not_null", t_computed_expression_parser::IS_NOT_NULL_FN);    \
+    sym_table.add_function("integer", t_computed_expression_parser::TO_INTEGER_FN);         \
+    sym_table.add_function("float", t_computed_expression_parser::TO_FLOAT_FN);             \
     sym_table.add_function("date", t_computed_expression_parser::MAKE_DATE_FN);             \
     sym_table.add_function("datetime", t_computed_expression_parser::MAKE_DATETIME_FN);     \
 

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -36,6 +36,12 @@ t_computed_expression_parser::IS_NULL_FN = computed_function::is_null();
 computed_function::is_not_null
 t_computed_expression_parser::IS_NOT_NULL_FN = computed_function::is_not_null();
 
+computed_function::make_date
+t_computed_expression_parser::MAKE_DATE_FN = computed_function::make_date();
+
+computed_function::make_datetime
+t_computed_expression_parser::MAKE_DATETIME_FN = computed_function::make_datetime();
+
 // As well as functions used for validation that have state but don't
 // need it to validate input types.
 computed_function::day_of_week
@@ -62,7 +68,7 @@ t_computed_expression_parser::LOWER_VALIDATOR_FN = computed_function::lower(null
 computed_function::length
 t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nullptr);
 
-#define REGISTER_COMPUTE_FUNCTIONS()                                                        \
+#define REGISTER_COMPUTE_FUNCTIONS(vocab)                                                        \
     computed_function::day_of_week day_of_week_fn = computed_function::day_of_week(vocab);         \
     computed_function::month_of_year month_of_year_fn = computed_function::month_of_year(vocab);   \
     computed_function::intern intern_fn = computed_function::intern(vocab);    \
@@ -88,6 +94,8 @@ t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nu
     sym_table.add_function("percent_of", t_computed_expression_parser::PERCENT_OF_FN);      \
     sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);            \
     sym_table.add_function("is_not_null", t_computed_expression_parser::IS_NOT_NULL_FN);    \
+    sym_table.add_function("date", t_computed_expression_parser::MAKE_DATE_FN);             \
+    sym_table.add_function("datetime", t_computed_expression_parser::MAKE_DATETIME_FN);     \
 
 #define REGISTER_VALIDATION_FUNCTIONS()                                                     \
     sym_table.add_function("today", computed_function::today);                              \
@@ -107,6 +115,8 @@ t_computed_expression_parser::LENGTH_VALIDATOR_FN = computed_function::length(nu
     sym_table.add_function("percent_of", t_computed_expression_parser::PERCENT_OF_FN);      \
     sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);            \
     sym_table.add_function("is_not_null", t_computed_expression_parser::IS_NOT_NULL_FN);    \
+    sym_table.add_function("date", t_computed_expression_parser::MAKE_DATE_FN);             \
+    sym_table.add_function("datetime", t_computed_expression_parser::MAKE_DATETIME_FN);     \
 
 /******************************************************************************
  *
@@ -135,7 +145,7 @@ t_computed_expression::compute(
     exprtk::symbol_table<t_tscalar> sym_table;
     sym_table.add_constants();
 
-    REGISTER_COMPUTE_FUNCTIONS()
+    REGISTER_COMPUTE_FUNCTIONS(vocab)
 
     exprtk::expression<t_tscalar> expr_definition;
     std::vector<std::pair<std::string, t_tscalar>> values;
@@ -230,7 +240,7 @@ t_computed_expression_parser::init() {
         .disable_base_function(exprtk::parser<t_tscalar>::settings_store::e_bf_max);
 }
 
-t_computed_expression
+std::shared_ptr<t_computed_expression>
 t_computed_expression_parser::precompute(
     const std::string& expression_alias,
     const std::string& expression_string,
@@ -277,7 +287,7 @@ t_computed_expression_parser::precompute(
 
     t_tscalar v = expr_definition.value();
 
-    return t_computed_expression(
+    return std::make_shared<t_computed_expression>(
         expression_alias,
         expression_string,
         parsed_expression_string,

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -24,72 +24,6 @@ using uint64 = std::uint64_t;
 using float32 = float;
 using float64 = double;
 
-// template <typename T>
-// col<T>::col(std::shared_ptr<t_data_table> data_table, const tsl::hopscotch_set<std::string>& input_columns)
-//     : m_schema(nullptr)
-//     , m_input_columns(std::move(input_columns))
-//     , m_columns({})
-//     , m_ridxs({}) {
-//         // TODO: move into init()?
-//         for (const auto& column_name : input_columns) {
-//             m_columns[column_name] = data_table->get_column(column_name);
-//             m_ridxs[column_name] = 0;
-//         }
-//     }
-
-// template <typename T>
-// col<T>::col(std::shared_ptr<t_schema> schema)
-//     : m_schema(schema)
-//     , m_columns({})
-//     , m_ridxs({}) {}
-
-// template <typename T>
-// col<T>::~col() {}
-
-// template <typename T>
-// T col<T>::next(
-//     const std::string& column_name) {
-//     // std::cout << "NOT IMPLEMENTED" << std::endl;
-//     std::string error = "next<T>() Not implemented!\n";
-//     PSP_COMPLAIN_AND_ABORT(error);
-// }
-
-// template <>
-// t_tscalar col<t_tscalar>::next(
-//     const std::string& column_name) {
-//     t_uindex ridx = m_ridxs[column_name];
-//     t_tscalar rval = m_columns[column_name]->get_scalar(ridx);
-//     m_ridxs[column_name] += 1;
-//     return rval;
-// }
-
-// template <typename T>
-// T col<T>::operator()(t_parameter_list parameters) {
-//     auto num_params = parameters.size();
-
-//     if (num_params == 0) {
-//         std::stringstream ss;
-//         ss << "Expression error: col() function cannot be empty." << std::endl;
-//         // std::cout << ss.str();
-//         PSP_COMPLAIN_AND_ABORT(ss.str());
-//     }
-
-//     t_string_view param = t_string_view(parameters[0]);
-//     std::string column_name(param.begin(), param.size());
-
-//     if (m_schema != nullptr) {
-//         t_tscalar rval;
-//         // scalar is valid here, as operations would fail and return
-//         // none if the inputs are not valid scalars.
-//         rval.m_status = STATUS_VALID;
-//         rval.m_type = m_schema->get_dtype(column_name);
-//         m_input_columns.insert(column_name);
-//         return rval;
-//     }
-
-//     return next(column_name);
-// }
-
 intern::intern(std::shared_ptr<t_vocab> expression_vocab)
     : exprtk::igeneric_function<t_tscalar>("S")
     , m_expression_vocab(expression_vocab)  {
@@ -101,34 +35,25 @@ intern::intern(std::shared_ptr<t_vocab> expression_vocab)
         sentinel.m_type = DTYPE_STR;
         sentinel.m_data.m_charptr = nullptr;
         m_sentinel = sentinel;
-
-        // m_none is a scalar with DTYPE_NONE that indicates an invalid
-        // call to the function.
-        m_none = mknone();
     }
 
 intern::~intern() {}
 
 t_tscalar intern::operator()(t_parameter_list parameters) {
-    std::string temp_str;
+    t_tscalar rval;
+    rval.clear();
+    rval.m_type = DTYPE_STR;
 
-    if (parameters.size() != 1) {
-        return m_none;
-    }
+    std::string temp_str;
 
     t_generic_type& gt = parameters[0];
 
-    if (t_generic_type::e_string == gt.type) {
-        // intern('abc') - with a scalar string
-        t_string_view temp_string(gt);
-        temp_str = std::string(temp_string.begin(), temp_string.end()).c_str();
+    // intern('abc') - with a scalar string
+    t_string_view temp_string(gt);
+    temp_str = std::string(temp_string.begin(), temp_string.end()).c_str();
 
-        // Don't allow empty strings
-        if (temp_str == "") return m_none;
-    } else {
-        // An invalid call.
-        return m_none;
-    }
+    // Don't allow empty strings
+    if (temp_str == "") return rval;
 
     // If the vocab is a nullptr, we are in type checking mode - TODO might be
     // better to make this explicit so that we never fall into an invalid mode
@@ -141,7 +66,6 @@ t_tscalar intern::operator()(t_parameter_list parameters) {
     // string inside the vocabulary.
     t_uindex interned = m_expression_vocab->get_interned(temp_str);
 
-    t_tscalar rval;
     rval.set(m_expression_vocab->unintern_c(interned));
     return rval;
 }
@@ -157,10 +81,6 @@ concat::concat(std::shared_ptr<t_vocab> expression_vocab)
         sentinel.m_type = DTYPE_STR;
         sentinel.m_data.m_charptr = nullptr;
         m_sentinel = sentinel;
-
-        // m_none is a scalar with DTYPE_NONE that indicates an invalid
-        // call to the function.
-        m_none = mknone();
     }
 
 concat::~concat() {}
@@ -171,7 +91,7 @@ t_tscalar concat::operator()(t_parameter_list parameters) {
     rval.clear();
     rval.m_type = DTYPE_STR;
 
-    if (parameters.size() == 0) return m_none;
+    if (parameters.size() == 0) return rval;
     
     for (auto i = 0; i < parameters.size(); ++i) {
         t_generic_type& gt = parameters[i];
@@ -201,7 +121,7 @@ t_tscalar concat::operator()(t_parameter_list parameters) {
             result += temp_scalar.to_string();
         } else {
             // An invalid call.
-            return m_none;
+            return rval;
         }
     }
 
@@ -219,7 +139,7 @@ t_tscalar concat::operator()(t_parameter_list parameters) {
 }
 
 upper::upper(std::shared_ptr<t_vocab> expression_vocab)
-    : exprtk::igeneric_function<t_tscalar>("?")
+    : exprtk::igeneric_function<t_tscalar>("T")
     , m_expression_vocab(expression_vocab)  {
         t_tscalar sentinel;
         sentinel.clear();
@@ -229,10 +149,6 @@ upper::upper(std::shared_ptr<t_vocab> expression_vocab)
         sentinel.m_type = DTYPE_STR;
         sentinel.m_data.m_charptr = nullptr;
         m_sentinel = sentinel;
-
-        // m_none is a scalar with DTYPE_NONE that indicates an invalid
-        // call to the function.
-        m_none = mknone();
     }
 
 upper::~upper() {}
@@ -244,29 +160,23 @@ t_tscalar upper::operator()(t_parameter_list parameters) {
     std::string temp_str;
 
     if (parameters.size() != 1) {
-        return m_none;
+        return rval;
     }
 
     t_generic_type& gt = parameters[0];
+    t_scalar_view temp(gt);
+    t_tscalar temp_scalar = temp();
 
-    if (t_generic_type::e_scalar == gt.type) {
-        t_scalar_view temp(gt);
-        t_tscalar temp_scalar = temp();
-
-        if (temp_scalar.get_dtype() != DTYPE_STR || temp_scalar.m_status == STATUS_CLEAR) {
-            rval.m_status = STATUS_CLEAR;
-            return rval;
-        }
-
-        if (!temp_scalar.is_valid()) {
-            return rval;
-        }
-
-        temp_str = temp_scalar.to_string();
-    } else {
-        // An invalid call.
-        return m_none;
+    if (temp_scalar.get_dtype() != DTYPE_STR || temp_scalar.m_status == STATUS_CLEAR) {
+        rval.m_status = STATUS_CLEAR;
+        return rval;
     }
+
+    if (!temp_scalar.is_valid()) {
+        return rval;
+    }
+
+    temp_str = temp_scalar.to_string();
 
     // don't try to intern an empty string as it will throw an error, but
     // by this point we know the params are valid - so return the sentinel
@@ -283,7 +193,7 @@ t_tscalar upper::operator()(t_parameter_list parameters) {
 }
 
 lower::lower(std::shared_ptr<t_vocab> expression_vocab)
-    : exprtk::igeneric_function<t_tscalar>("?")
+    : exprtk::igeneric_function<t_tscalar>("T")
     , m_expression_vocab(expression_vocab)  {
         t_tscalar sentinel;
         sentinel.clear();
@@ -293,10 +203,6 @@ lower::lower(std::shared_ptr<t_vocab> expression_vocab)
         sentinel.m_type = DTYPE_STR;
         sentinel.m_data.m_charptr = nullptr;
         m_sentinel = sentinel;
-
-        // m_none is a scalar with DTYPE_NONE that indicates an invalid
-        // call to the function.
-        m_none = mknone();
     }
 
 lower::~lower() {}
@@ -308,30 +214,23 @@ t_tscalar lower::operator()(t_parameter_list parameters) {
     std::string temp_str;
 
     if (parameters.size() != 1) {
-        return m_none;
+        return rval;
     }
 
     t_generic_type& gt = parameters[0];
+    t_scalar_view temp(gt);
+    t_tscalar temp_scalar = temp();
 
-    if (t_generic_type::e_scalar == gt.type) {
-        t_scalar_view temp(gt);
-        t_tscalar temp_scalar = temp();
-
-        if (temp_scalar.get_dtype() != DTYPE_STR || temp_scalar.m_status == STATUS_CLEAR) {
-            rval.m_status = STATUS_CLEAR;
-            return rval;
-        }
-
-        if (!temp_scalar.is_valid() || temp_scalar.is_none()) {
-            return rval;
-        }
-
-        temp_str = temp_scalar.to_string();
-    } else {
-        // An invalid call.
-        return m_none;
+    if (temp_scalar.get_dtype() != DTYPE_STR || temp_scalar.m_status == STATUS_CLEAR) {
+        rval.m_status = STATUS_CLEAR;
+        return rval;
     }
 
+    if (!temp_scalar.is_valid() || temp_scalar.is_none()) {
+        return rval;
+    }
+
+    temp_str = temp_scalar.to_string();
     // don't try to intern an empty string as it will throw an error, but
     // by this point we know the params are valid - so return the sentinel
     // string value.
@@ -347,7 +246,7 @@ t_tscalar lower::operator()(t_parameter_list parameters) {
 }
 
 length::length(std::shared_ptr<t_vocab> expression_vocab)
-    : exprtk::igeneric_function<t_tscalar>("?")
+    : exprtk::igeneric_function<t_tscalar>("T")
     , m_expression_vocab(expression_vocab)  {
         t_tscalar sentinel;
         sentinel.clear();
@@ -356,10 +255,6 @@ length::length(std::shared_ptr<t_vocab> expression_vocab)
         // valid call to the function without actually computing any values.
         sentinel.m_type = DTYPE_FLOAT64;
         m_sentinel = sentinel;
-
-        // m_none is a scalar with DTYPE_NONE that indicates an invalid
-        // call to the function.
-        m_none = mknone();
     }
 
 length::~length() {}
@@ -376,29 +271,23 @@ t_tscalar length::operator()(t_parameter_list parameters) {
     rval.m_type = DTYPE_FLOAT64;
 
     if (parameters.size() != 1) {
-        return m_none;
+        return rval;
     }
 
     t_generic_type& gt = parameters[0];
+    t_scalar_view temp(gt);
+    t_tscalar temp_scalar = temp();
 
-    if (t_generic_type::e_scalar == gt.type) {
-        t_scalar_view temp(gt);
-        t_tscalar temp_scalar = temp();
-
-        if (temp_scalar.get_dtype() != DTYPE_STR || temp_scalar.m_status == STATUS_CLEAR) {
-            rval.m_status = STATUS_CLEAR;
-            return rval;
-        }
-
-        if (!temp_scalar.is_valid() || temp_scalar.is_none()) {
-            return rval;
-        }
-
-        temp_str = temp_scalar.to_string();
-    } else {
-        // An invalid call.
-        return m_none;
+    if (temp_scalar.get_dtype() != DTYPE_STR || temp_scalar.m_status == STATUS_CLEAR) {
+        rval.m_status = STATUS_CLEAR;
+        return rval;
     }
+
+    if (!temp_scalar.is_valid() || temp_scalar.is_none()) {
+        return rval;
+    }
+
+    temp_str = temp_scalar.to_string();
 
     if (m_expression_vocab == nullptr) {
         return m_sentinel;
@@ -419,10 +308,6 @@ order::order(std::shared_ptr<t_vocab> expression_vocab)
         // valid call to the function without actually computing any values.
         sentinel.m_type = DTYPE_FLOAT64;
         m_sentinel = sentinel;
-
-        // m_none is a scalar with DTYPE_NONE that indicates an invalid
-        // call to the function.
-        m_none = mknone();
     }
 
 order::~order() {}
@@ -439,46 +324,42 @@ t_tscalar order::operator()(t_parameter_list parameters) {
     std::string temp_str;
 
     if (parameters.size() <= 1) {
-        return m_none;
+        return rval;
     }
 
     // generate the map if not generated
     if (m_order_map.size() == 0) {
         for (auto i = 0; i < parameters.size(); ++i) {
+            // Because all strings are interned, there should be no string
+            // literals passed to any functions.
             t_generic_type& gt = parameters[i];
+            t_scalar_view temp(gt);
+            t_tscalar temp_scalar = temp();
 
-            if (t_generic_type::e_scalar == gt.type) {
-                t_scalar_view temp(gt);
-                t_tscalar temp_scalar = temp();
+            // Invalid type
+            if (temp_scalar.get_dtype() != DTYPE_STR || temp_scalar.m_status == STATUS_CLEAR) {
+                rval.m_status = STATUS_CLEAR;
+                return rval;
+            }
 
-                // Invalid type
-                if (temp_scalar.get_dtype() != DTYPE_STR || temp_scalar.m_status == STATUS_CLEAR) {
-                    rval.m_status = STATUS_CLEAR;
-                    return rval;
-                }
+            // current param is the right type and we are type checking,
+            // so move on to the next param
+            if (m_expression_vocab == nullptr) {
+                continue;
+            }
 
-                // current param is the right type and we are type checking,
-                // so move on to the next param
-                if (m_expression_vocab == nullptr) {
-                    continue;
-                }
+            // no longer in type-checking - return if the param is invalid.
+            if (!temp_scalar.is_valid()) {
+                return rval;
+            }
 
-                // no longer in type-checking - return if the param is invalid.
-                if (!temp_scalar.is_valid()) {
-                    return rval;
-                }
-
-                // params[0] is the column, params[1] onward are sort params
-                if (i > 0) {
-                    // Read the string param and assign to the order map, and
-                    // then increment the internal counter.
-                    std::string value = temp_scalar.to_string();
-                    m_order_map[value] = m_order_idx;
-                    m_order_idx++;
-                }
-            } else {
-                // An invalid call.
-                return m_none;
+            // params[0] is the column, params[1] onward are sort params
+            if (i > 0) {
+                // Read the string param and assign to the order map, and
+                // then increment the internal counter.
+                std::string value = temp_scalar.to_string();
+                m_order_map[value] = m_order_idx;
+                m_order_idx++;
             }
         }
     }
@@ -515,9 +396,7 @@ t_tscalar order::operator()(t_parameter_list parameters) {
 }
 
 hour_of_day::hour_of_day()
-    : exprtk::igeneric_function<t_tscalar>("?") {
-    m_none = mknone();
-}
+    : exprtk::igeneric_function<t_tscalar>("T") {}
 
 hour_of_day::~hour_of_day() {}
 
@@ -532,31 +411,22 @@ t_tscalar hour_of_day::operator()(t_parameter_list parameters) {
     // be false, as comparisons are False across types.
     rval.m_type = DTYPE_FLOAT64;
 
-    if (parameters.size() != 1) {
-        return m_none;
-    }
-
     t_generic_type& gt = parameters[0];
+    t_scalar_view temp(gt);
+    t_tscalar temp_scalar = temp();
 
-    if (t_generic_type::e_scalar == gt.type) {
-        t_scalar_view temp(gt);
-        t_tscalar temp_scalar = temp();
-        t_dtype dtype = temp_scalar.get_dtype();
-        bool valid_dtype = dtype == DTYPE_DATE || dtype == DTYPE_TIME;
+    t_dtype dtype = temp_scalar.get_dtype();
+    bool valid_dtype = dtype == DTYPE_DATE || dtype == DTYPE_TIME;
 
-        if (!valid_dtype || temp_scalar.m_status == STATUS_CLEAR) {
-            rval.m_status = STATUS_CLEAR;
-        }
-
-        if (!temp_scalar.is_valid()) {
-            return rval;
-        }
-
-        val.set(temp_scalar);
-    } else {
-        // An invalid call.
-        return m_none;
+    if (!valid_dtype || temp_scalar.m_status == STATUS_CLEAR) {
+        rval.m_status = STATUS_CLEAR;
     }
+
+    if (!temp_scalar.is_valid()) {
+        return rval;
+    }
+
+    val.set(temp_scalar);
     
     if (val.get_dtype() == DTYPE_TIME) {
         // Convert the int64 to a milliseconds duration timestamp
@@ -606,7 +476,7 @@ const std::string months_of_year[12] = {
 };
 
 day_of_week::day_of_week(std::shared_ptr<t_vocab> expression_vocab)
-    : exprtk::igeneric_function<t_tscalar>("?")
+    : exprtk::igeneric_function<t_tscalar>("T")
     , m_expression_vocab(expression_vocab)  {
         t_tscalar sentinel;
         sentinel.clear();
@@ -616,10 +486,6 @@ day_of_week::day_of_week(std::shared_ptr<t_vocab> expression_vocab)
         sentinel.m_type = DTYPE_STR;
         sentinel.m_data.m_charptr = nullptr;
         m_sentinel = sentinel;
-
-        // m_none is a scalar with DTYPE_NONE that indicates an invalid
-        // call to the function.
-        m_none = mknone();
     }
 
 day_of_week::~day_of_week() {}
@@ -630,31 +496,21 @@ t_tscalar day_of_week::operator()(t_parameter_list parameters) {
     rval.clear();
     rval.m_type = DTYPE_STR;
 
-    if (parameters.size() != 1) {
-        return m_none;
-    }
-
     t_generic_type& gt = parameters[0];
+    t_scalar_view temp(gt);
+    t_tscalar temp_scalar = temp();
+    t_dtype dtype = temp_scalar.get_dtype();
+    bool valid_dtype = dtype == DTYPE_DATE || dtype == DTYPE_TIME;
 
-    if (t_generic_type::e_scalar == gt.type) {
-        t_scalar_view temp(gt);
-        t_tscalar temp_scalar = temp();
-        t_dtype dtype = temp_scalar.get_dtype();
-        bool valid_dtype = dtype == DTYPE_DATE || dtype == DTYPE_TIME;
-
-        if (!valid_dtype || temp_scalar.m_status == STATUS_CLEAR) {
-            rval.m_status = STATUS_CLEAR;
-        }
-
-        if (!temp_scalar.is_valid()) {
-            return rval;
-        }
-
-        val.set(temp_scalar);
-    } else {
-        // An invalid call.
-        return m_none;
+    if (!valid_dtype || temp_scalar.m_status == STATUS_CLEAR) {
+        rval.m_status = STATUS_CLEAR;
     }
+
+    if (!temp_scalar.is_valid()) {
+        return rval;
+    }
+
+    val.set(temp_scalar);
 
     if (m_expression_vocab == nullptr) {
         return m_sentinel;
@@ -702,7 +558,7 @@ t_tscalar day_of_week::operator()(t_parameter_list parameters) {
 }
 
 month_of_year::month_of_year(std::shared_ptr<t_vocab> expression_vocab)
-    : exprtk::igeneric_function<t_tscalar>("?")
+    : exprtk::igeneric_function<t_tscalar>("T")
     , m_expression_vocab(expression_vocab)  {
         t_tscalar sentinel;
         sentinel.clear();
@@ -712,10 +568,6 @@ month_of_year::month_of_year(std::shared_ptr<t_vocab> expression_vocab)
         sentinel.m_type = DTYPE_STR;
         sentinel.m_data.m_charptr = nullptr;
         m_sentinel = sentinel;
-
-        // m_none is a scalar with DTYPE_NONE that indicates an invalid
-        // call to the function.
-        m_none = mknone();
     }
 
 month_of_year::~month_of_year() {}
@@ -726,31 +578,22 @@ t_tscalar month_of_year::operator()(t_parameter_list parameters) {
     rval.clear();
     rval.m_type = DTYPE_STR;
 
-    if (parameters.size() != 1) {
-        return m_none;
-    }
-
     t_generic_type& gt = parameters[0];
+    t_scalar_view temp(gt);
+    t_tscalar temp_scalar = temp();
 
-    if (t_generic_type::e_scalar == gt.type) {
-        t_scalar_view temp(gt);
-        t_tscalar temp_scalar = temp();
-        t_dtype dtype = temp_scalar.get_dtype();
-        bool valid_dtype = dtype == DTYPE_DATE || dtype == DTYPE_TIME;
+    t_dtype dtype = temp_scalar.get_dtype();
+    bool valid_dtype = dtype == DTYPE_DATE || dtype == DTYPE_TIME;
 
-        if (!valid_dtype || temp_scalar.m_status == STATUS_CLEAR) {
-            rval.m_status = STATUS_CLEAR;
-        }
-
-        if (!temp_scalar.is_valid()) {
-            return rval;
-        }
-
-        val.set(temp_scalar);
-    } else {
-        // An invalid call.
-        return m_none;
+    if (!valid_dtype || temp_scalar.m_status == STATUS_CLEAR) {
+        rval.m_status = STATUS_CLEAR;
     }
+
+    if (!temp_scalar.is_valid()) {
+        return rval;
+    }
+
+    val.set(temp_scalar);
 
     if (m_expression_vocab == nullptr) {
         return m_sentinel;
@@ -803,9 +646,7 @@ bucket::UNIT_MAP = {
 
 
 bucket::bucket()
-    : exprtk::igeneric_function<t_tscalar>("T?") {
-    m_none = mknone();
-}
+    : exprtk::igeneric_function<t_tscalar>("T?") {}
 
 bucket::~bucket() {}
 
@@ -850,8 +691,10 @@ t_tscalar bucket::operator()(t_parameter_list parameters) {
     std::string unit_str = std::string(temp_string.begin(), temp_string.end());
 
     if (bucket::UNIT_MAP.count(unit_str) == 0) {
-        std::cerr << "[bucket] unknown unit in bucket - the valid units are 's', 'm', 'h', 'D', 'W', 'M', and 'Y'." << unit << std::endl;
-        return m_none;
+        std::cerr << "[bucket] unknown unit in bucket - the valid units are 's', 'm', 'h', 'D', 'W', 'M', and 'Y'." << std::endl;
+        rval.m_type = DTYPE_TIME;
+        rval.m_status = STATUS_CLEAR;
+        return rval;
     }
 
     t_date_bucket_unit date_bucket_unit = bucket::UNIT_MAP[unit_str];
@@ -878,8 +721,7 @@ t_tscalar bucket::operator()(t_parameter_list parameters) {
                 rval.m_type = DTYPE_DATE;
             } break;
             default: {
-                // shouldn't trigger this block - unit has already been validated
-                return m_none;
+                PSP_COMPLAIN_AND_ABORT("[bucket] invalid date bucket unit!");
             } break;
         }
     } else {
@@ -914,8 +756,7 @@ t_tscalar bucket::operator()(t_parameter_list parameters) {
             _year_bucket(val, rval);
         } break;
         default: {
-            // shouldn't trigger this block - unit has already been validated
-            return m_none;
+            PSP_COMPLAIN_AND_ABORT("[bucket] invalid date bucket unit!");
         } break;
     }
 
@@ -1162,7 +1003,7 @@ t_tscalar today() {
     return rval;
 }
 
-min_fn::min_fn() : m_none(mknone()) {}
+min_fn::min_fn() {}
 
 min_fn::~min_fn() {}
 
@@ -1192,7 +1033,7 @@ t_tscalar min_fn::operator()(t_parameter_list parameters) {
             }
         } else {
             std::cerr << "[min_fn] Invalid parameter in min_fn()" << std::endl;
-            return m_none;
+            return rval;
         }
     }
 
@@ -1213,7 +1054,7 @@ t_tscalar min_fn::operator()(t_parameter_list parameters) {
     return rval;
 }
 
-max_fn::max_fn() : m_none(mknone())  {}
+max_fn::max_fn() {}
 
 max_fn::~max_fn() {}
 
@@ -1243,7 +1084,7 @@ t_tscalar max_fn::operator()(t_parameter_list parameters) {
             }
         } else {
             std::cerr << "[max_fn] Invalid parameter in max_fn()" << std::endl;
-            return m_none;
+            return rval;
         }
     }
 
@@ -1265,8 +1106,7 @@ t_tscalar max_fn::operator()(t_parameter_list parameters) {
 }
 
 percent_of::percent_of()
-    : exprtk::igeneric_function<t_tscalar>("TT")
-    , m_none(mknone()) {}
+    : exprtk::igeneric_function<t_tscalar>("TT") {}
 
 percent_of::~percent_of() {}
 
@@ -1276,8 +1116,6 @@ t_tscalar percent_of::operator()(t_parameter_list parameters) {
 
     // Return a float so we can use it in conditionals
     rval.m_type = DTYPE_FLOAT64;
-
-    if (parameters.size() != 2) return m_none;
 
     t_generic_type& _x = parameters[0];
     t_generic_type& _y = parameters[1];
@@ -1305,8 +1143,7 @@ t_tscalar percent_of::operator()(t_parameter_list parameters) {
 }
 
 is_null::is_null()
-    : exprtk::igeneric_function<t_tscalar>("T")
-    , m_none(mknone()) {}
+    : exprtk::igeneric_function<t_tscalar>("T"){}
 
 is_null::~is_null() {}
 
@@ -1319,17 +1156,9 @@ t_tscalar is_null::operator()(t_parameter_list parameters) {
     // Return a float so we can use it in conditionals
     rval.m_type = DTYPE_FLOAT64;
 
-    for (auto i = 0; i < parameters.size(); ++i) {
-        t_generic_type& gt = parameters[i];
-
-        if (t_generic_type::e_scalar == gt.type) {
-            t_scalar_view temp(gt);
-            val.set(temp());
-        } else {
-            std::cerr << "[is_null] Invalid parameter in is_null()" << std::endl;
-            return m_none;
-        }
-    }
+    t_generic_type& gt = parameters[0];
+    t_scalar_view temp(gt);
+    val.set(temp());
 
     // Return a double so we can use it in conditionals
     rval.set(static_cast<double>(val.is_none() || !val.is_valid()));
@@ -1338,8 +1167,7 @@ t_tscalar is_null::operator()(t_parameter_list parameters) {
 }
 
 is_not_null::is_not_null()
-    : exprtk::igeneric_function<t_tscalar>("T")
-    , m_none(mknone()) {}
+    : exprtk::igeneric_function<t_tscalar>("T") {}
 
 is_not_null::~is_not_null() {}
 
@@ -1352,22 +1180,89 @@ t_tscalar is_not_null::operator()(t_parameter_list parameters) {
     // Return a float so we can use it in conditionals
     rval.m_type = DTYPE_FLOAT64;
 
-    for (auto i = 0; i < parameters.size(); ++i) {
-        t_generic_type& gt = parameters[i];
-
-        if (t_generic_type::e_scalar == gt.type) {
-            t_scalar_view temp(gt);
-            val.set(temp());
-        } else {
-            std::cerr << "[is_null] Invalid parameter in is_null()" << std::endl;
-            return m_none;
-        }
-    }
+    t_generic_type& gt = parameters[0];
+    t_scalar_view temp(gt);
+    val.set(temp());
 
     rval.set(static_cast<double>(!val.is_none() && val.is_valid()));
 
     return rval;
 }
+
+make_date::make_date()
+    : exprtk::igeneric_function<t_tscalar>("TTT") {}
+
+make_date::~make_date() {}
+
+t_tscalar make_date::operator()(t_parameter_list parameters) {
+    t_tscalar rval;
+    rval.clear();
+    rval.m_type = DTYPE_DATE;
+
+    // 0 = year, 1 = month, 2 = day
+    std::int32_t values[3] {0};
+
+    for (auto i = 0; i < parameters.size(); ++i) {
+        t_generic_type& gt = parameters[i];
+        t_scalar_view temp(gt);
+        t_tscalar temp_scalar;
+        
+        temp_scalar.set(temp());
+
+        if (!temp_scalar.is_numeric()) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        if (!temp_scalar.is_valid()) {
+            return rval;
+        }
+
+        std::int32_t value = temp_scalar.to_double();
+        values[i] = value;
+    }
+
+    // Disallow negative values
+    if (values[0] < 0 || values[1] <= 0 || values[1] > 12 || values[2] <= 0 || values[2] > 31) {
+        return rval;
+    }
+
+    // month is 0-11 in t_date
+    rval.set(t_date(values[0], values[1] - 1, values[2]));
+    return rval;
+}
+
+make_datetime::make_datetime()
+    : exprtk::igeneric_function<t_tscalar>("T") {}
+
+make_datetime::~make_datetime() {}
+
+t_tscalar make_datetime::operator()(t_parameter_list parameters) {
+    t_tscalar rval;
+    rval.clear();
+    rval.m_type = DTYPE_TIME;
+
+    t_generic_type& gt = parameters[0];
+    t_scalar_view temp(gt);
+    t_tscalar temp_scalar;
+    
+    temp_scalar.set(temp());
+    t_dtype dtype = temp_scalar.get_dtype();
+
+    if (dtype != DTYPE_INT64 && dtype != DTYPE_FLOAT64) {
+        rval.m_status = STATUS_CLEAR;
+        return rval;
+    }
+
+    if (!temp_scalar.is_valid()) {
+        return rval;
+    }
+    
+    std::int64_t timestamp = temp_scalar.to_double();
+    rval.set(t_time(timestamp));
+    return rval;
+}
+
 
 } // end namespace computed_function
 } // end namespace perspective

--- a/cpp/perspective/src/cpp/config.cpp
+++ b/cpp/perspective/src/cpp/config.cpp
@@ -21,7 +21,7 @@ t_config::t_config(
     const std::vector<std::string>& detail_columns,
     const std::vector<t_fterm>& fterms,
     t_filter_op combiner,
-    const std::vector<t_computed_expression>& expressions)
+    const std::vector<std::shared_ptr<t_computed_expression>>& expressions)
     : m_detail_columns(detail_columns)
     , m_fterms(fterms)
     , m_expressions(expressions)
@@ -48,7 +48,7 @@ t_config::t_config(
     const std::vector<t_aggspec>& aggregates,
     const std::vector<t_fterm>& fterms,
     t_filter_op combiner,
-    const std::vector<t_computed_expression>& expressions)
+    const std::vector<std::shared_ptr<t_computed_expression>>& expressions)
     : m_aggregates(aggregates)
     , m_fterms(fterms)
     , m_expressions(expressions)
@@ -70,7 +70,7 @@ t_config::t_config(
     const t_totals totals,
     const std::vector<t_fterm>& fterms,
     t_filter_op combiner,
-    const std::vector<t_computed_expression>& expressions,
+    const std::vector<std::shared_ptr<t_computed_expression>>& expressions,
     bool column_only)
     : m_aggregates(aggregates)
     , m_fterms(fterms)
@@ -380,7 +380,7 @@ t_config::get_fterms() const {
     return m_fterms;
 }
 
-std::vector<t_computed_expression>
+std::vector<std::shared_ptr<t_computed_expression>>
 t_config::get_expressions() const {
     return m_expressions;
 }

--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -679,9 +679,9 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> flattened_
     master_expression_table->set_size(flattened_masked->size());
 
     const auto& expressions = m_config.get_expressions();
-    for (const t_computed_expression& expr : expressions) {
+    for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr.compute(flattened_masked, master_expression_table, m_expression_vocab);
+        expr->compute(flattened_masked, master_expression_table, m_expression_vocab);
     }
 }
 
@@ -708,20 +708,20 @@ t_ctx_grouped_pkey::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr.compute(master, m_expression_tables->m_master, m_expression_vocab);
+        expr->compute(master, m_expression_tables->m_master, m_expression_vocab);
 
         // flattened: compute based on the latest update dataset
-        expr.compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
+        expr->compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr.compute(delta, m_expression_tables->m_delta, m_expression_vocab);
+        expr->compute(delta, m_expression_tables->m_delta, m_expression_vocab);
 
         // prev: the values of the updated rows before this update was applied
-        expr.compute(prev, m_expression_tables->m_prev, m_expression_vocab);
+        expr->compute(prev, m_expression_tables->m_prev, m_expression_vocab);
 
         // current: the current values of the updated rows
-        expr.compute(current, m_expression_tables->m_current, m_expression_vocab);
+        expr->compute(current, m_expression_tables->m_current, m_expression_vocab);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -623,9 +623,9 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     master_expression_table->set_size(flattened_masked->size());
 
     const auto& expressions = m_config.get_expressions();
-    for (const t_computed_expression& expr : expressions) {
+    for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr.compute(flattened_masked, master_expression_table, m_expression_vocab);
+        expr->compute(flattened_masked, master_expression_table, m_expression_vocab);
     }
 }
 
@@ -652,20 +652,20 @@ t_ctx1::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr.compute(master, m_expression_tables->m_master, m_expression_vocab);
+        expr->compute(master, m_expression_tables->m_master, m_expression_vocab);
 
         // flattened: compute based on the latest update dataset
-        expr.compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
+        expr->compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr.compute(delta, m_expression_tables->m_delta, m_expression_vocab);
+        expr->compute(delta, m_expression_tables->m_delta, m_expression_vocab);
 
         // prev: the values of the updated rows before this update was applied
-        expr.compute(prev, m_expression_tables->m_prev, m_expression_vocab);
+        expr->compute(prev, m_expression_tables->m_prev, m_expression_vocab);
 
         // current: the current values of the updated rows
-        expr.compute(current, m_expression_tables->m_current, m_expression_vocab);
+        expr->compute(current, m_expression_tables->m_current, m_expression_vocab);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/context_two.cpp
+++ b/cpp/perspective/src/cpp/context_two.cpp
@@ -1055,9 +1055,9 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     master_expression_table->set_size(flattened_masked->size());
 
     const auto& expressions = m_config.get_expressions();
-    for (const t_computed_expression& expr : expressions) {
+    for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr.compute(flattened_masked, master_expression_table, m_expression_vocab);
+        expr->compute(flattened_masked, master_expression_table, m_expression_vocab);
     }
 }
 
@@ -1084,20 +1084,20 @@ t_ctx2::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr.compute(master, m_expression_tables->m_master, m_expression_vocab);
+        expr->compute(master, m_expression_tables->m_master, m_expression_vocab);
 
         // flattened: compute based on the latest update dataset
-        expr.compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
+        expr->compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr.compute(delta, m_expression_tables->m_delta, m_expression_vocab);
+        expr->compute(delta, m_expression_tables->m_delta, m_expression_vocab);
 
         // prev: the values of the updated rows before this update was applied
-        expr.compute(prev, m_expression_tables->m_prev, m_expression_vocab);
+        expr->compute(prev, m_expression_tables->m_prev, m_expression_vocab);
 
         // current: the current values of the updated rows
-        expr.compute(current, m_expression_tables->m_current, m_expression_vocab);
+        expr->compute(current, m_expression_tables->m_current, m_expression_vocab);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -607,9 +607,9 @@ t_ctx0::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     master_expression_table->set_size(flattened_masked->size());
 
     const auto& expressions = m_config.get_expressions();
-    for (const t_computed_expression& expr : expressions) {
+    for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr.compute(flattened_masked, master_expression_table, m_expression_vocab);
+        expr->compute(flattened_masked, master_expression_table, m_expression_vocab);
     }
 }
 
@@ -636,20 +636,20 @@ t_ctx0::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr.compute(master, m_expression_tables->m_master, m_expression_vocab);
+        expr->compute(master, m_expression_tables->m_master, m_expression_vocab);
 
         // flattened: compute based on the latest update dataset
-        expr.compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
+        expr->compute(flattened, m_expression_tables->m_flattened, m_expression_vocab);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr.compute(delta, m_expression_tables->m_delta, m_expression_vocab);
+        expr->compute(delta, m_expression_tables->m_delta, m_expression_vocab);
 
         // prev: the values of the updated rows before this update was applied
-        expr.compute(prev, m_expression_tables->m_prev, m_expression_vocab);
+        expr->compute(prev, m_expression_tables->m_prev, m_expression_vocab);
 
         // current: the current values of the updated rows
-        expr.compute(current, m_expression_tables->m_current, m_expression_vocab);
+        expr->compute(current, m_expression_tables->m_current, m_expression_vocab);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -678,7 +678,6 @@ t_ctx0::read_column_from_gstate(
     const std::string& colname,
     const std::vector<t_tscalar>& pkeys,
     std::vector<t_tscalar>& out_data) const {
-    std::shared_ptr<t_data_table> master_table = m_gstate->get_table();
 
     if (is_expression_column(colname)) {
         m_gstate->read_column(
@@ -687,6 +686,7 @@ t_ctx0::read_column_from_gstate(
             pkeys,
             out_data);
     } else {
+        std::shared_ptr<t_data_table> master_table = m_gstate->get_table();
         m_gstate->read_column(
             *master_table,
             colname,

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1391,7 +1391,7 @@ namespace binding {
         }
 
         auto js_expressions = config.call<std::vector<std::vector<t_val>>>("get_expressions");
-        std::vector<t_computed_expression> expressions;
+        std::vector<std::shared_ptr<t_computed_expression>> expressions;
         expressions.reserve(js_expressions.size());
 
         // Will either abort() or succeed completely, and this isn't a public
@@ -1427,10 +1427,10 @@ namespace binding {
             }
 
             // If the expression cannot be parsed, it will abort() here.
-            t_computed_expression expression = t_computed_expression_parser::precompute(
+            std::shared_ptr<t_computed_expression> expression = t_computed_expression_parser::precompute(
                 expression_alias, expression_string, parsed_expression_string, column_ids, schema);
 
-            schema->add_column(expression_alias, expression.get_dtype());
+            schema->add_column(expression_alias, expression->get_dtype());
             expressions.push_back(expression);
         }
 
@@ -1919,7 +1919,7 @@ EMSCRIPTEN_BINDINGS(perspective) {
             const std::vector<std::string>&,
             const std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>>&,
             const std::vector<std::vector<std::string>>&,
-            const std::vector<t_computed_expression>&,
+            const std::vector<std::shared_ptr<t_computed_expression>>&,
             const std::string,
             bool>()
         .smart_ptr<std::shared_ptr<t_view_config>>("shared_ptr<t_view_config>")

--- a/cpp/perspective/src/cpp/expression_tables.cpp
+++ b/cpp/perspective/src/cpp/expression_tables.cpp
@@ -11,23 +11,14 @@
 
 namespace perspective {
 
-t_expression_tables::t_expression_tables() {
-    m_master = nullptr;
-    m_flattened = nullptr;
-    m_prev = nullptr;
-    m_current = nullptr;
-    m_delta = nullptr;
-    m_transitions = nullptr;
-}
-
 t_expression_tables::t_expression_tables(
-    const std::vector<t_computed_expression>& expressions) {
+    const std::vector<std::shared_ptr<t_computed_expression>>& expressions) {
     t_schema schema;
     t_schema transitions_schema;
 
     for (const auto& expr : expressions) {
-        const std::string& alias = expr.get_expression_alias();
-        schema.add_column(alias, expr.get_dtype());
+        const std::string& alias = expr->get_expression_alias();
+        schema.add_column(alias, expr->get_dtype());
         transitions_schema.add_column(alias, DTYPE_UINT8);
     }
 

--- a/cpp/perspective/src/cpp/time.cpp
+++ b/cpp/perspective/src/cpp/time.cpp
@@ -32,7 +32,7 @@ t_time::t_time(std::int64_t raw_val)
     : m_storage(raw_val) {}
 
 t_time::t_time(int year, int month, int day, int hour, int min, int sec)
-    : m_storage(to_gmtime(year, month, day, hour, min, sec) * 1000000LL) {}
+    : m_storage(static_cast<std::int64_t>(to_gmtime(year, month, day, hour, min, sec) * 1000)) {}
 
 std::int64_t
 t_time::raw_value() const {

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -352,8 +352,8 @@ View<CTX_T>::expression_schema() const {
     }
 
     for (const auto& expr : m_expressions) {
-        std::string expression_alias = expr.get_expression_alias();
-        new_schema[expression_alias] = dtype_to_str(expr.get_dtype());
+        std::string expression_alias = expr->get_expression_alias();
+        new_schema[expression_alias] = dtype_to_str(expr->get_dtype());
 
         if (m_row_pivots.size() > 0 && !is_column_only()) {
             new_schema[expression_alias] = _map_aggregate_types(expression_alias, new_schema[expression_alias]);
@@ -385,8 +385,8 @@ View<t_ctx0>::expression_schema() const {
     std::map<std::string, std::string> new_schema;
 
     for (const auto& expr : m_expressions) {
-        std::string expression_alias = expr.get_expression_alias();
-        new_schema[expression_alias] = dtype_to_str(expr.get_dtype());
+        std::string expression_alias = expr->get_expression_alias();
+        new_schema[expression_alias] = dtype_to_str(expr->get_dtype());
     }
 
     return new_schema;
@@ -818,7 +818,7 @@ View<CTX_T>::get_sort() const {
 }
 
 template <typename CTX_T>
-std::vector<t_computed_expression>
+std::vector<std::shared_ptr<t_computed_expression>>
 View<CTX_T>::get_expressions() const {
     return m_expressions;
 }

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -18,7 +18,7 @@ t_view_config::t_view_config(
         const std::vector<std::string>& columns,
         const std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>>& filter,
         const std::vector<std::vector<std::string>>& sort,
-        const std::vector<t_computed_expression>& expressions,
+        const std::vector<std::shared_ptr<t_computed_expression>>& expressions,
         const std::string& filter_op,
         bool column_only)
     : m_init(false)
@@ -50,7 +50,7 @@ t_view_config::validate(std::shared_ptr<t_schema> schema) {
     expression_aliases.reserve(m_expressions.size());
 
     for (const auto& expr : m_expressions) {
-        expression_aliases.insert(expr.get_expression_alias());
+        expression_aliases.insert(expr->get_expression_alias());
     }
 
     for (const std::string& col : m_columns) {
@@ -166,7 +166,7 @@ t_view_config::get_col_sortspec() const {
     return m_col_sortspec;
 }
 
-std::vector<t_computed_expression>
+std::vector<std::shared_ptr<t_computed_expression>>
 t_view_config::get_expressions() const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     return m_expressions;

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -136,6 +136,8 @@ public:
     static computed_function::max_fn MAX_FN;
     static computed_function::is_null IS_NULL_FN;
     static computed_function::is_not_null IS_NOT_NULL_FN;
+    static computed_function::to_integer TO_INTEGER_FN;
+    static computed_function::to_float TO_FLOAT_FN;
     static computed_function::make_date MAKE_DATE_FN;
     static computed_function::make_datetime MAKE_DATETIME_FN;
 };

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -136,6 +136,7 @@ public:
     static computed_function::max_fn MAX_FN;
     static computed_function::is_null IS_NULL_FN;
     static computed_function::is_not_null IS_NOT_NULL_FN;
+    static computed_function::to_string TO_STRING_VALIDATOR_FN;
     static computed_function::to_integer TO_INTEGER_FN;
     static computed_function::to_float TO_FLOAT_FN;
     static computed_function::make_date MAKE_DATE_FN;

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -32,9 +32,7 @@ namespace perspective {
  */
 class PERSPECTIVE_EXPORT t_computed_expression {
 public:
-    // allow this struct to be copy constructed since we store it in
-    // gnode, config, etc.
-    t_computed_expression() = default;
+    PSP_NON_COPYABLE(t_computed_expression);
 
     t_computed_expression(
         const std::string& expression_alias,
@@ -69,8 +67,9 @@ public:
 
     /**
      * @brief Given expression strings, validate the expression's dtype and
-     * return a new `t_computed_expression`. This method will abort() if
-     * an input column is invalid or the expression cannot be parsed.
+     * return a shared pointer to a new `t_computed_expression`. This method
+     * will abort() if an input column is invalid or the expression cannot be
+     * parsed.
      * 
      * @param expression_alias an alias for the expression, which will become
      * the name of the new expression column on the table.
@@ -81,9 +80,9 @@ public:
      * @param column_ids A map of column IDs to column names, which is used to
      * properly access column names from the symbol table.
      * @param schema 
-     * @return t_computed_expression 
+     * @return std::shared_ptr<t_computed_expression> 
      */
-    static t_computed_expression precompute(
+    static std::shared_ptr<t_computed_expression> precompute(
         const std::string& expression_alias,
         const std::string& expression_string,
         const std::string& parsed_expression_string,
@@ -137,6 +136,8 @@ public:
     static computed_function::max_fn MAX_FN;
     static computed_function::is_null IS_NULL_FN;
     static computed_function::is_not_null IS_NOT_NULL_FN;
+    static computed_function::make_date MAKE_DATE_FN;
+    static computed_function::make_datetime MAKE_DATETIME_FN;
 };
 
 /**

--- a/cpp/perspective/src/include/perspective/computed_function.h
+++ b/cpp/perspective/src/include/perspective/computed_function.h
@@ -31,36 +31,6 @@ typedef typename exprtk::igeneric_function<t_tscalar>::generic_type t_generic_ty
 typedef typename t_generic_type::scalar_view t_scalar_view;
 typedef typename t_generic_type::string_view t_string_view;
 
-/**
- * @brief A custom exprtk function that reaches into a column and returns the
- * value of the next row. Basically like an iterator but slow and bad, and this
- * should be fully deleted with a better implementation of "get a value from
- * a column". Unfortunately, because ExprTk UDFs don't allow vector return
- * this seems like a logical first step.
- * 
- * @tparam T 
- */
-// template <typename T>
-// struct col : public exprtk::igeneric_function<T> {
-//     typedef typename exprtk::igeneric_function<T>::parameter_list_t t_parameter_list;
-//     typedef typename exprtk::igeneric_function<T>::generic_type t_generic_type;
-//     typedef typename t_generic_type::string_view t_string_view;
-
-//     col(std::shared_ptr<t_data_table> data_table, const tsl::hopscotch_set<std::string>& input_columns);
-//     col(std::shared_ptr<t_schema> schema);
-
-//     ~col();
-
-//     T next(const std::string& column_name);
-
-//     T operator()(t_parameter_list parameters);
-
-//     std::shared_ptr<t_schema> m_schema;
-//     tsl::hopscotch_set<std::string> m_input_columns;
-//     std::map<std::string, std::shared_ptr<t_column>> m_columns;
-//     std::map<std::string, t_uindex> m_ridxs;
-// };
-
 #define STRING_FUNCTION_HEADER(NAME)                                    \
     struct NAME : public exprtk::igeneric_function<t_tscalar> {        \
         NAME(std::shared_ptr<t_vocab> expression_vocab);               \
@@ -68,7 +38,6 @@ typedef typename t_generic_type::string_view t_string_view;
         t_tscalar operator()(t_parameter_list parameters);              \
         std::shared_ptr<t_vocab> m_expression_vocab;                    \
         t_tscalar m_sentinel;                                           \
-        t_tscalar m_none;                                               \
     };                                                                  \
 
 // Place string literals into `expression_vocab` so they do not go out
@@ -108,7 +77,6 @@ struct order : public exprtk::igeneric_function<t_tscalar> {
 
     std::shared_ptr<t_vocab> m_expression_vocab;
     t_tscalar m_sentinel;
-    t_tscalar m_none;
 };
 
 /**
@@ -123,7 +91,6 @@ STRING_FUNCTION_HEADER(contains)
         NAME();                                                         \
         ~NAME();                                                        \
         t_tscalar operator()(t_parameter_list parameters);              \
-        t_tscalar m_none;                                               \
     };                                                                  \
 
 /**
@@ -172,7 +139,6 @@ struct bucket : public exprtk::igeneric_function<t_tscalar> {
 
     // faster unit lookups, since we are calling this lookup in a tight loop.
     static tsl::hopscotch_map<std::string, t_date_bucket_unit> UNIT_MAP;
-    t_tscalar m_none;
 };
 
 
@@ -227,6 +193,38 @@ FUNCTION_HEADER(is_null)
  * 
  */
 FUNCTION_HEADER(is_not_null)
+
+/**
+ * @brief Convert a column or scalar of any type to a string.
+ * 
+ */
+FUNCTION_HEADER(to_string)
+
+/**
+ * @brief Convert a column or scalar of any type to an integer, or null
+ * if the value is not parsable as an integer.
+ */
+FUNCTION_HEADER(to_integer)
+
+/**
+ * @brief Convert a column or scalar of any type to a float, or null
+ * if the value is not parsable as an float.
+ */
+FUNCTION_HEADER(to_float)
+
+/**
+ * @brief Given a Year, Month (1-12), and Day, create a new date value.
+ * Because we also extensively use `date.h` which exports its symbols under
+ * `date`, this function is given a name that does not conflict (even though
+ * it is registered using "date").
+ */
+FUNCTION_HEADER(make_date)
+
+/**
+ * @brief Given a POSIX timestamp of milliseconds since epoch, create a
+ * new datetime value.
+ */
+FUNCTION_HEADER(make_datetime)
 
 } // end namespace computed_function
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/computed_function.h
+++ b/cpp/perspective/src/include/perspective/computed_function.h
@@ -201,14 +201,16 @@ FUNCTION_HEADER(is_not_null)
 FUNCTION_HEADER(to_string)
 
 /**
- * @brief Convert a column or scalar of any type to an integer, or null
- * if the value is not parsable as an integer.
+ * @brief Convert a column or scalar of a non-string type to an integer, or null
+ * if the value is not parsable as an integer. If a string is passed in,
+ * return 0.
  */
 FUNCTION_HEADER(to_integer)
 
 /**
- * @brief Convert a column or scalar of any type to a float, or null
- * if the value is not parsable as an float.
+ * @brief Convert a column or scalar of a non-string type to a float, or null
+ * if the value is not parsable as an float. If a string is passed in,
+ * return 0.
  */
 FUNCTION_HEADER(to_float)
 

--- a/cpp/perspective/src/include/perspective/computed_function.h
+++ b/cpp/perspective/src/include/perspective/computed_function.h
@@ -198,19 +198,18 @@ FUNCTION_HEADER(is_not_null)
  * @brief Convert a column or scalar of any type to a string.
  * 
  */
-FUNCTION_HEADER(to_string)
+STRING_FUNCTION_HEADER(to_string)
 
 /**
- * @brief Convert a column or scalar of a non-string type to an integer, or null
- * if the value is not parsable as an integer. If a string is passed in,
- * return 0.
+ * @brief Convert a column or scalar to an integer, or null if the value is not
+ * parsable as an integer. In the WASM runtime, the integer is 32-bit and will
+ * return none if the result under/over flows.
  */
 FUNCTION_HEADER(to_integer)
 
 /**
- * @brief Convert a column or scalar of a non-string type to a float, or null
- * if the value is not parsable as an float. If a string is passed in,
- * return 0.
+ * @brief Convert a column or scalar to a float, or null if the value is not
+ * parsable as an float.
  */
 FUNCTION_HEADER(to_float)
 

--- a/cpp/perspective/src/include/perspective/config.h
+++ b/cpp/perspective/src/include/perspective/config.h
@@ -45,7 +45,7 @@ public:
         const std::vector<std::string>& detail_columns,
         const std::vector<t_fterm>& fterms,
         t_filter_op combiner,
-        const std::vector<t_computed_expression>& expressions);
+        const std::vector<std::shared_ptr<t_computed_expression>>& expressions);
 
     /**
      * @brief Construct a new config for a `t_ctx1` object, which has 1 or more `row_pivot`s
@@ -60,7 +60,7 @@ public:
         const std::vector<t_aggspec>& aggregates,
         const std::vector<t_fterm>& fterms,
         t_filter_op combiner,
-        const std::vector<t_computed_expression>& expressions);
+        const std::vector<std::shared_ptr<t_computed_expression>>& expressions);
 
     /**
      * @brief Construct a new config for a `t_ctx2` object, which has 1 or more `row_pivot`s and
@@ -81,7 +81,7 @@ public:
         const t_totals totals,
         const std::vector<t_fterm>& fterms,
         t_filter_op combiner,
-        const std::vector<t_computed_expression>& expressions,
+        const std::vector<std::shared_ptr<t_computed_expression>>& expressions,
         bool column_only);
 
     // An empty config, used for the unit context.
@@ -161,7 +161,7 @@ public:
 
     const std::vector<t_fterm>& get_fterms() const;
 
-    std::vector<t_computed_expression>
+    std::vector<std::shared_ptr<t_computed_expression>>
     get_expressions() const;
 
     t_totals get_totals() const;
@@ -196,7 +196,7 @@ private:
     std::vector<t_sortspec> m_sortspecs;
     std::vector<t_sortspec> m_col_sortspecs;
     std::vector<t_fterm> m_fterms;
-    std::vector<t_computed_expression> m_expressions;
+    std::vector<std::shared_ptr<t_computed_expression>> m_expressions;
     t_filter_op m_combiner;
     bool m_column_only;
 

--- a/cpp/perspective/src/include/perspective/expression_tables.h
+++ b/cpp/perspective/src/include/perspective/expression_tables.h
@@ -27,8 +27,10 @@ namespace perspective {
  */
 struct t_expression_tables {
 
-    t_expression_tables();
-    t_expression_tables(const std::vector<t_computed_expression>& expressions);
+    PSP_NON_COPYABLE(t_expression_tables);
+
+    t_expression_tables(
+        const std::vector<std::shared_ptr<t_computed_expression>>& expressions);
     
     void set_transitional_table_capacity(t_uindex capacity);
     void set_transitional_table_size(t_uindex size);

--- a/cpp/perspective/src/include/perspective/time.h
+++ b/cpp/perspective/src/include/perspective/time.h
@@ -73,6 +73,7 @@ public:
 
     t_time();
     explicit t_time(std::int64_t raw_val);
+
     t_time(std::int32_t year, std::int32_t month, std::int32_t day, std::int32_t hour,
         std::int32_t min, std::int32_t sec);
 

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -230,7 +230,7 @@ public:
     std::vector<t_aggspec> get_aggregates() const;
     std::vector<t_fterm> get_filter() const;
     std::vector<t_sortspec> get_sort() const;
-    std::vector<t_computed_expression> get_expressions() const;
+    std::vector<std::shared_ptr<t_computed_expression>> get_expressions() const;
     std::vector<t_tscalar> get_row_path(t_uindex idx) const;
     t_stepdelta get_step_delta(t_index bidx, t_index eidx) const;
     t_dtype get_column_dtype(t_uindex idx) const;
@@ -272,7 +272,7 @@ private:
     std::vector<t_fterm> m_filter;
     std::vector<t_sortspec> m_sort;
     std::vector<std::string> m_hidden_sort;
-    std::vector<t_computed_expression> m_expressions;
+    std::vector<std::shared_ptr<t_computed_expression>> m_expressions;
     bool m_column_only;
     t_uindex m_row_offset;
     t_uindex m_col_offset;

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -46,7 +46,7 @@ public:
         const std::vector<std::string>& columns,
         const std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>>& filter,
         const std::vector<std::vector<std::string>>& sort,
-        const std::vector<t_computed_expression>& expressions,
+        const std::vector<std::shared_ptr<t_computed_expression>>& expressions,
         const std::string& filter_op,
         bool column_only);
 
@@ -96,7 +96,7 @@ public:
 
     std::vector<t_sortspec> get_col_sortspec() const;
 
-    std::vector<t_computed_expression> get_expressions() const;
+    std::vector<std::shared_ptr<t_computed_expression>> get_expressions() const;
 
     t_filter_op get_filter_op() const;
 
@@ -164,7 +164,7 @@ private:
     std::vector<std::string> m_columns;
     std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>> m_filter;
     std::vector<std::vector<std::string>> m_sort;
-    std::vector<t_computed_expression> m_expressions;
+    std::vector<std::shared_ptr<t_computed_expression>> m_expressions;
 
     /**
      * @brief The ordered list of aggregate columns:

--- a/examples/workspace/src/index.js
+++ b/examples/workspace/src/index.js
@@ -19,7 +19,7 @@ const datasource = async () => {
     const resp = await req;
     const buffer = await resp.arrayBuffer();
     const worker = perspective.shared_worker();
-    return await worker.table(buffer, {limit: 10});
+    return await worker.table(buffer);
 };
 
 const DEFAULT_LAYOUT = {

--- a/examples/workspace/src/index.js
+++ b/examples/workspace/src/index.js
@@ -19,7 +19,7 @@ const datasource = async () => {
     const resp = await req;
     const buffer = await resp.arrayBuffer();
     const worker = perspective.shared_worker();
-    return await worker.table(buffer);
+    return await worker.table(buffer, {limit: 10});
 };
 
 const DEFAULT_LAYOUT = {

--- a/packages/perspective/test/js/expressions.js
+++ b/packages/perspective/test/js/expressions.js
@@ -15,6 +15,7 @@ const updates = require("./expressions/updates");
 const deltas = require("./expressions/deltas");
 const invariant = require("./expressions/invariant");
 const multiple_views = require("./expressions/multiple_views");
+const conversions = require("./expressions/conversions");
 
 module.exports = perspective => {
     functionality(perspective);
@@ -25,4 +26,5 @@ module.exports = perspective => {
     deltas(perspective);
     invariant(perspective);
     multiple_views(perspective);
+    conversions(perspective);
 };

--- a/packages/perspective/test/js/expressions/conversions.js
+++ b/packages/perspective/test/js/expressions/conversions.js
@@ -1,0 +1,261 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+/**
+ * Tests the correctness of each datetime computation function in various
+ * environments and parameters - different types, nulls, undefined, etc.
+ */
+module.exports = perspective => {
+    describe("date()", () => {
+        it("Should create a date from scalars", async () => {
+            const table = await perspective.table({
+                x: [1, 2, 3, 4]
+            });
+
+            const view = await table.view({
+                expressions: [`//computed \n date(2020, 7, 15)`, `//computed2 \n date(1970, 10, 29)`, `//computed3\n date(2020, 1, "x")`]
+            });
+
+            const result = await view.to_columns();
+            expect(result["computed"]).toEqual(Array(4).fill(new Date(2020, 6, 15).getTime()));
+            expect(result["computed2"]).toEqual(Array(4).fill(new Date(1970, 9, 29).getTime()));
+            expect(result["computed3"]).toEqual(
+                Array(4)
+                    .fill(true)
+                    .map((_, idx) => new Date(2020, 0, idx + 1).getTime())
+            );
+            await view.delete();
+            await table.delete();
+        });
+
+        it("Should create a date from int columns", async () => {
+            const table = await perspective.table({
+                y: "integer",
+                m: "integer",
+                d: "integer"
+            });
+
+            const view = await table.view({
+                expressions: [`//computed \n date("y", "m", "d")`]
+            });
+
+            table.update({
+                y: [0, 2020, 1776, 2018, 2020, 2020],
+                m: [1, 2, 5, 2, 12, null],
+                d: [1, 29, 31, 29, 31, 1]
+            });
+
+            const result = await view.to_columns();
+            const expected = [new Date(1900, 0, 1), new Date(2020, 1, 29), new Date(1776, 4, 31), new Date(2018, 1, 29), new Date(2020, 11, 31)].map(x => x.getTime());
+            expected.push(null);
+            expect(result["computed"]).toEqual(expected);
+            await view.delete();
+            await table.delete();
+        });
+
+        it("Should create a date from float columns", async () => {
+            const table = await perspective.table({
+                y: "float",
+                m: "float",
+                d: "float"
+            });
+
+            const view = await table.view({
+                expressions: [`//computed \n date("y", "m", "d")`]
+            });
+
+            table.update({
+                y: [0, 2020, 1776, 2018, 2020, 2020],
+                m: [1, 2, 5, 2, 12, null],
+                d: [1, 29, 31, 29, 31, 1]
+            });
+
+            const result = await view.to_columns();
+            const expected = [new Date(1900, 0, 1), new Date(2020, 1, 29), new Date(1776, 4, 31), new Date(2018, 1, 29), new Date(2020, 11, 31)].map(x => x.getTime());
+            expected.push(null);
+            expect(result["computed"]).toEqual(expected);
+            await view.delete();
+            await table.delete();
+        });
+
+        it("Should create a date from numeric columns and skip invalid values", async () => {
+            const table = await perspective.table({
+                y: [-100, 0, 2000, 3000],
+                m: [12, 0, 12, 11],
+                d: [1, 10, 32, 10]
+            });
+
+            const view = await table.view({
+                expressions: [`//computed \n date("y", "m", "d")`]
+            });
+
+            const result = await view.to_columns();
+            expect(result["computed"]).toEqual([null, null, null, new Date(3000, 10, 10).getTime()]);
+            await view.delete();
+            await table.delete();
+        });
+
+        it("Should create a date from variables inside expression", async () => {
+            const table = await perspective.table({
+                x: [20200101, 20090531, 19801220, 20200229]
+            });
+
+            const view = await table.view({
+                expressions: [`//computed \n var year := floor("x" / 10000); var month := floor("x" % 10000 / 100); var day := floor("x" % 100); date(year, month, day)`]
+            });
+
+            const result = await view.to_columns();
+            expect(result["computed"]).toEqual([new Date(2020, 0, 1), new Date(2009, 4, 31), new Date(1980, 11, 20), new Date(2020, 1, 29)].map(x => x.getTime()));
+            await view.delete();
+            await table.delete();
+        });
+
+        it("Should validate inputs", async () => {
+            const table = await perspective.table({
+                y: [-100, 0, 2000, 3000],
+                m: [12, 0, 12, 11],
+                d: [1, 10, 32, 10]
+            });
+
+            const validated = await table.validate_expressions([`//computed \n date()`, `//computed2 \n date('abc', 'def', '123')`, `//computed3\ndate("y", "m", "d")`]);
+
+            expect(validated.expression_schema).toEqual({
+                computed3: "date"
+            });
+
+            expect(validated.errors).toEqual({
+                computed: "Parser Error - Zero parameter call to generic function: date not allowed",
+                computed2: "Type Error - inputs do not resolve to a valid expression."
+            });
+
+            await table.delete();
+        });
+    });
+
+    describe("datetime()", () => {
+        it("Should create a datetime from scalars", async () => {
+            const table = await perspective.table({
+                x: [1, 2, 3, 4]
+            });
+
+            const a = new Date(2005, 6, 31, 11, 59, 32).getTime();
+            const b = new Date(2005, 6, 31, 11, 59, 32).getTime();
+
+            const view = await table.view({
+                expressions: [`//computed \n datetime(${a})`, `//computed2 \n datetime(${b})`]
+            });
+
+            expect(await view.expression_schema()).toEqual({
+                computed: "datetime",
+                computed2: "datetime"
+            });
+
+            const result = await view.to_columns();
+            expect(result["computed"]).toEqual(Array(4).fill(a));
+            expect(result["computed2"]).toEqual(Array(4).fill(b));
+            await view.delete();
+            await table.delete();
+        });
+
+        it("Should not create a datetime from int columns as int32 is too small", async () => {
+            const table = await perspective.table({
+                x: "integer"
+            });
+
+            const view = await table.view({
+                expressions: [`//computed \n datetime("x")`]
+            });
+
+            const data = [new Date(2020, 1, 29, 5, 1, 2), new Date(1776, 4, 31, 13, 23, 18), new Date(2018, 1, 29, 19, 39, 43), new Date(2020, 11, 31, 23, 59, 59)].map(x => x.getTime());
+            data.push(null);
+
+            table.update({
+                x: data
+            });
+
+            let result = await view.to_columns();
+
+            expect(result["computed"]).toEqual(Array(5).fill(null));
+            await view.delete();
+            await table.delete();
+        });
+
+        it("Should create a datetime from float columns", async () => {
+            const table = await perspective.table({
+                x: "float"
+            });
+
+            const view = await table.view({
+                expressions: [`//computed \n datetime("x")`]
+            });
+
+            const data = [new Date(2020, 1, 29, 5, 1, 2), new Date(1776, 4, 31, 13, 23, 18), new Date(2018, 1, 29, 19, 39, 43), new Date(2020, 11, 31, 23, 59, 59)].map(x => x.getTime());
+            data.push(null);
+
+            table.update({
+                x: data
+            });
+
+            const result = await view.to_columns();
+            expect(result["computed"]).toEqual(data);
+            await view.delete();
+            await table.delete();
+        });
+
+        it("Should create a datetime from numeric scalars < 0", async () => {
+            const table = await perspective.table({
+                x: [1]
+            });
+
+            const view = await table.view({
+                expressions: [`//computed1 \n datetime(-1)`, `//computed2 \n datetime(0)`, `//computed3 \n datetime(${new Date(2002, 11, 12, 13, 14, 15).getTime()})`]
+            });
+
+            expect(await view.expression_schema()).toEqual({
+                computed1: "datetime",
+                computed2: "datetime",
+                computed3: "datetime"
+            });
+
+            const result = await view.to_columns();
+
+            expect(result["computed1"]).toEqual([-1]);
+            expect(result["computed2"]).toEqual([0]);
+            expect(result["computed3"]).toEqual([new Date(2002, 11, 12, 13, 14, 15).getTime()]);
+            await view.delete();
+            await table.delete();
+        });
+
+        it("Should validate inputs", async () => {
+            const table = await perspective.table({
+                x: [1]
+            });
+
+            const validated = await table.validate_expressions([
+                `//computed1 \n datetime()`,
+                `//computed2 \n datetime('abcd')`,
+                `//computed3 \n datetime(today())`,
+                `//computed4 \n datetime(now())`,
+                `//computed5 \n datetime(123456, 7)`
+            ]);
+
+            expect(validated.expression_schema).toEqual({});
+
+            expect(validated.errors).toEqual({
+                computed1: "Parser Error - Zero parameter call to generic function: datetime not allowed",
+                computed2: "Type Error - inputs do not resolve to a valid expression.",
+                computed3: "Type Error - inputs do not resolve to a valid expression.",
+                computed4: "Type Error - inputs do not resolve to a valid expression.",
+                computed5: "Parser Error - Failed parameter type check for function 'datetime', Expected 'T'  call set: 'TT'"
+            });
+
+            await table.delete();
+        });
+    });
+};

--- a/python/perspective/perspective/include/perspective/python.h
+++ b/python/perspective/perspective/include/perspective/python.h
@@ -202,7 +202,7 @@ PYBIND11_MODULE(libbinding, m)
             const std::vector<std::string>&,
             const std::vector<std::tuple<std::string, std::string, std::vector<t_tscalar>>>&,
             const std::vector<std::vector<std::string>>&,
-            const std::vector<t_computed_expression>&,
+            const std::vector<std::shared_ptr<t_computed_expression>>&,
             const std::string,
             bool>())
         .def("add_filter_term", &t_view_config::add_filter_term);

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -139,7 +139,7 @@ make_view_config(
     }
 
     auto p_expressions = config.attr("get_expressions")().cast<std::vector<std::vector<t_val>>>();
-    std::vector<t_computed_expression> expressions;
+    std::vector<std::shared_ptr<t_computed_expression>> expressions;
     expressions.reserve(p_expressions.size());
 
     // Will either abort() or succeed completely, and this isn't a public
@@ -174,11 +174,11 @@ make_view_config(
         }
 
         // If the expression cannot be parsed, it will abort() here.
-        t_computed_expression expression = t_computed_expression_parser::precompute(
+        std::shared_ptr<t_computed_expression> expression = t_computed_expression_parser::precompute(
             expression_alias, expression_string, parsed_expression_string, column_ids, schema);
 
         expressions.push_back(expression);
-        schema->add_column(expression_alias, expression.get_dtype());
+        schema->add_column(expression_alias, expression->get_dtype());
     }
 
     // construct filters with filter terms, and fill the vector of tuples

--- a/rust/perspective-vieux/src/rust/exprtk.rs
+++ b/rust/perspective-vieux/src/rust/exprtk.rs
@@ -37,6 +37,13 @@ thread_local! {
     static COMPLETIONS: RegisterCompletionItemSuggestions = RegisterCompletionItemSuggestions {
         suggestions: vec![
             CompletionItemSuggestion {
+                label: "var",
+                kind: 17,
+                insert_text: "var ${1:x := 1}",
+                insert_text_rules: 4,
+                documentation: "Declare a new local variable",
+            },
+            CompletionItemSuggestion {
                 label: "abs",
                 kind: 1,
                 insert_text: "abs(${1:x})",
@@ -53,7 +60,7 @@ thread_local! {
             CompletionItemSuggestion {
                 label: "bucket",
                 kind: 1,
-                insert_text: "bucket(${1:x})",
+                insert_text: "bucket(${1:x}, ${2:y})",
                 insert_text_rules: 4,
                 documentation: "Bucket x by y",
             },
@@ -130,7 +137,7 @@ thread_local! {
             CompletionItemSuggestion {
                 label: "logn",
                 kind: 1,
-                insert_text: "logn(${1:x})",
+                insert_text: "logn(${1:x}, ${2:N})",
                 insert_text_rules: 4,
                 documentation: "Base N log of x where N >= 0",
             },
@@ -165,14 +172,14 @@ thread_local! {
             CompletionItemSuggestion {
                 label: "pow",
                 kind: 1,
-                insert_text: "pow(${1:x})",
+                insert_text: "pow(${1:x}, ${2:y})",
                 insert_text_rules: 4,
                 documentation: "x to the power of y",
             },
             CompletionItemSuggestion {
                 label: "root",
                 kind: 1,
-                insert_text: "root(${1:x})",
+                insert_text: "root(${1:x}, ${2:N})",
                 insert_text_rules: 4,
                 documentation: "N-th root of x where N >= 0",
             },
@@ -340,7 +347,7 @@ thread_local! {
             CompletionItemSuggestion {
                 label: "concat",
                 kind: 1,
-                insert_text: "concat(${1:x})",
+                insert_text: "concat(${1:x}, ${2:y})",
                 insert_text_rules: 4,
                 documentation: "Concatenate string literals and columns",
             },
@@ -382,14 +389,14 @@ thread_local! {
             CompletionItemSuggestion {
                 label: "now",
                 kind: 1,
-                insert_text: "now(${1:x})",
+                insert_text: "now()",
                 insert_text_rules: 4,
                 documentation: "The current datetime in local time",
             },
             CompletionItemSuggestion {
                 label: "today",
                 kind: 1,
-                insert_text: "today(${1:x})",
+                insert_text: "today()",
                 insert_text_rules: 4,
                 documentation: "The current date in local time",
             },
@@ -429,18 +436,60 @@ thread_local! {
                 documentation: "Boolean value false",
             },
             CompletionItemSuggestion {
-                label: "if else",
-                kind: 1,
-                insert_text: "if else(${1:x})",
+                label: "if",
+                kind: 17,
+                insert_text: "if (${1:condition}) {} else {}",
                 insert_text_rules: 4,
-                documentation: "if/else conditional",
+                documentation: "If/else conditional",
+            },
+            CompletionItemSuggestion {
+                label: "else if",
+                kind: 17,
+                insert_text: "else if (${1:condition}) {}",
+                insert_text_rules: 4,
+                documentation: "Else if conditional",
             },
             CompletionItemSuggestion {
                 label: "for",
-                kind: 1,
-                insert_text: "for(${1:x})",
+                kind: 17,
+                insert_text: "for (${1:x}) {}",
                 insert_text_rules: 4,
                 documentation: "For loop",
+            },
+            CompletionItemSuggestion {
+                label: "string",
+                kind: 1,
+                insert_text: "string(${1:x})",
+                insert_text_rules: 4,
+                documentation: "Convert the argument to a string",
+            },
+            CompletionItemSuggestion {
+                label: "integer",
+                kind: 1,
+                insert_text: "integer(${1:x})",
+                insert_text_rules: 4,
+                documentation: "Convert the argument to an integer",
+            },
+            CompletionItemSuggestion {
+                label: "float",
+                kind: 1,
+                insert_text: "float(${1:x})",
+                insert_text_rules: 4,
+                documentation: "Convert the argument to a float",
+            },
+            CompletionItemSuggestion {
+                label: "date",
+                kind: 1,
+                insert_text: "date(${1:year}, ${1:month}, ${1:day})",
+                insert_text_rules: 4,
+                documentation: "Given a year, month (1-12) and day, create a new date",
+            },
+            CompletionItemSuggestion {
+                label: "datetime",
+                kind: 1,
+                insert_text: "datetime(${1:timestamp})",
+                insert_text_rules: 4,
+                documentation: "Given a POSIX timestamp of milliseconds since epoch, create a new datetime",
             },
         ]
     };


### PR DESCRIPTION
This PR adds a set of type conversion functions to the expression language, which will allow users to quickly clean/coerce their data within Perspective if it is inferred as the wrong format:

- `integer(x)`: converts a column or scalar of any type to an integer. In `Perspective.js`, integers are 32-bit, thus values that overflow/underflow will be output as `null`.
- `float(x)`: converts a column or scalar of any type to a float.
- `string(x)`: converts a column or scalar of any type into a string. `date` values are output using the format `YYYY-MM-DD`, and `datetime` values are output using the format `YYYY-MM-DD HH:MM:SS`. Conversion of floats to strings can lose precision.
- `date(year, month, day)`: given a year, month (1-12), and day, create a new `date` value. This allows for parsing of numerical date formats that were previously impossible to cast to a date, such as `YYYYMMDD`. Parsing can be done with a simple expression:

```javascript
var year := floor("x" / 10000); // "x" is a column of numbers in the format YYYYMMDD
var month := floor("x" % 10000 / 100);
var day := floor("x" % 100);
date(year, month, day)
```
- `datetime(timestamp)`: given a POSIX timestamp of milliseconds since epoch, create a new datetime value. This allows for timestamp columns which would usually be inferred as `float` (unless the table is provided with a schema marking the column as a `datetime`) to be converted into datetimes. Because of the addition of scalars, converting from a seconds-since-epoch timestamp to a milliseconds timestamp is simple:

```javascript
datetime("timestamp" * 1000)
```
Additionally, this PR removes a little debug cruft left over from #1431, and edits the Monaco autocomplete definitions to include the proper parameters for `bucket`, `if/else`, and `var`. 