### PR TITLE
Read CSV strings in perspective-python

### DIFF
--- a/cmake/arrow/CMakeLists.txt
+++ b/cmake/arrow/CMakeLists.txt
@@ -104,6 +104,7 @@ set(ARROW_SRCS
 if (PSP_PYTHON_BUILD)
     set(ARROW_SRCS
         ${ARROW_SRCS}
+        ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/csv/reader.cc
         ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/datum.cc
         ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/io/file.cc
         ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/tensor/coo_converter.cc

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -546,6 +546,7 @@ set (SOURCE_FILES
 	${PSP_CPP_SRC}/src/cpp/view.cpp
 	${PSP_CPP_SRC}/src/cpp/view_config.cpp
 	${PSP_CPP_SRC}/src/cpp/vocab.cpp
+	${PSP_CPP_SRC}/src/cpp/arrow_csv.cpp
 	)
 
 set(PYTHON_SOURCE_FILES ${SOURCE_FILES}
@@ -553,7 +554,6 @@ set(PYTHON_SOURCE_FILES ${SOURCE_FILES}
 )
 
 set(WASM_SOURCE_FILES ${SOURCE_FILES}
-	${PSP_CPP_SRC}/src/cpp/arrow_csv.cpp
 	${PSP_CPP_SRC}/src/cpp/vendor/arrow_single_threaded_reader.cpp
 )
 

--- a/cpp/perspective/src/cpp/arrow_csv.cpp
+++ b/cpp/perspective/src/cpp/arrow_csv.cpp
@@ -12,9 +12,13 @@
 #include <arrow/util/value_parsing.h>
 #include <arrow/io/memory.h>
 
-// This causes build warnings
-// https://github.com/emscripten-core/emscripten/issues/8574
-#include <perspective/vendor/arrow_single_threaded_reader.h>
+#ifdef PSP_ENABLE_WASM
+    // This causes build warnings
+    // https://github.com/emscripten-core/emscripten/issues/8574
+    #include <perspective/vendor/arrow_single_threaded_reader.h>
+#else
+    #include <arrow/csv/reader.h>
+#endif
 
 namespace perspective {
 namespace apachearrow {

--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -574,18 +574,26 @@ namespace apachearrow {
 
             // Fill validity bitmap
             std::int64_t null_count = array->null_count();
+
             if (null_count == 0) {
                 col->valid_raw_fill();
             } else {
                 const uint8_t* null_bitmap = array->null_bitmap_data();
 
-                // arrow packs bools into a bitmap
-                for (uint32_t i = 0; i < len; ++i) {
-                    std::uint8_t elem = null_bitmap[i / 8];
-                    bool v = elem & (1 << (i % 8));
-                    col->set_valid(offset + i, v);
+                // If the arrow column is of null type, the null bitmap is
+                // a nullptr - so just mark everything as invalid and move on.
+                if (null_bitmap == NULL) {
+                    col->invalid_raw_fill();
+                } else {
+                    // Read the null bitmap and set the correct rows as valid
+                    for (uint32_t i = 0; i < len; ++i) {
+                        std::uint8_t elem = null_bitmap[i / 8];
+                        bool v = elem & (1 << (i % 8));
+                        col->set_valid(offset + i, v);
+                    }
                 }
             }
+
             offset += len;
         }
     }

--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -172,9 +172,8 @@ namespace apachearrow {
         }
     }
 
-#ifdef PSP_ENABLE_WASM
     void
-    ArrowLoader::init_csv(std::string& csv, bool is_update,  std::unordered_map<std::string, std::shared_ptr<arrow::DataType>>& psp_schema) {        
+    ArrowLoader::init_csv(std::string& csv, bool is_update, std::unordered_map<std::string, std::shared_ptr<arrow::DataType>>& psp_schema) {        
         m_table = csvToTable(csv, is_update, psp_schema);
 
         std::shared_ptr<arrow::Schema> schema = m_table->schema();
@@ -185,7 +184,6 @@ namespace apachearrow {
             m_types.push_back(convert_type(field->type()->name()));
         }
     }
-#endif
 
     void
     ArrowLoader::fill_table(

--- a/cpp/perspective/src/cpp/column.cpp
+++ b/cpp/perspective/src/cpp/column.cpp
@@ -822,6 +822,11 @@ t_column::valid_raw_fill() {
 }
 
 void
+t_column::invalid_raw_fill() {
+    m_status->raw_fill(STATUS_INVALID);
+}
+
+void
 t_column::copy(const t_column* other, const std::vector<t_uindex>& indices, t_uindex offset) {
     PSP_VERBOSE_ASSERT(m_dtype == other->get_dtype(), "Cannot copy from diff dtype");
 

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1160,7 +1160,7 @@ namespace binding {
                 arrow_loader.initialize(ptr, length);
             }
             
-            // Always use the `Table` column names and data types on up
+            // Always use the `Table` column names and data types on update
             if (table_initialized && is_update) {
                 auto gnode_output_schema = gnode->get_output_schema();
                 auto schema = gnode_output_schema.drop({"psp_okey"});

--- a/cpp/perspective/src/include/perspective/arrow_loader.h
+++ b/cpp/perspective/src/include/perspective/arrow_loader.h
@@ -20,10 +20,7 @@
 #include <arrow/util/decimal.h>
 #include <arrow/io/memory.h>
 #include <arrow/ipc/reader.h>
-
-#if ARROW_VERSION_MAJOR >= 1
 #include <perspective/arrow_csv.h>
-#endif
 
 namespace perspective {
 namespace apachearrow {
@@ -40,14 +37,12 @@ namespace apachearrow {
          */
         void initialize(uintptr_t ptr, std::uint32_t);
 
-#ifdef PSP_ENABLE_WASM
         /**
          * @brief Initialize the arrow loader with a CSV.
          * 
          * @param ptr 
          */
         void init_csv(std::string& csv, bool is_update, std::unordered_map<std::string, std::shared_ptr<arrow::DataType>>& schema);
-#endif
 
         /**
          * @brief Given an arrow binary and a data table, load the arrow into

--- a/cpp/perspective/src/include/perspective/column.h
+++ b/cpp/perspective/src/include/perspective/column.h
@@ -183,6 +183,7 @@ public:
     std::shared_ptr<t_column> clone(const t_mask& mask) const;
 
     void valid_raw_fill();
+    void invalid_raw_fill();
 
     template <typename DATA_T>
     void copy_helper(

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -799,6 +799,44 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("CSV constructor with null columns", async function() {
+            const table = await perspective.table("x,y\n1,");
+            const view = await table.view();
+            expect(await table.schema()).toEqual({
+                x: "integer",
+                y: "string"
+            });
+            const result = await view.to_columns();
+            expect(result).toEqual({
+                x: [1],
+                y: [null]
+            });
+            await view.delete();
+            await table.delete();
+        });
+
+        it("CSV constructor indexed, with null columns, and update", async function() {
+            const table = await perspective.table("x,y\n1,", {index: "x"});
+            const view = await table.view();
+            expect(await table.schema()).toEqual({
+                x: "integer",
+                y: "string"
+            });
+            const result = await view.to_columns();
+            expect(result).toEqual({
+                x: [1],
+                y: [null]
+            });
+            table.update("x,y\n1,abc\n2,123");
+            const result2 = await view.to_columns();
+            expect(result2).toEqual({
+                x: [1, 2],
+                y: ["abc", "123"]
+            });
+            await view.delete();
+            await table.delete();
+        });
+
         it("Meta constructor", async function() {
             var table = await perspective.table(meta);
             var view = await table.view();

--- a/python/perspective/perspective/include/perspective/python/table.h
+++ b/python/perspective/perspective/include/perspective/python/table.h
@@ -21,7 +21,17 @@ namespace binding {
  *
  * Table API
  */
-std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor, std::uint32_t limit, py::str index, t_op op, bool is_update, bool is_arrow, t_uindex port_id);
+std::shared_ptr<Table> make_table_py(
+    t_val table,
+    t_data_accessor accessor,
+    std::uint32_t limit,
+    py::str index,
+    t_op op,
+    bool is_update,
+    bool is_arrow,
+    bool is_csv,
+    t_uindex port_id
+);
 
 } //namespace binding
 } //namespace perspective

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -60,6 +60,9 @@ class Table(object):
             # always true if we are loading a CSV
             self._is_arrow = True
 
+            if len(data) > 0 and data[0] == ",":
+                data = "_" + data
+
         if self._is_arrow:
             _accessor = data
         else:
@@ -284,6 +287,9 @@ class Table(object):
             # always true if we are loading a CSV
             _is_arrow = True
 
+            if len(data) > 0 and data[0] == ",":
+                data = "_" + data
+
         if _is_arrow:
             _accessor = data
             self._table = make_table(
@@ -293,7 +299,7 @@ class Table(object):
                 self._index or "",
                 t_op.OP_INSERT,
                 True,
-                True,
+                _is_arrow,
                 _is_csv,
                 port_id,
             )

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -53,6 +53,13 @@ class Table(object):
                 writing at row 0.
         """
         self._is_arrow = isinstance(data, (bytes, bytearray))
+        self._is_csv = isinstance(data, str)
+
+        if self._is_csv:
+            # CSVs are loaded using the Arrow interface, so is_arrow is
+            # always true if we are loading a CSV
+            self._is_arrow = True
+
         if self._is_arrow:
             _accessor = data
         else:
@@ -74,6 +81,7 @@ class Table(object):
             t_op.OP_INSERT,
             False,
             self._is_arrow,
+            self._is_csv,
             0,
         )
 
@@ -269,6 +277,12 @@ class Table(object):
             port_id = 0
 
         _is_arrow = isinstance(data, (bytes, bytearray))
+        _is_csv = isinstance(data, str)
+
+        if _is_csv:
+            # CSVs are loaded using the Arrow interface, so is_arrow is
+            # always true if we are loading a CSV
+            _is_arrow = True
 
         if _is_arrow:
             _accessor = data
@@ -280,6 +294,7 @@ class Table(object):
                 t_op.OP_INSERT,
                 True,
                 True,
+                _is_csv,
                 port_id,
             )
             self._state_manager.set_process(
@@ -317,6 +332,7 @@ class Table(object):
             t_op.OP_INSERT,
             True,
             False,
+            False,
             port_id,
         )
         self._state_manager.set_process(self._table.get_pool(), self._table.get_id())
@@ -353,6 +369,7 @@ class Table(object):
             self._index or "",
             t_op.OP_DELETE,
             True,
+            False,
             False,
             port_id,
         )

--- a/python/perspective/perspective/tests/core/test_async.py
+++ b/python/perspective/perspective/tests/core/test_async.py
@@ -77,6 +77,24 @@ class TestAsync(object):
         assert _task() == 5
         tbl.delete()
 
+    def test_async_queue_process_csv(self):
+        """Make sure GIL release during CSV loading works"""     
+        tbl = Table("x,y,z\n1,a,true\n2,b,false\n3,c,true\n4,d,false")
+        manager = PerspectiveManager()
+        manager.set_loop_callback(TestAsync.loop.add_callback)
+        manager.host(tbl)
+
+        @syncify
+        def _task():
+            assert tbl.size() == 4
+            for i in range(5):
+                tbl.update("x,y,z\n1,a,true\n2,b,false\n3,c,true\n4,d,false")
+            return tbl.size()
+
+        assert _task() == 24
+
+        tbl.delete()
+
     def test_async_call_loop(self):
         tbl = Table({"a": int, "b": float, "c": str})
         manager = PerspectiveManager()

--- a/python/perspective/perspective/tests/table/test_table.py
+++ b/python/perspective/perspective/tests/table/test_table.py
@@ -36,6 +36,45 @@ class TestTable(object):
         tbl.update({"a": [4, 5, 6]})
         assert _PerspectiveStateManager.TO_PROCESS == {}
 
+    def test_table_csv(self):
+        data = "x,y,z\n1,a,true\n2,b,false\n3,c,true\n4,d,false"
+        tbl = Table(data)
+        assert tbl.schema() == {
+            "x": int,
+            "y": str,
+            "z": bool
+        }
+        view = tbl.view()
+        assert view.to_dict() == {
+            "x": [1, 2, 3, 4],
+            "y": ["a", "b", "c", "d"],
+            "z": [True, False, True, False]
+        }
+
+    def test_table_correct_csv_nan_end(self):
+        tbl = Table("str,int\n,1\n,2\nabc,3")
+        assert tbl.schema() == {
+            "str": str,
+            "int": int
+        }
+        assert tbl.size() == 3
+        assert tbl.view().to_dict() == {
+            "str": ["", "", "abc"],
+            "int": [1, 2, 3]
+        }
+
+    def test_table_correct_csv_nan_intermittent(self):
+        tbl = Table("str,float\nabc,\n,2.5\nghi,")
+        assert tbl.schema() == {
+            "str": str,
+            "float": float
+        }
+        assert tbl.size() == 3
+        assert tbl.view().to_dict() == {
+            "str": ["abc", "", "ghi"],
+            "float": [None, 2.5, None]
+        }
+
     def test_table_int(self):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)

--- a/python/perspective/perspective/tests/table/test_table.py
+++ b/python/perspective/perspective/tests/table/test_table.py
@@ -51,6 +51,35 @@ class TestTable(object):
             "z": [True, False, True, False]
         }
 
+    def test_table_csv_with_nulls(self):
+        tbl = Table("x,y\n1,")
+        assert tbl.schema() == {
+            "x": int,
+            "y": str
+        }
+        view = tbl.view()
+        assert view.to_dict() == {
+            "x": [1],
+            "y": [None]
+        }
+
+    def test_table_csv_with_nulls_updated(self):
+        tbl = Table("x,y\n1,", index="x")
+        assert tbl.schema() == {
+            "x": int,
+            "y": str
+        }
+        view = tbl.view()
+        assert view.to_dict() == {
+            "x": [1],
+            "y": [None]
+        }
+        tbl.update("x,y\n1,abc\n2,123")
+        assert view.to_dict() == {
+            "x": [1, 2],
+            "y": ["abc", "123"]
+        }
+
     def test_table_correct_csv_nan_end(self):
         tbl = Table("str,int\n,1\n,2\nabc,3")
         assert tbl.schema() == {

--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -847,7 +847,7 @@ class TestTablePandas(object):
             "datetime": [None, datetime(2019, 7, 11, 10, 30, 55)]
         }
 
-    def test_table_correct_csv_nan_end(self):
+    def test_table_pandas_correct_csv_nan_end(self):
         s = "str,int\n,1\n,2\nabc,3"
         if six.PY2:
             s = unicode(s)
@@ -866,7 +866,7 @@ class TestTablePandas(object):
             "int": [1, 2, 3]
         }
 
-    def test_table_correct_csv_nan_intermittent(self):
+    def test_table_pandas_correct_csv_nan_intermittent(self):
         s = "str,float\nabc,\n,2\nghi,"
         if six.PY2:
             s = unicode(s)

--- a/python/perspective/perspective/tests/table/test_update.py
+++ b/python/perspective/perspective/tests/table/test_update.py
@@ -27,6 +27,43 @@ class TestUpdate(object):
         tbl.update({"a": ["abc"], "b": [123]})
         assert tbl.view().to_records() == [{"a": "abc", "b": 123}]
 
+    def test_update_csv(self):
+        tbl = Table({
+            "a": str,
+            "b": int
+        })
+
+        view = tbl.view()
+        tbl.update("a,b\nxyz,123\ndef,100000000")
+
+        assert view.to_dict() == {
+            "a": ["xyz", "def"],
+            "b": [123, 100000000]
+        }
+
+    def test_update_csv_indexed(self):
+        tbl = Table({
+            "a": str,
+            "b": float
+        }, index="a")
+
+        view = tbl.view()
+        tbl.update("a,b\nxyz,1.23456718\ndef,100000000.1")
+
+        assert view.to_dict() == {
+            "a": ["def", "xyz"],
+            "b": [100000000.1, 1.23456718]
+        }
+
+        tbl.update("a,b\nxyz,0.00000001\ndef,1234.5678\nefg,100.2")
+
+        assert view.to_dict() == {
+            "a": ["def", "efg", "xyz"],
+            "b": [1234.5678, 100.2, 0.00000001]
+        }
+
+
+
     def test_update_append(self):
         tbl = Table([{"a": "abc", "b": 123}])
         tbl.update([{"a": "def", "b": 456}])


### PR DESCRIPTION
This PR enables direct loading of CSV strings inside `perspective-python` using the Apache Arrow-based loader used in `perspective.js`. The CSV loader uses the version of `reader.cc` shipped with Apache Arrow, and not the custom `single_threaded_reader.cpp` which is implemented for the WASM binding. During the loading of CSVs, as is the case with loading regular Arrow binaries, the GIL is released by the C++ binding.

### Changelog

- Enables and tests load & update of CSV strings in Python library
- Unifies CMake build of Arrow CSV reader files
- Fixes a bug in Python where parsing a CSV with a null column, such as `"x,y\n1,"` would cause a segfault when trying to read into an invalid `null_bitmap_data` pointer.