### PR TITLE
Static wstring_converter

### DIFF
--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -18,6 +18,10 @@ using namespace perspective;
 namespace perspective {
 namespace binding {
 
+    // Initialize static wstring -> string converter for use in `scalar_to_val`.
+    std::wstring_convert<utf8convert_type, wchar_t> _wstring_converter::CONVERTER = 
+        std::wstring_convert<utf8convert_type, wchar_t>("", L"<Invalid>");
+
     /******************************************************************************
      *
      * Utility
@@ -150,8 +154,7 @@ namespace binding {
             }
             case DTYPE_STR:
             default: {
-                std::wstring_convert<utf8convert_type, wchar_t> converter("", L"<Invalid>");
-                return t_val(converter.from_bytes(scalar.to_string()));
+                return t_val(_wstring_converter::CONVERTER.from_bytes(scalar.to_string()));
             }
         }
     }

--- a/cpp/perspective/src/include/perspective/emscripten.h
+++ b/cpp/perspective/src/include/perspective/emscripten.h
@@ -56,5 +56,19 @@ namespace binding {
     t_val scalar_to(const t_tscalar& scalar);
     t_val scalar_to_val(
         const t_tscalar& scalar, bool cast_double = false, bool cast_string = false);
+
+
+    // Create a static wstring -> string converter. Because the constructor
+    // we use (with error strings) uses a shift state that is reset before
+    // each conversion (), it should be safe to statically initialize the
+    // converter just once, especially as there are no thread safety issues
+    // (yet) to worry about in the WASM binding.
+    struct _wstring_converter {
+        // Store the static variable inside a class so it doesn't get shadowed
+        // in every .cpp file. The static variable gets initialized at the top
+        // of emscripten.cpp.
+        static std::wstring_convert<utf8convert_type, wchar_t> CONVERTER;
+    };
+
 } // namespace binding
 } // namespace perspective


### PR DESCRIPTION
In `Perspective.js`, we use an `std::wstring_convert` when converting string scalars to Javascript strings. Currently, the converter is initialized per call to `scalar_to_val`, which occurs in a tight loop - by making the converter static we should gain some performance benefits.

TODO: ascertain said performance benefits