### PR TITLE
More regex functions - find, substring, replace

### DIFF
--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -436,11 +436,15 @@ t_computed_function_store::t_computed_function_store(t_expression_vocab& vocab,
     , m_lower_fn(computed_function::lower(vocab, is_type_validator))
     , m_to_string_fn(computed_function::to_string(vocab, is_type_validator))
     , m_match_fn(computed_function::match(regex_mapping))
-    , m_fullmatch_fn(computed_function::fullmatch(regex_mapping))
+    , m_match_all_fn(computed_function::match_all(regex_mapping))
     , m_search_fn(
           computed_function::search(vocab, regex_mapping, is_type_validator))
     , m_indexof_fn(computed_function::indexof(regex_mapping))
-    , m_substring_fn(computed_function::substring(vocab, is_type_validator)) {}
+    , m_substring_fn(computed_function::substring(vocab, is_type_validator))
+    , m_replace_fn(
+          computed_function::replace(vocab, regex_mapping, is_type_validator))
+    , m_replace_all_fn(
+          computed_function::replace_all(vocab, regex_mapping, is_type_validator)) {}
 
 void
 t_computed_function_store::register_computed_functions(
@@ -490,10 +494,12 @@ t_computed_function_store::register_computed_functions(
 
     // Regex functions
     sym_table.add_function("match", m_match_fn);
-    sym_table.add_function("fullmatch", m_fullmatch_fn);
+    sym_table.add_function("match_all", m_match_all_fn);
     sym_table.add_function("search", m_search_fn);
     sym_table.add_function("indexof", m_indexof_fn);
     sym_table.add_function("substring", m_substring_fn);
+    sym_table.add_function("replace", m_replace_fn);
+    sym_table.add_function("replace_all", m_replace_all_fn);
 
     // And scalar constants
     sym_table.add_constant("True", t_computed_expression_parser::TRUE_SCALAR);

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -69,6 +69,9 @@ computed_function::make_date t_computed_expression_parser::MAKE_DATE_FN
 computed_function::make_datetime t_computed_expression_parser::MAKE_DATETIME_FN
     = computed_function::make_datetime();
 
+computed_function::random t_computed_expression_parser::RANDOM_FN
+    = computed_function::random();
+
 t_tscalar t_computed_expression_parser::TRUE_SCALAR = mktscalar(true);
 
 t_tscalar t_computed_expression_parser::FALSE_SCALAR = mktscalar(false);
@@ -453,12 +456,16 @@ t_computed_function_store::register_computed_functions(
     sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);
     sym_table.add_function(
         "is_not_null", t_computed_expression_parser::IS_NOT_NULL_FN);
+    sym_table.add_function(
+        "random", t_computed_expression_parser::RANDOM_FN);
 
     // Date/datetime functions
     sym_table.add_function(
         "hour_of_day", t_computed_expression_parser::HOUR_OF_DAY_FN);
     sym_table.add_function("day_of_week", m_day_of_week_fn);
     sym_table.add_function("month_of_year", m_month_of_year_fn);
+    sym_table.add_function("today", computed_function::today);
+    sym_table.add_function("now", computed_function::now);
 
     // String functions
     sym_table.add_function("intern", m_intern_fn);
@@ -483,10 +490,6 @@ t_computed_function_store::register_computed_functions(
     sym_table.add_function("match", m_match_fn);
     sym_table.add_function("fullmatch", m_fullmatch_fn);
     sym_table.add_function("search", m_search_fn);
-
-    // Register static free functions as well
-    sym_table.add_function("today", computed_function::today);
-    sym_table.add_function("now", computed_function::now);
 
     // And scalar constants
     sym_table.add_constant("True", t_computed_expression_parser::TRUE_SCALAR);

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -438,7 +438,8 @@ t_computed_function_store::t_computed_function_store(t_expression_vocab& vocab,
     , m_match_fn(computed_function::match(regex_mapping))
     , m_fullmatch_fn(computed_function::fullmatch(regex_mapping))
     , m_search_fn(
-          computed_function::search(vocab, regex_mapping, is_type_validator)) {}
+          computed_function::search(vocab, regex_mapping, is_type_validator))
+    , m_indexof_fn(computed_function::indexof(regex_mapping)) {}
 
 void
 t_computed_function_store::register_computed_functions(
@@ -490,6 +491,7 @@ t_computed_function_store::register_computed_functions(
     sym_table.add_function("match", m_match_fn);
     sym_table.add_function("fullmatch", m_fullmatch_fn);
     sym_table.add_function("search", m_search_fn);
+    sym_table.add_function("indexof", m_indexof_fn);
 
     // And scalar constants
     sym_table.add_constant("True", t_computed_expression_parser::TRUE_SCALAR);

--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -439,7 +439,8 @@ t_computed_function_store::t_computed_function_store(t_expression_vocab& vocab,
     , m_fullmatch_fn(computed_function::fullmatch(regex_mapping))
     , m_search_fn(
           computed_function::search(vocab, regex_mapping, is_type_validator))
-    , m_indexof_fn(computed_function::indexof(regex_mapping)) {}
+    , m_indexof_fn(computed_function::indexof(regex_mapping))
+    , m_substring_fn(computed_function::substring(vocab, is_type_validator)) {}
 
 void
 t_computed_function_store::register_computed_functions(
@@ -492,6 +493,7 @@ t_computed_function_store::register_computed_functions(
     sym_table.add_function("fullmatch", m_fullmatch_fn);
     sym_table.add_function("search", m_search_fn);
     sym_table.add_function("indexof", m_indexof_fn);
+    sym_table.add_function("substring", m_substring_fn);
 
     // And scalar constants
     sym_table.add_constant("True", t_computed_expression_parser::TRUE_SCALAR);

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -13,17 +13,6 @@ namespace perspective {
 
 namespace computed_function {
 
-    using int8 = std::int8_t;
-    using int16 = std::int16_t;
-    using int32 = std::int32_t;
-    using int64 = std::int64_t;
-    using uint8 = std::uint8_t;
-    using uint16 = std::uint16_t;
-    using uint32 = std::uint32_t;
-    using uint64 = std::uint64_t;
-    using float32 = float;
-    using float64 = double;
-
     intern::intern(t_expression_vocab& expression_vocab, bool is_type_validator)
         : exprtk::igeneric_function<t_tscalar>("S")
         , m_expression_vocab(expression_vocab)
@@ -1651,5 +1640,23 @@ namespace computed_function {
         return rval;
     }
 
+    // Set up random number generator
+    std::default_random_engine random::RANDOM_ENGINE
+        = std::default_random_engine();
+    std::uniform_real_distribution<double> random::DISTRIBUTION
+        = std::uniform_real_distribution<double>(0, 1);
+
+    random::random()
+        : exprtk::igeneric_function<t_tscalar>("Z") {}
+
+    random::~random() {}
+
+    t_tscalar
+    random::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+        rval.set(random::DISTRIBUTION(random::RANDOM_ENGINE));
+        return rval;
+    }
 } // end namespace computed_function
 } // end namespace perspective

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -627,9 +627,10 @@ namespace computed_function {
         t_tscalar rval;
         rval.clear();
         rval.m_type = DTYPE_STR;
+        auto num_params = parameters.size();
 
         // substring(string, start_idx) or substring(string, start_idx, length)
-        if (parameters.size() != 2 && parameters.size() != 3) {
+        if (num_params != 2 && num_params != 3) {
             rval.m_status = STATUS_CLEAR;
             return rval;
         }
@@ -645,7 +646,7 @@ namespace computed_function {
         // npos == all chars until end of the string
         std::int64_t substring_length = std::string::npos;
 
-        for (auto i = 0; i < parameters.size(); ++i) {
+        for (auto i = 0; i < num_params; ++i) {
             const t_generic_type& gt = parameters[i];
 
             if (gt.type == t_generic_type::e_scalar) {
@@ -655,6 +656,7 @@ namespace computed_function {
                 // type check - first param must be string, 2nd and 3rd param
                 // must be numeric, all must be valid
                 t_dtype dtype = temp_scalar.get_dtype();
+
                 if ((i == 0 && dtype != DTYPE_STR)
                     || (i != 0 && !temp_scalar.is_numeric())
                     || temp_scalar.m_status == STATUS_CLEAR) {
@@ -691,16 +693,11 @@ namespace computed_function {
         std::size_t length = search_string.length();
 
         // Value check: strings cannot be 0 length, indices must be valid
-        if ((!m_is_type_validator && length == 0) || start_idx < 0
-            || substring_length < 0
+        if (length == 0 || start_idx < 0
+            || (num_params == 3 && substring_length < 0)
             || start_idx >= length
             || (substring_length != std::string::npos 
                 && start_idx + substring_length > length)) {
-            rval.m_status = STATUS_CLEAR;
-            return rval;
-        }
-
-        if (m_is_type_validator) {
             return rval;
         }
 

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -42,10 +42,6 @@ namespace computed_function {
         std::string temp_str
             = std::string(temp_string.begin(), temp_string.end());
 
-        // Don't allow empty strings from the user
-        if (temp_str == "")
-            return rval;
-
         if (m_is_type_validator) {
             // Return the sentinel value which indicates a valid output from
             // type checking, as the output value is not STATUS_CLEAR
@@ -443,14 +439,14 @@ namespace computed_function {
         return rval;
     }
 
-    fullmatch::fullmatch(t_regex_mapping& regex_mapping)
+    match_all::match_all(t_regex_mapping& regex_mapping)
         : exprtk::igeneric_function<t_tscalar>("TS")
         , m_regex_mapping(regex_mapping) {}
 
-    fullmatch::~fullmatch() {}
+    match_all::~match_all() {}
 
     t_tscalar
-    fullmatch::operator()(t_parameter_list parameters) {
+    match_all::operator()(t_parameter_list parameters) {
         t_tscalar rval;
         rval.clear();
         rval.m_type = DTYPE_BOOL;
@@ -673,7 +669,7 @@ namespace computed_function {
                 }
 
                 // Passed type checking, assign values
-                if (i == 0 && !m_is_type_validator) {
+                if (i == 0) {
                     search_string = temp_scalar.to_string();
                 } else if (i == 1) {
                     start_idx = temp_scalar.to_double();
@@ -685,6 +681,11 @@ namespace computed_function {
                 rval.m_status = STATUS_CLEAR;
                 return rval;
             }
+        }
+        
+        // done type checking
+        if (m_is_type_validator) {
+            return rval;
         }
 
         std::size_t length = search_string.length();
@@ -714,6 +715,194 @@ namespace computed_function {
 
         rval.set(m_expression_vocab.intern(
             search_string.substr(start_idx, end_idx)));
+
+        return rval;
+    }
+
+    replace::replace(t_expression_vocab& expression_vocab,
+        t_regex_mapping& regex_mapping, bool is_type_validator)
+        : exprtk::igeneric_function<t_tscalar>("TS?")
+        , m_expression_vocab(expression_vocab)
+        , m_regex_mapping(regex_mapping)
+        , m_is_type_validator(is_type_validator) {}
+
+    replace::~replace() {}
+
+    t_tscalar
+    replace::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+        rval.m_type = DTYPE_STR;
+
+        // the string to be replaced
+        t_scalar_view string_scalar_view(parameters[0]);
+        t_tscalar string_scalar = string_scalar_view();
+
+        // the replace pattern
+        t_string_view pattern_view(parameters[1]);
+        std::string match_pattern =
+            std::string(pattern_view.begin(), pattern_view.end());
+
+        // replacer can be a string literal, for the string '' as intern does
+        // not pick up on empty strings but we need to be able to replace
+        // with empty string. Thus, type-check replacer before continuing.
+        const t_generic_type& gt(parameters[2]);
+        t_tscalar replacer_scalar;
+
+        if (gt.type == t_generic_type::e_scalar) {
+            t_scalar_view replacer_view(gt);
+            replacer_scalar = replacer_view();
+        } else if (gt.type == t_generic_type::e_string) {
+            t_string_view replacer_view(gt);
+            std::string replacer_str =
+                std::string(replacer_view.begin(), replacer_view.end());
+
+            // only the empty string should be passed in as a string literal,
+            // all other strings must be interned first.
+            if (replacer_str.size() != 0) {
+                rval.m_status = STATUS_CLEAR;
+                return rval;
+            }
+
+            // use the empty string from vocab
+            replacer_scalar.set(m_expression_vocab.get_empty_string());
+        } else {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        if (string_scalar.m_type != DTYPE_STR
+            || replacer_scalar.m_type != DTYPE_STR
+            || match_pattern.size() == 0)  {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+        
+        // typecheck the regex
+        RE2* compiled_pattern = m_regex_mapping.intern(match_pattern);
+
+        if (compiled_pattern == nullptr) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        // done with type_checking
+        if (m_is_type_validator) return rval;
+
+        // make a copy of search_str, as replace() will mutate it and we
+        // don't want to mutate the string in the vocab
+        std::string search_string = string_scalar.to_string();
+
+        if (search_string.size() == 0) return rval;
+
+        // but we can take a reference to the replacer
+        const std::string& replacer_string = replacer_scalar.to_string();
+        re2::StringPiece replacer(replacer_string);
+
+        bool replaced = RE2::Replace(
+            &(search_string), *(compiled_pattern), replacer);
+
+        if (!replaced) {
+            // Return the original result if the replacement didn't happen
+            return string_scalar;
+        }
+
+        // Or the string with the replacement set
+        rval.set(m_expression_vocab.intern(search_string));
+
+        return rval;
+    }
+
+    replace_all::replace_all(t_expression_vocab& expression_vocab,
+        t_regex_mapping& regex_mapping, bool is_type_validator)
+        : exprtk::igeneric_function<t_tscalar>("TS?")
+        , m_expression_vocab(expression_vocab)
+        , m_regex_mapping(regex_mapping)
+        , m_is_type_validator(is_type_validator) {}
+
+    replace_all::~replace_all() {}
+
+    t_tscalar
+    replace_all::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+        rval.m_type = DTYPE_STR;
+
+        // the string to be replaced
+        t_scalar_view string_scalar_view(parameters[0]);
+        t_tscalar string_scalar = string_scalar_view();
+
+        // the replace pattern
+        t_string_view pattern_view(parameters[1]);
+        std::string match_pattern =
+            std::string(pattern_view.begin(), pattern_view.end());
+
+        // replacer can be a string literal, for the string '' as intern does
+        // not pick up on empty strings but we need to be able to replace
+        // with empty string. Thus, type-check replacer before continuing.
+        const t_generic_type& gt(parameters[2]);
+        t_tscalar replacer_scalar;
+
+        if (gt.type == t_generic_type::e_scalar) {
+            t_scalar_view replacer_view(gt);
+            replacer_scalar = replacer_view();
+        } else if (gt.type == t_generic_type::e_string) {
+            t_string_view replacer_view(gt);
+            std::string replacer_str =
+                std::string(replacer_view.begin(), replacer_view.end());
+
+            // only the empty string should be passed in as a string literal,
+            // all other strings must be interned first.
+            if (replacer_str.size() != 0) {
+                rval.m_status = STATUS_CLEAR;
+                return rval;
+            }
+
+            // use the empty string from vocab
+            replacer_scalar.set(m_expression_vocab.get_empty_string());
+        } else {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        if (string_scalar.m_type != DTYPE_STR
+            || replacer_scalar.m_type != DTYPE_STR
+            || match_pattern.size() == 0)  {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+        
+        // typecheck the regex
+        RE2* compiled_pattern = m_regex_mapping.intern(match_pattern);
+
+        if (compiled_pattern == nullptr) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        // done with type_checking
+        if (m_is_type_validator) return rval;
+
+        // make a copy of search_str, as replace() will mutate it and we
+        // don't want to mutate the string in the vocab
+        std::string search_string = string_scalar.to_string();
+
+        if (search_string.size() == 0) return rval;
+
+        // but we can take a reference to the replacer
+        const std::string& replacer_string = replacer_scalar.to_string();
+        re2::StringPiece replacer(replacer_string);
+
+        std::size_t replaced = RE2::GlobalReplace(
+            &(search_string), *(compiled_pattern), replacer);
+
+        if (replaced == 0) {
+            // Return the original result if the replacement didn't happen
+            return string_scalar;
+        }
+
+        // Or the string with the replacement set
+        rval.set(m_expression_vocab.intern(search_string));
 
         return rval;
     }

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -628,7 +628,7 @@ namespace computed_function {
         rval.clear();
         rval.m_type = DTYPE_STR;
 
-        // substring(string, start_idx) or substring(string, start_idx, end_idx)
+        // substring(string, start_idx) or substring(string, start_idx, length)
         if (parameters.size() != 2 && parameters.size() != 3) {
             rval.m_status = STATUS_CLEAR;
             return rval;
@@ -643,7 +643,7 @@ namespace computed_function {
         std::int64_t start_idx;
 
         // npos == all chars until end of the string
-        std::int64_t end_idx = std::string::npos;
+        std::int64_t substring_length = std::string::npos;
 
         for (auto i = 0; i < parameters.size(); ++i) {
             const t_generic_type& gt = parameters[i];
@@ -674,7 +674,7 @@ namespace computed_function {
                 } else if (i == 1) {
                     start_idx = temp_scalar.to_double();
                 } else if (i == 2) {
-                    end_idx = temp_scalar.to_double();
+                    substring_length = temp_scalar.to_double();
                 }
             } else {
                 // called with invalid params - exit
@@ -691,10 +691,11 @@ namespace computed_function {
         std::size_t length = search_string.length();
 
         // Value check: strings cannot be 0 length, indices must be valid
-        if ((!m_is_type_validator && length == 0) || start_idx < 0 || end_idx < 0
+        if ((!m_is_type_validator && length == 0) || start_idx < 0
+            || substring_length < 0
             || start_idx >= length
-            || (end_idx != std::string::npos && end_idx >= length)
-            || end_idx < start_idx) {
+            || (substring_length != std::string::npos 
+                && start_idx + substring_length > length)) {
             rval.m_status = STATUS_CLEAR;
             return rval;
         }
@@ -703,18 +704,8 @@ namespace computed_function {
             return rval;
         }
 
-
-        if (end_idx != std::string::npos) {
-            // std::string::substr takes start_idx and num of characters, so
-            // we need to convert the end index to num of chars instead
-            end_idx = (end_idx - start_idx) + 1;
-
-            // but if our substr len > length, we need to set it to all chars
-            if (start_idx + end_idx > length) end_idx = std::string::npos;
-        }
-
         rval.set(m_expression_vocab.intern(
-            search_string.substr(start_idx, end_idx)));
+            search_string.substr(start_idx, substring_length)));
 
         return rval;
     }

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -203,10 +203,12 @@ struct PERSPECTIVE_EXPORT t_computed_function_store {
     computed_function::lower m_lower_fn;
     computed_function::to_string m_to_string_fn;
     computed_function::match m_match_fn;
-    computed_function::fullmatch m_fullmatch_fn;
+    computed_function::match_all m_match_all_fn;
     computed_function::search m_search_fn;
     computed_function::indexof m_indexof_fn;
     computed_function::substring m_substring_fn;
+    computed_function::replace m_replace_fn;
+    computed_function::replace_all m_replace_all_fn;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -145,6 +145,7 @@ public:
     static computed_function::to_boolean TO_BOOLEAN_FN;
     static computed_function::make_date MAKE_DATE_FN;
     static computed_function::make_datetime MAKE_DATETIME_FN;
+    static computed_function::random RANDOM_FN;
 
     // constants for True and False as DTYPE_BOOL scalars
     static t_tscalar TRUE_SCALAR;

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -206,6 +206,7 @@ struct PERSPECTIVE_EXPORT t_computed_function_store {
     computed_function::fullmatch m_fullmatch_fn;
     computed_function::search m_search_fn;
     computed_function::indexof m_indexof_fn;
+    computed_function::substring m_substring_fn;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -205,6 +205,7 @@ struct PERSPECTIVE_EXPORT t_computed_function_store {
     computed_function::match m_match_fn;
     computed_function::fullmatch m_fullmatch_fn;
     computed_function::search m_search_fn;
+    computed_function::indexof m_indexof_fn;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/computed_function.h
+++ b/cpp/perspective/src/include/perspective/computed_function.h
@@ -20,6 +20,7 @@
 #include <perspective/expression_vocab.h>
 #include <perspective/regex.h>
 #include <boost/algorithm/string.hpp>
+#include <random>
 #include <type_traits>
 #include <date/date.h>
 #include <tsl/hopscotch_set.h>
@@ -321,6 +322,21 @@ namespace computed_function {
      * new datetime value.
      */
     FUNCTION_HEADER(make_datetime)
+
+    /**
+     * @brief Return a random float between 0.0 and 1.0, inclusive.
+     */
+    struct random : public exprtk::igeneric_function<t_tscalar> {
+        random();
+        ~random();
+
+        t_tscalar operator()(t_parameter_list parameters);
+
+        // faster unit lookups, since we are calling this lookup in a tight
+        // loop.
+        static std::default_random_engine RANDOM_ENGINE;
+        static std::uniform_real_distribution<double> DISTRIBUTION;
+    };
 
 } // end namespace computed_function
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/computed_function.h
+++ b/cpp/perspective/src/include/perspective/computed_function.h
@@ -131,10 +131,10 @@ namespace computed_function {
     REGEX_FUNCTION_HEADER(match)
 
     /**
-     * @brief fullmatch(string, pattern) => True if the string fully matches
+     * @brief match_all(string, pattern) => True if the string fully matches
      * pattern, and False otherwise.
      */
-    REGEX_FUNCTION_HEADER(fullmatch)
+    REGEX_FUNCTION_HEADER(match_all)
 
     /**
      * @brief search(string, pattern) => Returns the substring in the first
@@ -159,11 +159,18 @@ namespace computed_function {
     STRING_FUNCTION_HEADER(substring)
 
     /**
-     * @brief replace(string, pattern, replace_str) => string with all matches
-     * of pattern replaced with replace_str, or the original string without
-     * any replacements if the string does not match pattern.
+     * @brief replace(string, replace_str, pattern) => Replaces the first match
+     * of pattern inside string with replace_str, or returns the original
+     * string if no replacements were made.
      */
     REGEX_STRING_FUNCTION_HEADER(replace)
+
+    /**
+     * @brief replace_all(string, replace_str, pattern) => Replaces all matches
+     * of pattern inside string with replace_str, or returns the original
+     * string if no replacements were made.
+     */
+    REGEX_STRING_FUNCTION_HEADER(replace_all)
 
 #define FUNCTION_HEADER(NAME)                                                  \
     struct NAME : public exprtk::igeneric_function<t_tscalar> {                \

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1466,7 +1466,7 @@ export default function (Module) {
             // First, look for a column alias, which is a // style comment
             // on the first line of the expression.
             let expression_alias;
-            let alias_match = expression_string.match(/^\/\/(?<alias>.+?)$/m);
+            let alias_match = expression_string.match(/^\/\/(?<alias>.+?)\n/);
 
             if (alias_match?.groups?.alias) {
                 expression_alias = alias_match.groups.alias.trim();

--- a/packages/perspective/test/js/expressions/conversions.js
+++ b/packages/perspective/test/js/expressions/conversions.js
@@ -784,7 +784,7 @@ module.exports = (perspective) => {
 
             expect(validated.errors).toEqual({
                 computed: {
-                    column: 8,
+                    column: 7,
                     error_message:
                         "Parser Error - Zero parameter call to generic function: date not allowed",
                     line: 1,
@@ -959,7 +959,7 @@ module.exports = (perspective) => {
 
             expect(validated.errors).toEqual({
                 computed1: {
-                    column: 12,
+                    column: 11,
                     error_message:
                         "Parser Error - Zero parameter call to generic function: datetime not allowed",
                     line: 1,
@@ -985,7 +985,7 @@ module.exports = (perspective) => {
                 computed5: {
                     error_message:
                         "Parser Error - Failed parameter type check for function 'datetime', Expected 'T' call set: 'TT'",
-                    column: 21,
+                    column: 20,
                     line: 1,
                 },
             });

--- a/packages/perspective/test/js/expressions/functionality.js
+++ b/packages/perspective/test/js/expressions/functionality.js
@@ -1210,15 +1210,20 @@ module.exports = (perspective) => {
             const table = await perspective.table({a: [1, 2, 3]});
             const view = await table.view({
                 expressions: [
-                    `// abc
-                    var x := 1 + 2; // another comment
-                    x + 3 + 4 # comment`,
+                    "var x := 1 + 2;\n// another comment\nx + 3 + 4 # comment",
                 ],
             });
             const schema = await view.expression_schema();
-            expect(schema).toEqual({abc: "float"});
+            expect(schema).toEqual({
+                "var x := 1 + 2;\n// another comment\nx + 3 + 4 # comment":
+                    "float",
+            });
             const result = await view.to_columns();
-            expect(result["abc"]).toEqual(Array(3).fill(10));
+            expect(
+                result[
+                    "var x := 1 + 2;\n// another comment\nx + 3 + 4 # comment"
+                ]
+            ).toEqual(Array(3).fill(10));
             await view.delete();
             await table.delete();
         });

--- a/packages/perspective/test/js/expressions/functionality.js
+++ b/packages/perspective/test/js/expressions/functionality.js
@@ -491,7 +491,7 @@ module.exports = (perspective) => {
 
                 expect(schema.expression_schema["expr"]).toBeUndefined();
                 expect(schema.errors["expr"]).toEqual({
-                    column: 63,
+                    column: 62,
                     line: 1,
                     error_message:
                         "Parser Error - Invalid expression encountered",

--- a/packages/perspective/test/js/expressions/numeric.js
+++ b/packages/perspective/test/js/expressions/numeric.js
@@ -1163,6 +1163,32 @@ module.exports = (perspective) => {
                 await view.delete();
                 await table.delete();
             });
+
+            it("random", async function () {
+                const table = await perspective.table({
+                    x: "float",
+                });
+
+                const data = [];
+                for (let i = 0; i < 1000; i++) {
+                    data.push(i);
+                }
+                table.update({x: data});
+                const view = await table.view({
+                    expressions: ["random()"],
+                });
+                const schema = await view.expression_schema();
+                expect(schema).toEqual({"random()": "float"});
+                const result = await view.to_columns();
+
+                for (let i = 0; i < 1000; i++) {
+                    const res = result["random()"][i];
+                    expect(res >= 0 && res <= 1).toBe(true);
+                }
+
+                await view.delete();
+                await table.delete();
+            });
         });
 
         describe("Booleans", function () {

--- a/packages/perspective/test/js/expressions/string.js
+++ b/packages/perspective/test/js/expressions/string.js
@@ -214,7 +214,7 @@ module.exports = (perspective) => {
                     line: 0,
                 },
                 col4: {
-                    column: 8,
+                    column: 7,
                     error_message:
                         "Parser Error - Zero parameter call to generic function: order not allowed",
                     line: 1,
@@ -919,7 +919,7 @@ module.exports = (perspective) => {
             await table.delete();
         });
 
-        it("fullmatch string with string", async () => {
+        it("match_all string with string", async () => {
             const table = await perspective.table({
                 a: "string",
                 b: "string",
@@ -933,13 +933,13 @@ module.exports = (perspective) => {
             });
 
             const expressions = [
-                `fullmatch("a", 'ABC')`,
-                "fullmatch('aBc', '[aAbBcC]{3}')",
-                `fullmatch("a", 'A')`,
-                `fullmatch("c", '[0-9]{3}')`,
-                `fullmatch("c", '4567')`,
-                `fullmatch("c", '4567123')`,
-                `fullmatch("c", '[0-9]+')`,
+                `match_all("a", 'ABC')`,
+                "match_all('aBc', '[aAbBcC]{3}')",
+                `match_all("a", 'A')`,
+                `match_all("c", '[0-9]{3}')`,
+                `match_all("c", '4567')`,
+                `match_all("c", '4567123')`,
+                `match_all("c", '[0-9]+')`,
             ];
 
             const view = await table.view({
@@ -1032,17 +1032,17 @@ module.exports = (perspective) => {
             await table.delete();
         });
 
-        it("fullmatch string with bad regex should fail type-checking", async () => {
+        it("match_all string with bad regex should fail type-checking", async () => {
             const table = await perspective.table({
                 a: ["ABC", "DEF", "cbA", "HIjK", "lMNoP"],
                 b: ["ABC", "ad", "asudfh", "HIjK", "lMNoP"],
             });
 
             const expressions = [
-                `fullmatch("a", '*.')`,
-                "fullmatch('abc', '(?=a)')",
-                `fullmatch("a", '?')`,
-                `fullmatch("a", '+.')`,
+                `match_all("a", '*.')`,
+                "match_all('abc', '(?=a)')",
+                `match_all("a", '?')`,
+                `match_all("a", '+.')`,
             ];
 
             const validated = await table.validate_expressions(expressions);
@@ -1122,17 +1122,17 @@ module.exports = (perspective) => {
             await table.delete();
         });
 
-        it("fullmatch should only work on strings", async () => {
+        it("match_all should only work on strings", async () => {
             const table = await perspective.table({
                 a: ["ABC", "DEF", "cbA", "HIjK", "lMNoP"],
                 b: ["abc123", "abc567", "abc56", "1234567", "aaa000"],
             });
 
             const expressions = [
-                `fullmatch("a", "b")`,
-                `fullmatch("a", 123)`,
-                `fullmatch(today(), '[a-z]{3}[0-9]{3}')`,
-                `fullmatch(False, '[0-9]{7}')`,
+                `match_all("a", "b")`,
+                `match_all("a", 123)`,
+                `match_all(today(), '[a-z]{3}[0-9]{3}')`,
+                `match_all(False, '[0-9]{7}')`,
             ];
 
             const validated = await table.validate_expressions(expressions);
@@ -1142,11 +1142,11 @@ module.exports = (perspective) => {
             }
 
             expect(validated.errors[expressions[0]].error_message).toEqual(
-                "Parser Error - Failed parameter type check for function 'fullmatch', Expected 'TS' call set: 'TT'"
+                "Parser Error - Failed parameter type check for function 'match_all', Expected 'TS' call set: 'TT'"
             );
 
             expect(validated.errors[expressions[1]].error_message).toEqual(
-                "Parser Error - Failed parameter type check for function 'fullmatch', Expected 'TS' call set: 'TT'"
+                "Parser Error - Failed parameter type check for function 'match_all', Expected 'TS' call set: 'TT'"
             );
 
             expect(validated.errors[expressions[2]]).toEqual({
@@ -1209,16 +1209,16 @@ module.exports = (perspective) => {
             await table.delete();
         });
 
-        it("fullmatch string with regex", async () => {
+        it("match_all string with regex", async () => {
             const table = await perspective.table({
                 a: ["ABC", "DEF", "cbA", "HIjK", "lMNoP"],
                 b: ["abc123", "abc567", "abc56", "1234567", "aaa0001234"],
             });
 
             const expressions = [
-                `fullmatch("a", '.*')`,
-                `fullmatch("b", '[a-z]{3}[0-9]{3}')`,
-                `fullmatch("b", '[0-9]{7}')`,
+                `match_all("a", '.*')`,
+                `match_all("b", '[a-z]{3}[0-9]{3}')`,
+                `match_all("b", '[0-9]{7}')`,
             ];
 
             const view = await table.view({
@@ -1296,7 +1296,7 @@ module.exports = (perspective) => {
             await table.delete();
         });
 
-        it("fullmatch string with regex, randomized", async () => {
+        it("match_all string with regex, randomized", async () => {
             const data = {a: []};
 
             for (let i = 0; i < 500; i++) {
@@ -1306,8 +1306,8 @@ module.exports = (perspective) => {
             const table = await perspective.table(data);
 
             const expressions = [
-                `fullmatch("a", '.*')`, // should match everything
-                `fullmatch("a", '.{100}')`, // should match strings the size of max
+                `match_all("a", '.*')`, // should match everything
+                `match_all("a", '.{100}')`, // should match strings the size of max
             ];
 
             const view = await table.view({
@@ -1387,15 +1387,15 @@ module.exports = (perspective) => {
             await table.delete();
         });
 
-        it("fullmatch string and null with regex", async () => {
+        it("match_all string and null with regex", async () => {
             const table = await perspective.table({
                 a: ["ABC", "abc", null, "AbC", "12345", "123456"],
             });
 
             const expressions = [
-                `fullmatch("a", '.*')`,
-                `fullmatch("a", '[aAbBcC]{3}')`,
-                `fullmatch("a", '[0-9]{5}')`,
+                `match_all("a", '.*')`,
+                `match_all("a", '[aAbBcC]{3}')`,
+                `match_all("a", '[0-9]{5}')`,
             ];
 
             const view = await table.view({
@@ -1667,7 +1667,7 @@ module.exports = (perspective) => {
             const pattern = "(.*)";
             const fns = [
                 "match",
-                "fullmatch",
+                "match_all",
                 "search",
                 "indexof",
                 "substring",
@@ -1724,7 +1724,7 @@ module.exports = (perspective) => {
             const pattern = "(.*)";
             const fns = [
                 "match",
-                "fullmatch",
+                "match_all",
                 "search",
                 "indexof",
                 "substring",
@@ -2205,6 +2205,148 @@ module.exports = (perspective) => {
 
                 await view.delete();
             }
+
+            await table.delete();
+        });
+
+        it("replace", async () => {
+            const digits = () => {
+                const output = [];
+                for (let i = 0; i < 4; i++) {
+                    output.push(randchoice(NUMERIC));
+                }
+                return output.join("");
+            };
+
+            const data = [];
+            const index = [];
+
+            for (let i = 0; i < 1000; i++) {
+                const separator = Math.random() > 0.5 ? " " : "-";
+                const num = `${digits()}${separator}${digits()}${separator}${digits()}${separator}${digits()}`;
+                data.push(num);
+                index.push(i);
+            }
+
+            const table = await perspective.table({a: "string", b: "string"});
+            table.update({a: data, b: index});
+            const expressions = [
+                `//w\nreplace('abc-def-hijk', '-', '')`,
+                `//x\nreplace("a", '[0-9]{4}$', "b")`,
+                `//y\nreplace("a", '[a-z]{4}$', "b")`,
+                `//z\nvar x := 'long string, very cool!'; replace("a", '^[0-9]{4}', x)`,
+            ];
+            const validate = await table.validate_expressions(expressions);
+            expect(validate.expression_schema).toEqual({
+                w: "string",
+                x: "string",
+                y: "string",
+                z: "string",
+            });
+
+            const view = await table.view({expressions});
+            const result = await view.to_columns();
+
+            for (let i = 0; i < 100; i++) {
+                const source = result["a"][i];
+                const idx = result["b"][i];
+                expect(result["w"][i]).toEqual("abcdef-hijk");
+                expect(result["x"][i]).toEqual(
+                    source.replace(/[0-9]{4}$/, idx)
+                );
+                expect(result["y"][i]).toEqual(source);
+                expect(result["z"][i]).toEqual(
+                    source.replace(/^[0-9]{4}/, "long string, very cool!")
+                );
+            }
+
+            await view.delete();
+            await table.delete();
+        });
+
+        it("replace invalid", async () => {
+            const table = await perspective.table({a: "string", b: "string"});
+
+            const expressions = [
+                `//v\nreplace('abc-def-hijk', '-', 123)`,
+                `//w\nreplace('', '-', today())`,
+                `//x\nreplace("a", '[0-9]{4}$', today())`,
+                `//y\nreplace("a", '[a-z]{4}$', null)`,
+                `//z\nvar x := 123; replace("a", '^[0-9]{4}', x)`,
+            ];
+            const validate = await table.validate_expressions(expressions);
+            expect(validate.expression_schema).toEqual({});
+
+            await table.delete();
+        });
+
+        it("replace all", async () => {
+            const digits = () => {
+                const output = [];
+                for (let i = 0; i < 4; i++) {
+                    output.push(randchoice(NUMERIC));
+                }
+                return output.join("");
+            };
+
+            const data = [];
+            const index = [];
+
+            for (let i = 0; i < 1000; i++) {
+                const separator = Math.random() > 0.5 ? " " : "-";
+                const num = `${digits()}${separator}${digits()}${separator}${digits()}${separator}${digits()}`;
+                data.push(num);
+                index.push(i);
+            }
+
+            const table = await perspective.table({a: "string", b: "string"});
+            table.update({a: data, b: index});
+            const expressions = [
+                `//w\nreplace_all('abc-def-hijk', '-', '')`,
+                `//x\nreplace_all("a", '[0-9]{4}', "b")`,
+                `//y\nreplace_all("a", '[a-z]{4}', "b")`,
+                `//z\nvar x := 'long string, very cool!'; replace_all("a", '[0-9]{4}', x)`,
+            ];
+            const validate = await table.validate_expressions(expressions);
+            expect(validate.expression_schema).toEqual({
+                w: "string",
+                x: "string",
+                y: "string",
+                z: "string",
+            });
+
+            const view = await table.view({expressions});
+            const result = await view.to_columns();
+
+            for (let i = 0; i < 100; i++) {
+                const source = result["a"][i];
+                const idx = result["b"][i];
+                expect(result["w"][i]).toEqual("abcdefhijk");
+                expect(result["x"][i]).toEqual(
+                    source.replace(/[0-9]{4}/g, () => idx)
+                );
+                expect(result["y"][i]).toEqual(source);
+                expect(result["z"][i]).toEqual(
+                    source.replace(/[0-9]{4}/g, () => "long string, very cool!")
+                );
+            }
+
+            await view.delete();
+            await table.delete();
+        });
+
+        it("replace all invalid", async () => {
+            const table = await perspective.table({a: "string", b: "string"});
+
+            const expressions = [
+                `//v\nreplace_all('abc-def-hijk', '-', 123)`,
+                `//w\nreplace_all('', '-', today())`,
+                `//x\nreplace_all("a", '[0-9]{4}$', today())`,
+                `//y\nreplace_all("a", '[a-z]{4}$', null)`,
+                `//z\nvar x := 123; replace_all("a", '^[0-9]{4}', x)`,
+            ];
+            const validate = await table.validate_expressions(expressions);
+            expect(validate.expression_schema).toEqual({});
 
             await table.delete();
         });

--- a/packages/perspective/test/js/expressions/string.js
+++ b/packages/perspective/test/js/expressions/string.js
@@ -1966,6 +1966,8 @@ module.exports = (perspective) => {
             });
             const view = await table.view({
                 expressions: [
+                    "substring('abcdef', 0)",
+                    "substring('abcdef', 3)",
                     'substring("x", 3)',
                     'substring("x", -1)',
                     'substring("x", 1, 10000)',
@@ -1979,6 +1981,12 @@ module.exports = (perspective) => {
                 ],
             });
             const results = await view.to_columns();
+            expect(results["substring('abcdef', 0)"]).toEqual(
+                Array(5).fill("abcdef")
+            );
+            expect(results["substring('abcdef', 3)"]).toEqual(
+                Array(5).fill("def")
+            );
             expect(results['substring("x", 3)']).toEqual([
                 ", def, efg",
                 "def",

--- a/packages/perspective/test/js/leaks.spec.js
+++ b/packages/perspective/test/js/leaks.spec.js
@@ -143,7 +143,7 @@ describe("leaks", function () {
         it.skip("0 sided regex does not leak", async () => {
             const expressions = [
                 "match(\"a\", '.{1}')",
-                "fullmatch(\"a\", '[a-z]{1}')",
+                "match_all(\"a\", '[a-z]{1}')",
                 "search(\"a\", '.')",
             ];
 

--- a/packages/perspective/test/js/leaks.spec.js
+++ b/packages/perspective/test/js/leaks.spec.js
@@ -135,6 +135,62 @@ describe("leaks", function () {
             await table.delete();
         });
 
+        /**
+         * Because the expression vocab and the regex cache is per-table and
+         * not per-view, we should be able to leak test the table creation
+         * and view creation.
+         */
+        it.skip("0 sided regex does not leak", async () => {
+            const expressions = [
+                "match(\"a\", '.{1}')",
+                "fullmatch(\"a\", '[a-z]{1}')",
+                "search(\"a\", '.')",
+            ];
+
+            await leak_test(async () => {
+                const table = await perspective.table({
+                    a: "abcdefghijklmnopqrstuvwxyz".split(""),
+                });
+                const view = await table.view({
+                    expressions: [
+                        expressions[
+                            Math.floor(Math.random() * expressions.length)
+                        ],
+                    ],
+                });
+                const expression_schema = await view.expression_schema();
+                expect(Object.keys(expression_schema).length).toEqual(1);
+                await view.delete();
+                await table.delete();
+            });
+        });
+
+        it.skip("0 sided string does not leak", async () => {
+            const table = await perspective.table({
+                a: "abcdefghijklmnopqrstuvwxyz".split(""),
+            });
+
+            const expressions = [
+                "var x := 'abcdefghijklmnopqrstuvwxyz'; concat(\"a\", x, 'abc')",
+                "var x := 'abcdefghijklmnopqrstuvwxyz'; var y := 'defhijklmnopqrst'; concat(\"a\", x, 'abc', y)",
+            ];
+
+            await leak_test(async () => {
+                const view = await table.view({
+                    expressions: [
+                        expressions[
+                            Math.floor(Math.random() * expressions.length)
+                        ],
+                    ],
+                });
+                const expression_schema = await view.expression_schema();
+                expect(Object.keys(expression_schema).length).toEqual(1);
+                await view.delete();
+            });
+
+            await table.delete();
+        });
+
         it("1 sided does not leak", async () => {
             const table = await perspective.table({
                 a: [1, 2, 3, 4],

--- a/python/perspective/perspective/table/_utils.py
+++ b/python/perspective/perspective/table/_utils.py
@@ -15,7 +15,7 @@ ALIAS_REGEX = re.compile(r"//(.+)\n")
 EXPRESSION_COLUMN_NAME_REGEX = re.compile(r"\"(.*?[^\\])\"")
 STRING_LITERAL_REGEX = re.compile(r"'(.*?[^\\])'")
 FUNCTION_LITERAL_REGEX = re.compile(
-    r"(bucket|match|fullmatch|search|indexof)\(.*?,\s*(intern\(\'(.+)\'\)).*\)"
+    r"(bucket|match|match_all|search|indexof)\(.*?,\s*(intern\(\'(.+)\'\)).*\)"
 )
 BOOLEAN_LITERAL_REGEX = re.compile(r"([a-zA-Z_]+[a-zA-Z0-9_]*)")
 
@@ -206,8 +206,7 @@ def _parse_expression_strings(expressions):
             parsed,
         )
 
-        print(parsed)
-
+        # TODO fix this regex for replace and replace_all
         # remove the `intern()` in bucket and regex functions that take
         # string literal parameters.
         parsed = re.sub(FUNCTION_LITERAL_REGEX, _replace_interned_param, parsed)

--- a/python/perspective/perspective/table/_utils.py
+++ b/python/perspective/perspective/table/_utils.py
@@ -137,6 +137,7 @@ def _replace_interned_param(match_obj):
     value = match_obj.group(3)
     intern_idx = full.index(intern_fn)
 
+    print(full, intern_fn, value, intern_idx, match_obj.group(1))
     # from fn(param, intern('string'), param, param...) to
     # fn (param, 'string', ...)
     return "{}'{}'{}".format(
@@ -205,9 +206,12 @@ def _parse_expression_strings(expressions):
             parsed,
         )
 
+        print(parsed)
+
         # remove the `intern()` in bucket and regex functions that take
         # string literal parameters.
         parsed = re.sub(FUNCTION_LITERAL_REGEX, _replace_interned_param, parsed)
+        print(parsed)
 
         validated = [alias, expression, parsed, column_id_map]
 

--- a/python/perspective/perspective/tests/table/test_view_expression.py
+++ b/python/perspective/perspective/tests/table/test_view_expression.py
@@ -1740,7 +1740,6 @@ class TestViewExpression(object):
             assert results["parsed"][i] == expected
             assert results["is_number?"][i] == True
 
-
     def test_view_expression_newlines(self):
         table = Table({"a": [
             "abc\ndef",

--- a/python/perspective/perspective/tests/table/test_view_expression.py
+++ b/python/perspective/perspective/tests/table/test_view_expression.py
@@ -1687,7 +1687,7 @@ class TestViewExpression(object):
         expressions = [
             "// address\nsearch(\"a\", '^([a-zA-Z0-9._-]+)@')",
             "// domain\nsearch(\"a\", '@([a-zA-Z.]+)$')",
-            "//is_email?\nfullmatch(\"a\", '^([a-zA-Z0-9._-]+)@([a-zA-Z.]+)$')",
+            "//is_email?\nmatch_all(\"a\", '^([a-zA-Z0-9._-]+)@([a-zA-Z.]+)$')",
             "//has_at?\nmatch(\"a\", '@')"
         ]
 
@@ -1729,7 +1729,7 @@ class TestViewExpression(object):
         parts[2] := search("a", '^[0-9]{4}[ -][0-9]{4}[ -]([0-9]{4})[ -][0-9]{4}');
         parts[3] := search("a", '^[0-9]{4}[ -][0-9]{4}[ -][0-9]{4}[ -]([0-9]{4})');
         concat(parts[0], parts[1], parts[2], parts[3])
-        """, "//is_number?\nfullmatch(\"a\", '^[0-9]{4}[ -][0-9]{4}[ -][0-9]{4}[ -][0-9]{4}')"])
+        """, "//is_number?\nmatch_all(\"a\", '^[0-9]{4}[ -][0-9]{4}[ -][0-9]{4}[ -][0-9]{4}')"])
         schema = view.expression_schema()
         assert schema == {"parsed": str, "is_number?": bool}
         results = view.to_columns()

--- a/python/perspective/perspective/tests/table/test_view_expression.py
+++ b/python/perspective/perspective/tests/table/test_view_expression.py
@@ -1673,10 +1673,10 @@ class TestViewExpression(object):
 
     def test_view_expession_multicomment(self):
         table = Table({"a": [1, 2, 3, 4]})
-        view = table.view(expressions=["//abc\nvar x := 1 + 2; // def\nx + 100 // cdefghijk"])
-        assert view.expression_schema() == {"abc": float}
+        view = table.view(expressions=["var x := 1 + 2;\n// def\nx + 100 // cdefghijk"])
+        assert view.expression_schema() == {"var x := 1 + 2;\n// def\nx + 100 // cdefghijk": float}
         assert view.to_columns() == {
-            "abc": [103, 103, 103, 103],
+            "var x := 1 + 2;\n// def\nx + 100 // cdefghijk": [103, 103, 103, 103],
             "a": [1, 2, 3, 4]
         }
     

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -525,6 +525,13 @@ thread_local! {
                 documentation: "Converts the given argument to a boolean".to_owned(),
             },
             CompletionItemSuggestion {
+                label: "random".to_owned(),
+                kind: 1,
+                insert_text: "random()".to_owned(),
+                insert_text_rules: 4,
+                documentation: "Returns a random float between 0 and 1, inclusive.".to_owned(),
+            },
+            CompletionItemSuggestion {
                 label: "match".to_owned(),
                 kind: 1,
                 insert_text: "match(${1:string}, ${2:pattern})".to_owned(),
@@ -532,9 +539,9 @@ thread_local! {
                 documentation: "Returns True if any part of string matches pattern, and False otherwise.".to_owned(),
             },
             CompletionItemSuggestion {
-                label: "fullmatch".to_owned(),
+                label: "match_all".to_owned(),
                 kind: 1,
-                insert_text: "fullmatch(${1:string}, ${2:pattern})".to_owned(),
+                insert_text: "match_all(${1:string}, ${2:pattern})".to_owned(),
                 insert_text_rules: 4,
                 documentation: "Returns True if the whole string matches pattern, and False otherwise.".to_owned(),
             },
@@ -560,11 +567,18 @@ thread_local! {
                 documentation: "Returns a substring of string starting from start_idx and ending at end_idx. If end_idx is not passed in, returns substring from start_idx to the end of the string. Returns null if the string or any indices are invalid.".to_owned(),
             },
             CompletionItemSuggestion {
-                label: "random".to_owned(),
+                label: "replace".to_owned(),
                 kind: 1,
-                insert_text: "random()".to_owned(),
+                insert_text: "replace(${1:string}, ${2:pattern}, ${3:replacer})".to_owned(),
                 insert_text_rules: 4,
-                documentation: "Returns a random float between 0 and 1, inclusive.".to_owned(),
+                documentation: "Replaces the first match of pattern in string with replacer, or return the original string if no replaces were made.".to_owned(),
+            },
+            CompletionItemSuggestion {
+                label: "replace_all".to_owned(),
+                kind: 1,
+                insert_text: "replace(${1:string}, ${2:pattern}, ${3:replacer})".to_owned(),
+                insert_text_rules: 4,
+                documentation: "Replaces all non-overlapping matches of pattern in string with replacer, or return the original string if no replaces were made.".to_owned(),
             },
         ]
     };

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -553,6 +553,13 @@ thread_local! {
                 documentation: "Writes into index 0 and 1 of output_vector the start and end indices of the substring that matches the first capturing group in pattern.\n\nReturns true if there is a match and output was written, or false if there are no capturing groups in the pattern, if there are no matches, or if the indices are invalid.".to_owned(),
             },
             CompletionItemSuggestion {
+                label: "substring".to_owned(),
+                kind: 1,
+                insert_text: "substring(${1:string}, ${2:start_idx}, ${3:end_idx})".to_owned(),
+                insert_text_rules: 4,
+                documentation: "Returns a substring of string starting from start_idx and ending at end_idx. If end_idx is not passed in, returns substring from start_idx to the end of the string. Returns null if the string or any indices are invalid.".to_owned(),
+            },
+            CompletionItemSuggestion {
                 label: "random".to_owned(),
                 kind: 1,
                 insert_text: "random()".to_owned(),

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -562,9 +562,9 @@ thread_local! {
             CompletionItemSuggestion {
                 label: "substring".to_owned(),
                 kind: 1,
-                insert_text: "substring(${1:string}, ${2:start_idx}, ${3:end_idx})".to_owned(),
+                insert_text: "substring(${1:string}, ${2:start_idx}, ${3:length})".to_owned(),
                 insert_text_rules: 4,
-                documentation: "Returns a substring of string starting from start_idx and ending at end_idx. If end_idx is not passed in, returns substring from start_idx to the end of the string. Returns null if the string or any indices are invalid.".to_owned(),
+                documentation: "Returns a substring of string from start_idx with the given length. If length is not passed in, returns substring from start_idx to the end of the string. Returns null if the string or any indices are invalid.".to_owned(),
             },
             CompletionItemSuggestion {
                 label: "replace".to_owned(),

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -545,6 +545,13 @@ thread_local! {
                 insert_text_rules: 4,
                 documentation: "Returns the substring that matches the first capturing group in pattern, or null if there are no capturing groups in the pattern or if there are no matches.".to_owned(),
             },
+            CompletionItemSuggestion {
+                label: "random".to_owned(),
+                kind: 1,
+                insert_text: "random()".to_owned(),
+                insert_text_rules: 4,
+                documentation: "Returns a random float between 0 and 1, inclusive.".to_owned(),
+            },
         ]
     };
 }

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -546,6 +546,13 @@ thread_local! {
                 documentation: "Returns the substring that matches the first capturing group in pattern, or null if there are no capturing groups in the pattern or if there are no matches.".to_owned(),
             },
             CompletionItemSuggestion {
+                label: "indexof".to_owned(),
+                kind: 1,
+                insert_text: "indexof(${1:string}, ${2:pattern}, ${3:output_vector})".to_owned(),
+                insert_text_rules: 4,
+                documentation: "Writes into index 0 and 1 of output_vector the start and end indices of the substring that matches the first capturing group in pattern.\n\nReturns true if there is a match and output was written, or false if there are no capturing groups in the pattern, if there are no matches, or if the indices are invalid.".to_owned(),
+            },
+            CompletionItemSuggestion {
                 label: "random".to_owned(),
                 kind: 1,
                 insert_text: "random()".to_owned(),


### PR DESCRIPTION
PR on top of #1596, but this one can be merged first to show all the changes - it's in a separate PR to make code review easier.

This PR adds more regex functions:

- `find(string, pattern, output_vector)`: writes the start and end-index (0-indexed) of the first match in string of the first capturing group in pattern. Values can be read from the output vector as follows: `var vec[2]; find("x", '(.*)', vec) ? vec[0] + vec[1] : null`. Returns `true` if a match was found and values were written to the output vector, and `false` otherwise.
- `substring(string, start_idx, length?)`: returns the substring of string from `start_idx` (0-indexed) with the specified `length`. If the length is not provided, returns the substring from start_idx to the end of the string, or null if the string is invalid or indices are invalid.
- `replace(string, pattern, replacer)`: replaces the _first_ match of `pattern` in `string` with `replacer`, and returns the replaced string or the original string if no replacements were made.
- `replace_all(string, pattern, replacer)`: replaces _all_ matches (non-overlapping) of `pattern` in `string` with `replacer`, and returns the replaced string or the original string if no replacements were made.

This PR also renames `fullmatch` from #1596 to `match_all` to remain consistent with the `replace`/`replace_all` API.

With this suite of Regex functions, one can easily clean and convert data from within Perspective - poorly formatted strings, dates that could not be parsed, monetary values that you want to convert to a float but cannot because of other string tokens, etc. can all be cleaned and properly converted from within Perspective's expression API.