### PR TITLE
Add Regex functions using Exprtk and RE2

### DIFF
--- a/cmake/re2.txt.in
+++ b/cmake/re2.txt.in
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.7.2)
+
+project(re2-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(re2
+  GIT_REPOSITORY    https://github.com/google/re2.git
+  GIT_TAG           2021-09-01
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/re2-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/re2-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+  CMAKE_ARGS        "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+)

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -323,6 +323,7 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 		#########################
 		# PYTHON BINDINGS BUILD #
 		#########################
+		set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 		include_directories("${PSP_PYTHON_SRC}/perspective/include")
 
 		# Set CMP0094 to NEW - find the first version that matches constraints,
@@ -426,6 +427,9 @@ endif()
 # Build minimal arrow itself
 psp_build_dep("arrow" "${PSP_CMAKE_MODULE_PATH}/arrow.txt.in")
 
+# Build re2 as our regex library
+psp_build_dep("re2" "${PSP_CMAKE_MODULE_PATH}/re2.txt.in")
+
 find_package(Flatbuffers)
 if(NOT FLATBUFFERS_FOUND)
 	message(FATAL_ERROR"${Red}Flatbuffers could not be located${ColorReset}")
@@ -508,6 +512,7 @@ set (SOURCE_FILES
 	${PSP_CPP_SRC}/src/cpp/raii_impl_osx.cpp
 	${PSP_CPP_SRC}/src/cpp/raii_impl_win.cpp
 	${PSP_CPP_SRC}/src/cpp/range.cpp
+	${PSP_CPP_SRC}/src/cpp/regex.cpp
 	${PSP_CPP_SRC}/src/cpp/rlookup.cpp
 	${PSP_CPP_SRC}/src/cpp/scalar.cpp
 	${PSP_CPP_SRC}/src/cpp/schema_column.cpp
@@ -580,7 +585,7 @@ if (PSP_WASM_BUILD)
 	add_library(psp ${WASM_SOURCE_FILES})
 	target_compile_definitions(psp PRIVATE PSP_ENABLE_WASM=1)
 	set_target_properties(psp PROPERTIES COMPILE_FLAGS "")
-	target_link_libraries(psp arrow)
+	target_link_libraries(psp arrow re2)
 
 	# "esm/erspective.cpp.js" from CMAKE_EXECUTABLE_SYNTAX
 	add_executable(perspective_esm src/cpp/emscripten.cpp)
@@ -652,7 +657,7 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
 		endif()
 
 		# Link against minimal arrow static library
-		target_link_libraries(psp arrow)
+		target_link_libraries(psp arrow re2)
 
 		target_link_libraries(binding psp)
 

--- a/cpp/perspective/src/cpp/arrow_csv.cpp
+++ b/cpp/perspective/src/cpp/arrow_csv.cpp
@@ -20,47 +20,55 @@
 #include <arrow/csv/reader.h>
 #endif
 
-
 template <class TimePoint>
-static inline arrow::TimestampType::c_type ConvertTimePoint(TimePoint tp, arrow::TimeUnit::type unit) {
-  auto duration = tp.time_since_epoch();
-  switch (unit) {
-    case arrow::TimeUnit::SECOND:
-      return std::chrono::duration_cast<std::chrono::seconds>(duration).count();
-    case arrow::TimeUnit::MILLI:
-      return std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-    case arrow::TimeUnit::MICRO:
-      return std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
-    case arrow::TimeUnit::NANO:
-      return std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
-    default:
-      // Compiler errors without default case even though all enum cases are handled
-      assert(0);
-      return 0;
-  }
+static inline arrow::TimestampType::c_type
+ConvertTimePoint(TimePoint tp, arrow::TimeUnit::type unit) {
+    auto duration = tp.time_since_epoch();
+    switch (unit) {
+        case arrow::TimeUnit::SECOND:
+            return std::chrono::duration_cast<std::chrono::seconds>(duration)
+                .count();
+        case arrow::TimeUnit::MILLI:
+            return std::chrono::duration_cast<std::chrono::milliseconds>(
+                duration)
+                .count();
+        case arrow::TimeUnit::MICRO:
+            return std::chrono::duration_cast<std::chrono::microseconds>(
+                duration)
+                .count();
+        case arrow::TimeUnit::NANO:
+            return std::chrono::duration_cast<std::chrono::nanoseconds>(
+                duration)
+                .count();
+        default:
+            // Compiler errors without default case even though all enum cases
+            // are handled
+            assert(0);
+            return 0;
+    }
 }
 
-
-static inline bool ParseYYYY_MM_DD(const char* s,
-                                   arrow_vendored::date::year_month_day* out) {
-  uint16_t year = 0;
-  uint8_t month = 0;
-  uint8_t day = 0;
-  if (ARROW_PREDICT_FALSE(s[4] != '-') || ARROW_PREDICT_FALSE(s[7] != '-')) {
-    return false;
-  }
-  if (ARROW_PREDICT_FALSE(!arrow::internal::ParseUnsigned(s + 0, 4, &year))) {
-    return false;
-  }
-  if (ARROW_PREDICT_FALSE(!arrow::internal::ParseUnsigned(s + 5, 2, &month))) {
-    return false;
-  }
-  if (ARROW_PREDICT_FALSE(!arrow::internal::ParseUnsigned(s + 8, 2, &day))) {
-    return false;
-  }
-  *out = {arrow_vendored::date::year{year}, arrow_vendored::date::month{month},
-          arrow_vendored::date::day{day}};
-  return out->ok();
+static inline bool
+ParseYYYY_MM_DD(const char* s, arrow_vendored::date::year_month_day* out) {
+    uint16_t year = 0;
+    uint8_t month = 0;
+    uint8_t day = 0;
+    if (ARROW_PREDICT_FALSE(s[4] != '-') || ARROW_PREDICT_FALSE(s[7] != '-')) {
+        return false;
+    }
+    if (ARROW_PREDICT_FALSE(!arrow::internal::ParseUnsigned(s + 0, 4, &year))) {
+        return false;
+    }
+    if (ARROW_PREDICT_FALSE(
+            !arrow::internal::ParseUnsigned(s + 5, 2, &month))) {
+        return false;
+    }
+    if (ARROW_PREDICT_FALSE(!arrow::internal::ParseUnsigned(s + 8, 2, &day))) {
+        return false;
+    }
+    *out = {arrow_vendored::date::year{year},
+        arrow_vendored::date::month{month}, arrow_vendored::date::day{day}};
+    return out->ok();
 }
 
 namespace perspective {
@@ -143,9 +151,7 @@ namespace apachearrow {
                 if (length == 23) {
                     // "YYYY-MM-DD[ T]hh:mm:ss.sss"
                     arrow_vendored::date::year_month_day ymd;
-                    if (ARROW_PREDICT_FALSE(
-                            !ParseYYYY_MM_DD(
-                                s, &ymd))) {
+                    if (ARROW_PREDICT_FALSE(!ParseYYYY_MM_DD(s, &ymd))) {
                         return false;
                     }
                     std::chrono::seconds seconds;
@@ -166,9 +172,7 @@ namespace apachearrow {
                 } else if (length == 25) {
                     // "2008-09-15[ T]15:53:00+05:00"
                     arrow_vendored::date::year_month_day ymd;
-                    if (ARROW_PREDICT_FALSE(
-                            !ParseYYYY_MM_DD(
-                                s, &ymd))) {
+                    if (ARROW_PREDICT_FALSE(!ParseYYYY_MM_DD(s, &ymd))) {
                         return false;
                     }
                     std::chrono::seconds seconds;

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -91,7 +91,8 @@ t_computed_expression::t_computed_expression(
 
 void
 t_computed_expression::compute(std::shared_ptr<t_data_table> source_table,
-    std::shared_ptr<t_data_table> destination_table, t_expression_vocab& vocab) const {
+    std::shared_ptr<t_data_table> destination_table, t_expression_vocab& vocab,
+    t_regex_mapping& regex_mapping) const {
     // TODO: share symtables across pre/re/compute
     exprtk::symbol_table<t_tscalar> sym_table;
 
@@ -100,7 +101,7 @@ t_computed_expression::compute(std::shared_ptr<t_data_table> source_table,
 
     // Create a function store, with is_type_validator set to false as we
     // are calculating values, not type-checking.
-    t_computed_function_store function_store(vocab, false);
+    t_computed_function_store function_store(vocab, regex_mapping, false);
     function_store.register_computed_functions(sym_table);
 
     exprtk::expression<t_tscalar> expr_definition;
@@ -209,13 +210,14 @@ t_computed_expression_parser::precompute(const std::string& expression_alias,
     const std::string& expression_string,
     const std::string& parsed_expression_string,
     const std::vector<std::pair<std::string, std::string>>& column_ids,
-    std::shared_ptr<t_schema> schema, t_expression_vocab& vocab) {
+    std::shared_ptr<t_schema> schema, t_expression_vocab& vocab,
+    t_regex_mapping& regex_mapping) {
     exprtk::symbol_table<t_tscalar> sym_table;
     sym_table.add_constants();
 
     // Create a function store, with is_type_validator set to true as we are
     // just getting the output types.
-    t_computed_function_store function_store(vocab, true);
+    t_computed_function_store function_store(vocab, regex_mapping, true);
     function_store.register_computed_functions(sym_table);
 
     std::vector<t_tscalar> values;
@@ -271,7 +273,8 @@ t_computed_expression_parser::get_dtype(const std::string& expression_alias,
     const std::string& expression_string,
     const std::string& parsed_expression_string,
     const std::vector<std::pair<std::string, std::string>>& column_ids,
-    const t_schema& schema, t_expression_error& error, t_expression_vocab& vocab) {
+    const t_schema& schema, t_expression_error& error,
+    t_expression_vocab& vocab, t_regex_mapping& regex_mapping) {
     exprtk::symbol_table<t_tscalar> sym_table;
     sym_table.add_constants();
 
@@ -279,7 +282,7 @@ t_computed_expression_parser::get_dtype(const std::string& expression_alias,
 
     // Create a function store, with is_type_validator set to true as we are
     // just validating the output types.
-    t_computed_function_store function_store(vocab, true);
+    t_computed_function_store function_store(vocab, regex_mapping, true);
     function_store.register_computed_functions(sym_table);
 
     auto num_input_columns = column_ids.size();
@@ -418,8 +421,8 @@ t_validated_expression_map::get_expression_errors() const {
     return m_expression_errors;
 }
 
-t_computed_function_store::t_computed_function_store(
-    t_expression_vocab& vocab, bool is_type_validator)
+t_computed_function_store::t_computed_function_store(t_expression_vocab& vocab,
+    t_regex_mapping& regex_mapping, bool is_type_validator)
     : m_day_of_week_fn(computed_function::day_of_week(vocab, is_type_validator))
     , m_month_of_year_fn(
           computed_function::month_of_year(vocab, is_type_validator))
@@ -428,7 +431,9 @@ t_computed_function_store::t_computed_function_store(
     , m_order_fn(computed_function::order(is_type_validator))
     , m_upper_fn(computed_function::upper(vocab, is_type_validator))
     , m_lower_fn(computed_function::lower(vocab, is_type_validator))
-    , m_to_string_fn(computed_function::to_string(vocab, is_type_validator)) {}
+    , m_to_string_fn(computed_function::to_string(vocab, is_type_validator))
+    , m_match_fn(computed_function::match(regex_mapping))
+    , m_fullmatch_fn(computed_function::fullmatch(regex_mapping)) {}
 
 void
 t_computed_function_store::register_computed_functions(
@@ -451,6 +456,8 @@ t_computed_function_store::register_computed_functions(
     sym_table.add_function("lower", m_lower_fn);
     sym_table.add_function("length", t_computed_expression_parser::LENGTH_FN);
     sym_table.add_function("string", m_to_string_fn);
+    sym_table.add_function("match", m_match_fn);
+    sym_table.add_function("fullmatch", m_fullmatch_fn);
     sym_table.add_function(
         "percent_of", t_computed_expression_parser::PERCENT_OF_FN);
     sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -433,11 +433,14 @@ t_computed_function_store::t_computed_function_store(t_expression_vocab& vocab,
     , m_lower_fn(computed_function::lower(vocab, is_type_validator))
     , m_to_string_fn(computed_function::to_string(vocab, is_type_validator))
     , m_match_fn(computed_function::match(regex_mapping))
-    , m_fullmatch_fn(computed_function::fullmatch(regex_mapping)) {}
+    , m_fullmatch_fn(computed_function::fullmatch(regex_mapping))
+    , m_search_fn(
+          computed_function::search(vocab, regex_mapping, is_type_validator)) {}
 
 void
 t_computed_function_store::register_computed_functions(
     exprtk::symbol_table<t_tscalar>& sym_table) {
+    // General/numeric functions
     sym_table.add_function("bucket", t_computed_expression_parser::BUCKET_FN);
     sym_table.add_reserved_function(
         "inrange", t_computed_expression_parser::INRANGE_FN);
@@ -446,23 +449,26 @@ t_computed_function_store::register_computed_functions(
     sym_table.add_reserved_function(
         "max", t_computed_expression_parser::MAX_FN);
     sym_table.add_function(
+        "percent_of", t_computed_expression_parser::PERCENT_OF_FN);
+    sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);
+    sym_table.add_function(
+        "is_not_null", t_computed_expression_parser::IS_NOT_NULL_FN);
+
+    // Date/datetime functions
+    sym_table.add_function(
         "hour_of_day", t_computed_expression_parser::HOUR_OF_DAY_FN);
     sym_table.add_function("day_of_week", m_day_of_week_fn);
     sym_table.add_function("month_of_year", m_month_of_year_fn);
+
+    // String functions
     sym_table.add_function("intern", m_intern_fn);
     sym_table.add_function("concat", m_concat_fn);
     sym_table.add_function("order", m_order_fn);
     sym_table.add_function("upper", m_upper_fn);
     sym_table.add_function("lower", m_lower_fn);
     sym_table.add_function("length", t_computed_expression_parser::LENGTH_FN);
-    sym_table.add_function("string", m_to_string_fn);
-    sym_table.add_function("match", m_match_fn);
-    sym_table.add_function("fullmatch", m_fullmatch_fn);
-    sym_table.add_function(
-        "percent_of", t_computed_expression_parser::PERCENT_OF_FN);
-    sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);
-    sym_table.add_function(
-        "is_not_null", t_computed_expression_parser::IS_NOT_NULL_FN);
+
+    // Type conversion functions
     sym_table.add_function(
         "integer", t_computed_expression_parser::TO_INTEGER_FN);
     sym_table.add_function("float", t_computed_expression_parser::TO_FLOAT_FN);
@@ -471,6 +477,12 @@ t_computed_function_store::register_computed_functions(
     sym_table.add_function("date", t_computed_expression_parser::MAKE_DATE_FN);
     sym_table.add_function(
         "datetime", t_computed_expression_parser::MAKE_DATETIME_FN);
+    sym_table.add_function("string", m_to_string_fn);
+
+    // Regex functions
+    sym_table.add_function("match", m_match_fn);
+    sym_table.add_function("fullmatch", m_fullmatch_fn);
+    sym_table.add_function("search", m_search_fn);
 
     // Register static free functions as well
     sym_table.add_function("today", computed_function::today);

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -184,7 +184,6 @@ namespace computed_function {
 
         boost::to_upper(temp_str);
 
-
         rval.set(m_expression_vocab.intern(temp_str));
         return rval;
     }
@@ -410,6 +409,96 @@ namespace computed_function {
         m_order_idx = 0;
     }
 
+    match::match(t_regex_mapping& regex_mapping)
+        : exprtk::igeneric_function<t_tscalar>("TS")
+        , m_regex_mapping(regex_mapping) {}
+
+    match::~match() {}
+
+    t_tscalar
+    match::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+        rval.m_type = DTYPE_BOOL;
+
+        // Parameters already validated
+        t_scalar_view str_view(parameters[0]);
+        t_string_view pattern_view(parameters[1]);
+
+        t_tscalar str = str_view();
+        std::string match_pattern
+            = std::string(pattern_view.begin(), pattern_view.end());
+
+        // Type-check: only operate on strings, and pattern must be > size 0
+        if (str.get_dtype() != DTYPE_STR || str.m_status == STATUS_CLEAR
+            || match_pattern.size() == 0) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        RE2* compiled_pattern = m_regex_mapping.intern(match_pattern);
+
+        if (compiled_pattern == nullptr) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        if (!str.is_valid())
+            return rval;
+
+        const std::string& match_string = str.to_string();
+
+        // Get the pattern from the map and perform the match.
+        rval.set(RE2::PartialMatch(match_string, *compiled_pattern));
+
+        return rval;
+    }
+
+    fullmatch::fullmatch(t_regex_mapping& regex_mapping)
+        : exprtk::igeneric_function<t_tscalar>("TS")
+        , m_regex_mapping(regex_mapping) {}
+
+    fullmatch::~fullmatch() {}
+
+    t_tscalar
+    fullmatch::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+        rval.m_type = DTYPE_BOOL;
+
+        // Parameters already validated
+        t_scalar_view str_view(parameters[0]);
+        t_string_view pattern_view(parameters[1]);
+
+        t_tscalar str = str_view();
+        std::string match_pattern
+            = std::string(pattern_view.begin(), pattern_view.end());
+
+        // Type-check: only operate on strings, and pattern must be > size 0
+        if (str.get_dtype() != DTYPE_STR || str.m_status == STATUS_CLEAR
+            || match_pattern.size() == 0) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        RE2* compiled_pattern = m_regex_mapping.intern(match_pattern);
+
+        if (compiled_pattern == nullptr) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        if (!str.is_valid())
+            return rval;
+
+        const std::string& match_string = str.to_string();
+
+        // Get the pattern from the map and perform the match.
+        rval.set(RE2::FullMatch(match_string, *compiled_pattern));
+
+        return rval;
+    }
+
     hour_of_day::hour_of_day()
         : exprtk::igeneric_function<t_tscalar>("T") {}
 
@@ -473,7 +562,8 @@ namespace computed_function {
         "03 March", "04 April", "05 May", "06 June", "07 July", "08 August",
         "09 September", "10 October", "11 November", "12 December"};
 
-    day_of_week::day_of_week(t_expression_vocab& expression_vocab, bool is_type_validator)
+    day_of_week::day_of_week(
+        t_expression_vocab& expression_vocab, bool is_type_validator)
         : exprtk::igeneric_function<t_tscalar>("T")
         , m_expression_vocab(expression_vocab)
         , m_is_type_validator(is_type_validator) {
@@ -1262,7 +1352,8 @@ namespace computed_function {
         return rval;
     }
 
-    to_string::to_string(t_expression_vocab& expression_vocab, bool is_type_validator)
+    to_string::to_string(
+        t_expression_vocab& expression_vocab, bool is_type_validator)
         : exprtk::igeneric_function<t_tscalar>("T")
         , m_expression_vocab(expression_vocab)
         , m_is_type_validator(is_type_validator) {

--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -688,7 +688,8 @@ t_ctx_grouped_pkey::get_column_dtype(t_uindex idx) const {
 
 void
 t_ctx_grouped_pkey::compute_expressions(
-    std::shared_ptr<t_data_table> flattened_masked, t_expression_vocab& expression_vocab) {
+    std::shared_ptr<t_data_table> flattened_masked,
+    t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
@@ -703,8 +704,8 @@ t_ctx_grouped_pkey::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr->compute(
-            flattened_masked, master_expression_table, expression_vocab);
+        expr->compute(flattened_masked, master_expression_table,
+            expression_vocab, regex_mapping);
     }
 }
 
@@ -714,7 +715,8 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> master,
     std::shared_ptr<t_data_table> delta, std::shared_ptr<t_data_table> prev,
     std::shared_ptr<t_data_table> current,
     std::shared_ptr<t_data_table> transitions,
-    std::shared_ptr<t_data_table> existed, t_expression_vocab& expression_vocab) {
+    std::shared_ptr<t_data_table> existed, t_expression_vocab& expression_vocab,
+    t_regex_mapping& regex_mapping) {
     // Clear the tables so they are ready for this round of updates
     m_expression_tables->clear_transitional_tables();
 
@@ -731,22 +733,25 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr->compute(master, m_expression_tables->m_master, expression_vocab);
+        expr->compute(master, m_expression_tables->m_master, expression_vocab,
+            regex_mapping);
 
         // flattened: compute based on the latest update dataset
-        expr->compute(
-            flattened, m_expression_tables->m_flattened, expression_vocab);
+        expr->compute(flattened, m_expression_tables->m_flattened,
+            expression_vocab, regex_mapping);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr->compute(delta, m_expression_tables->m_delta, expression_vocab);
+        expr->compute(delta, m_expression_tables->m_delta, expression_vocab,
+            regex_mapping);
 
         // prev: the values of the updated rows before this update was applied
-        expr->compute(prev, m_expression_tables->m_prev, expression_vocab);
+        expr->compute(
+            prev, m_expression_tables->m_prev, expression_vocab, regex_mapping);
 
         // current: the current values of the updated rows
-        expr->compute(
-            current, m_expression_tables->m_current, expression_vocab);
+        expr->compute(current, m_expression_tables->m_current, expression_vocab,
+            regex_mapping);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -608,8 +608,8 @@ t_ctx1::get_trav_depth(t_index idx) const {
 }
 
 void
-t_ctx1::compute_expressions(
-    std::shared_ptr<t_data_table> flattened_masked, t_expression_vocab& expression_vocab) {
+t_ctx1::compute_expressions(std::shared_ptr<t_data_table> flattened_masked,
+    t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
@@ -625,8 +625,8 @@ t_ctx1::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr->compute(
-            flattened_masked, master_expression_table, expression_vocab);
+        expr->compute(flattened_masked, master_expression_table,
+            expression_vocab, regex_mapping);
     }
 }
 
@@ -636,7 +636,8 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> master,
     std::shared_ptr<t_data_table> delta, std::shared_ptr<t_data_table> prev,
     std::shared_ptr<t_data_table> current,
     std::shared_ptr<t_data_table> transitions,
-    std::shared_ptr<t_data_table> existed, t_expression_vocab& expression_vocab) {
+    std::shared_ptr<t_data_table> existed, t_expression_vocab& expression_vocab,
+    t_regex_mapping& regex_mapping) {
     // Clear the tables so they are ready for this round of updates
     m_expression_tables->clear_transitional_tables();
 
@@ -653,22 +654,25 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr->compute(master, m_expression_tables->m_master, expression_vocab);
+        expr->compute(master, m_expression_tables->m_master, expression_vocab,
+            regex_mapping);
 
         // flattened: compute based on the latest update dataset
-        expr->compute(
-            flattened, m_expression_tables->m_flattened, expression_vocab);
+        expr->compute(flattened, m_expression_tables->m_flattened,
+            expression_vocab, regex_mapping);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr->compute(delta, m_expression_tables->m_delta, expression_vocab);
+        expr->compute(delta, m_expression_tables->m_delta, expression_vocab,
+            regex_mapping);
 
         // prev: the values of the updated rows before this update was applied
-        expr->compute(prev, m_expression_tables->m_prev, expression_vocab);
+        expr->compute(
+            prev, m_expression_tables->m_prev, expression_vocab, regex_mapping);
 
         // current: the current values of the updated rows
-        expr->compute(
-            current, m_expression_tables->m_current, expression_vocab);
+        expr->compute(current, m_expression_tables->m_current, expression_vocab,
+            regex_mapping);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/context_two.cpp
+++ b/cpp/perspective/src/cpp/context_two.cpp
@@ -1050,8 +1050,8 @@ t_ctx2::get_column_dtype(t_uindex idx) const {
 }
 
 void
-t_ctx2::compute_expressions(
-    std::shared_ptr<t_data_table> flattened_masked, t_expression_vocab& expression_vocab) {
+t_ctx2::compute_expressions(std::shared_ptr<t_data_table> flattened_masked,
+    t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
@@ -1067,8 +1067,8 @@ t_ctx2::compute_expressions(
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr->compute(
-            flattened_masked, master_expression_table, expression_vocab);
+        expr->compute(flattened_masked, master_expression_table,
+            expression_vocab, regex_mapping);
     }
 }
 
@@ -1078,7 +1078,8 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> master,
     std::shared_ptr<t_data_table> delta, std::shared_ptr<t_data_table> prev,
     std::shared_ptr<t_data_table> current,
     std::shared_ptr<t_data_table> transitions,
-    std::shared_ptr<t_data_table> existed, t_expression_vocab& expression_vocab) {
+    std::shared_ptr<t_data_table> existed, t_expression_vocab& expression_vocab,
+    t_regex_mapping& regex_mapping) {
     // Clear the tables so they are ready for this round of updates
     m_expression_tables->clear_transitional_tables();
 
@@ -1095,22 +1096,25 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr->compute(master, m_expression_tables->m_master, expression_vocab);
+        expr->compute(master, m_expression_tables->m_master, expression_vocab,
+            regex_mapping);
 
         // flattened: compute based on the latest update dataset
-        expr->compute(
-            flattened, m_expression_tables->m_flattened, expression_vocab);
+        expr->compute(flattened, m_expression_tables->m_flattened,
+            expression_vocab, regex_mapping);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr->compute(delta, m_expression_tables->m_delta, expression_vocab);
+        expr->compute(delta, m_expression_tables->m_delta, expression_vocab,
+            regex_mapping);
 
         // prev: the values of the updated rows before this update was applied
-        expr->compute(prev, m_expression_tables->m_prev, expression_vocab);
+        expr->compute(
+            prev, m_expression_tables->m_prev, expression_vocab, regex_mapping);
 
         // current: the current values of the updated rows
-        expr->compute(
-            current, m_expression_tables->m_current, expression_vocab);
+        expr->compute(current, m_expression_tables->m_current, expression_vocab,
+            regex_mapping);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1471,6 +1471,8 @@ namespace binding {
         expressions.reserve(js_expressions.size());
 
         t_expression_vocab& expression_vocab = *(gnode.get_expression_vocab());
+        t_regex_mapping& regex_mapping
+            = *(gnode.get_expression_regex_mapping());
 
         // Will either abort() or succeed completely, and this isn't a public
         // API so we can directly index for speed.
@@ -1511,7 +1513,7 @@ namespace binding {
             std::shared_ptr<t_computed_expression> expression
                 = t_computed_expression_parser::precompute(expression_alias,
                     expression_string, parsed_expression_string, column_ids,
-                    schema, expression_vocab);
+                    schema, expression_vocab, regex_mapping);
 
             schema->add_column(expression_alias, expression->get_dtype());
             expressions.push_back(expression);

--- a/cpp/perspective/src/cpp/regex.cpp
+++ b/cpp/perspective/src/cpp/regex.cpp
@@ -1,0 +1,37 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+#include <perspective/regex.h>
+
+namespace perspective {
+
+RE2*
+t_regex_mapping::intern(const std::string& pattern) {
+    if (m_regex_map.count(pattern) == 1) {
+        return m_regex_map[pattern].get();
+    }
+
+    std::shared_ptr<RE2> compiled_pattern
+        = std::make_shared<RE2>(pattern, RE2::Quiet);
+
+    if (!compiled_pattern->ok()) {
+        // TODO: provide a better error message when the regex can't compile.
+        return nullptr;
+    }
+
+    m_regex_map[pattern] = compiled_pattern;
+    return m_regex_map[pattern].get();
+}
+
+void
+t_regex_mapping::clear() {
+    m_regex_map.clear();
+}
+
+} // end namespace perspective

--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -88,6 +88,7 @@ Table::validate_expressions(
     // Use the gnode's expression vocab to validate expressions so we never
     // have string-typed scalars with nullptr.
     t_expression_vocab& expression_vocab = *(m_gnode->get_expression_vocab());
+    t_regex_mapping& regex_mapping = *(m_gnode->get_expression_regex_mapping());
 
     for (const auto& expr : expressions) {
         const std::string& expression_alias = std::get<0>(expr);
@@ -112,7 +113,7 @@ Table::validate_expressions(
 
         t_dtype expression_dtype = t_computed_expression_parser::get_dtype(
             expression_alias, expression_string, parsed_expression_string,
-            column_ids, gnode_schema, error, expression_vocab);
+            column_ids, gnode_schema, error, expression_vocab, regex_mapping);
 
         // FIXME: none == bad type? what about clear
         if (expression_dtype == DTYPE_NONE) {

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -52,7 +52,7 @@ public:
 
     void compute(std::shared_ptr<t_data_table> source_table,
         std::shared_ptr<t_data_table> destination_table,
-        t_expression_vocab& vocab) const;
+        t_expression_vocab& vocab, t_regex_mapping& regex_mapping) const;
 
     const std::string& get_expression_alias() const;
     const std::string& get_expression_string() const;
@@ -95,7 +95,8 @@ public:
         const std::string& expression_string,
         const std::string& parsed_expression_string,
         const std::vector<std::pair<std::string, std::string>>& column_ids,
-        std::shared_ptr<t_schema> schema, t_expression_vocab& vocab);
+        std::shared_ptr<t_schema> schema, t_expression_vocab& vocab,
+        t_regex_mapping& regex_mapping);
 
     /**
      * @brief Returns the dtype of the given expression, or `DTYPE_NONE`
@@ -122,7 +123,7 @@ public:
         const std::string& parsed_expression_string,
         const std::vector<std::pair<std::string, std::string>>& column_ids,
         const t_schema& schema, t_expression_error& error,
-        t_expression_vocab& vocab);
+        t_expression_vocab& vocab, t_regex_mapping& regex_mapping);
 
     static std::shared_ptr<exprtk::parser<t_tscalar>> PARSER;
 
@@ -178,8 +179,8 @@ struct PERSPECTIVE_EXPORT t_validated_expression_map {
 struct PERSPECTIVE_EXPORT t_computed_function_store {
     PSP_NON_COPYABLE(t_computed_function_store);
 
-    t_computed_function_store(
-        t_expression_vocab& vocab, bool is_type_validator);
+    t_computed_function_store(t_expression_vocab& vocab,
+        t_regex_mapping& regex_mapping, bool is_type_validator);
 
     void register_computed_functions(
         exprtk::symbol_table<t_tscalar>& sym_table);
@@ -200,6 +201,8 @@ struct PERSPECTIVE_EXPORT t_computed_function_store {
     computed_function::upper m_upper_fn;
     computed_function::lower m_lower_fn;
     computed_function::to_string m_to_string_fn;
+    computed_function::match m_match_fn;
+    computed_function::fullmatch m_fullmatch_fn;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -203,6 +203,7 @@ struct PERSPECTIVE_EXPORT t_computed_function_store {
     computed_function::to_string m_to_string_fn;
     computed_function::match m_match_fn;
     computed_function::fullmatch m_fullmatch_fn;
+    computed_function::search m_search_fn;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/computed_function.h
+++ b/cpp/perspective/src/include/perspective/computed_function.h
@@ -36,14 +36,7 @@ namespace computed_function {
     typedef typename t_generic_type::vector_view t_vector_view;
     typedef typename t_generic_type::string_view t_string_view;
 
-// A function that uses `t_regex_mapping` to cache repeated invocations
-// of a parsed RE2 regex over a column. The `t_regex_mapping` is passed in
-// from the `t_computed_expression` object, so each expression that is created
-// has its own map. In benchmarks, this leads to a sustained 40-50% improvement
-// in the performance of regex functions as the map is initialized and the
-// regex object cached inside the first call to precompute(), and all
-// subsequent calls will use the cached object instead of initializing a new
-// boost::regex.
+// A regex function that caches its parsed regex objects.
 #define REGEX_FUNCTION_HEADER(NAME)                                            \
     struct NAME : public exprtk::igeneric_function<t_tscalar> {                \
         NAME(t_regex_mapping& regex_mapping);                                  \
@@ -59,9 +52,9 @@ namespace computed_function {
             t_regex_mapping& regex_mapping, bool is_type_validator);           \
         ~NAME();                                                               \
         t_tscalar operator()(t_parameter_list parameters);                     \
-        bool m_is_type_validator;                                              \
         t_expression_vocab& m_expression_vocab;                                \
         t_regex_mapping& m_regex_mapping;                                      \
+        bool m_is_type_validator;                                              \
     };
 
 // A function that returns a new string that is not part of the original
@@ -79,8 +72,8 @@ namespace computed_function {
         ~NAME();                                                               \
         t_tscalar operator()(t_parameter_list parameters);                     \
         t_expression_vocab& m_expression_vocab;                                \
-        bool m_is_type_validator;                                              \
         t_tscalar m_sentinel;                                                  \
+        bool m_is_type_validator;                                              \
     };
 
     // TODO PSP_NON_COPYABLE all functions
@@ -143,7 +136,9 @@ namespace computed_function {
     REGEX_FUNCTION_HEADER(fullmatch)
 
     /**
-     * @brief search(string, pattern) => The
+     * @brief search(string, pattern) => Returns the substring in the first
+     * capturing group that matches pattern. If the regex does not have any
+     * capturing groups, fails type checking and returns null.
      */
     REGEX_STRING_FUNCTION_HEADER(search)
 

--- a/cpp/perspective/src/include/perspective/context_common_decls.h
+++ b/cpp/perspective/src/include/perspective/context_common_decls.h
@@ -93,15 +93,16 @@ std::shared_ptr<t_expression_tables> get_expression_tables() const;
 
 // Given shared pointers to data tables from the gnode, use them to
 // compute the results of expression columns.
-void compute_expressions(
-    std::shared_ptr<t_data_table> flattened_masked, t_expression_vocab& expression_vocab);
+void compute_expressions(std::shared_ptr<t_data_table> flattened_masked,
+    t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping);
 
 void compute_expressions(std::shared_ptr<t_data_table> master,
     std::shared_ptr<t_data_table> flattened,
     std::shared_ptr<t_data_table> delta, std::shared_ptr<t_data_table> prev,
     std::shared_ptr<t_data_table> current,
     std::shared_ptr<t_data_table> transitions,
-    std::shared_ptr<t_data_table> existed, t_expression_vocab& expression_vocab);
+    std::shared_ptr<t_data_table> existed, t_expression_vocab& expression_vocab,
+    t_regex_mapping& regex_mapping);
 
 // Unity api
 std::vector<t_tscalar> unity_get_row_data(t_uindex idx) const;

--- a/cpp/perspective/src/include/perspective/context_grouped_pkey.h
+++ b/cpp/perspective/src/include/perspective/context_grouped_pkey.h
@@ -18,6 +18,7 @@
 #include <perspective/sym_table.h>
 #include <perspective/expression_tables.h>
 #include <perspective/expression_vocab.h>
+#include <perspective/regex.h>
 
 namespace perspective {
 

--- a/cpp/perspective/src/include/perspective/context_one.h
+++ b/cpp/perspective/src/include/perspective/context_one.h
@@ -17,6 +17,7 @@
 #include <perspective/data_table.h>
 #include <perspective/expression_tables.h>
 #include <perspective/expression_vocab.h>
+#include <perspective/regex.h>
 
 namespace perspective {
 

--- a/cpp/perspective/src/include/perspective/context_two.h
+++ b/cpp/perspective/src/include/perspective/context_two.h
@@ -19,6 +19,7 @@
 #include <perspective/data_table.h>
 #include <perspective/expression_tables.h>
 #include <perspective/expression_vocab.h>
+#include <perspective/regex.h>
 
 namespace perspective {
 

--- a/cpp/perspective/src/include/perspective/context_zero.h
+++ b/cpp/perspective/src/include/perspective/context_zero.h
@@ -19,6 +19,7 @@
 #include <perspective/data_table.h>
 #include <perspective/expression_tables.h>
 #include <perspective/expression_vocab.h>
+#include <perspective/regex.h>
 #include <tsl/hopscotch_set.h>
 
 namespace perspective {

--- a/cpp/perspective/src/include/perspective/expression_vocab.h
+++ b/cpp/perspective/src/include/perspective/expression_vocab.h
@@ -17,26 +17,26 @@ public:
     PSP_NON_COPYABLE(t_expression_vocab);
 
     t_expression_vocab();
-    
+
     /**
      * @brief Given a const char* to a string, intern it into the current
      * vocab page, and return the pointer to the string that has been
      * interned into the vocab. The returned pointer is guaranteed to be
      * valid for the lifetime of the `t_expression_vocab` instance.
-     * 
-     * @param str 
-     * @return const char* 
+     *
+     * @param str
+     * @return const char*
      */
     const char* intern(const char* str);
     const char* intern(const std::string& str);
 
     void clear();
-    
+
     /**
      * @brief Returns the empty string owned by the vocab, which will be valid
      * as long as the vocab is alive.
-     * 
-     * @return const char* 
+     *
+     * @return const char*
      */
     const char* get_empty_string() const;
 
@@ -58,8 +58,8 @@ private:
     std::size_t m_max_vocab_size;
 
     std::size_t m_current_vocab_size;
-    
-    // An empty string for validation functions to use. 
+
+    // An empty string for validation functions to use.
     std::string m_empty_string;
 };
 

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -23,6 +23,7 @@
 #include <perspective/computed_expression.h>
 #include <perspective/computed_function.h>
 #include <perspective/expression_tables.h>
+#include <perspective/regex.h>
 #include <tsl/ordered_map.h>
 #ifdef PSP_PARALLEL_FOR
 #include <thread>
@@ -205,6 +206,7 @@ public:
     std::string repr() const;
 
     std::shared_ptr<t_expression_vocab> get_expression_vocab() const;
+    std::shared_ptr<t_regex_mapping> get_expression_regex_mapping() const;
 
 #ifdef PSP_PARALLEL_FOR
     void set_event_loop_thread_id(std::thread::id id);
@@ -360,6 +362,7 @@ private:
     bool m_was_updated;
 
     std::shared_ptr<t_expression_vocab> m_expression_vocab;
+    std::shared_ptr<t_regex_mapping> m_expression_regex_mapping;
 
 #ifdef PSP_ENABLE_PYTHON
     std::thread::id m_event_loop_thread_id;

--- a/cpp/perspective/src/include/perspective/parallel_for.h
+++ b/cpp/perspective/src/include/perspective/parallel_for.h
@@ -17,7 +17,8 @@
 namespace perspective {
 
 template <class FUNCTION>
-void parallel_for(int num_tasks, FUNCTION&& func) {
+void
+parallel_for(int num_tasks, FUNCTION&& func) {
     auto status = arrow::internal::ParallelFor(num_tasks, func);
     if (!status.ok()) {
         PSP_COMPLAIN_AND_ABORT("ParallelFor failed");

--- a/cpp/perspective/src/include/perspective/regex.h
+++ b/cpp/perspective/src/include/perspective/regex.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+#pragma once
+
+#include <perspective/first.h>
+#include <perspective/base.h>
+#include <perspective/exports.h>
+#include <tsl/hopscotch_map.h>
+#include <re2/re2.h>
+
+namespace perspective {
+
+/**
+ * @brief Caches RE2 objects by pattern string.
+ */
+struct PERSPECTIVE_EXPORT t_regex_mapping {
+
+    /**
+     * @brief Given a regex pattern string, store it in the map if it does not
+     * exist already, and return a raw pointer to the stored RE2 object which
+     * will be valid as long as the mapping is alive.
+     *
+     * @param pattern
+     * @return RE2&
+     */
+    RE2* intern(const std::string& pattern);
+
+    void clear();
+
+    // Store pointers to RE2 objects as the default copy assignment operator
+    // for RE2 is disabled.
+    tsl::hopscotch_map<std::string, std::shared_ptr<RE2>> m_regex_map;
+};
+
+} // end namespace perspective

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1526,10 +1526,10 @@ export default function (Module) {
             // way of handling it.
             // TODO I concur  -- texodus
             parsed_expression_string = parsed_expression_string.replace(
-                /(bucket|match|fullmatch|find|indexof)\(.*?,\s*(intern\(\'(.+)\'\)).*\)/g,
+                /(bucket|match|fullmatch|search|indexof)\(.*?,\s*(intern\(\'(.+)\'\)).*\)/g,
                 (match, _, intern_fn, value) => {
-                    // Takes a string of the form find(x, intern('y'), z)
-                    // and removes intern() to create find(x, 'y', z)
+                    // Takes a string of the form fn(x, intern('y'), z)
+                    // and removes intern() to create fn(x, 'y', z)
                     const intern_idx = match.indexOf(intern_fn);
                     return `${match.substring(
                         0,

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1520,14 +1520,23 @@ export default function (Module) {
                 (match) => `intern(${match})`
             );
 
-            // Replace intern() for bucket, as it takes a string literal
-            // parameter and does not work if that param is interned. TODO:
-            // this is clumsy and we should have a better way of handling it.
+            // Replace intern() for bucket and regex functions that take
+            // a string literal parameter and does not work if that param is
+            // interned. TODO: this is clumsy and we should have a better
+            // way of handling it.
             // TODO I concur  -- texodus
             parsed_expression_string = parsed_expression_string.replace(
-                /bucket\(.*?,\s*(intern\(\'([smhDWMY])\'\))\s*\)/g,
-                (match, full, value) => {
-                    return `${match.substr(0, match.indexOf(full))}'${value}')`;
+                /(bucket|match|fullmatch|find|indexof)\(.*?,\s*(intern\(\'(.+)\'\)).*\)/g,
+                (match, _, intern_fn, value) => {
+                    // Takes a string of the form find(x, intern('y'), z)
+                    // and removes intern() to create find(x, 'y', z)
+                    const intern_idx = match.indexOf(intern_fn);
+                    return `${match.substring(
+                        0,
+                        intern_idx
+                    )}'${value}'${match.substring(
+                        intern_idx + intern_fn.length
+                    )}`;
                 }
             );
 
@@ -1574,7 +1583,10 @@ export default function (Module) {
      * // {'"Sales" + "Profit"': "float"}
      * console.log(results.expression_schema);
      *
-     * // {"invalid": "unknown token!", "1 + 'string'": "TypeError"}
+     * // {
+     * //   "invalid": {column: 0, line: 0, error_message: "unknown token!"},
+     * //   "1 + 'string'": {column: 0, line: 0, error_message: "Type Error"}
+     * // }
      * console.log(results.errors);
      */
     table.prototype.validate_expressions = function (

--- a/packages/perspective/test/js/expressions/functionality.js
+++ b/packages/perspective/test/js/expressions/functionality.js
@@ -1206,6 +1206,23 @@ module.exports = (perspective) => {
             table.delete();
         });
 
+        it("Should only parse first comment as an alias", async () => {
+            const table = await perspective.table({a: [1, 2, 3]});
+            const view = await table.view({
+                expressions: [
+                    `// abc
+                    var x := 1 + 2; // another comment
+                    x + 3 + 4 # comment`,
+                ],
+            });
+            const schema = await view.expression_schema();
+            expect(schema).toEqual({abc: "float"});
+            const result = await view.to_columns();
+            expect(result["abc"]).toEqual(Array(3).fill(10));
+            await view.delete();
+            await table.delete();
+        });
+
         it("Should be able to alias a real column in `view()`", async function () {
             const table = await perspective.table(
                 expressions_common.all_types_arrow.slice()

--- a/packages/perspective/test/js/expressions/functionality.js
+++ b/packages/perspective/test/js/expressions/functionality.js
@@ -2962,6 +2962,10 @@ module.exports = (perspective) => {
                         'upper("c")',
                         `bucket("b", 'M')`,
                         `bucket("b", 's')`,
+                        `bucket("b",'M')`,
+                        `bucket("b",'s')`,
+                        `bucket("b",       'M')`,
+                        `bucket("b",       's')`,
                     ],
                 });
                 const schema = await view.expression_schema();
@@ -2974,6 +2978,10 @@ module.exports = (perspective) => {
                     'upper("c")': "string",
                     "bucket(\"b\", 'M')": "date",
                     "bucket(\"b\", 's')": "datetime",
+                    "bucket(\"b\",'M')": "date",
+                    "bucket(\"b\",'s')": "datetime",
+                    "bucket(\"b\",       'M')": "date",
+                    "bucket(\"b\",       's')": "datetime",
                 });
                 view.delete();
                 table.delete();

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -145,6 +145,7 @@ make_view_config(
 
     // Validate expressions using the vocab
     t_expression_vocab& expression_vocab = *(gnode.get_expression_vocab());
+    t_regex_mapping& regex_mapping = *(gnode.get_expression_regex_mapping());
 
     // Will either abort() or succeed completely, and this isn't a public
     // API so we can directly index for speed.
@@ -178,8 +179,10 @@ make_view_config(
         }
 
         // If the expression cannot be parsed, it will abort() here.
-        std::shared_ptr<t_computed_expression> expression = t_computed_expression_parser::precompute(
-            expression_alias, expression_string, parsed_expression_string, column_ids, schema, expression_vocab);
+        std::shared_ptr<t_computed_expression> expression =
+            t_computed_expression_parser::precompute(
+                expression_alias, expression_string, parsed_expression_string,
+                column_ids, schema, expression_vocab, regex_mapping);
 
         expressions.push_back(expression);
         schema->add_column(expression_alias, expression->get_dtype());

--- a/python/perspective/perspective/table/_utils.py
+++ b/python/perspective/perspective/table/_utils.py
@@ -14,7 +14,9 @@ from .libbinding import t_dtype
 ALIAS_REGEX = re.compile(r"//(.+)\n")
 EXPRESSION_COLUMN_NAME_REGEX = re.compile(r"\"(.*?[^\\])\"")
 STRING_LITERAL_REGEX = re.compile(r"'(.*?[^\\])'")
-BUCKET_LITERAL_REGEX = re.compile(r"bucket\(.*?,\s*(intern\(\'([smhDWMY])\'\))\s*\)")
+FUNCTION_LITERAL_REGEX = re.compile(
+    r"(bucket|match|fullmatch|find|indexof)\(.*?,\s*(intern\(\'(.+)\'\)).*\)"
+)
 BOOLEAN_LITERAL_REGEX = re.compile(r"([a-zA-Z_]+[a-zA-Z0-9_]*)")
 
 
@@ -126,7 +128,7 @@ def _replace_expression_column_name(
     return column_name_map[column_name]
 
 
-def _replace_bucket_unit(match_obj):
+def _replace_interned_param(match_obj):
     """Replace the intern('unit') in `bucket()` with just the string
     literal, because the unit determines the return type of the column and the
     function would not be able to validate a unit if it was interned."""
@@ -200,7 +202,7 @@ def _parse_expression_strings(expressions):
         )
 
         # remove the `intern()` in bucket - TODO: this is messy
-        parsed = re.sub(BUCKET_LITERAL_REGEX, _replace_bucket_unit, parsed)
+        parsed = re.sub(FUNCTION_LITERAL_REGEX, _replace_interned_param, parsed)
 
         validated = [alias, expression, parsed, column_id_map]
 

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -53,6 +53,10 @@ thread_local! {
                 open: "[",
                 close: "]"
             },
+            AutoClosingPairs {
+                open: "{",
+                close: "}"
+            },
         ]
     };
 
@@ -519,6 +523,20 @@ thread_local! {
                 insert_text: "boolean(${1:x})".to_owned(),
                 insert_text_rules: 4,
                 documentation: "Converts the given argument to a boolean".to_owned(),
+            },
+            CompletionItemSuggestion {
+                label: "match".to_owned(),
+                kind: 1,
+                insert_text: "match(${1:string}, ${2:pattern})".to_owned(),
+                insert_text_rules: 4,
+                documentation: "Returns True if any part of string matches pattern, and False otherwise.".to_owned(),
+            },
+            CompletionItemSuggestion {
+                label: "fullmatch".to_owned(),
+                kind: 1,
+                insert_text: "fullmatch(${1:string}, ${2:pattern})".to_owned(),
+                insert_text_rules: 4,
+                documentation: "Returns True if the whole string matches pattern, and False otherwise.".to_owned(),
             },
         ]
     };

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -538,6 +538,13 @@ thread_local! {
                 insert_text_rules: 4,
                 documentation: "Returns True if the whole string matches pattern, and False otherwise.".to_owned(),
             },
+            CompletionItemSuggestion {
+                label: "search".to_owned(),
+                kind: 1,
+                insert_text: "search(${1:string}, ${2:pattern})".to_owned(),
+                insert_text_rules: 4,
+                documentation: "Returns the substring that matches the first capturing group in pattern, or null if there are no capturing groups in the pattern or if there are no matches.".to_owned(),
+            },
         ]
     };
 }


### PR DESCRIPTION
This PR is a first cut at adding regular expression functionality to Perspective's expression API, including (for now) three functions:

- `match(string, pattern)` returns True if any substring of string matches pattern
- `fullmatch(string, pattern)` returns True if the whole string matches pattern
- `search(string, pattern)` returns the first substring that matches the first capturing group in pattern. Because we are using RE2, a regex without a capturing group will be rejected by the type-checker as RE2 does not return the full match, only the results of the capturing group.

The functions themselves are not extremely complicated, as they mostly defer to RE2 to perform the match. However, for performance and to avoid repeatedly compiling regex objects on the same string for each row, I've added a regex cache that works similarly to a `t_vocab`, so that all valid compiled regexes are stored for the lifetime of the table. This required a large scale refactor of the existing code, hence this PR being created before additional functionality is added.

We chose RE2 as the regex implementation for several reasons:

- As opposed to Boost which has various unknowns that pertain to the build (is it already present on the system? is the version present header-only or built? is apache arrow pulling in boost already?), we can easily reason about the RE2 build: it's added as an external dependency and it's linked against in our CMakeLists.
- The worst-case linear time guarantee means we don't have to build our own checks for "will this regex crash the Perspective engine" and focus on building out functionality and tuning the API
- We benchmarked RE2 against both `boost::regex` and a custom regex matcher that farmed out functionality to the binding langauge (JS/Python) using Emscripten/Pybind, and while RE2 was slower than Boost and faster than the binding language solution, it offered the least uncertainty/unknowns in terms of the build.
- The syntax is a little different, and some features (such as lookbehinds) are unavailable, but RE2 remains widely used in GoLang and Google products that use regex (Google Sheets, data products, etc.) and answers to common syntax questions are available online.

We need a few extra things to fully flesh this feature out:

- Right now, regexes must be string literals, and we have a complicated regular expression that takes a string of the format `function(..., intern('string literal'), ...)` and converts it to `function(..., 'string literal', ...)`. It would be great to figure out a way to auto-intern strings only when we need them, as compared to the current iteration which interns all strings based on a regex that detects single quotes, and then we have to perform a complex replace operation to "un-intern" those strings. This will only get more complicated as our custom function signatures become more complex.
- Because the regex pattern can't be interned, any expression that assigns a pattern to a variable (such as `var pattern := '(.*)'; search("a", pattern)` is invalid. This is annoying for writing longer, more complex regexes that are used in multiple functions, and goes back to the problem with intern as stated above.
- More functions: substring, replace, indexof, etc.
- Accessing arbitrary capture groups - search() only returns the first capture group, but we should be able to return any group with something like `search(string, pattern, group_number=1)`
- A consume function, which would consume the input string and write the results to a vector:

```
var results[3]; // any vector big enough to hold all the groups

// column = string with a weird date format like "05 19 2021"
var success := fullsearch("column", '^([0-9]{2}) ([0-9]{2}) ([0-9]{4})', results)
success ? date(integer(results[2]), integer(results[0]), integer([results[1])) : null
```
