### PR TITLE
Fix JupyterLab widget `filter` traitlet

### DIFF
--- a/packages/perspective-jupyterlab/src/js/model.js
+++ b/packages/perspective-jupyterlab/src/js/model.js
@@ -31,7 +31,7 @@ export class PerspectiveModel extends DOMWidgetModel {
             column_pivots: [],
             aggregates: {},
             sort: [],
-            filters: [],
+            filter: [],
             expressions: [],
             plugin_config: {},
             dark: false,

--- a/packages/perspective-jupyterlab/src/js/view.js
+++ b/packages/perspective-jupyterlab/src/js/view.js
@@ -105,7 +105,7 @@ export class PerspectiveView extends DOMWidgetView {
         this.model.on("change:column_pivots", this.column_pivots_changed, this);
         this.model.on("change:aggregates", this.aggregates_changed, this);
         this.model.on("change:sort", this.sort_changed, this);
-        this.model.on("change:filters", this.filters_changed, this);
+        this.model.on("change:filter", this.filter_changed, this);
         this.model.on("change:expressions", this.expressions_changed, this);
         this.model.on("change:plugin_config", this.plugin_config_changed, this);
         this.model.on("change:dark", this.dark_changed, this);
@@ -395,7 +395,7 @@ export class PerspectiveView extends DOMWidgetView {
         });
     }
 
-    filters_changed() {
+    filter_changed() {
         this.pWidget.restore({
             filter: this.model.get("filter"),
         });

--- a/python/perspective/perspective/tests/viewer/test_validate.py
+++ b/python/perspective/perspective/tests/viewer/test_validate.py
@@ -31,22 +31,22 @@ class TestValidate:
         with raises(PerspectiveError):
             validate.validate_plugin("hypergrid")
 
-    def test_validate_filters_valid(self):
+    def test_validate_filter_valid(self):
         filters = [["a", ">", 1], ["b", "==", "abc"]]
-        assert validate.validate_filters(filters) == filters
+        assert validate.validate_filter(filters) == filters
 
-    def test_validate_filters_invalid(self):
+    def test_validate_filter_invalid(self):
         with raises(PerspectiveError):
             filters = [["a", ">"], ["b", "invalid" "abc"]]
-            validate.validate_filters(filters)
+            validate.validate_filter(filters)
 
-    def test_validate_filters_is_null(self):
+    def test_validate_filter_is_null(self):
         filters = [["a", "is null"]]
-        assert validate.validate_filters(filters) == filters
+        assert validate.validate_filter(filters) == filters
 
-    def test_validate_filters_is_not_null(self):
+    def test_validate_filter_is_not_null(self):
         filters = [["a", "is not null"]]
-        assert validate.validate_filters(filters) == filters
+        assert validate.validate_filter(filters) == filters
 
     def test_validate_expressions(self):
         computed = ["// expression1 \n 'Hello'"]

--- a/python/perspective/perspective/tests/viewer/test_viewer.py
+++ b/python/perspective/perspective/tests/viewer/test_viewer.py
@@ -185,43 +185,43 @@ class TestViewer:
 
     def test_viewer_reset(self):
         table = Table({"a": [1, 2, 3]})
-        viewer = PerspectiveViewer(plugin="X Bar", filters=[["a", "==", 2]])
+        viewer = PerspectiveViewer(plugin="X Bar", filter=[["a", "==", 2]])
         viewer.load(table)
-        assert viewer.filters == [["a", "==", 2]]
+        assert viewer.filter == [["a", "==", 2]]
         viewer.reset()
         assert viewer.plugin == "Datagrid"
-        assert viewer.filters == []
+        assert viewer.filter == []
 
     # delete
 
     def test_viewer_delete(self):
         table = Table({"a": [1, 2, 3]})
-        viewer = PerspectiveViewer(plugin="X Bar", filters=[["a", "==", 2]])
+        viewer = PerspectiveViewer(plugin="X Bar", filter=[["a", "==", 2]])
         viewer.load(table)
-        assert viewer.filters == [["a", "==", 2]]
+        assert viewer.filter == [["a", "==", 2]]
         viewer.delete()
         assert viewer.table_name is None
         assert viewer.table is None
 
     def test_viewer_delete_without_table(self):
         table = Table({"a": [1, 2, 3]})
-        viewer = PerspectiveViewer(plugin="X Bar", filters=[["a", "==", 2]])
+        viewer = PerspectiveViewer(plugin="X Bar", filter=[["a", "==", 2]])
         viewer.load(table)
-        assert viewer.filters == [["a", "==", 2]]
+        assert viewer.filter == [["a", "==", 2]]
         viewer.delete(delete_table=False)
         assert viewer.table_name is not None
         assert viewer.table is not None
-        assert viewer.filters == []
+        assert viewer.filter == []
 
     def test_save_restore(self):
         table = Table({"a": [1, 2, 3]})
-        viewer = PerspectiveViewer(plugin="X Bar", filters=[["a", "==", 2]], editable=True, expressions=['"a" * 2'])
+        viewer = PerspectiveViewer(plugin="X Bar", filter=[["a", "==", 2]], editable=True, expressions=['"a" * 2'])
         viewer.load(table)
 
         # Save config
         config = viewer.save()
-        assert viewer.filters == [["a", "==", 2]]
-        assert config["filters"] == [["a", "==", 2]]
+        assert viewer.filter == [["a", "==", 2]]
+        assert config["filter"] == [["a", "==", 2]]
         assert viewer.plugin == "X Bar"
         assert config["plugin"] == "X Bar"
         assert config["editable"] is True
@@ -230,13 +230,13 @@ class TestViewer:
         # reset configuration
         viewer.reset()
         assert viewer.plugin == "Datagrid"
-        assert viewer.filters == []
+        assert viewer.filter == []
         assert viewer.editable is False
         assert viewer.expressions == []
 
         # restore configuration
         viewer.restore(**config)
-        assert viewer.filters == [["a", "==", 2]]
+        assert viewer.filter == [["a", "==", 2]]
         assert viewer.plugin == "X Bar"
         assert viewer.editable is True
         assert viewer.expressions == ['"a" * 2']

--- a/python/perspective/perspective/viewer/validate.py
+++ b/python/perspective/perspective/viewer/validate.py
@@ -107,7 +107,7 @@ def validate_sort(sort):
         raise PerspectiveError("Cannot parse sort type: %s", str(type(sort)))
 
 
-def validate_filters(filters):
+def validate_filter(filters):
     if filters is None:
         return []
 
@@ -122,7 +122,7 @@ def validate_filters(filters):
     if isinstance(filters, list):
         for f in filters:
             if not isinstance(f, list):
-                raise PerspectiveError("`filters` kwarg must be a list!")
+                raise PerspectiveError("`filter` kwarg must be a list!")
 
             for i, item in enumerate(f):
                 if i == 1:
@@ -145,7 +145,7 @@ def validate_filters(filters):
         return filters
     else:
         raise PerspectiveError(
-            "Cannot parse filters type: {}".format(str(type(filters)))
+            "Cannot parse filter type: {}".format(str(type(filters)))
         )
 
 

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -15,7 +15,7 @@ from .validate import (
     validate_column_pivots,
     validate_aggregates,
     validate_sort,
-    validate_filters,
+    validate_filter,
     validate_expressions,
     validate_plugin_config,
 )
@@ -45,7 +45,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
     PERSISTENT_ATTRIBUTES = (
         "row_pivots",
         "column_pivots",
-        "filters",
+        "filter",
         "sort",
         "aggregates",
         "columns",
@@ -63,7 +63,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         column_pivots=None,
         aggregates=None,
         sort=None,
-        filters=None,
+        filter=None,
         expressions=None,
         plugin_config=None,
         dark=None,
@@ -125,7 +125,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         self.column_pivots = validate_column_pivots(column_pivots) or []
         self.aggregates = validate_aggregates(aggregates) or {}
         self.sort = validate_sort(sort) or []
-        self.filters = validate_filters(filters) or []
+        self.filter = validate_filter(filter) or []
         self.expressions = validate_expressions(expressions) or []
         self.plugin_config = validate_plugin_config(plugin_config) or {}
         self.dark = dark
@@ -261,7 +261,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         """
         self.row_pivots = []
         self.column_pivots = []
-        self.filters = []
+        self.filter = []
         self.sort = []
         self.expressions = []
         self.aggregates = {}

--- a/python/perspective/perspective/viewer/viewer_traitlets.py
+++ b/python/perspective/perspective/viewer/viewer_traitlets.py
@@ -14,7 +14,7 @@ from .validate import (
     validate_column_pivots,
     validate_aggregates,
     validate_sort,
-    validate_filters,
+    validate_filter,
     validate_expressions,
     validate_plugin_config,
 )
@@ -41,7 +41,7 @@ class PerspectiveTraitlets(HasTraits):
     column_pivots = List(trait=Unicode(), default_value=[]).tag(sync=True)
     aggregates = Dict(default_value={}).tag(sync=True)
     sort = List(default_value=[]).tag(sync=True)
-    filters = List(default_value=[]).tag(sync=True)
+    filter = List(default_value=[]).tag(sync=True)
     expressions = List(default_value=[]).tag(sync=True)
     plugin_config = Dict(default_value={}).tag(sync=True)
     dark = Bool(None, allow_none=True).tag(sync=True)
@@ -73,9 +73,9 @@ class PerspectiveTraitlets(HasTraits):
     def _validate_sort(self, proposal):
         return validate_sort(proposal.value)
 
-    @validate("filters")
-    def _validate_filters(self, proposal):
-        return validate_filters(proposal.value)
+    @validate("filter")
+    def _validate_filter(self, proposal):
+        return validate_filter(proposal.value)
 
     @validate("expressions")
     def _validate_expressions(self, proposal):

--- a/scripts/jlab_link.js
+++ b/scripts/jlab_link.js
@@ -14,6 +14,7 @@ const packages = [
     "./rust/perspective-viewer",
     "./packages/perspective-viewer-datagrid",
     "./packages/perspective-viewer-d3fc",
+    "./packages/perspective-jupyterlab",
 ];
 
 /**

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -152,8 +152,7 @@ async function focus_package() {
 }
 
 async function javascript_options() {
-    const new_config = await inquirer.prompt([PROMPT_DEBUG, PROMPT_DOCKER]);
-    const local_puppeteer = fs.existsSync("node_modules/puppeteer");
+    const new_config = await inquirer.prompt([PROMPT_DEBUG]);
     CONFIG.add(new_config);
     CONFIG.write();
 }


### PR DESCRIPTION
Fixes an issue in the JupyterLab `PerspectiveWidget` Python class `filter` traitlet, which was set to `filters` in this class alone, causing the property to be mis-parsed on the client.  Though this API changed in `1.0.0` (or rather, where the API previously allowed either, only `filter` is now accepted), this is not technically a breaking change as it never worked in a release version after this (and there has been no release versions).  Even the docs for e.g. the class's constructor refer to this kwarg as `filter`.  Hence, I won't mark this `breaking` and will only become a minor perspective release - but worth noting this is still "breaking" in that pre `1.0.0` code still won't work without a rename.

I can't believe I have to add this, but please do not contact Perspective contributors with bug reports on their personal emails, cell phones, etc!  Use Github Issues to open a short report, it takes minutes. 