### PR TITLE
Fix `perspective-workspace` errors

### DIFF
--- a/packages/perspective-viewer-datagrid/package.json
+++ b/packages/perspective-viewer-datagrid/package.json
@@ -9,6 +9,7 @@
             "require": "./dist/umd/perspective-viewer-datagrid.js",
             "import": "./dist/esm/perspective-viewer-datagrid.js"
         },
+        "./dist/*": "./dist/*",
         "./package.json": "./package.json"
     },
     "files": [

--- a/packages/perspective-workspace/src/js/perspective-workspace.js
+++ b/packages/perspective-workspace/src/js/perspective-workspace.js
@@ -189,15 +189,11 @@ class PerspectiveWorkspaceElement extends HTMLElement {
     _light_dom_changed() {
         const viewers = Array.from(this.childNodes);
         for (const viewer of viewers) {
-            if (
-                [Node.TEXT_NODE, document.COMMENT_NODE].indexOf(
-                    viewer.nodeType
-                ) > -1
-            ) {
-                continue;
+            if (viewer.tagName === "PERSPECTIVE-VIEWER") {
+                this.workspace.update_widget_for_viewer(viewer);
             }
-            this.workspace.update_widget_for_viewer(viewer);
         }
+
         this.workspace.remove_unslotted_widgets(viewers);
     }
 

--- a/rust/perspective-viewer/src/rust/renderer.rs
+++ b/rust/perspective-viewer/src/rust/renderer.rs
@@ -210,6 +210,14 @@ impl Renderer {
         Ok(changed)
     }
 
+    pub async fn with_lock(
+        self,
+        task: impl Future<Output = Result<JsValue, JsValue>>,
+    ) -> Result<JsValue, JsValue> {
+        let draw_mutex = self.draw_lock();
+        draw_mutex.lock(task).await
+    }
+
     pub async fn resize(&self) -> Result<JsValue, JsValue> {
         let draw_mutex = self.draw_lock();
         let timer = self.render_timer();


### PR DESCRIPTION
* Fixes `<perspective-viewer>`'s `delete()` method to be `async`, and internally acquire the draw lock.  This prevents a mid-executing call to `draw()` from losing access to the data due to an interrupting `delete()`, causing a segfault.  This may happen when, e.g., a panel-close occurs in `<perspective-workspace>` quickly after a `draw()` was triggered on that panel, before it completes.
* Fixes threshold for light DOM update trigger, which caused errors when customizations are applied to a `<perspective-viewer>` in a workspace, which is subsequently closed.