### PR TITLE
Fix hidden sort aggregate as `unique` only when sorted on the same axis

### DIFF
--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -249,6 +249,7 @@ t_view_config::fill_aggspecs(std::shared_ptr<t_schema> schema) {
                                        m_column_pivots.end(), column)
                 != m_column_pivots.end();
             bool is_column_only = m_row_pivots.size() == 0 || m_column_only;
+            bool is_row_sort = sort[1].rfind("col", 0) != 0;
 
             std::vector<t_dep> dependencies{t_dep(column, DEPTYPE_COLUMN)};
             t_aggtype agg_type;
@@ -256,8 +257,9 @@ t_view_config::fill_aggspecs(std::shared_ptr<t_schema> schema) {
             if (is_column_only) {
                 // Always sort by `ANY` in column only views
                 agg_type = t_aggtype::AGGTYPE_ANY;
-            } else if (is_row_pivot || is_column_pivot) {
-                // Otherwise if the hidden column is in pivots, use `UNIQUE`
+            } else if ((is_row_pivot && is_row_sort) || (is_column_pivot && !is_row_sort)) {
+                // Otherwise if the hidden column is in pivot on the same axis,
+                // use `UNIQUE`
                 agg_type = t_aggtype::AGGTYPE_UNIQUE;
             } else if (m_aggregates.count(column) > 0) {
                 auto col = m_aggregates.at(column);

--- a/packages/perspective/test/js/sort.js
+++ b/packages/perspective/test/js/sort.js
@@ -792,6 +792,32 @@ module.exports = (perspective) => {
                 table.delete();
             });
 
+            it("row pivot ['x'], column pivot ['y'], hidden sorted on row pivot", async function () {
+                const table = await perspective.table({
+                    x: ["a", "a", "b", "c"],
+                    y: ["x", "x", "y", "x"],
+                    z: [1, 2, 3, 4],
+                });
+                const view = await table.view({
+                    columns: ["z"],
+                    row_pivots: ["y"],
+                    column_pivots: ["x"],
+                    sort: [["x", "desc"]],
+                });
+                const paths = await view.column_paths();
+                expect(paths).toEqual(["__ROW_PATH__", "a|z", "b|z", "c|z"]);
+                const expected = {
+                    __ROW_PATH__: [[], ["x"], ["y"]],
+                    "a|z": [3, 3, null],
+                    "b|z": [3, null, 3],
+                    "c|z": [4, 4, null],
+                };
+                const result = await view.to_columns();
+                expect(result).toEqual(expected);
+                view.delete();
+                table.delete();
+            });
+
             it("column pivot ['y'] has correct # of columns", async function () {
                 var table = await perspective.table(data);
                 var view = await table.view({

--- a/rust/perspective-viewer/src/themes/material.less
+++ b/rust/perspective-viewer/src/themes/material.less
@@ -56,8 +56,8 @@ perspective-expression-editor {
     --sort-order-desc--before: "arrow_downward";
     --sort-order-none--before: "remove";
     --close_button--before: "close";
-    --sort-order-col-asc--before: "arrow_back";
-    --sort-order-col-desc--before: "arrow_forward";
+    --sort-order-col-asc--before: "arrow_forward";
+    --sort-order-col-desc--before: "arrow_back";
 
     --select--background-color: none;
     --select--padding: 0px;


### PR DESCRIPTION
When a column which is in a pivot position is also selected as a sort column, but not a visible column, using the default aggregate (`count` or `sum`) will appear to arbitrarily re-order the pivot axis, since this aggregate value is not visible but the pivot value in the row or column header is.  Because of this, we always use `unique` as an aggregate when this condition is detected.  However, this check previously only checked that such a column was in _any_ pivot position, when really it should only apply to pivots on the same axis as the sort (e.g. row pivots with a hidden sort, or column pivots with a hidden column sort).  This PR addresses this issue and adds a test for the case.