### PR TITLE
Re-enable Python dist

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -400,7 +400,7 @@ jobs:
       - ${{ parameters.initSteps }}
       - ${{ parameters.windowsInitSteps }}
       - ${{ parameters.pythonBuildVS2019Steps }}
-      # - ${{ parameters.pythonWindowsWheelVS2019Steps }}
+      - ${{ parameters.pythonWindowsWheelVS2019Steps }}
 
   - job: "MacOS_Catalina"
     pool:


### PR DESCRIPTION
`perspective-python` does not have a`1.0.6` release because [Python Windows wheels are failing in CI](https://dev.azure.com/finosfoundation/perspective/_build/results?buildId=3747&view=logs&s=96ac2280-8cb4-5df5-99de-dd2da759617d) - after once more merging a CMake/build PR without manually triggering a full-run CI pass.  This PR draft re-enables them in `azure-pipelines.yml`, while standing in silent vigil for `perspective-python@1.0.6`.