### PR TITLE
Persistent column widths

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
+++ b/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
@@ -68,6 +68,11 @@ function styleListener(regularTable) {
                 this._open_column_styles_menu[0] === metadata._virtual_x
             );
             td.classList.toggle("psp-menu-enabled", is_numeric && !is_corner);
+            td.classList.toggle(
+                "psp-is-width-override",
+                regularTable._column_sizes?.override[metadata.size_key] !==
+                    undefined
+            );
         }
     }
 

--- a/packages/perspective-viewer-datagrid/src/less/regular_table.less
+++ b/packages/perspective-viewer-datagrid/src/less/regular_table.less
@@ -140,6 +140,13 @@ regular-table thead tr:last-child th {
     min-width: 50px !important;
 }
 
+.psp-is-width-override .rt-column-resize,
+.rt-column-resize:hover {
+    border: 1px dashed #999;
+    border-bottom-width: 0px;
+    border-left-width: 0px;
+}
+
 regular-table table {
     user-select: none;
     color: #161616;


### PR DESCRIPTION
Adds persistent column widths, as well as visual indicators when a column can be (or has been) resized.

![resize_indicator](https://user-images.githubusercontent.com/60666/134728391-127e9ece-1cbb-482b-9197-635e5c2abccd.gif)
