### PR TITLE
Fix memory errors when streaming updates with expression columns

### DIFF
--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -676,6 +676,7 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> flattened_
     std::shared_ptr<t_data_table> master_expression_table = m_expression_tables->m_master;
 
     // Set the master table to the right size.
+    master_expression_table->reserve(flattened_masked->size());
     master_expression_table->set_size(flattened_masked->size());
 
     const auto& expressions = m_config.get_expressions();
@@ -698,12 +699,14 @@ t_ctx_grouped_pkey::compute_expressions(
     m_expression_tables->clear_transitional_tables();
 
     // All tables are the same size
-    m_expression_tables->set_transitional_table_capacity(flattened->size());
-    m_expression_tables->set_transitional_table_size(flattened->size());
+    t_uindex flattened_num_rows = flattened->size();
+    m_expression_tables->reserve_transitional_table_size(flattened_num_rows);
+    m_expression_tables->set_transitional_table_size(flattened_num_rows);
 
-    // Update the master expression table's capacity and size
-    m_expression_tables->m_master->set_capacity(master->get_capacity());
-    m_expression_tables->m_master->set_size(master->size());
+    // Update the master expression table's size
+    t_uindex master_num_rows = master->size();
+    m_expression_tables->m_master->reserve(master_num_rows);
+    m_expression_tables->m_master->set_size(master_num_rows);
 
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -620,7 +620,9 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     std::shared_ptr<t_data_table> master_expression_table = m_expression_tables->m_master;
 
     // Set the master table to the right size.
-    master_expression_table->set_size(flattened_masked->size());
+    t_uindex num_rows = flattened_masked->size();
+    master_expression_table->reserve(num_rows);
+    master_expression_table->set_size(num_rows);
 
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
@@ -642,12 +644,14 @@ t_ctx1::compute_expressions(
     m_expression_tables->clear_transitional_tables();
 
     // All tables are the same size
-    m_expression_tables->set_transitional_table_capacity(flattened->size());
-    m_expression_tables->set_transitional_table_size(flattened->size());
+    t_uindex flattened_num_rows = flattened->size();
+    m_expression_tables->reserve_transitional_table_size(flattened_num_rows);
+    m_expression_tables->set_transitional_table_size(flattened_num_rows);
 
-    // Update the master expression table's capacity and size
-    m_expression_tables->m_master->set_capacity(master->get_capacity());
-    m_expression_tables->m_master->set_size(master->size());
+    // Update the master expression table's size
+    t_uindex master_num_rows = master->size();
+    m_expression_tables->m_master->reserve(master_num_rows);
+    m_expression_tables->m_master->set_size(master_num_rows);
 
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {

--- a/cpp/perspective/src/cpp/context_two.cpp
+++ b/cpp/perspective/src/cpp/context_two.cpp
@@ -1052,7 +1052,9 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     std::shared_ptr<t_data_table> master_expression_table = m_expression_tables->m_master;
 
     // Set the master table to the right size.
-    master_expression_table->set_size(flattened_masked->size());
+    t_uindex num_rows = flattened_masked->size();
+    master_expression_table->reserve(num_rows);
+    master_expression_table->set_size(num_rows);
 
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
@@ -1074,12 +1076,14 @@ t_ctx2::compute_expressions(
     m_expression_tables->clear_transitional_tables();
 
     // All tables are the same size
-    m_expression_tables->set_transitional_table_capacity(flattened->size());
-    m_expression_tables->set_transitional_table_size(flattened->size());
+    t_uindex flattened_num_rows = flattened->size();
+    m_expression_tables->reserve_transitional_table_size(flattened_num_rows);
+    m_expression_tables->set_transitional_table_size(flattened_num_rows);
 
-    // Update the master expression table's capacity and size
-    m_expression_tables->m_master->set_capacity(master->get_capacity());
-    m_expression_tables->m_master->set_size(master->size());
+    // Update the master expression table's size
+    t_uindex master_num_rows = master->size();
+    m_expression_tables->m_master->reserve(master_num_rows);
+    m_expression_tables->m_master->set_size(master_num_rows);
 
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -604,7 +604,9 @@ t_ctx0::compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
     std::shared_ptr<t_data_table> master_expression_table = m_expression_tables->m_master;
 
     // Set the master table to the right size.
-    master_expression_table->set_size(flattened_masked->size());
+    t_uindex num_rows = flattened_masked->size();
+    master_expression_table->reserve(num_rows);
+    master_expression_table->set_size(num_rows);
 
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
@@ -626,12 +628,14 @@ t_ctx0::compute_expressions(
     m_expression_tables->clear_transitional_tables();
 
     // All tables are the same size
-    m_expression_tables->set_transitional_table_capacity(flattened->size());
-    m_expression_tables->set_transitional_table_size(flattened->size());
+    t_uindex flattened_num_rows = flattened->size();
+    m_expression_tables->reserve_transitional_table_size(flattened_num_rows);
+    m_expression_tables->set_transitional_table_size(flattened_num_rows);
 
-    // Update the master expression table's capacity and size
-    m_expression_tables->m_master->set_capacity(master->get_capacity());
-    m_expression_tables->m_master->set_size(master->size());
+    // Update the master expression table's size
+    t_uindex master_num_rows = master->size();
+    m_expression_tables->m_master->reserve(master_num_rows);
+    m_expression_tables->m_master->set_size(master_num_rows);
 
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {

--- a/cpp/perspective/src/cpp/expression_tables.cpp
+++ b/cpp/perspective/src/cpp/expression_tables.cpp
@@ -108,12 +108,12 @@ t_expression_tables::calculate_transitions(std::shared_ptr<t_data_table> existed
 }
 
 void
-t_expression_tables::set_transitional_table_capacity(t_uindex capacity) {
-    m_flattened->set_capacity(capacity);
-    m_prev->set_capacity(capacity);
-    m_current->set_capacity(capacity);
-    m_delta->set_capacity(capacity);
-    m_transitions->set_capacity(capacity);
+t_expression_tables::reserve_transitional_table_size(t_uindex size) {
+    m_flattened->reserve(size);
+    m_prev->reserve(size);
+    m_current->reserve(size);
+    m_delta->reserve(size);
+    m_transitions->reserve(size);
 }
 
 void

--- a/cpp/perspective/src/include/perspective/data_table.h
+++ b/cpp/perspective/src/include/perspective/data_table.h
@@ -69,7 +69,12 @@ public:
         t_uindex init_cap, t_backing_store backing_store);
     ~t_data_table();
 
-    void init();
+    /**
+     * @brief Initialize the `t_data_table`. If `make_columns` is True (the
+     * default option), construct and initialize the `t_column`s for the
+     * table.
+     */
+    void init(bool make_columns = true);
 
     const std::string& name() const;
 

--- a/cpp/perspective/src/include/perspective/expression_tables.h
+++ b/cpp/perspective/src/include/perspective/expression_tables.h
@@ -32,8 +32,19 @@ struct t_expression_tables {
     t_expression_tables(
         const std::vector<std::shared_ptr<t_computed_expression>>& expressions);
     
-    void set_transitional_table_capacity(t_uindex capacity);
+    /**
+     * @brief Reserve space on each transitional table - reserve is important
+     * because it also reserves space on each underlying column, whereas
+     * `set_capacity` only affects the table, and can lead to a situation where
+     * the table's capacity and the capacity of underlying columns grow out
+     * of sync, which causes memory errors.
+     * 
+     * @param size 
+     */
+    void reserve_transitional_table_size(t_uindex size);
+
     void set_transitional_table_size(t_uindex size);
+
     void clear_transitional_tables();
 
     // Calculate the `t_transitions` value for each row.

--- a/packages/perspective/test/js/expressions/updates.js
+++ b/packages/perspective/test/js/expressions/updates.js
@@ -126,6 +126,52 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("Expressions should respond to multiple streaming updates", async function() {
+            const table = await perspective.table({
+                x: [1.5, 2.5, 3.5, 4.5],
+                y: ["A", "B", "C", "D"]
+            });
+            const view = await table.view({
+                expressions: ["123", '//c0\n10 + "x"', '//c1\nlower("y")', `//c2\nconcat("y", ' ', 'abcd')`]
+            });
+
+            const before = await view.to_columns();
+            expect(before["123"]).toEqual(Array(4).fill(123));
+            expect(before["c0"]).toEqual([11.5, 12.5, 13.5, 14.5]);
+            expect(before["c1"]).toEqual(["a", "b", "c", "d"]);
+            expect(before["c2"]).toEqual(["A abcd", "B abcd", "C abcd", "D abcd"]);
+
+            for (let i = 0; i < 5; i++) {
+                table.update({
+                    x: [1.5, 2.5, 3.5, 4.5],
+                    y: ["A", "B", "C", "D"]
+                });
+            }
+
+            const after = await view.to_columns();
+            expect(await view.num_rows()).toEqual(24);
+            console.log(after);
+            expect(after["123"]).toEqual(Array(24).fill(123));
+            expect(after["c0"]).toEqual(
+                Array(6)
+                    .fill([11.5, 12.5, 13.5, 14.5])
+                    .flat()
+            );
+            expect(after["c1"]).toEqual(
+                Array(6)
+                    .fill([["a", "b", "c", "d"]])
+                    .flat()
+            );
+            expect(after["c2"]).toEqual(
+                Array(6)
+                    .fill([["A abcd", "B abcd", "C abcd", "D abcd"]])
+                    .flat()
+            );
+
+            view.delete();
+            table.delete();
+        });
+
         it("Conditional expressions should respond to partial updates", async function() {
             const table = await perspective.table(
                 {

--- a/packages/perspective/test/js/expressions/updates.js
+++ b/packages/perspective/test/js/expressions/updates.js
@@ -152,21 +152,34 @@ module.exports = perspective => {
             expect(await view.num_rows()).toEqual(24);
             console.log(after);
             expect(after["123"]).toEqual(Array(24).fill(123));
-            expect(after["c0"]).toEqual(
-                Array(6)
-                    .fill([11.5, 12.5, 13.5, 14.5])
-                    .flat()
-            );
-            expect(after["c1"]).toEqual(
-                Array(6)
-                    .fill([["a", "b", "c", "d"]])
-                    .flat()
-            );
-            expect(after["c2"]).toEqual(
-                Array(6)
-                    .fill([["A abcd", "B abcd", "C abcd", "D abcd"]])
-                    .flat()
-            );
+            expect(after["c0"]).toEqual([11.5, 12.5, 13.5, 14.5, 11.5, 12.5, 13.5, 14.5, 11.5, 12.5, 13.5, 14.5, 11.5, 12.5, 13.5, 14.5, 11.5, 12.5, 13.5, 14.5, 11.5, 12.5, 13.5, 14.5]);
+            expect(after["c1"]).toEqual(["a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d"]);
+            expect(after["c2"]).toEqual([
+                "A abcd",
+                "B abcd",
+                "C abcd",
+                "D abcd",
+                "A abcd",
+                "B abcd",
+                "C abcd",
+                "D abcd",
+                "A abcd",
+                "B abcd",
+                "C abcd",
+                "D abcd",
+                "A abcd",
+                "B abcd",
+                "C abcd",
+                "D abcd",
+                "A abcd",
+                "B abcd",
+                "C abcd",
+                "D abcd",
+                "A abcd",
+                "B abcd",
+                "C abcd",
+                "D abcd"
+            ]);
 
             view.delete();
             table.delete();

--- a/python/perspective/perspective/tests/table/test_view_expression.py
+++ b/python/perspective/perspective/tests/table/test_view_expression.py
@@ -6,6 +6,7 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
+from random import random
 from pytest import raises
 from datetime import date, datetime
 from time import mktime
@@ -64,6 +65,22 @@ class TestViewExpression(object):
             "computed": [6, 8, 10, 12],
         }
         assert view.expression_schema() == {"computed": float}
+
+
+    def test_view_streaming_expression(self):
+        def data():
+            return [{"a": random()} for _ in range(50)]
+
+        table = Table(data())
+        view = table.view(expressions=["123"])
+
+        for i in range(5):
+            table.update(data())
+        
+        assert table.size() == 300
+        result = view.to_dict()
+        assert result["123"] == [123 for _ in range(300)]
+
 
     def test_view_expression_create_no_alias(self):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})

--- a/python/perspective/perspective/tests/table/test_view_expression.py
+++ b/python/perspective/perspective/tests/table/test_view_expression.py
@@ -81,6 +81,43 @@ class TestViewExpression(object):
         result = view.to_dict()
         assert result["123"] == [123 for _ in range(300)]
 
+    def test_view_streaming_expression_limit(self):
+        def data():
+            return [{"a": random()} for _ in range(55)]
+
+        table = Table(data(), limit=50)
+        view = table.view(expressions=["123"])
+
+        for i in range(5):
+            table.update(data())
+        
+        assert table.size() == 50
+        result = view.to_dict()
+        assert result["123"] == [123 for _ in range(50)]
+
+    def test_view_streaming_expression_one(self):
+        def data():
+            return [{"a": random()} for _ in range(50)]
+
+        table = Table(data())
+        view = table.view(row_pivots=["c0"], expressions=['//c0\n"a" * 2'])
+
+        for i in range(5):
+            table.update(data())
+        
+        assert table.size() == 300
+
+    def test_view_streaming_expression_two(self):
+        def data():
+            return [{"a": random()} for _ in range(50)]
+
+        table = Table(data())
+        view = table.view(row_pivots=["c0"], column_pivots=["c1"], expressions=['//c0\n"a" * 2', "//c1\n'new string'"])
+
+        for i in range(5):
+            table.update(data())
+        
+        assert table.size() == 300
 
     def test_view_expression_create_no_alias(self):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})


### PR DESCRIPTION
This PR fixes a memory issue that was encountered on `streaming.js` and in Python, where trivial constructions of expression columns caused hard-to-debug memory errors in both Javascript and Python. After some debugging and generating a minimal repro in Python, I found the issue in the way we handle `capacity` and `size` for the expression tables that live on each context.

Specifically, during each cycle of computing the expressions, the code called `set_capacity` on each of the expression tables to match the capacity of `flattened`, and then `set_size` on each of the tables to match the size of `flattened`. However, setting the capacity of the `t_data_table` does not set the capacity of its `t_column` or `t_lstore` objects.

I added a call to `verify` for each expressions table and saw that the transitions table was broken, where the capacity of the column was 8 bytes (the default empty capacity) yet the size was set to 50 bytes (50 rows in the test dataset * 1 byte per `uint8_t` in the transitions column). Looking at the code of `t_lstore::reserve_impl`, it seems like the implementation chooses capacity as `max(size, capacity)` so there isn't an obvious place where the memory corruption happens.

However, replacing `set_capacity` with `reserve` - which _does_ change the capacity of the underlying columns and lstore - fixed the issue both in `streaming.js` and in the Python library. I've added a test in the Python library that fails immediately with various aborts and segfaults on master, and it fully passes consistently on this branch.

Additionally, I added a fix where the underlying `t_column`s are not allocated when the the table returned from `t_data_table::join` is created, thus preventing additional unnecessary allocation and reallocation (as the column is immediately replaced by the columns from the two input tables to `join`).