### PR TITLE
Fix Binder by updating Jupyterlab to 3.0.14 from 3.0.9

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
 ipywidgets==7.5.1
-jupyterlab==3.0.9
+jupyterlab==3.0.14
 pandas==0.25.3
 pyarrow==3.0.0


### PR DESCRIPTION
Currently our Binder examples are broken with the following error which states that "Module `@finos/perspective-jupyterlab`, Semver range `~0.9.0` is not a valid widget":

<img width="470" alt="IMG_9913" src="https://user-images.githubusercontent.com/13220267/124638646-c75edc00-debd-11eb-93fd-46499fb3c841.png">

In adding a breakpoint and checking the widget registry in JS, `@finos/perspective-jupyterlab` is not registered. This error reproduces across versions of Perspective, and could only be fixed by installing Jupyterlab `v3.0.14`. I went through the release logs and tried to find a fixed issue/enhancement pertaining to the widget registry, but did not find anything relevant. However, 3.0.14 is now no longer the newest version of Jupyterlab so this is acceptable as a fix for our public examples.