### PR TITLE
Add new aggregates to ViewConfig enum

### DIFF
--- a/packages/perspective/test/js/expressions/conversions.js
+++ b/packages/perspective/test/js/expressions/conversions.js
@@ -708,7 +708,7 @@ module.exports = perspective => {
                     line: 0
                 },
                 computed5: {
-                    error_message: "Parser Error - Failed parameter type check for function 'datetime', Expected 'T'  call set: 'TT'",
+                    error_message: "Parser Error - Failed parameter type check for function 'datetime', Expected 'T' call set: 'TT'",
                     column: 21,
                     line: 1
                 }

--- a/rust/perspective-vieux/src/rust/config/view_config.rs
+++ b/rust/perspective-vieux/src/rust/config/view_config.rs
@@ -148,8 +148,8 @@ pub enum SingleAggregate {
     #[serde(rename = "median")]
     Median,
 
-    #[serde(rename = "first")]
-    First,
+    #[serde(rename = "first by index")]
+    FirstByIndex,
 
     #[serde(rename = "last by index")]
     LastByIndex,
@@ -177,6 +177,12 @@ pub enum SingleAggregate {
 
     #[serde(rename = "low")]
     Low,
+
+    #[serde(rename = "stddev")]
+    StdDev,
+
+    #[serde(rename = "var")]
+    Var,
 }
 
 impl Display for SingleAggregate {


### PR DESCRIPTION
This fixes an issue where some aggregates (`stddev`, `var`, and `first by index`) are not working in the viewer because they were not added to the `ViewConfig` aggregate in `perspective-vieux`.