### PR TITLE
Remove filter limit

### DIFF
--- a/packages/perspective-viewer/src/js/viewer/dom_element.js
+++ b/packages/perspective-viewer/src/js/viewer/dom_element.js
@@ -103,9 +103,7 @@ export class DomElement extends PerspectiveElement {
 
                         if (nrows < 100000) {
                             // Autocomplete
-                            const json = await view.to_json({
-                                end_row: 10
-                            });
+                            const json = await view.to_json();
                             row.choices(this._autocomplete_choices(json, type));
                         } else {
                             console.warn(`perspective-viewer did not generate autocompletion results - ${nrows} is greater than limit of 100,000 rows.`);


### PR DESCRIPTION
Reverts filter limiting behavior of #1282.  This behavior is not present on the #1488 branch, but in order to alleviate upgrade hurdles, this PR backports this change to `v0.10.x`.