### PR TITLE
Fix D3 alt-axis regression

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/axis/chartFactory.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/chartFactory.js
@@ -129,7 +129,7 @@ const chartFactory = (xAxis, yAxis, cartesian, canvas) => {
 
             // Column 5 of the grid
             container
-                .enter()
+                // .enter()
                 .append("div")
                 .attr("class", "y-label right-label")
                 .style("grid-column", 5)

--- a/packages/perspective-viewer-d3fc/src/js/legend/legend.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/legend.js
@@ -52,7 +52,9 @@ function legendComponent(scrollLegendComponent, scaleModifier) {
             scrollLegend
                 .scale(scale)
                 .orient("vertical")
-                .on("cellclick", function (d) {
+                .on("cellclick", function (_d) {
+                    // d3-svg-legend is very outdated and incompat with d3 6.x
+                    const d = this.__data__;
                     settings.hideKeys = settings.hideKeys || [];
                     if (settings.hideKeys.includes(d)) {
                         settings.hideKeys = settings.hideKeys.filter(


### PR DESCRIPTION
* Fixes a regression introduced in upgrading  #1599, which is now incompatible with dependency-dependency `d3-svg-legend`.  The regression manifested as un-clickable legend items.
* Fixes a regression in the way `enter()` is calculated, which honestly I'm unclear as to how it worked previously ... but is now fixed none the less.
