### PR TITLE
Fix #1562, fix regressions in PerspectiveWidget

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
 ipywidgets==7.5.1
-jupyterlab==3.0.14
+jupyterlab==3.1.14
 pandas==0.25.3
 pyarrow==3.0.0

--- a/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
+++ b/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
@@ -53,6 +53,64 @@ utils.with_jupyterlab(process.env.__JUPYTERLAB_PORT__, () => {
                     expect(num_rows).toEqual(5);
                 }
             );
+
+            test.jupyterlab(
+                "Loads data",
+                [
+                    "w = perspective.PerspectiveWidget(arrow_data, columns=['f64', 'str', 'datetime'])",
+                    "w",
+                ],
+                async (page) => {
+                    const viewer = await default_body(page);
+                    const num_columns = await viewer.evaluate(
+                        async (viewer) => {
+                            const tbl = viewer.querySelector("regular-table");
+                            return tbl.querySelector("thead tr")
+                                .childElementCount;
+                        }
+                    );
+
+                    expect(num_columns).toEqual(3);
+
+                    const num_rows = await viewer.evaluate(async (viewer) => {
+                        const tbl = viewer.querySelector("regular-table");
+                        return tbl.querySelectorAll("tbody tr").length;
+                    });
+
+                    expect(num_rows).toEqual(5);
+                }
+            );
+
+            test.jupyterlab(
+                "Loads updates",
+                [
+                    [
+                        "table = perspective.Table(arrow_data)",
+                        "w = perspective.PerspectiveWidget(table, columns=['f64', 'str', 'datetime'])",
+                    ].join("\n"),
+                    "w",
+                    "table.update(arrow_data)",
+                ],
+                async (page) => {
+                    const viewer = await default_body(page);
+                    const num_columns = await viewer.evaluate(
+                        async (viewer) => {
+                            const tbl = viewer.querySelector("regular-table");
+                            return tbl.querySelector("thead tr")
+                                .childElementCount;
+                        }
+                    );
+
+                    expect(num_columns).toEqual(3);
+
+                    const num_rows = await viewer.evaluate(async (viewer) => {
+                        const tbl = viewer.querySelector("regular-table");
+                        return tbl.querySelectorAll("tbody tr").length;
+                    });
+
+                    expect(num_rows).toEqual(10);
+                }
+            );
         },
         {name: "Simple", root: path.join(__dirname, "..", "..")}
     );

--- a/python/perspective/perspective/core/plugin.py
+++ b/python/perspective/perspective/core/plugin.py
@@ -17,7 +17,7 @@ class Plugin(Enum):
         >>> widget = PerspectiveWidget(data, plugin=Plugin.TREEMAP)
     """
 
-    GRID = "datagrid"
+    GRID = "Datagrid"
 
     YBAR = "Y Bar"
     XBAR = "X Bar"

--- a/python/perspective/perspective/tests/core/test_plugin.py
+++ b/python/perspective/perspective/tests/core/test_plugin.py
@@ -16,7 +16,7 @@ class TestPlugin:
     def test_plugin_widget_load_grid(self):
         data = {"a": [1, 2, 3], "b": ["a", "b", "c"]}
         widget = PerspectiveWidget(data, plugin=Plugin.GRID)
-        assert widget.plugin == "datagrid"
+        assert widget.plugin == "Datagrid"
 
     def test_plugin_widget_load(self):
         data = {"a": [1, 2, 3], "b": ["a", "b", "c"]}

--- a/python/perspective/perspective/tests/viewer/test_validate.py
+++ b/python/perspective/perspective/tests/viewer/test_validate.py
@@ -18,7 +18,7 @@ class TestValidate:
         assert validate.validate_plugin(Plugin.XBAR) == "X Bar"
 
     def test_validate_plugin_valid_instance_datagrid(self):
-        assert validate.validate_plugin(Plugin.GRID) == "datagrid"
+        assert validate.validate_plugin(Plugin.GRID) == "Datagrid"
 
     def test_validate_plugin_valid_string(self):
         assert validate.validate_plugin("X Bar") == "X Bar"

--- a/python/perspective/perspective/tests/viewer/test_viewer.py
+++ b/python/perspective/perspective/tests/viewer/test_viewer.py
@@ -189,7 +189,7 @@ class TestViewer:
         viewer.load(table)
         assert viewer.filters == [["a", "==", 2]]
         viewer.reset()
-        assert viewer.plugin == "datagrid"
+        assert viewer.plugin == "Datagrid"
         assert viewer.filters == []
 
     # delete
@@ -229,7 +229,7 @@ class TestViewer:
 
         # reset configuration
         viewer.reset()
-        assert viewer.plugin == "datagrid"
+        assert viewer.plugin == "Datagrid"
         assert viewer.filters == []
         assert viewer.editable is False
         assert viewer.expressions == []
@@ -242,7 +242,7 @@ class TestViewer:
         assert viewer.expressions == ['"a" * 2']
 
     def test_save_restore_plugin_config(self):
-        viewer = PerspectiveViewer(plugin="datagrid", plugin_config={"a": {"fixed": 4}})
+        viewer = PerspectiveViewer(plugin="Datagrid", plugin_config={"a": {"fixed": 4}})
         config = viewer.save()
 
         assert config["plugin_config"] == {

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -57,7 +57,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
 
     def __init__(
         self,
-        plugin="datagrid",
+        plugin="Datagrid",
         columns=None,
         row_pivots=None,
         column_pivots=None,
@@ -266,7 +266,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         self.expressions = []
         self.aggregates = {}
         self.columns = []
-        self.plugin = "datagrid"
+        self.plugin = "Datagrid"
         self.plugin_config = {}
         self.editable = False
 

--- a/python/perspective/perspective/viewer/viewer_traitlets.py
+++ b/python/perspective/perspective/viewer/viewer_traitlets.py
@@ -35,7 +35,7 @@ class PerspectiveTraitlets(HasTraits):
     """
 
     # `perspective-viewer` options
-    plugin = Unicode("datagrid").tag(sync=True)
+    plugin = Unicode("Datagrid").tag(sync=True)
     columns = List(default_value=[]).tag(sync=True)
     row_pivots = List(trait=Unicode(), default_value=[]).tag(sync=True, o=True)
     column_pivots = List(trait=Unicode(), default_value=[]).tag(sync=True)


### PR DESCRIPTION
This PR fixes some issues with PerspectiveWidget:

- Updates were broken in the RC release but are now working
- Client-server editing is now working again
- Use one shared_worker for all widget instances, instead of a new worker per-instance
- Update binder to 3.1.14, as Jupyterlab 3.0.x has a Webpack issue that causes a parse error when importing the Widget front-end.
- Remove the MutationObserver on widget attributes as the attributes are no longer fixed on the front-end

As written in #1560, the goal for the widget is for a complete rewrite that cleans up both the Python and the JS side, and removes any dependency on traitlets. However, this PR fixes the regressions between the 1.0.0 RC release and our last release.