### PR TITLE
Fix #1566, remove deprecated flags from WASM debug build

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -232,9 +232,9 @@ if (PSP_WASM_BUILD)
 	if(CMAKE_BUILD_TYPE_LOWER STREQUAL debug)
 		set(OPT_FLAGS " \
 			-O0 \
-			-g4 \
+			-g3 \
+			-gsource-map \
 			--profiling \
-			-s WARN_UNALIGNED=1 \
 			-Wcast-align \
 			-Wover-aligned \
 			")

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1587,6 +1587,10 @@ export default function (Module) {
             errors: {},
         };
 
+        // A mapping of all expression aliases to expression strings for both
+        // valid and invalid expressions.
+        const expression_alias_map = {};
+
         if (!expressions || expressions.length === 0) return validated;
         expressions = parse_expression_strings(expressions);
 
@@ -1600,7 +1604,6 @@ export default function (Module) {
                 inner.push_back(val);
             }
             vector.push_back(inner);
-            validated.expression_alias[expression[0]] = expression[1];
         }
 
         const validation_results = __MODULE__.validate_expressions(
@@ -1621,6 +1624,9 @@ export default function (Module) {
             }
 
             validated.expression_schema[alias] = dtype;
+
+            // Only add valid expressions to output expression alias map
+            validated.expression_alias[alias] = expression_alias_map[alias];
         }
 
         const error_aliases = expression_errors.keys();

--- a/packages/perspective/test/js/expressions/functionality.js
+++ b/packages/perspective/test/js/expressions/functionality.js
@@ -2638,6 +2638,7 @@ module.exports = (perspective) => {
                     'max(100, "a")', // valid
                 ];
                 const results = await table.validate_expressions(expressions);
+
                 expect(results.expression_schema).toEqual({
                     '"a" + "d"': "float",
                     '"c"': "string",
@@ -2646,6 +2647,7 @@ module.exports = (perspective) => {
                     'max(100, "a")': "float",
                     "concat(\"c\", ' ', \"c\", 'abc')": "string",
                 });
+
                 table.delete();
             });
 

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -185,7 +185,7 @@ class Table(object):
             as_string (:obj:`bool`): If True, returns the data types as string
                 representations so they can be serialized.
         """
-        validated = {"expression_schema": {}, "errors": {}}
+        validated = {"expression_schema": {}, "errors": {}, "expression_alias": {}}
 
         if len(expressions) == 0:
             return validated
@@ -195,10 +195,22 @@ class Table(object):
         expression_schema = validation_results.get_expression_schema()
         expression_errors = validation_results.get_expression_errors()
 
+        # all alias to all expressions
+        expression_alias_map = {}
+
+        for expression in expressions:
+            # expression_alias can be used to map the alias to the
+            # full expression string in the UI.
+            expression_alias_map[expression[0]] = expression[1]
+
         for (alias, dtype) in iteritems(expression_schema):
             if not as_string:
                 dtype = _str_to_pythontype(dtype)
+
             validated["expression_schema"][alias] = expression_schema[alias]
+
+            # only add to output expression_alias if the expression is valid
+            validated["expression_alias"][alias] = expression_alias_map[alias]
 
         for (alias, error) in iteritems(expression_errors):
             error_dict = {}

--- a/python/perspective/perspective/tests/manager/test_manager.py
+++ b/python/perspective/perspective/tests/manager/test_manager.py
@@ -332,7 +332,10 @@ class TestPerspectiveManager(object):
                 "expression_schema": {
                     "abc": "float"
                 },
-                "errors": {}
+                "errors": {},
+                "expression_alias": {
+                    "abc": '// abc \n "a" + "a"'
+                }
             }
         })
 

--- a/python/perspective/perspective/tests/table/test_view_expression.py
+++ b/python/perspective/perspective/tests/table/test_view_expression.py
@@ -19,6 +19,7 @@ class TestViewExpression(object):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
         validate = table.validate_expressions([])
         assert validate["expression_schema"] == {}
+        assert validate["expression_alias"] == {}
         assert validate["errors"] == {}
 
     def test_view_expression_schema_empty(self):
@@ -27,9 +28,51 @@ class TestViewExpression(object):
         assert view.to_columns() == {"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]}
         assert view.expression_schema() == {}
 
+    def test_view_validate_expressions_alias_map_errors(self):
+        table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+        expressions = [
+            '// x\n"a"',
+            '// y\n"b" * 0.5',
+            "// c\n'abcdefg'",
+            "// d\ntrue and false",
+            '// e\nfloat("a") > 2 ? null : 1',
+            "// f\ntoday()",
+            "// g\nnow()",
+            "// h\nlength(123)",
+        ]
+
+        validated = table.validate_expressions(expressions)
+
+        aliases = ["x", "y", "c", "d", "e", "f", "g"]
+
+        for idx, alias in enumerate(aliases):
+            assert validated["expression_alias"][alias] == expressions[idx]
+
+        assert "h" not in validated["expression_alias"]
+
+    def test_view_validate_expressions_alias_map(self):
+        table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+        expressions = [
+            '// x\n"a"',
+            '// y\n"b" * 0.5',
+            "// c\n'abcdefg'",
+            "// d\ntrue and false",
+            '// e\nfloat("a") > 2 ? null : 1',
+            "// f\ntoday()",
+            "// g\nnow()",
+            "// h\nlength('abcd')",
+        ]
+
+        validated = table.validate_expressions(expressions)
+
+        aliases = ["x", "y", "c", "d", "e", "f", "g", "h"]
+
+        for idx, alias in enumerate(aliases):
+            assert validated["expression_alias"][alias] == expressions[idx]
+
     def test_view_expression_schema_all_types(self):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-        view = table.view(expressions=[
+        expressions = [
             '"a"',
             '"b" * 0.5',
             "'abcdefg'",
@@ -37,8 +80,10 @@ class TestViewExpression(object):
             'float("a") > 2 ? null : 1',
             "today()",
             "now()",
-            "length('abcd')"
-        ])
+            "length('abcd')",
+        ]
+
+        view = table.view(expressions=expressions)
         assert view.expression_schema() == {
             '"a"': int,
             '"b" * 0.5': float,
@@ -47,12 +92,13 @@ class TestViewExpression(object):
             'float("a") > 2 ? null : 1': float,
             "today()": date,
             "now()": datetime,
-            "length('abcd')": float
+            "length('abcd')": float,
         }
 
         result = view.to_columns()
         today = datetime(date.today().year, date.today().month, date.today().day)
         del result["now()"]  # no need to match datetime.now()
+
         assert result == {
             "a": [1, 2, 3, 4],
             "b": [5, 6, 7, 8],
@@ -65,12 +111,18 @@ class TestViewExpression(object):
             "length('abcd')": [4 for _ in range(4)]
         }
 
+        validated = table.validate_expressions(expressions)
+
+        for expr in expressions:
+            assert validated["expression_alias"][expr] == expr
+
     def test_table_validate_expressions_with_errors(self):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
         validate = table.validate_expressions(
             ['"Sales" + "Profit"', "datetime()", "string()", "for () {}"]
         )
         assert validate["expression_schema"] == {}
+        assert validate["expression_alias"] == {}
         assert validate["errors"] == {
             '"Sales" + "Profit"': {
                 "column": 0,


### PR DESCRIPTION
This PR fixes server mode Python by fixing the output of `validate_expressions`, which was missing a field in the Python implementation. In the pre-1.0.0 viewer, `expression_alias` was a map of expression aliases to the whole expression string so the user could hover over a column in the UI and see the expression from whence it came. With the "edit expression" button added in 1.0.0, it is no longer necessary to see the whole expression separate from the editor.

Even though the `expression_alias` field is not used in the viewer, it is required and type-checked by Rust and thus threw an unrecoverable error when loading the table from Python. The long-term fix is to move all validation and parsing logic for expressions, along with other logic that is implemented twice in both JS and Python, all into C++.

Additionally, the WASM debug build was outputting deprecated flag warnings, which have been rectified.