### PR TITLE
Persist edited expressions and add 'Reset' button

### DIFF
--- a/rust/perspective-viewer/src/less/expression-editor.less
+++ b/rust/perspective-viewer/src/less/expression-editor.less
@@ -66,7 +66,8 @@
             opacity: 0.5;
         }
 
-        &#psp-expression-editor-button-save {
+        &#psp-expression-editor-button-save,
+        &#psp-expression-editor-button-reset {
             color: inherit;
             font-family: inherit;
             font-weight: 300;
@@ -85,13 +86,20 @@
                 margin-right: 6px;
                 font-size: 14px;
                 font-family: "Material Icons";
-                content: "save";
             }
 
             &:hover {
                 background-color: rgba(0, 0, 0, 0.05);
                 transition: none;
             }
+        }
+
+        &#psp-expression-editor-button-save:before {
+            content: "save";
+        }
+
+        &#psp-expression-editor-button-reset:before {
+            content: "refresh";
         }
     }
 }

--- a/rust/perspective-viewer/src/rust/components/column_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector.rs
@@ -183,8 +183,11 @@ impl Component for ColumnSelector {
             }
             ColumnSelectorMsg::OpenExpressionEditor => {
                 let on_save = self.link.callback(ColumnSelectorMsg::SaveExpression);
-                let mut element =
-                    ExpressionEditorElement::new(self.props.session.clone(), on_save);
+                let mut element = ExpressionEditorElement::new(
+                    self.props.session.clone(),
+                    on_save,
+                    None,
+                );
 
                 let target = self.add_expression_ref.cast::<HtmlElement>().unwrap();
                 element.open(target);

--- a/rust/perspective-viewer/src/rust/components/config_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/config_selector.rs
@@ -129,8 +129,7 @@ impl Component for ConfigSelector {
 
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
-            ConfigSelectorMsg::DragStart(_)
-            | ConfigSelectorMsg::ViewCreated => true,
+            ConfigSelectorMsg::DragStart(_) | ConfigSelectorMsg::ViewCreated => true,
             ConfigSelectorMsg::DragEnd => true,
             ConfigSelectorMsg::DragOverRowPivots(index) => {
                 self.props.dragdrop.drag_enter(DropAction::RowPivots, index)
@@ -279,9 +278,7 @@ impl Component for ConfigSelector {
         // web_sys::console::log_1(&"redraw".into());
         let dragend = Callback::from({
             let dragdrop = self.props.dragdrop.clone();
-            move |_event| {
-                dragdrop.drag_end()
-            }
+            move |_event| dragdrop.drag_end()
         });
 
         html! {

--- a/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
@@ -200,7 +200,9 @@ where
                     .cloned();
 
                 if !self.props.allow_duplicates {
-                    columns.retain(|x| x.1 .1.as_ref().unwrap().props.get_item() != *column);
+                    columns.retain(|x| {
+                        x.1 .1.as_ref().unwrap().props.get_item() != *column
+                    });
                 }
 
                 // If inserting into the middle of the list, use

--- a/rust/perspective-viewer/src/rust/components/containers/dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/dropdown.rs
@@ -167,7 +167,7 @@ where
             html! {
                 <>
                     <label>{ "weighted mean" }</label>
-                    <div 
+                    <div
                         class="dropdown-width-container"
                         data-value={ format!("{}", self.props.selected) }>
                         { select }
@@ -176,7 +176,7 @@ where
             }
         } else {
             html! {
-                <div 
+                <div
                     class="dropdown-width-container"
                     data-value={ format!("{}", self.props.selected) }>
                     { select }

--- a/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
@@ -31,7 +31,7 @@ impl Drop for ResizingState {
     /// Without this, the `Closure` objects would not leak, but the document will
     /// continue to call them, causing runtime exceptions.
     fn drop(&mut self) {
-        let result = maybe! {
+        let result: Result<(), JsValue> = maybe! {
             let document = web_sys::window().unwrap().document().unwrap();
             let body = document.body().unwrap();
             let mousemove = self.mousemove.as_ref().unchecked_ref();

--- a/rust/perspective-viewer/src/rust/components/expression_toolbar.rs
+++ b/rust/perspective-viewer/src/rust/components/expression_toolbar.rs
@@ -8,9 +8,9 @@
 
 use crate::config::*;
 use crate::custom_elements::expression_editor::ExpressionEditorElement;
+use crate::dragdrop::*;
 use crate::renderer::*;
 use crate::session::*;
-use crate::dragdrop::*;
 use crate::*;
 
 use wasm_bindgen_futures::spawn_local;
@@ -39,7 +39,12 @@ impl ExpressionToolbarProps {
     }
 
     pub fn close_expr(&self) {
-        let expression = self.session.metadata().get_alias_expression(&self.name);
+        let expression = self
+            .session
+            .metadata()
+            .get_expression_by_alias(&self.name)
+            .unwrap();
+
         let ViewConfig {
             mut expressions, ..
         } = self.session.get_view_config();
@@ -52,7 +57,12 @@ impl ExpressionToolbarProps {
     }
 
     fn is_closable(&self) -> bool {
-        !self.session.is_column_expression_in_use(&self.name) && !self.dragdrop.get_drag_column().map(|x| x == self.name).unwrap_or_default()
+        !self.session.is_column_expression_in_use(&self.name)
+            && !self
+                .dragdrop
+                .get_drag_column()
+                .map(|x| x == self.name)
+                .unwrap_or_default()
     }
 }
 
@@ -118,16 +128,13 @@ impl Component for ExpressionToolbar {
                 let target =
                     self.props.add_expression_ref.cast::<HtmlElement>().unwrap();
 
-                let expr = self
-                    .props
-                    .session
-                    .metadata()
-                    .get_alias_expression(&self.props.name);
-                let mut element =
-                    ExpressionEditorElement::new(self.props.session.clone(), on_save);
+                let mut element = ExpressionEditorElement::new(
+                    self.props.session.clone(),
+                    on_save,
+                    Some(self.props.name.to_owned()),
+                );
 
                 element.open(target);
-                element.set_content(&expr);
                 self.expression_editor = Some(element);
                 false
             }

--- a/rust/perspective-viewer/src/rust/components/filter_item.rs
+++ b/rust/perspective-viewer/src/rust/components/filter_item.rs
@@ -17,9 +17,9 @@ use super::containers::dragdrop_list::*;
 use super::containers::dropdown::*;
 
 use chrono::{Local, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use wasm_bindgen::JsCast;
 use web_sys::*;
 use yew::prelude::*;
-use wasm_bindgen::JsCast;
 
 /// A control for a single filter condition.
 pub struct FilterItem {
@@ -109,9 +109,7 @@ impl FilterItemProperties {
             (Type::Bool, FilterTerm::Scalar(Scalar::Bool(x))) => {
                 Some((if *x { "true" } else { "false" }).to_owned())
             }
-            (Type::Bool, _) => {
-                Some("true".to_owned())
-            }
+            (Type::Bool, _) => Some("true".to_owned()),
             (_, x) => Some(format!("{}", x)),
         }
     }
@@ -133,11 +131,9 @@ impl FilterItemProperties {
                 FilterOp::IsNotNull,
                 FilterOp::IsNull,
             ],
-            Some(Type::Bool) => vec![
-                FilterOp::EQ,
-                FilterOp::IsNull,
-                FilterOp::IsNotNull
-            ],
+            Some(Type::Bool) => {
+                vec![FilterOp::EQ, FilterOp::IsNull, FilterOp::IsNotNull]
+            }
             Some(_) => vec![
                 FilterOp::EQ,
                 FilterOp::NE,
@@ -148,7 +144,7 @@ impl FilterItemProperties {
                 FilterOp::IsNotNull,
                 FilterOp::IsNull,
             ],
-            _ => vec![]
+            _ => vec![],
         }
     }
 
@@ -262,7 +258,12 @@ impl Component for FilterItem {
             props.update_filter_input(input.clone());
         }
 
-        FilterItem { props, link, input, input_ref }
+        FilterItem {
+            props,
+            link,
+            input,
+            input_ref,
+        }
     }
 
     fn update(&mut self, msg: FilterItemMsg) -> bool {
@@ -278,7 +279,7 @@ impl Component for FilterItem {
                 } else {
                     input
                 };
-                
+
                 if self.props.is_suggestable() {
                     self.props.filter_dropdown.autocomplete(
                         column,
@@ -343,11 +344,7 @@ impl Component for FilterItem {
         let idx = self.props.idx;
         let filter = self.props.filter.clone();
         let column = filter.0.to_owned();
-        let col_type = self
-            .props
-            .session
-            .metadata()
-            .get_column_table_type(&column);
+        let col_type = self.props.session.metadata().get_column_table_type(&column);
 
         let select = self.link.callback(FilterItemMsg::FilterOpSelect);
 
@@ -471,7 +468,7 @@ impl Component for FilterItem {
                         checked={ self.input == "true" }
                         oninput={ input }/>
                 }
-            },
+            }
             None => {
                 html! {}
             }
@@ -518,7 +515,7 @@ impl Component for FilterItem {
                                 }
                             </label>
                         }
-                    } 
+                    }
                 }
             </>
         }

--- a/rust/perspective-viewer/src/rust/components/pivot_item.rs
+++ b/rust/perspective-viewer/src/rust/components/pivot_item.rs
@@ -52,9 +52,7 @@ impl Component for PivotItem {
 
         let dragend = Callback::from({
             let dragdrop = self.props.dragdrop.clone();
-            move |_event| {
-                dragdrop.drag_end()
-            }
+            move |_event| dragdrop.drag_end()
         });
 
         html! {

--- a/rust/perspective-viewer/src/rust/config/aggregates.rs
+++ b/rust/perspective-viewer/src/rust/config/aggregates.rs
@@ -148,16 +148,14 @@ impl FromStr for SingleAggregate {
     }
 }
 
-#[derive(Clone, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
-#[cfg_attr(test, derive(Debug))]
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde()]
 pub enum MultiAggregate {
     #[serde(rename = "weighted mean")]
     WeightedMean,
 }
 
-#[derive(Clone, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
-#[cfg_attr(test, derive(Debug))]
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(untagged)]
 pub enum Aggregate {
     SingleAggregate(SingleAggregate),

--- a/rust/perspective-viewer/src/rust/config/view_config.rs
+++ b/rust/perspective-viewer/src/rust/config/view_config.rs
@@ -25,8 +25,8 @@ use {crate::*, js_sys::Array};
 #[cfg(test)]
 use wasm_bindgen_test::*;
 
-#[derive(Clone, Deserialize, Default, Serialize)]
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Clone, Debug, Deserialize, Default, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
 #[serde(deny_unknown_fields)]
 pub struct ViewConfig {
     #[serde(default)]

--- a/rust/perspective-viewer/src/rust/custom_elements/expression_editor.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/expression_editor.rs
@@ -32,6 +32,7 @@ impl ExpressionEditorElement {
     pub fn new(
         session: Session,
         on_save: Callback<JsValue>,
+        alias: Option<String>,
     ) -> ExpressionEditorElement {
         let document = window().unwrap().document().unwrap();
         let editor = document
@@ -66,6 +67,7 @@ impl ExpressionEditorElement {
             on_init,
             on_validate,
             session,
+            alias,
         };
 
         let modal = ModalElement::new(editor, props, true);
@@ -81,11 +83,6 @@ impl ExpressionEditorElement {
 
     pub fn destroy(self) -> Result<(), JsValue> {
         self.modal.destroy()
-    }
-
-    pub fn set_content(&self, content: &str) {
-        self.modal
-            .send_message(ExpressionEditorMsg::SetContent(content.to_owned()));
     }
 
     pub fn connected_callback(&self) {}

--- a/rust/perspective-viewer/src/rust/dragdrop.rs
+++ b/rust/perspective-viewer/src/rust/dragdrop.rs
@@ -71,18 +71,11 @@ impl DragDrop {
         self.borrow().on_drop_action.add_listener(callback)
     }
 
-    pub fn add_on_drag_action(
-        &self,
-        callback: Callback<DragEffect>,
-    ) -> Subscription {
+    pub fn add_on_drag_action(&self, callback: Callback<DragEffect>) -> Subscription {
         self.borrow().on_drag_action.add_listener(callback)
     }
 
-
-    pub fn add_on_dragend_action(
-        &self,
-        callback: Callback<()>,
-    ) -> Subscription {
+    pub fn add_on_dragend_action(&self, callback: Callback<()>) -> Subscription {
         self.borrow().on_dragend_action.add_listener(callback)
     }
 

--- a/rust/perspective-viewer/src/rust/session.rs
+++ b/rust/perspective-viewer/src/rust/session.rs
@@ -88,7 +88,7 @@ impl Session {
         std::cell::Ref::map(self.borrow(), |x| &x.metadata)
     }
 
-    fn metadata_mut(&self) -> MetadataMutRef<'_> {
+    pub fn metadata_mut(&self) -> MetadataMutRef<'_> {
         std::cell::RefMut::map(self.borrow_mut(), |x| &mut x.metadata)
     }
 
@@ -283,7 +283,7 @@ impl Session {
         column: &str,
         expression: &JsValue,
     ) -> ViewConfigUpdate {
-        let old_expression = self.metadata().get_alias_expression(column);
+        let old_expression = self.metadata().get_expression_by_alias(column).unwrap();
         let new_name = self
             .get_validated_expression_name(expression)
             .await
@@ -375,10 +375,21 @@ impl Session {
         }
     }
 
+    async fn get_validated_expression_name(
+        &self,
+        expr: &JsValue,
+    ) -> Result<String, JsValue> {
+        let arr = [expr].iter().collect::<js_sys::Array>();
+        let table = self.borrow().table.as_ref().unwrap().clone();
+        let schema = table.validate_expressions(arr).await?.expression_schema();
+        let schema_keys = js_sys::Object::keys(&schema);
+        schema_keys.get(0).as_string().into_jserror()
+    }
+
     /// Validate an expression string (as a JsValue since it comes from `monaco`),
     /// and marshall the results.
     pub async fn validate_expr(
-        self,
+        &self,
         expr: JsValue,
     ) -> Result<Option<PerspectiveValidationError>, JsValue> {
         let arr = [expr].iter().collect::<js_sys::Array>();
@@ -391,17 +402,6 @@ impl Session {
         } else {
             Ok(None)
         }
-    }
-
-    pub async fn get_validated_expression_name(
-        &self,
-        expr: &JsValue,
-    ) -> Result<String, JsValue> {
-        let arr = [expr].iter().collect::<js_sys::Array>();
-        let table = self.borrow().table.as_ref().unwrap().clone();
-        let schema = table.validate_expressions(arr).await?.expression_schema();
-        let schema_keys = js_sys::Object::keys(&schema);
-        schema_keys.get(0).as_string().into_jserror()
     }
 
     pub async fn copy_to_clipboard(self, flat: bool) -> Result<(), JsValue> {

--- a/rust/perspective-viewer/src/rust/session.rs
+++ b/rust/perspective-viewer/src/rust/session.rs
@@ -214,13 +214,19 @@ impl Session {
             DropAction::Active => {
                 if is_to_swap || is_from_required {
                     let column = Some(column);
-                    config.columns.extend(std::iter::repeat(None).take(
-                        if index >= (config.columns.len() - 1) {
-                            index + (1 - config.columns.len())
+                    config.columns.extend(std::iter::repeat(None).take({
+                        let fill_to = requirements
+                            .names
+                            .as_ref()
+                            .map(|x| std::cmp::max(x.len() - 1, index))
+                            .unwrap_or(index);
+
+                        if fill_to >= (config.columns.len() - 1) {
+                            fill_to + 1 - config.columns.len()
                         } else {
                             0
-                        },
-                    ));
+                        }
+                    }));
 
                     if let Some(prev) = config.columns.iter().position(|x| *x == column)
                     {

--- a/rust/perspective-viewer/src/rust/utils/js_object.rs
+++ b/rust/perspective-viewer/src/rust/utils/js_object.rs
@@ -37,13 +37,12 @@ macro_rules! js_object {
 
 #[macro_export]
 macro_rules! js_log {
-    ($x:expr) => {
+    ($x:expr) => {{
         const DEBUG_ONLY_WARNING: &str = $x;
-        web_sys::console::log_1(&JsValue::from(&$x));
-    };
-    ($x:expr $(, $y:expr)*) => {
+        web_sys::console::log_1(&JsValue::from($x));
+    }};
+    ($x:expr $(, $y:expr)*) => {{
         const DEBUG_ONLY_WARNING: &str = $x;
         web_sys::console::log_1(&format!($x, $($y)*).into());
-    };
+    }};
 }
-

--- a/rust/perspective-viewer/src/rust/utils/js_object.rs
+++ b/rust/perspective-viewer/src/rust/utils/js_object.rs
@@ -43,6 +43,6 @@ macro_rules! js_log {
     }};
     ($x:expr $(, $y:expr)*) => {{
         const DEBUG_ONLY_WARNING: &str = $x;
-        web_sys::console::log_1(&format!($x, $($y)*).into());
+        web_sys::console::log_1(&format!($x, $($y),*).into());
     }};
 }

--- a/rust/perspective-viewer/src/rust/utils/mod.rs
+++ b/rust/perspective-viewer/src/rust/utils/mod.rs
@@ -32,22 +32,9 @@ pub use self::weak_component_link::*;
 
 #[macro_export]
 macro_rules! maybe {
-    ($($exp:stmt);* $(;)*) => {{
+    ($($exp:stmt);*) => {{
         #[must_use]
-        let x: Result<_, JsValue> = (|| {
-            $(
-                $exp
-            )*
-        })();
-        x
-    }};
-}
-
-#[macro_export]
-macro_rules! optionally {
-    ($($exp:stmt);* $(;)*) => {{
-        #[must_use]
-        let x: Option<_> = (|| {
+        let x = (|| {
             $(
                 $exp
             )*

--- a/rust/perspective-viewer/test/js/expressions.spec.js
+++ b/rust/perspective-viewer/test/js/expressions.spec.js
@@ -15,7 +15,7 @@ utils.with_server({}, () => {
         "superstore.html",
         () => {
             test.capture(
-                "click on add column button opens the expression UI.",
+                "Click on add column button opens the expression UI.",
                 async (page) => {
                     await page.evaluate(async () => {
                         const elem =
@@ -37,7 +37,6 @@ utils.with_server({}, () => {
                         )?.shadowRoot;
 
                         return (
-                            root?.querySelector(".cdr.squiggly-error") &&
                             root?.querySelector(".rename-label") &&
                             root?.querySelector(
                                 ".invisible.scrollbar.vertical.fade"

--- a/rust/perspective-viewer/test/results/results.json
+++ b/rust/perspective-viewer/test/results/results.json
@@ -3,7 +3,7 @@
     "superstore.html/doesn't leak elements.": "d0fd18b3d4d7c183c5ed155b4bf37972",
     "superstore.html/doesn't leak views when setting row pivots.": "54daaa4bbbe59f6ed4acc301ba871bab",
     "superstore.html/doesn't leak views when setting filters.": "6dfc1e505f1428424c3265f0236f22fc",
-    "__GIT_COMMIT__": "564651306a91bcb1b924cde262fc8a3f165d45de",
+    "__GIT_COMMIT__": "5cc59f02d059866edf364cab23b534f5032f4ec8",
     "blank.html/Handles reloading with a schema.": "e58c62f6e0ff16dc4d753f99e0fc39c3",
     "superstore_shows_a_grid_without_any_settings_applied_": "ae1c4690d978598ca14c8669244ce604",
     "superstore_Responsive_Layout_shows_horizontal_columns_on_small_vertical_viewports_": "57ba3ad341cf8a0e4df6ab96715ff2a0",
@@ -40,7 +40,7 @@
     "Expressions_An_expression_with_invalid_input_columns_should_disable_the_save_button": "075ae3d2fc31640504f814f60e5ef713",
     "Expressions_Should_overwrite_a_duplicate_expression_alias": "64a130829b6ce1764cdcc12208daffd3",
     "Expressions_Should_save_an_expression_when_the_save_butotn_is_clicked": "d41d8cd98f00b204e9800998ecf8427e",
-    "Expressions_Should_save_an_expression_when_the_save_button_is_clicked": "eb111042126a5354e1179b4429ee29fe",
+    "Expressions_Should_save_an_expression_when_the_save_button_is_clicked": "d41d8cd98f00b204e9800998ecf8427e",
     "Expressions_Should_overwrite_a_duplicate_expression": "fbe33e5c198466c9e0612ad5346d16db",
     "Expressions_Resetting_the_viewer_should_delete_all_expressions": "d41d8cd98f00b204e9800998ecf8427e",
     "Expressions_Resetting_the_viewer_when_expression_as_in_columns_field,_should_delete_all_expressions": "d41d8cd98f00b204e9800998ecf8427e",
@@ -64,5 +64,6 @@
     "superstore_restore()_fires_the__perspective-config-update__event": "ded04b5d6cb96a3651578334f189b20e",
     "superstore_restore_fires_the__perspective-config-update__event": "a2b7aac3c25e901de78a351acf7319ec",
     "superstore_save_returns_the_current_config": "a2b7aac3c25e901de78a351acf7319ec",
-    "superstore_restore_restores_a_config_from_save": "a2b7aac3c25e901de78a351acf7319ec"
+    "superstore_restore_restores_a_config_from_save": "a2b7aac3c25e901de78a351acf7319ec",
+    "Expressions_Click_on_add_column_button_opens_the_expression_UI_": "8e7377788674bf0c2f0278ba6bafe219"
 }


### PR DESCRIPTION
This PR makes the Expression Editor's contents persistent, even when not saved e.g. when focus is lost.  This works even in the case where e.g. the expression column is moved while the expression is in an edited state.  A `Reset` button had also been added to reset the editor's contents to reflect the current `View` state.

![edit-persist](https://user-images.githubusercontent.com/60666/139562342-a301e4a8-4608-4f0d-8cd7-9bb420b0f04c.gif)
