### PR TITLE
Fix M1 (Apple Silicon) build for `perspective-python` and improve developer docs

### DIFF
--- a/cmake/modules/FindFlatbuffers.cmake
+++ b/cmake/modules/FindFlatbuffers.cmake
@@ -42,13 +42,13 @@ if (WIN32)
 else()
   find_path(FLATBUFFERS_INCLUDE_DIR flatbuffers/flatbuffers.h
     PATHS ${FLATBUFFERS_ROOT}/include
-    HINTS /usr/local /usr/local/flatbuffers /usr/local/Homebrew /usr ~/homebrew/ /usr/local/include /usr/local/flatbuffers/include /usr/include ~/homebrew/include
+    HINTS /usr/local /usr/local/flatbuffers /usr/local/Homebrew /usr ~/homebrew/ /usr/local/include /usr/local/flatbuffers/include /usr/include ~/homebrew/include /opt/homebrew/include
     NO_CMAKE_SYSTEM_PATH
     NO_SYSTEM_ENVIRONMENT_PATH)
 
   find_program(FLATBUFFERS_COMPILER flatc
     PATHS ${FLATBUFFERS_ROOT}/bin
-    HINTS /usr/local/bin /usr/bin /usr/local/Homebrew/bin ~/homebrew/bin
+    HINTS /usr/local/bin /usr/bin /usr/local/Homebrew/bin ~/homebrew/bin /opt/homebrew/bin
     NO_CMAKE_SYSTEM_PATH
     NO_SYSTEM_ENVIRONMENT_PATH)
 

--- a/docs/md/development.md
+++ b/docs/md/development.md
@@ -128,12 +128,7 @@ To build the Python library, first configure your project to Python via
 yarn build
 ```
 
-`perspective-python` supports Python 3.7 and upwards, as well as Python 2.7.17.
-To build the Python 2 version of the library, use the `--python2` flag:
-
-```bash
-yarn build --python2
-```
+`perspective-python` supports Python 3.7 and upwards.
 
 ## System-Specific Instructions
 
@@ -143,19 +138,12 @@ Install system dependencies through Homebrew:
 
 ```bash
 brew install cmake
-brew install boost@1.67
+brew install boost
 brew install flatbuffers
 ```
 
-#### `perspective-python`
-
-If you're building the Python 2 version of the library, make sure your version
-of Python 2 is the latest version (`2.7.17`) supplied by Homebrew, and not the
-earlier version that ships with MacOS. To install Python 2 using Homebrew:
-
-```bash
-brew install python2
-```
+On M1 (Apple Silicon) systems, make sure your brew-installed dependencies are in
+`/opt/homebrew` (the default location), and that `/opt/homebrew/bin` is on the `PATH`.
 
 ### Windows 10
 

--- a/docs/md/development.md
+++ b/docs/md/development.md
@@ -22,7 +22,16 @@ To switch your development toolchain between the two, use `yarn setup`. Once the
 setup script has been run, common commands like `yarn build` and `yarn test`
 automatically call the correct build and test tools.
 
-## Building
+### System Dependencies
+
+`Perspective.js` and `perspective-python` **require** the following system dependencies to be installed:
+
+- [CMake](https://cmake.org/) (version 3.15.4 or higher)
+- [Boost](https://www.boost.org/) (version 1.67 or higher, must be built - not header-only)
+- [Flatbuffers](https://google.github.io/flatbuffers/flatbuffers_guide_building.html)
+## Build
+
+Make sure you have the system dependencies installed. For specifics depending on your OS, check the [system-specific instructions](#system-specific-instructions) below.
 
 To run a build, use
 
@@ -43,21 +52,6 @@ packages, e.g. `examples/simple` like so:
 ```bash
 yarn start simple
 ```
-
-#### Docker
-
-[Docker](https://docs.docker.com/install/) images with pre-built development
-environments are provided for the Python libraries.
-
-To build Perspective using Docker, select the option in `yarn setup`.
-
-### System Dependencies
-
-`Perspective.js` and `perspective-python` **require** the following system dependencies to be installed:
-
-- [CMake](https://cmake.org/) (version 3.15.4 or higher)
-- [Boost](https://www.boost.org/) (version 1.67 or higher, must be built - not header-only)
-- [Flatbuffers](https://google.github.io/flatbuffers/flatbuffers_guide_building.html)
 
 ## `Perspective.js`
 
@@ -91,6 +85,8 @@ To install this specific version of Emscripten:
 ./emsdk install 2.0.6
 ```
 
+---
+
 ### `perspective-jupyterlab`
 
 To install the Jupyterlab plugin from your local working directory, give
@@ -119,9 +115,11 @@ when it looks for Perspective packages, instead of fetching them from NPM.
 5. Whenever you run `jupyter lab clean`, you will need to run `yarn jlab_link`
 again to re-register the symlinks.
 
+---
+
 ## `perspective-python`
 
-To build the Python library, first configure your project to Python via
+To build the Python library, first configure your project to build Python via
 `yarn setup`, then run:
 
 ```bash
@@ -130,6 +128,14 @@ yarn build
 
 `perspective-python` supports Python 3.7 and upwards.
 
+### Docker
+
+[Docker](https://docs.docker.com/install/) images with pre-built development
+environments are provided for the Python libraries.
+
+To build Perspective using Docker, select the option in `yarn setup`.
+
+---
 ## System-Specific Instructions
 
 ### MacOS/OSX
@@ -180,7 +186,9 @@ ln -s /usr/local/flatbuffers/flatc /usr/local/bin/flatc
 chmod +x /usr/local/flatbuffers/flatc
 ```
 
-## Testing
+---
+
+## Test
 
 You can run the test suite simply with the standard NPM command, which will both
 build the test suite for every package and run them.
@@ -277,7 +285,9 @@ correct this, run tests with the `TZ=UTC`, i.e.
 TZ=UTC yarn test --verbose
 ```
 
-## Benchmarking
+---
+
+## Benchmark
 
 You can generate benchmarks specific to your machine's OS and CPU architecture
 with Perspective's benchmark suite, which will generate a `report.html` file in

--- a/scripts/lint_python.js
+++ b/scripts/lint_python.js
@@ -10,8 +10,7 @@ const {execute, docker, resolve, getarg, python_image} = require("./script_utils
 
 const IS_DOCKER = process.env.PSP_DOCKER;
 const IS_PY2 = getarg("--python2");
-const PYTHON = IS_PY2 ? "python2" : getarg("--python38") ? "python3.8" : getarg("--python36") ? "python3.6" : "python3.7";
-
+let PYTHON = IS_PY2 ? "python2" : getarg("--python38") ? "python3.8" : getarg("--python36") ? "python3.6" : "python3.7";
 let IMAGE = "manylinux2014";
 
 if (IS_DOCKER) {
@@ -25,6 +24,14 @@ if (IS_DOCKER) {
 }
 
 const IS_FIX = getarg("--fix");
+
+// Check that the `PYTHON` command is valid, else default to `python`.
+try {
+    execute_throw`${PYTHON} --version`;
+} catch (e) {
+    console.warn(`\`${PYTHON}\` not found - using \`python\` instead.`);
+    PYTHON = "python";
+}
 
 try {
     let cmd;

--- a/scripts/test_python.js
+++ b/scripts/test_python.js
@@ -76,6 +76,14 @@ try {
     PYTHON = "python";
 }
 
+// Check that the `PYTHON` command is valid, else default to `python`.
+try {
+    execute_throw`${PYTHON} --version`;
+} catch (e) {
+    console.warn(`\`${PYTHON}\` not found - using \`python\` instead.`);
+    PYTHON = "python";
+}
+
 try {
     execute(pytest_client_mode(IS_DOCKER));
     execute(pytest(IS_DOCKER));


### PR DESCRIPTION
This PR fixes the build for `perspective-python` on Apple's M1 architecture by fixing the Flatbuffer find path to use `opt/homebrew`, the default install location for M1. We don't currently publish any M1 wheels but following the [developer documentation](https://perspective.finos.org/docs/md/development.html) will lead to a successful installation.

The developer docs are also improved in this PR to give it a more readable structure + remove deprecated docs about Python 2.