### PR TITLE
Fix column section collapse with expressions

### DIFF
--- a/rust/perspective-viewer/src/rust/components/column_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector.rs
@@ -246,7 +246,9 @@ impl Component for ColumnSelector {
                 .callback(|_| ColumnSelectorMsg::OpenExpressionEditor);
 
             let select = self.link.callback(|()| ColumnSelectorMsg::ViewCreated);
-            let active_columns_class = if config.columns.len() == all_columns.len() {
+            let active_columns_class = if config.columns.len()
+                == all_columns.len() + config.expressions.len()
+            {
                 ""
             } else {
                 "collapse"


### PR DESCRIPTION
Fixes incorrect section-collapse logic which caused column selector to malfunction, as reported by @sc1f 