### PR TITLE
Preserve `expressions` on reset (shift+ to force)

### DIFF
--- a/rust/perspective-viewer/src/rust/components/status_bar.rs
+++ b/rust/perspective-viewer/src/rust/components/status_bar.rs
@@ -20,7 +20,7 @@ use yew::prelude::*;
 #[derive(Properties, Clone)]
 pub struct StatusBarProps {
     pub id: String,
-    pub on_reset: Callback<()>,
+    pub on_reset: Callback<bool>,
     pub session: Session,
 
     #[cfg(test)]
@@ -29,7 +29,7 @@ pub struct StatusBarProps {
 }
 
 pub enum StatusBarMsg {
-    Reset,
+    Reset(bool),
     Export(bool),
     Copy(bool),
     TableStatsChanged,
@@ -77,8 +77,8 @@ impl Component for StatusBar {
                 true
             }
             StatusBarMsg::TableStatsChanged => true,
-            StatusBarMsg::Reset => {
-                self.props.on_reset.emit(());
+            StatusBarMsg::Reset(all) => {
+                self.props.on_reset.emit(all);
                 false
             }
             StatusBarMsg::Export(flat) => {
@@ -109,7 +109,9 @@ impl Component for StatusBar {
         let stats = self.props.session.get_table_stats();
         let class_name = self.status_class_name(&stats);
         let is_updating_class_name = if self.is_updating { "updating" } else { " " };
-        let reset = self.link.callback(|_| StatusBarMsg::Reset);
+        let reset = self
+            .link
+            .callback(|event: MouseEvent| StatusBarMsg::Reset(event.shift_key()));
         let export = self
             .link
             .callback(|event: MouseEvent| StatusBarMsg::Export(event.shift_key()));

--- a/rust/perspective-viewer/src/rust/components/tests/status_bar.rs
+++ b/rust/perspective-viewer/src/rust/components/tests/status_bar.rs
@@ -25,7 +25,7 @@ pub fn test_callbacks_invoked() {
     let token = Rc::new(Cell::new(0));
     let on_reset = Callback::from({
         clone!(token);
-        move |()| token.set(1)
+        move |_| token.set(1)
     });
 
     let session = Session::default();
@@ -47,14 +47,14 @@ pub fn test_callbacks_invoked() {
     status_bar.send_message(StatusBarMsg::Copy(false));
     assert_eq!(token.get(), 0);
     let status_bar = link.borrow().clone().unwrap();
-    status_bar.send_message(StatusBarMsg::Reset);
+    status_bar.send_message(StatusBarMsg::Reset(false));
     assert_eq!(token.get(), 1);
 }
 
 fn gen(stats: &Option<TableStats>) -> (HtmlElement, Session) {
     let link: WeakComponentLink<StatusBar> = WeakComponentLink::default();
     let div = NodeRef::default();
-    let on_reset = Callback::from(|()| ());
+    let on_reset = Callback::from(|_| ());
     let session = Session::default();
     test_html! {
         <StatusBar

--- a/rust/perspective-viewer/src/rust/components/viewer.rs
+++ b/rust/perspective-viewer/src/rust/components/viewer.rs
@@ -39,7 +39,7 @@ pub struct PerspectiveViewerProps {
 }
 
 pub enum Msg {
-    Reset(Option<Sender<()>>),
+    Reset(bool, Option<Sender<()>>),
     ApplySettings(Option<SettingsUpdate>),
     ToggleSettings(
         Option<SettingsUpdate>,
@@ -84,11 +84,11 @@ impl Component for PerspectiveViewer {
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
             Msg::PreloadFontsUpdate => true,
-            Msg::Reset(sender) => {
+            Msg::Reset(all, sender) => {
                 let renderer = self.props.renderer.clone();
                 let session = self.props.session.clone();
                 let _ = promisify_ignore_view_delete(async move {
-                    session.reset();
+                    session.reset(all);
                     renderer.reset();
                     let result =
                         renderer.draw(session.validate().await.create_view()).await;
@@ -212,7 +212,7 @@ impl Component for PerspectiveViewer {
                     <StatusBar
                         id="status_bar"
                         session={ self.props.session.clone() }
-                        on_reset={ self.link.callback(|_| Msg::Reset(None)) }>
+                        on_reset={ self.link.callback(|all| Msg::Reset(all, None)) }>
                     </StatusBar>
                     <div
                         id="settings_button"

--- a/rust/perspective-viewer/src/rust/config/view_config.rs
+++ b/rust/perspective-viewer/src/rust/config/view_config.rs
@@ -74,8 +74,13 @@ impl ViewConfig {
         !self.row_pivots.is_empty() || !self.column_pivots.is_empty()
     }
 
-    pub fn reset(&mut self) {
-        std::mem::swap(self, &mut ViewConfig::default());
+    pub fn reset(&mut self, reset_expressions: bool) {
+        let mut config = ViewConfig::default();
+        if !reset_expressions {
+            config.expressions = self.expressions.clone();
+        }
+        std::mem::swap(self, &mut config);
+        web_sys::console::log_1(&format!("{:?}", &self).into());
     }
 
     /// Apply `ViewConfigUpdate` to a `ViewConfig`, ignoring any fields in `update`

--- a/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
@@ -435,14 +435,18 @@ impl PerspectiveViewerElement {
     }
 
     /// Reset the viewer's `ViewerConfig` to the default.
-    pub fn js_reset(&self) -> js_sys::Promise {
+    ///
+    /// # Arguments
+    /// - `all` Whether to clear `expressions` also.
+    pub fn js_reset(&self, reset_expressions: JsValue) -> js_sys::Promise {
         let (sender, receiver) = channel::<()>();
         let root = self.root.clone();
+        let all = reset_expressions.as_bool().unwrap_or_default();
         promisify_ignore_view_delete(async move {
             root.borrow()
                 .as_ref()
                 .ok_or("Already deleted!")?
-                .send_message(Msg::Reset(Some(sender)));
+                .send_message(Msg::Reset(all, Some(sender)));
             receiver.await.map_err(|_| JsValue::from("Cancelled"))?;
             Ok(JsValue::UNDEFINED)
         })
@@ -491,10 +495,7 @@ impl PerspectiveViewerElement {
         promisify_ignore_view_delete(async move {
             let view = session.get_view().into_jserror()?;
             let plugins = renderer.get_all_plugins();
-            let tasks = plugins.iter().map(|plugin| {
-                let view = &view;
-                async move { plugin.restyle(view).await }
-            });
+            let tasks = plugins.iter().map(|plugin| plugin.restyle(&view));
 
             join_all(tasks)
                 .await

--- a/rust/perspective-viewer/src/rust/session.rs
+++ b/rust/perspective-viewer/src/rust/session.rs
@@ -93,16 +93,19 @@ impl Session {
     }
 
     /// Reset this `Session`'s `View` state, but preserve the `Table`.
-    pub fn reset(&self) {
+    ///
+    /// # Arguments
+    /// - `keep_expressions` Whether to reset the `expressions` property.
+    pub fn reset(&self, reset_expressions: bool) {
         self.borrow_mut().view_sub = None;
-        self.borrow_mut().config.reset();
+        self.borrow_mut().config.reset(reset_expressions);
     }
 
     /// Reset this (presumably shared) `Session` to its initial state, returning a
     /// bool indicating whether this `Session` had a table which was deleted.
     /// TODO Table should be an immutable constructor parameter to `Session`.
     pub fn delete(&self) -> bool {
-        self.reset();
+        self.reset(false);
         self.borrow_mut().metadata = SessionMetadata::default();
         self.borrow_mut().table = None;
         false

--- a/rust/perspective-viewer/src/ts/viewer.ts
+++ b/rust/perspective-viewer/src/ts/viewer.ts
@@ -320,15 +320,16 @@ export class HTMLPerspectiveViewerElement extends HTMLElement {
      * state.
      *
      * @category Persistence
+     * @param all Should `expressions` param be reset as well, defaults to
      * @example
      * ```javascript
      * const viewer = document.querySelector("perspective-viewer");
      * await viewer.reset();
      * ```
      */
-    async reset(): Promise<void> {
+    async reset(all = false): Promise<void> {
         await this.load_wasm();
-        await this.instance.js_reset();
+        await this.instance.js_reset(all);
     }
 
     /**

--- a/rust/perspective-viewer/test/js/expressions.spec.js
+++ b/rust/perspective-viewer/test/js/expressions.spec.js
@@ -257,7 +257,31 @@ utils.with_server({}, () => {
                         await elem.restore({
                             expressions: ["3 + 4", "1 + 2"],
                         });
-                        await elem.reset();
+                        await elem.reset(true);
+                    });
+
+                    return page.evaluate(async () => {
+                        const elem =
+                            document.querySelector("perspective-viewer");
+                        return elem.shadowRoot.querySelector(
+                            "#expression-columns"
+                        ).innerHTML;
+                    });
+                }
+            );
+
+            test.capture(
+                "Resetting the viewer partially should not delete all expressions",
+                async (page) => {
+                    await page.evaluate(async () => {
+                        document.activeElement.blur();
+                        const elem =
+                            document.querySelector("perspective-viewer");
+                        await elem.toggleConfig(true);
+                        await elem.restore({
+                            expressions: ["3 + 4", "1 + 2"],
+                        });
+                        await elem.reset(false);
                     });
 
                     return page.evaluate(async () => {
@@ -282,7 +306,32 @@ utils.with_server({}, () => {
                             columns: ["1 + 2"],
                             expressions: ["3 + 4", "1 + 2"],
                         });
-                        await elem.reset();
+                        await elem.reset(true);
+                    });
+
+                    return page.evaluate(async () => {
+                        const elem =
+                            document.querySelector("perspective-viewer");
+                        return elem.shadowRoot.querySelector(
+                            "#expression-columns"
+                        ).innerHTML;
+                    });
+                }
+            );
+
+            test.capture(
+                "Resetting the viewer partially when expression as in columns field, should not delete all expressions",
+                async (page) => {
+                    await page.evaluate(async () => {
+                        document.activeElement.blur();
+                        const elem =
+                            document.querySelector("perspective-viewer");
+                        await elem.toggleConfig(true);
+                        await elem.restore({
+                            columns: ["1 + 2"],
+                            expressions: ["3 + 4", "1 + 2"],
+                        });
+                        await elem.reset(false);
                     });
 
                     return page.evaluate(async () => {
@@ -310,7 +359,7 @@ utils.with_server({}, () => {
                             filter: [["1 + 2", "==", 3]],
                             expressions: ["3 + 4", "1 + 2"],
                         });
-                        await elem.reset();
+                        await elem.reset(true);
                     });
 
                     return page.evaluate(async () => {

--- a/rust/perspective-viewer/test/results/results.json
+++ b/rust/perspective-viewer/test/results/results.json
@@ -3,7 +3,7 @@
     "superstore.html/doesn't leak elements.": "d0fd18b3d4d7c183c5ed155b4bf37972",
     "superstore.html/doesn't leak views when setting row pivots.": "54daaa4bbbe59f6ed4acc301ba871bab",
     "superstore.html/doesn't leak views when setting filters.": "6dfc1e505f1428424c3265f0236f22fc",
-    "__GIT_COMMIT__": "dc176eb138833bf0ff7c6c0520f6c2162e932b38",
+    "__GIT_COMMIT__": "b2b42a3e843a25e2ca0c9c39838aab6375f760e0",
     "blank.html/Handles reloading with a schema.": "e58c62f6e0ff16dc4d753f99e0fc39c3",
     "superstore_shows_a_grid_without_any_settings_applied_": "ae1c4690d978598ca14c8669244ce604",
     "superstore_Responsive_Layout_shows_horizontal_columns_on_small_vertical_viewports_": "57ba3ad341cf8a0e4df6ab96715ff2a0",
@@ -65,5 +65,7 @@
     "superstore_restore_fires_the__perspective-config-update__event": "94207660854a9e203ad7f8051333611f",
     "superstore_save_returns_the_current_config": "94207660854a9e203ad7f8051333611f",
     "superstore_restore_restores_a_config_from_save": "94207660854a9e203ad7f8051333611f",
-    "Expressions_Click_on_add_column_button_opens_the_expression_UI_": "41eab73e5a1831116702e9a03f579eb9"
+    "Expressions_Click_on_add_column_button_opens_the_expression_UI_": "41eab73e5a1831116702e9a03f579eb9",
+    "Expressions_Resetting_the_viewer_partially_should_not_delete_all_expressions": "0c15f7064c3299a7dba47477c7028d1d",
+    "Expressions_Resetting_the_viewer_partially_when_expression_as_in_columns_field,_should_not_delete_all_expressions": "0c15f7064c3299a7dba47477c7028d1d"
 }


### PR DESCRIPTION
This PR changes the behavior of the Reset button in `<perspective-viewer>`'s `StatusBar` component to preserve `expressions`, thus only resetting the properties of the underlying `View`.  `shift+click` can be used to override this behavior and clear `expressions` as well.

`reset()` has also been changed to `reset(reset_expressions: bool)`, and will behave the same way unless `reset_expressions` is `true`.