### PR TITLE
Fixes #1340 - removes dependency on removed ipywidgets API

### DIFF
--- a/python/perspective/perspective/tests/client_mode/test_client_mode.py
+++ b/python/perspective/perspective/tests/client_mode/test_client_mode.py
@@ -330,22 +330,6 @@ class TestClient(object):
         widget.update(data)
         assert hasattr(widget, "table") is False
 
-    def test_widget_client_update_cached(self):
-        import perspective
-        assert perspective.is_libpsp() is False
-        data = {"a": [1, 2]}
-        widget = perspective.PerspectiveWidget(data)
-        mocked_post = partial(mock_post, assert_msg={
-            "cmd": "update",
-            "data": data
-        })
-        widget.post = MethodType(mocked_post, widget)
-        widget.update(data)
-        assert widget._predisplay_update_cache == [data]
-        widget._displayed = True
-        widget.update(data)
-        assert widget._predisplay_update_cache == [data]
-
     def test_widget_client_replace(self):
         import perspective
         assert perspective.is_libpsp() is False

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -263,9 +263,6 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
             ...     filter=[["a", ">", 1]],
             ...     expressions=["// new column \n \"Sales\" + \"Profit\""])
         """
-        self._displayed = False
-        self.on_displayed(self._on_display)
-
         # Trigger special flow when receiving an ArrayBuffer/binary
         self._pending_binary = None
 
@@ -281,10 +278,6 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
 
         # Pass table load options to the front-end, unless in server mode
         self._options = {}
-
-        if self.client:
-            # Cache calls to `update()` before the widget has been displayed.
-            self._predisplay_update_cache = []
 
         if index is not None and limit is not None:
             raise PerspectiveError("Index and Limit cannot be set at the same time!")
@@ -378,10 +371,6 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
         method. Otherwise, it calls `Viewer.update()` using `super()`.
         """
         if self.client is True:
-            if self._displayed is False:
-                self._predisplay_update_cache.append(data)
-                return
-
             # serialize the data and send a custom message to the browser
             if isinstance(data, pandas.DataFrame) or isinstance(data, pandas.Series):
                 data, _ = deconstruct_pandas(data)
@@ -491,13 +480,6 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
                 # return the dataset or table name to the front-end
                 msg = self._make_load_message()
                 self.send(msg.to_dict())
-
-                # In client mode, users can call `update()` before the widget
-                # is visible. This applies the updates after the viewer has
-                # loaded the initial dataset.
-                if self.client is True and len(self._predisplay_update_cache) > 0:
-                    for data in self._predisplay_update_cache:
-                        self.update(data)
             else:
                 # If the message has `binary_length` set, wait for the arrow
                 # and join it with the JSON message.
@@ -557,9 +539,3 @@ class PerspectiveWidget(Widget, PerspectiveViewer):
             raise PerspectiveError(
                 "Widget does not have any data loaded - use the `load()` method to provide it with data."
             )
-
-    def _on_display(self, widget, **kwargs):
-        """When the widget has been displayed, make sure `displayed` is set to
-        True so updates stop being cached.
-        """
-        self._displayed = True


### PR DESCRIPTION
This PR removes the use of `ipywidgets.Widget.on_displayed` from `PerspectiveWidget`, which makes `PerspectiveWidget` compatible with ipywidget >= 8.0.0.

This API was originally used for an esoteric feature: on the widget, in client mode, if the user called `widget.update` before the widget was displayed, the updates were not cached and thus silently dropped. Since the first releases of `perspective-python`, we've tremendously cleaned up our build process and now offer wheels for all platforms, which should make client mode rarely used, if at all. Thus, this feature is slated for removal to maintain our compatibility with future ipywidgets versions.
