### PR TITLE
Preload fonts

### DIFF
--- a/docs/js/concepts.js
+++ b/docs/js/concepts.js
@@ -3,6 +3,10 @@ import perspective from "@finos/perspective";
 const worker = perspective.shared_worker();
 
 async function main() {
+    if (window.location.pathname === "/" || window.location.pathname === "/index.html") {
+        return;
+    }
+
     const arrow = await fetch("../../arrow/superstore.arrow");
     const table = await worker.table(await arrow.arrayBuffer());
 

--- a/docs/js/examples.js
+++ b/docs/js/examples.js
@@ -35,8 +35,10 @@ async function run_with_theme(page, is_dark = false) {
     </perspective-viewer>
     <script>
         const WORKER = window.perspective.worker();
-        function on_load() {
+        async function on_load() {
             var el = document.getElementsByTagName('perspective-viewer')[0];
+            const plugin = await el._vieux.get_plugin("Heatmap");
+            plugin.render_warning = false;
             WORKER.table(this.response).then(table => {
                 el.load(table);
                 el.toggleConfig();

--- a/docs/js/features.js
+++ b/docs/js/features.js
@@ -846,5 +846,17 @@ exports.EXAMPLES = [
             sort: [["Discount", "col asc"]]
         },
         viewport: {width: 600, height: 450}
+    },
+    {
+        name: "Heatmap 4",
+        config: {
+            plugin: "Heatmap",
+            columns: ["Profit"],
+            expressions: ['bucket("Profit", 100)', "bucket(\"Order Date\", 'M')"],
+            "row-pivots": ["bucket(\"Order Date\", 'M')"],
+            "column-pivots": ['bucket("Profit", 100)'],
+            plugin_config: {}
+        },
+        viewport: {width: 600, height: 450}
     }
 ];

--- a/docs/js/fonts.js
+++ b/docs/js/fonts.js
@@ -1,0 +1,7 @@
+const WebFont = require("webfontloader");
+
+WebFont.load({
+    google: {
+        families: ["Roboto Mono:200,400", "Material Icons", "Orbitron:900", "Open Sans:300,400"]
+    }
+});

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -177,6 +177,12 @@ function get_arrow(callback) {
 }
 
 window.addEventListener("DOMContentLoaded", async function() {
+    for (const img of document.querySelectorAll("img")) {
+        if (img.dataset.src) {
+            img.setAttribute("src", img.dataset.src);
+        }
+    }
+
     if (window.location.pathname !== "/" && window.location.pathname !== "/index.html") {
         return;
     }

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -11,8 +11,36 @@ import {appendChild} from "domutils";
 import {div} from "prelude-ls";
 import {getEffectiveConstraintOfTypeParameter} from "typescript";
 
-var SECURITIES = ["AAPL.N", "MSFT.N", "AMZN.N", "GOOGL.N", "FB.N", "TSLA.N", "BABA.N", "TSM.N", "V.N", "NVDA.N", "JPM.N", "JNJ.N", "WMT.N", "UNH.N", "MA.N", "BAC.N"];
-var CLIENTS = ["Homer", "Marge", "Bart", "Lisa", "Maggie"];
+var SECURITIES = [
+    "AAPL.N",
+    "MSFT.N",
+    "AMZN.N",
+    "GOOGL.N",
+    "FB.N",
+    "TSLA.N",
+    "BABA.N",
+    "TSM.N",
+    "V.N",
+    "NVDA.N",
+    "JPM.N",
+    "JNJ.N",
+    "WMT.N",
+    "UNH.N",
+    "MA.N",
+    "BAC.N",
+    "DIS.N",
+    "ASML.N",
+    "ADBE.N",
+    "CMCSA.N",
+    "NKE.N",
+    "XOM.N",
+    "TM.N",
+    "KO.N",
+    "ORCL.N",
+    "NFLX.N"
+];
+
+var CLIENTS = ["Homer", "Marge", "Bart", "Lisa", "Maggie", "Barney", "Ned", "Moe"];
 var id = 0;
 
 function randn_bm() {
@@ -24,7 +52,7 @@ function randn_bm() {
 }
 
 function newRow() {
-    id = id % 500;
+    id = id % 1000;
     return {
         name: SECURITIES[Math.floor(Math.random() * SECURITIES.length)],
         client: CLIENTS[Math.floor(Math.random() * CLIENTS.length)],
@@ -37,39 +65,18 @@ function newRow() {
     };
 }
 
-var styleElement = document.createElement("style");
-styleElement.innerText = `
-.homeContainer perspective-viewer, perspective-viewer {
-    box-shadow: none !important;
-    overflow: visible !important;
-    --plugin--box-shadow:  0 2px 4px 0 rgb(0 0 0 / 10%);
-}
-
-.homeContainer perspective-viewer {
-    background: none !important;
-}`;
-
-document.head.appendChild(styleElement);
-
-var freq = 1,
-    freqdir = 1,
+var freq = 100,
     elem;
 
 function update(table) {
-    var viewport_height = document.documentElement.clientHeight;
-    if (viewport_height - window.scrollY > 0) {
-        table.update([newRow(), newRow(), newRow()]);
+    if (freq !== 190) {
+        var viewport_height = document.documentElement.clientHeight;
+        if (viewport_height - window.scrollY > 0) {
+            table.update([newRow(), newRow(), newRow()]);
+        }
     }
-    // if (freq === 0) {
-    //     setTimeout(() => update(table), 3000);
-    //     // freqdir = 1;
-    // } else {
-    setTimeout(() => update(table), 100);
-    // }
-    // if (freq > 60) {
-    //     freqdir = -1;
-    // }
-    // freq += freqdir;
+
+    setTimeout(() => update(table), freq);
 }
 
 function select(id) {
@@ -175,7 +182,7 @@ window.addEventListener("DOMContentLoaded", async function() {
     }
 
     var data = [];
-    for (var x = 0; x < 500; x++) {
+    for (var x = 0; x < 1000; x++) {
         data.push(newRow());
     }
     elem = Array.prototype.slice.call(document.querySelectorAll("perspective-viewer"))[0];
@@ -188,13 +195,17 @@ window.addEventListener("DOMContentLoaded", async function() {
         update(tbl, 0);
     });
 
-    document.querySelector("#grid").addEventListener("mouseenter", () => select("#grid"));
-    document.querySelector("#grid2").addEventListener("mouseenter", () => select("#grid2"));
-    document.querySelector("#cyclone").addEventListener("mouseenter", () => select("#cyclone"));
-    document.querySelector("#pivot").addEventListener("mouseenter", () => select("#pivot"));
-    document.querySelector("#crosssect").addEventListener("mouseenter", () => select("#crosssect"));
-    document.querySelector("#intersect").addEventListener("mouseenter", () => select("#intersect"));
-    document.querySelector("#enhance").addEventListener("mouseenter", () => select("#enhance"));
+    document.querySelector("#velocity").addEventListener("input", function(event) {
+        freq = (-9 / 5) * this.value + 190;
+    });
+
+    document.querySelector("#grid").addEventListener("mousedown", () => select("#grid"));
+    document.querySelector("#grid2").addEventListener("mousedown", () => select("#grid2"));
+    document.querySelector("#cyclone").addEventListener("mousedown", () => select("#cyclone"));
+    document.querySelector("#pivot").addEventListener("mousedown", () => select("#pivot"));
+    document.querySelector("#crosssect").addEventListener("mousedown", () => select("#crosssect"));
+    document.querySelector("#intersect").addEventListener("mousedown", () => select("#intersect"));
+    document.querySelector("#enhance").addEventListener("mousedown", () => select("#enhance"));
 
     select("#grid");
 

--- a/docs/pages/en/index.js
+++ b/docs/pages/en/index.js
@@ -51,7 +51,7 @@ const SplashContainer = props => (
 
 const Logo = props => (
     <div className="projectLogo">
-        <img src={props.img_src} />
+        <img data-src={props.img_src} />
     </div>
 );
 
@@ -157,7 +157,7 @@ const GalleryBlock = props => {
         .map((user, i) => {
             return (
                 <a href={user.infoLink} key={i}>
-                    <img style={{width: "33.3%"}} src={user.image} alt={user.caption} title={user.caption} />
+                    <img style={{width: "33.3%"}} data-src={user.image} alt={user.caption} title={user.caption} />
                 </a>
             );
         });
@@ -451,7 +451,7 @@ const Showcase = props => {
             return (
                 <a href={user.infoLink} key={i}>
                     <h4>{user.caption}</h4>
-                    <img src={user.image} alt={user.caption} title={user.caption} />
+                    <img data-src={user.image} alt={user.caption} title={user.caption} />
                 </a>
             );
         });
@@ -472,7 +472,7 @@ const ChartTypes = props => {
     const showcase_light = Array.from(Array(75).keys()).map((user, i) => {
         return (
             <a className="feature" key={i} data-key={i}>
-                <img src={`features/feature_${i}.png`} />
+                <img data-src={`features/feature_${i}.png`} />
             </a>
         );
     });
@@ -480,7 +480,7 @@ const ChartTypes = props => {
     const showcase_dark = Array.from(Array(75).keys()).map((user, i) => {
         return (
             <a className="feature" key={i} data-key={i}>
-                <img src={`features/feature_${i}_dark.png`} />
+                <img data-src={`features/feature_${i}_dark.png`} />
             </a>
         );
     });

--- a/docs/pages/en/index.js
+++ b/docs/pages/en/index.js
@@ -90,6 +90,7 @@ class HomeSplash extends React.Component {
                         <Button id="intersect">Treemap</Button>
                         <Button id="pivot">Heatmap</Button>
                     </PromoSection>
+                    <input id="velocity" type="range" class="slider"></input>
                 </div>
             </SplashContainer>
         );
@@ -468,7 +469,7 @@ const ChartTypes = props => {
         return null;
     }
 
-    const showcase_light = Array.from(Array(74).keys()).map((user, i) => {
+    const showcase_light = Array.from(Array(75).keys()).map((user, i) => {
         return (
             <a className="feature" key={i} data-key={i}>
                 <img src={`features/feature_${i}.png`} />
@@ -476,7 +477,7 @@ const ChartTypes = props => {
         );
     });
 
-    const showcase_dark = Array.from(Array(74).keys()).map((user, i) => {
+    const showcase_dark = Array.from(Array(75).keys()).map((user, i) => {
         return (
             <a className="feature" key={i} data-key={i}>
                 <img src={`features/feature_${i}_dark.png`} />

--- a/docs/siteConfig.js
+++ b/docs/siteConfig.js
@@ -78,14 +78,14 @@ const siteConfig = {
     highlight: {
         theme: "atom-one-light"
     },
-    scripts: ["https://buttons.github.io/buttons.js", "js/index.js"],
-    stylesheets: [
-        "https://fonts.googleapis.com/css?family=Material+Icons",
-        "https://fonts.googleapis.com/css?family=Open+Sans",
-        "https://fonts.googleapis.com/css?family=Public+Sans",
-        "https://fonts.googleapis.com/css?family=Roboto+Mono",
-        "https://fonts.googleapis.com/css2?family=Orbitron:wght@900"
-    ],
+    scripts: ["js/fonts.js", "https://buttons.github.io/buttons.js", "js/index.js"],
+    // stylesheets: [
+    //     "https://fonts.googleapis.com/css?family=Material+Icons",
+    //     "https://fonts.googleapis.com/css?family=Open+Sans",
+    //     "https://fonts.googleapis.com/css?family=Public+Sans",
+    //     "https://fonts.googleapis.com/css?family=Roboto+Mono",
+    //     "https://fonts.googleapis.com/css2?family=Orbitron:wght@900"
+    // ],
     onPageNav: "separate",
     ogImage: "img/perspective.png",
     twitterImage: "img/perspective.png"

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -164,6 +164,50 @@ h2.headerTitle {
 }
 
 .homeContainer perspective-viewer, perspective-viewer {
+    box-shadow: none !important;
+    /* overflow: visible !important; */
+    --plugin--box-shadow:  0 2px 4px 0 rgb(0 0 0 / 10%);
+}
+
+.slider {
+    margin-top: 12px;
+    width: 200px;
+    -webkit-appearance: none;
+    height: 10px;
+    border-radius: 5px;  
+    background: rgba(0,0,0,0.5);
+    border-color: #f9f9f9;
+    border: 1px solid #666;
+    outline: none;
+    opacity: 0.7;
+    -webkit-transition: .2s;
+    transition: opacity .2s;
+  }
+  
+  .slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%; 
+    background: #242526;
+    border: 1px solid #666;
+    cursor: pointer;
+  }
+  
+  .slider::-moz-range-thumb {
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    background: #04AA6D;
+    cursor: pointer;
+  }
+
+.homeContainer perspective-viewer {
+    background: none !important;
+}
+
+.homeContainer perspective-viewer, perspective-viewer {
     --d3fc-full--gradient: linear-gradient(#4d342f 0%, #e4521b 22.5%, #feeb65 42.5%, #f0f0f0 50%, #dcedc8 57.5%, #42b3d5 67.5%, #1a237e 100%);
     --d3fc-positive--gradient: linear-gradient(#222222 0%, #1a237e 35%, #42b3d5 70%, #dcedc8 100%);
     --d3fc-negative--gradient: linear-gradient(#feeb65 0%, #e4521b 35%, #4d342f 70%, #222222 100%);

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -21,6 +21,10 @@ body {
     background: #242526;
 }
 
+.homeContainer .projectTitle {
+    font-family: "Open Sans";
+}
+
 .darkBackground, .darkBackground perspective-viewer {
     background-color: #242526 !important;
 }
@@ -84,7 +88,7 @@ body {
 }
 
 h2.headerTitle {
-    font-family: "Public Sans", Arial, Helvetica, sans-serif;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
     color: #f9f9f9 !important;
     transition: opacity 0.1s ease-in;
 }
@@ -98,7 +102,7 @@ h2.headerTitle {
 }
 
 .logo {
-    font-family: "Public Sans", Arial, Helvetica, sans-serif;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
     height: 50% !important;
     opacity: 0;
     transition: opacity 0.2s;
@@ -133,7 +137,7 @@ h2.headerTitle {
 
 .homeContainer .projectTitle {
     color: #f9f9f9;
-    font-family: "Public Sans";
+    font-family: "Open Sans";
 }
 
 .homeContainer .projectTitle i {
@@ -309,12 +313,12 @@ ol li::before {
     content: counter(list-counter) ".";
     font-weight: bold;
     margin-right: 0.5rem;
-    font-family: "Public Sans", Arial, Helvetica, sans-serif;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
     line-height: 1;
 }
 
 h1, h2, h3, h4, h5, h6 {
-    font-family: "Public Sans", Arial, Helvetica, sans-serif;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
 }
 
 h1, h2 {
@@ -322,7 +326,7 @@ h1, h2 {
 }
 
 p, span, oi, li {
-    font-family: "Public Sans", Arial, Helvetica, sans-serif;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
 }
 
 code *, pre * {

--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -2,39 +2,80 @@ const path = require("path");
 // const common = require("@finos/perspective/src/config/common.config.js");
 const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
 
-module.exports = {
-    mode: process.env.NODE_ENV || "development",
-    entry: "./js/index.js",
-    output: {
-        filename: "index.js",
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "static/js")
+module.exports = [
+    {
+        mode: process.env.NODE_ENV || "development",
+        entry: "./js/index.js",
+        output: {
+            filename: "index.js",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "static/js")
+        },
+        plugins: [new PerspectivePlugin({})],
+        module: {
+            rules: [
+                {
+                    test: /\.js$/,
+                    enforce: "pre",
+                    use: ["source-map-loader"]
+                },
+                {
+                    test: /\.less$/,
+                    use: [{loader: "style-loader"}, {loader: "css-loader"}, {loader: "less-loader"}]
+                },
+                {
+                    test: /\.(png|jpe?g|gif)$/i,
+                    use: [
+                        {
+                            loader: "file-loader"
+                        }
+                    ]
+                }
+            ]
+        },
+        devServer: {
+            contentBase: [path.join(__dirname, "dist"), path.join(__dirname, "../../node_modules/superstore-arrow")]
+        },
+        devtool: "source-map",
+        ignoreWarnings: [/Failed to parse source map/],
+        experiments: {
+            syncWebAssembly: true
+        }
     },
-    plugins: [new PerspectivePlugin({})],
-    module: {
-        rules: [
-            {
-                test: /\.js$/,
-                enforce: "pre",
-                use: ["source-map-loader"]
-            },
-            {
-                test: /\.less$/,
-                use: [{loader: "style-loader"}, {loader: "css-loader"}, {loader: "less-loader"}]
-            },
-            {
-                test: /\.(png|jpe?g|gif)$/i,
-                use: [
-                    {
-                        loader: "file-loader"
-                    }
-                ]
-            }
-        ]
-    },
-    devServer: {
-        contentBase: [path.join(__dirname, "dist"), path.join(__dirname, "../../node_modules/superstore-arrow")]
-    },
-    devtool: "source-map",
-    ignoreWarnings: [/Failed to parse source map/]
-};
+    {
+        mode: process.env.NODE_ENV || "development",
+        entry: "./js/fonts.js",
+        output: {
+            filename: "fonts.js",
+            libraryTarget: "umd",
+            path: path.resolve(__dirname, "static/js")
+        }
+        // plugins: [new PerspectivePlugin({})],
+        // module: {
+        //     rules: [
+        // {
+        //     test: /\.js$/,
+        //     enforce: "pre",
+        //     use: ["source-map-loader"]
+        // },
+        // {
+        //     test: /\.less$/,
+        //     use: [{loader: "style-loader"}, {loader: "css-loader"}, {loader: "less-loader"}]
+        // },
+        // {
+        //     test: /\.(png|jpe?g|gif)$/i,
+        //     use: [
+        //         {
+        //             loader: "file-loader"
+        //         }
+        //     ]
+        // }
+        //     ]
+        // },
+        // devServer: {
+        //     contentBase: [path.join(__dirname, "dist"), path.join(__dirname, "../../node_modules/superstore-arrow")]
+        // },
+        // devtool: "source-map",
+        // ignoreWarnings: [/Failed to parse source map/]
+    }
+];

--- a/examples/blocks/src/citibike/index.html
+++ b/examples/blocks/src/citibike/index.html
@@ -1,6 +1,10 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+
+        <script src="https://cdn.jsdelivr.net/npm/webfontloader"></script>
+        <script>WebFont.load({google:{families:["Roboto Mono:200,400","Material Icons","Open Sans:300,400"]}})</script>
+
         <link rel='stylesheet' href="/node_modules/@finos/perspective-workspace/dist/umd/material.css">
         <link rel='stylesheet' href="index.css"> 
       

--- a/examples/blocks/src/csv/index.html
+++ b/examples/blocks/src/csv/index.html
@@ -5,6 +5,9 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
 
+    <script src="https://cdn.jsdelivr.net/npm/webfontloader"></script>
+    <script>WebFont.load({google:{families:["Roboto Mono:200,400","Material Icons","Open Sans:300,400"]}})</script>
+
     <script src="/node_modules/@finos/perspective/dist/umd/perspective.js"></script>
     <script src="/node_modules/@finos/perspective-viewer/dist/umd/perspective-viewer.js"></script>
     <script src="/node_modules/@finos/perspective-viewer-datagrid/dist/umd/perspective-viewer-datagrid.js"></script>

--- a/examples/blocks/src/editable/index.html
+++ b/examples/blocks/src/editable/index.html
@@ -13,6 +13,9 @@
 <head>
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+    
+    <script src="https://cdn.jsdelivr.net/npm/webfontloader"></script>
+    <script>WebFont.load({google:{families:["Roboto Mono:200,400","Material Icons","Open Sans:300,400"]}})</script>
 
     <script src="/node_modules/@finos/perspective/dist/umd/perspective.js"></script>
     <script src="/node_modules/@finos/perspective-viewer/dist/umd/perspective-viewer.js"></script>

--- a/examples/blocks/src/movies/index.html
+++ b/examples/blocks/src/movies/index.html
@@ -1,6 +1,10 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+
+        <script src="https://cdn.jsdelivr.net/npm/webfontloader"></script>
+        <script>WebFont.load({google:{families:["Roboto Mono:200,400","Material Icons","Open Sans:300,400"]}})</script>
+
         <link rel='stylesheet' href="/node_modules/@finos/perspective-workspace/dist/umd/material.dark.css">
       
         <script src="/node_modules/@finos/perspective-workspace/dist/umd/perspective-workspace.js"></script>

--- a/examples/blocks/src/olympics/index.html
+++ b/examples/blocks/src/olympics/index.html
@@ -1,6 +1,10 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+
+        <script src="https://cdn.jsdelivr.net/npm/webfontloader"></script>
+        <script>WebFont.load({google:{families:["Roboto Mono:200,400","Material Icons","Open Sans:300,400"]}})</script>
+
         <link rel='stylesheet' href="/node_modules/@finos/perspective-workspace/dist/umd/material.css">
       
         <script src="/node_modules/@finos/perspective-workspace/dist/umd/perspective-workspace.js"></script>

--- a/examples/blocks/src/streaming/index.html
+++ b/examples/blocks/src/streaming/index.html
@@ -5,6 +5,9 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
 
+    <script src="https://cdn.jsdelivr.net/npm/webfontloader"></script>
+    <script>WebFont.load({google:{families:["Roboto Mono:200,400","Material Icons","Open Sans:300,400"]}})</script>
+
     <script src="/node_modules/@finos/perspective/dist/umd/perspective.js"></script>
     <script src="/node_modules/@finos/perspective-viewer/dist/umd/perspective-viewer.js"></script>
     <script src="/node_modules/@finos/perspective-viewer-datagrid/dist/umd/perspective-viewer-datagrid.js"></script>

--- a/examples/blocks/src/superstore/index.html
+++ b/examples/blocks/src/superstore/index.html
@@ -2,6 +2,9 @@
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
 
+        <script src="https://cdn.jsdelivr.net/npm/webfontloader"></script>
+        <script>WebFont.load({google:{families:["Roboto Mono:200,400","Material Icons","Open Sans:300,400"]}})</script>
+
         <link rel='stylesheet' href="/node_modules/@finos/perspective-workspace/dist/umd/material.css">
 
         <script src="/node_modules/@finos/perspective-workspace/dist/umd/perspective-workspace.js"></script>

--- a/examples/blocks/src/workspace/index.html
+++ b/examples/blocks/src/workspace/index.html
@@ -13,7 +13,9 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
 
-    <!-- <script src="perspective-viewer.js"></script> -->
+    <script src="https://cdn.jsdelivr.net/npm/webfontloader"></script>
+    <script>WebFont.load({google:{families:["Roboto Mono:200,400","Material Icons","Open Sans:300,400"]}})</script>
+
     <script src="perspective-workspace.js"></script>
     <script src="perspective-viewer-datagrid.js"></script>
     <script src="perspective-viewer-d3fc.js"></script>

--- a/examples/workspace/src/index.html
+++ b/examples/workspace/src/index.html
@@ -2,6 +2,10 @@
 <html>
   <head>
     <meta charset="UTF-8">
+
+    <script src="https://cdn.jsdelivr.net/npm/webfontloader"></script>
+    <script>WebFont.load({google:{families:["Roboto Mono:200,400","Material Icons","Open Sans:300,400"]}})</script>
+
   </head>
   <body>
     <perspective-workspace id="workspace">

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
         "ts-jest": "^25.1.0",
         "ts-loader": "^6.2.0",
         "typescript": "^3.7.4",
+        "webfontloader": "^1.6.28",
         "webpack": "^5.14.0",
         "webpack-cli": "^4.3.1",
         "webpack-dev-server": "^3.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17073,6 +17073,11 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
+webfontloader@^1.6.28:
+  version "1.6.28"
+  resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
+  integrity sha1-23hhKSU8tujq5UwvsF+HCvZnW64=
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
* Adds [`webfontloader`](https://github.com/typekit/webfontloader) font loading for `docs` and `examples` projects that use the Material themes, in order to suppress [FOUT](https://css-tricks.com/fout-foit-foft/).
* Couples `.view()` and `draw()` calls within the same transaction, such that updates which are queue-d do not render.
* Adds a throttle control to the `docs` site, so users can disable the animation if they wish (or speed it up).  Also changes hover-activate chart type buttons into click-activate.