### PR TITLE
Fix `datetime`/`date`/`integer`/`float` filter occasionally resetting while typing

### DIFF
--- a/rust/perspective-viewer/src/rust/components/filter_item.rs
+++ b/rust/perspective-viewer/src/rust/components/filter_item.rs
@@ -381,8 +381,6 @@ impl Component for FilterItem {
                     step="1"
                     ref={ noderef.clone() }
                     onkeydown={ keydown }
-                    onfocus={ focus }
-                    onblur={ blur }
                     value={ self.input.clone() }
                     oninput={ input }/>
             },
@@ -393,8 +391,6 @@ impl Component for FilterItem {
                     class="num-filter"
                     ref={ noderef.clone() }
                     onkeydown={ keydown }
-                    onfocus={ focus }
-                    onblur={ blur }
                     value={ self.input.clone() }
                     oninput={ input }/>
             },
@@ -420,8 +416,6 @@ impl Component for FilterItem {
                     class="date-filter"
                     ref={ noderef.clone() }
                     onkeydown={ keydown }
-                    onfocus={ focus }
-                    onblur={ blur }
                     value={ self.input.clone() }
                     oninput={ input }/>
             },
@@ -433,8 +427,6 @@ impl Component for FilterItem {
                     step="0.001"
                     ref={ noderef.clone() }
                     onkeydown={ keydown }
-                    onfocus={ focus }
-                    onblur={ blur }
                     value={ self.input.clone() }
                     oninput={ input }/>
             },


### PR DESCRIPTION
Fixes #1645, I believe.  I had quite a bit of trouble reproducing this as described in the bug report, but did experience some rare value-clearing related to a race condition between the cell input and focus, which this PR fixes by removing focus hooks for non-completion filters (which were never functional for these filter types).