### PR TITLE
[Formatting] force line-feed line endings for all text files for easier windows development

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@ docs/**/* linguist-documentation
 python/perspective/notebooks/* linguist-documentation
 python/perspective/docs/* linguist-documentation
 results/*.json linguist-documentation
-*.js text eol=lf
 **/test/**/* linguist-documentation
 **/tests/**/* linguist-documentation
 examples/**/* linguist-documentation
@@ -13,3 +12,5 @@ cmake/** linguist-documentation
 CMakeLists.txt linguist-documentation
 docker/** linguist-documentation
 **/*.sh linguist-documentation
+
+* text=auto eol=lf


### PR DESCRIPTION
im doing some work on windows for conda and dont want to leak crlf into the code, we only enforce on `.js` files rn