### PR TITLE
Fix Treemap zoom when a group level is `null`

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/data/treeData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/treeData.js
@@ -89,12 +89,13 @@ export function treeData(settings) {
                     : [d.value, d.data.color]
                           .concat(d.data.tooltip || [])
                           .filter((x) => x !== undefined);
+
             d.crossValue = d
                 .ancestors()
                 .slice(0, -1)
                 .reverse()
-                .map((cross) => cross.data.name)
-                .join("|");
+                .map((cross) => cross.data.name);
+
             d.key = set[0];
             d.label = toValue(
                 settings.crossValues[d.depth - 1 < 0 ? 0 : d.depth - 1].type,

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLabel.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLabel.js
@@ -147,7 +147,7 @@ const textLevelHelper = (d, treemapLevel, crossValues) => {
     if (
         !crossValues
             .filter((x) => x !== "")
-            .every((x) => d.crossValue.split("|").includes(x))
+            .every((x) => d.crossValue.includes(x))
     )
         return textVisability.zero;
     switch (d.depth) {

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLevelCalculation.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapLevelCalculation.js
@@ -13,7 +13,7 @@ import treemapLayout from "./treemapLayout";
 import {textOpacity} from "./treemapLabel";
 
 const includesAllCrossValues = (d, crossValues) =>
-    crossValues.every((val) => d.crossValue.split("|").includes(val));
+    crossValues.every((val) => d.crossValue.includes(val));
 
 export function calculateSubTreeMap(
     d,
@@ -103,7 +103,7 @@ function approximateAttributesForAllNodes(
         const height = calcHeight(d) * dimensionMultiplier.height;
         const visible =
             includesAllCrossValues(d, crossValues) &&
-            d.data.name != crossValues[treemapLevel - 1];
+            d.data.name !== crossValues[treemapLevel - 1];
 
         d.mapLevel[treemapLevel] = {
             x0,

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapSeries.js
@@ -86,7 +86,7 @@ export function treemapSeries() {
             .attr("y", (d) => d.y0 + calcHeight(d) / 2)
             .text((d) => d.label);
 
-        const rootNode = rects.filter((d) => d.crossValue === "").datum();
+        const rootNode = rects.filter((d) => d.crossValue.length === 0).datum();
         calculateRootLevelMap(nodesMerge, rootNode);
 
         toggleLabels(nodesMerge, 0, []);

--- a/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapTransitions.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/treemap/treemapTransitions.js
@@ -35,7 +35,7 @@ export function returnToLevel(
     root_settings
 ) {
     if (settings.treemapLevel > 0) {
-        const crossValues = rootNode.crossValue.split("|");
+        const crossValues = rootNode.crossValue;
         executeTransition(
             rootNode,
             rects,
@@ -57,7 +57,7 @@ export function returnToLevel(
             .slice(1, settings.treemapRoute.length)
             .forEach((cv) => {
                 const d = nodesMerge.filter((d) => d.crossValue === cv).datum();
-                const crossValues = d.crossValue.split("|");
+                const crossValues = d.crossValue;
                 calculateSubTreeMap(
                     d,
                     crossValues,
@@ -108,7 +108,8 @@ export function changeLevel(
 
     settings.treemapLevel = d.depth;
 
-    const crossValues = d.crossValue.split("|");
+    const crossValues = d.crossValue;
+
     if (
         !d.mapLevel[settings.treemapLevel] ||
         !d.mapLevel[settings.treemapLevel].levelRoot

--- a/packages/perspective-workspace/test/js/integration/restore.spec.js
+++ b/packages/perspective-workspace/test/js/integration/restore.spec.js
@@ -107,6 +107,10 @@ function tests(extract) {
                 await workspace.duplicate(widget);
             });
 
+            await page.evaluate(async () => {
+                await workspace.notifyResize(true);
+            });
+
             return extract(page);
         }
     );

--- a/rust/perspective-viewer/src/rust/components/config_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/config_selector.rs
@@ -275,7 +275,6 @@ impl Component for ConfigSelector {
             ""
         };
 
-        // web_sys::console::log_1(&"redraw".into());
         let dragend = Callback::from({
             let dragdrop = self.props.dragdrop.clone();
             move |_event| dragdrop.drag_end()

--- a/rust/perspective-viewer/src/rust/config/view_config.rs
+++ b/rust/perspective-viewer/src/rust/config/view_config.rs
@@ -80,7 +80,6 @@ impl ViewConfig {
             config.expressions = self.expressions.clone();
         }
         std::mem::swap(self, &mut config);
-        web_sys::console::log_1(&format!("{:?}", &self).into());
     }
 
     /// Apply `ViewConfigUpdate` to a `ViewConfig`, ignoring any fields in `update`


### PR DESCRIPTION
When a `Group by` with `null` values was present in a parent group using the `"Treemap"` plugin, zooming in from that level and back out would fail to properly draw the original treemap.  This occurred only when zooming, as the bug is not related to the initial SVG render itself, but the attribute-modifying zoom-in/zoom-out code that changes visibility/position of the treemap SVG elements.  Here, group identity was checked using the column encoding `"name1|name2"` and `.split("|")`, which encodes `[null]` as an empty string and is indistinguishable from `[]`.  However, this string-encoding is only used a few times, and is generated from the correct `Array` representation _only_ for treemaps, so this PR just replaces just it with this original `Array` and removes the string-decoding for the handful of usages.

This is related to #1628 and has the same behavior, except in a much narrower context e.g. only in the presence of `null` groups.  This fix however is completely un-related to the fix in #1652.