### PR TITLE
Add required dependencies for webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
         "rollup-plugin-sourcemaps": "^0.6.3",
         "rollup-plugin-string": "^3.0.0",
         "sinon": "^7.3.1",
-        "string-replace-loader": "^3.0.1",
         "style-loader": "^0.18.2",
         "term-img": "^4.1.0",
         "ts-jest": "^25.1.0",

--- a/packages/perspective-webpack-plugin/index.js
+++ b/packages/perspective-webpack-plugin/index.js
@@ -38,7 +38,7 @@ class PerspectiveWebpackPlugin {
             type: "javascript/auto",
             include: this.options.workerPath,
             use: {
-                loader: "worker-loader",
+                loader: require.resolve("worker-loader"),
                 options: {
                     filename: this.options.workerName
                 }
@@ -50,7 +50,7 @@ class PerspectiveWebpackPlugin {
             type: "javascript/auto",
             include: /monaco\-editor/,
             use: {
-                loader: "worker-loader",
+                loader: require.resolve("worker-loader"),
                 options: {
                     filename: "editor.worker.js"
                 }
@@ -66,7 +66,7 @@ class PerspectiveWebpackPlugin {
                 include: /@finos\/perspective\-vieux/,
                 use: [
                     {
-                        loader: "string-replace-loader",
+                        loader: require.resolve("string-replace-loader"),
                         options: {
                             search: /webpackMode:\s*?"eager"/g,
                             replace: ""
@@ -82,7 +82,7 @@ class PerspectiveWebpackPlugin {
                 type: "javascript/auto",
                 include: this.options.wasmPath,
                 use: {
-                    loader: "file-loader",
+                    loader: require.resolve("file-loader"),
                     options: {
                         name: this.options.wasmName
                     }
@@ -93,7 +93,7 @@ class PerspectiveWebpackPlugin {
                 test: /\.wasm$/,
                 type: "javascript/auto",
                 include: this.options.wasmPath,
-                loader: "arraybuffer-loader"
+                loader: require.resolve("arraybuffer-loader")
             });
         }
 
@@ -101,9 +101,9 @@ class PerspectiveWebpackPlugin {
             test: /\.css$/,
             include: /monaco\-editor/,
             use: [
-                {loader: "css-loader", options: {sourceMap: false}},
+                {loader: require.resolve("css-loader"), options: {sourceMap: false}},
                 {
-                    loader: "postcss-loader",
+                    loader: require.resolve("postcss-loader"),
                     options: {
                         sourceMap: false,
                         postcssOptions: {
@@ -124,7 +124,7 @@ class PerspectiveWebpackPlugin {
         rules.push({
             test: /\.ttf$/,
             include: /monaco\-editor/,
-            use: ["file-loader"]
+            use: [require.resolve("file-loader")]
         });
 
         const perspective_config = get_config();
@@ -134,7 +134,7 @@ class PerspectiveWebpackPlugin {
                 include: /perspective[\\/].+?[\\/]config[\\/]index\.js$/,
                 use: [
                     {
-                        loader: "string-replace-loader",
+                        loader: require.resolve("string-replace-loader"),
                         options: {
                             search: "global.__TEMPLATE_CONFIG__",
                             replace: JSON.stringify(perspective_config, null, 4)

--- a/packages/perspective-webpack-plugin/package.json
+++ b/packages/perspective-webpack-plugin/package.json
@@ -23,12 +23,14 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
+        "arraybuffer-loader": "^1.0.2",
         "css-loader": "^0.28.7",
         "cssnano": "^4.1.10",
         "cssnano-preset-lite": "^1.0.1",
         "file-loader": "^2.0.0",
         "postcss": "^8.2.6",
         "postcss-loader": "^4.1.0",
+        "string-replace-loader": "^3.0.1",
         "worker-loader": "^3.0.7"
     },
     "peerDependencies": {


### PR DESCRIPTION
- Resolve loaders relative to the current package location to ensure that the `perspective` version of loaders is picked up. 
- Add required dependencies for webpack plugin, currently when installing into a repository without `string-replace-loader` builds will start failing due to the missing dependency. 