### PR TITLE
Resizable expression editor

### DIFF
--- a/rust/perspective-viewer/build.js
+++ b/rust/perspective-viewer/build.js
@@ -112,12 +112,6 @@ const INHERIT = {
 };
 
 async function build_all() {
-    // generate declaration in parallel because tsc is sloooow.
-    let tsc;
-    if (fs.existsSync("dist/pkg/perspective_viewer.js")) {
-        tsc = exec("yarn tsc --emitDeclarationOnly --outDir dist/esm", INHERIT);
-    }
-
     await Promise.all(PREBUILD.map(build)).catch(() => process.exit(1));
 
     const debug = process.env.PSP_DEBUG ? "--debug" : "";
@@ -131,17 +125,13 @@ async function build_all() {
     fs.rmSync("dist/pkg/.gitignore");
     fs.rmSync("dist/pkg/README.md");
 
-    if (typeof tsc === "undefined") {
-        tsc = exec("yarn tsc --emitDeclarationOnly --outDir dist/esm", INHERIT);
-    }
+    execSync("yarn tsc --project tsconfig.json", INHERIT);
 
     await Promise.all(BUILD.map(build)).catch(() => process.exit(1));
     await Promise.all(POSTBUILD.map(build)).catch(() => process.exit(1));
 
     // legacy compat
     execSync("cpy dist/css/* dist/umd");
-
-    await tsc;
 }
 
 build_all();

--- a/rust/perspective-viewer/src/less/expression-editor.less
+++ b/rust/perspective-viewer/src/less/expression-editor.less
@@ -8,6 +8,7 @@
  */
 
 @import "./monaco.less";
+@import "./split-panel.less";
 
 :host {
     position: fixed;
@@ -21,10 +22,28 @@
     user-select: none;
     background-color: white;
 
-    #monaco-container {
+    #editor-container {
+        min-width: 0px;
         width: 400px;
+    }
+
+    #horizontal-resize {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        width: 8px;
+        &:hover {
+            cursor: ew-resize;
+            background: rgba(0, 0, 0, 0.05);
+        }
+    }
+
+    #monaco-container {
+        width: 100%;
         height: 200px;
         overflow: visible;
+        // margin-right: 8px;
         &::-webkit-resizer {
             appearance: var(--monaco-container--appearance, auto);
         }
@@ -45,6 +64,7 @@
         justify-content: flex-end;
         margin-left: 20px;
         margin-top: 12px;
+        margin-right: 8px;
     }
 
     .psp-expression-editor__button {
@@ -76,7 +96,6 @@
             opacity: 0.1;
             background-color: inherit;
             transition: background-color 0.2s;
-            padding-right: 0 6px;
 
             &:not([disabled]) {
                 opacity: 1;
@@ -92,6 +111,10 @@
                 background-color: rgba(0, 0, 0, 0.05);
                 transition: none;
             }
+        }
+
+        &#psp-expression-editor-button-save {
+            margin-right: 12px;
         }
 
         &#psp-expression-editor-button-save:before {

--- a/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
@@ -109,6 +109,9 @@ pub struct SplitPanelProps {
     pub id: String,
     pub children: Children,
 
+    #[prop_or_default]
+    pub on_resize: Option<Callback<(i32, i32)>>,
+
     #[cfg(test)]
     #[prop_or_default]
     pub weak_link: WeakComponentLink<SplitPanel>,
@@ -178,6 +181,10 @@ impl Component for SplitPanel {
             SplitPanelMsg::MoveResizing(client_x) => {
                 self.style = self.resize_state.as_ref().map(|state| {
                     let width = max(0, state.width + (client_x - state.start));
+                    if let Some(ref cb) = self.props.on_resize {
+                        cb.emit((std::cmp::max(0, width), 400));
+                    }
+
                     format!("width: {}px", width)
                 })
             }

--- a/rust/perspective-viewer/src/rust/js/monaco.rs
+++ b/rust/perspective-viewer/src/rust/js/monaco.rs
@@ -106,6 +106,9 @@ extern "C" {
     #[derive(Clone)]
     pub type JsMonacoEditor;
 
+    #[wasm_bindgen(method, js_name = "layout")]
+    pub fn layout(this: &JsMonacoEditor, arg: &JsValue);
+
     #[wasm_bindgen(method, js_name = "getModel")]
     pub fn get_model(this: &JsMonacoEditor) -> JsMonacoModel;
 
@@ -178,6 +181,12 @@ extern "C" {
 // pub struct RegisterCompletionItemProviderArgs {
 //     pub provider_completion_items: Closure< ... >,
 // }
+
+#[derive(Serialize)]
+pub struct ResizeArgs {
+    pub width: u32,
+    pub height: u32,
+}
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/rust/perspective-viewer/tsconfig.json
+++ b/rust/perspective-viewer/tsconfig.json
@@ -3,11 +3,13 @@
         "module": "esnext",
         "target": "es2018",
         "declaration": true,
+        "diagnostics": true,
         "emitDeclarationOnly": true,
         "outDir": "dist/esm",
         "rootDir": "src/ts",
         "allowSyntheticDefaultImports": true,
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        "skipLibCheck": true
     },
-    "files": ["src/ts/perspective-viewer.ts"]
+    "files": ["src/ts/perspective-viewer.ts"],
 }


### PR DESCRIPTION
Adds simple resizing to the expression editor widget.  This PR lacks persistence and vertical/corner resizing, as well as proper anchor support, but even as a small addition helps a lot when writing complex ExprTK expressions.