### PR TITLE
Add theme support to monaco

### DIFF
--- a/packages/perspective-viewer/src/themes/material.dark.less
+++ b/packages/perspective-viewer/src/themes/material.dark.less
@@ -42,6 +42,7 @@ perspective-viewer, .perspective-viewer-material-dark {
     --expression--function-color: @lightblue600;
     --expression--error-color: rgb(255, 136, 136);
     --input-dragover--background: linear-gradient(to top, rgbs(38, 112, 169, 0.5), transparent 50%);
+    --monaco-theme: vs-dark;
 
     table {
         color: white;

--- a/packages/perspective-workspace/src/theme/material.dark.less
+++ b/packages/perspective-workspace/src/theme/material.dark.less
@@ -25,7 +25,7 @@ perspective-viewer.workspace-master-widget {
     --plugin--background: @grey800;
 }
 
-perspective-column-style {
+perspective-column-style, perspective-expression-editor {
     background-color: @grey700;
     color: #FFFFFF;
     border: 1px solid @grey500;

--- a/packages/perspective-workspace/src/theme/material.less
+++ b/packages/perspective-workspace/src/theme/material.less
@@ -22,7 +22,7 @@ perspective-viewer.workspace-master-widget {
     }
 }
 
-perspective-column-style {
+perspective-column-style, perspective-expression-editor {
     background-color: #FFFFFF;
     color: #161616;
     border: 1px solid #E0E4E9;

--- a/rust/perspective-vieux/src/rust/components/expression_editor.rs
+++ b/rust/perspective-vieux/src/rust/components/expression_editor.rs
@@ -33,6 +33,7 @@ pub struct ExpressionEditorProps {
     pub on_init_callback: Rc<dyn Fn()>,
     pub on_validate_callback: Rc<dyn Fn(bool)>,
     pub session: Session,
+    pub monaco_theme: String,
 }
 
 /// A label widget which displays a row count and a "projection" count, the number of
@@ -144,7 +145,7 @@ impl Component for ExpressionEditor {
         if first_render {
             let this = self.clone();
             let _ = future_to_promise(async move {
-                let editor = init_monaco().await.unwrap();
+                let editor = init_monaco(&this.props.monaco_theme).await.unwrap();
                 let args = EditorArgs {
                     theme: "exprtk-theme",
                     value: "",

--- a/rust/perspective-vieux/src/rust/custom_elements/expression_editor.rs
+++ b/rust/perspective-vieux/src/rust/custom_elements/expression_editor.rs
@@ -34,11 +34,13 @@ impl PerspectiveExpressionEditorElement {
         on_save_callback: Rc<dyn Fn(JsValue)>,
         on_init_callback: Rc<dyn Fn()>,
         on_validate_callback: Rc<dyn Fn(bool)>,
+        monaco_theme: String
     ) -> PerspectiveExpressionEditorElement {
         let props = ExpressionEditorProps {
             on_save_callback,
             on_init_callback,
             on_validate_callback,
+            monaco_theme,
             session,
         };
 

--- a/rust/perspective-vieux/src/rust/custom_elements/vieux.rs
+++ b/rust/perspective-vieux/src/rust/custom_elements/vieux.rs
@@ -21,6 +21,16 @@ use wasm_bindgen_futures::future_to_promise;
 use web_sys::*;
 use yew::prelude::*;
 
+fn get_theme(elem: &HtmlElement) -> String {
+    let styles = window().unwrap().get_computed_style(elem).unwrap().unwrap();
+    match &styles.get_property_value("--monaco-theme") {
+        Err(_) => "vs",
+        Ok(ref s) if s.trim() == "" => "vs",
+        Ok(x) => x.trim(),
+    }
+    .to_owned()
+}
+
 /// A `customElements` external API.
 #[wasm_bindgen]
 #[derive(Clone)]
@@ -119,12 +129,14 @@ impl PerspectiveVieuxElement {
                 .unwrap();
         });
 
+        let monaco_theme = get_theme(&target);
         let mut element = PerspectiveExpressionEditorElement::new(
             editor,
             self.session.clone(),
             on_save,
             on_init,
             on_validate,
+            monaco_theme,
         );
 
         element.open(target).unwrap();


### PR DESCRIPTION
Adds theme support via the `--monaco-editor--theme` CSS variable, as well as supports for Perspective's `material-dark` theme.