### PR TITLE
Upgrade Arrow to `6.0.2`

### DIFF
--- a/cmake/arrow.txt.in
+++ b/cmake/arrow.txt.in
@@ -10,7 +10,7 @@ project(arrow-download NONE)
 include(ExternalProject)
 ExternalProject_Add(apachearrow
   GIT_REPOSITORY    https://github.com/apache/arrow.git
-  GIT_TAG           apache-arrow-5.0.0
+  GIT_TAG           apache-arrow-6.0.1
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/arrow-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/arrow-build"
   CONFIGURE_COMMAND ""

--- a/cmake/arrow/CMakeLists.txt
+++ b/cmake/arrow/CMakeLists.txt
@@ -83,6 +83,7 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/testing/util.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/basic_decimal.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/bit_block_counter.cc
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/bit_run_reader.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/bit_util.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/bitmap_builders.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/bitmap_ops.cc
@@ -105,6 +106,7 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/task_group.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/thread_pool.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/trie.cc
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/unreachable.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/utf8.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/value_parsing.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/vendored/double-conversion/double-conversion.cc

--- a/cmake/arrow/config.h
+++ b/cmake/arrow/config.h
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#define ARROW_VERSION_MAJOR 5
+#define ARROW_VERSION_MAJOR 6
 #define ARROW_VERSION_MINOR 0
-#define ARROW_VERSION_PATCH 0
+#define ARROW_VERSION_PATCH 1
 #define ARROW_VERSION ((ARROW_VERSION_MAJOR * 1000) + ARROW_VERSION_MINOR) * 1000 + ARROW_VERSION_PATCH
 
 /* #undef DOUBLE_CONVERSION_HAS_CASE_INSENSIBILITY */


### PR DESCRIPTION
Rebased from #1636

Benchmarks look flat but its worth not letting these changes accumulate until we _need_ to upgrade.

<img width="753" alt="Screen Shot 2021-12-19 at 7 15 01 PM" src="https://user-images.githubusercontent.com/60666/146698645-aefa19c5-a9fe-4742-a8e7-4bfddc457ad3.png">

