### PR TITLE
80% reduction in `.wasm` asset size

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn prepush

--- a/cpp/perspective/build.js
+++ b/cpp/perspective/build.js
@@ -1,6 +1,8 @@
 const {execSync} = require("child_process");
 const os = require("os");
 const path = require("path");
+const fflate = require("fflate");
+const fs = require("fs");
 
 const stdio = "inherit";
 const env = process.PSP_DEBUG ? "debug" : "release";
@@ -21,6 +23,10 @@ try {
     });
     execSync(`cpy esm/**/* ../esm`, {cwd, stdio});
     execSync(`cpy cjs/**/* ../cjs`, {cwd, stdio});
+
+    const wasm = fs.readFileSync("dist/esm/perspective.cpp.wasm");
+    const compressed = fflate.compressSync(wasm);
+    fs.writeFileSync("dist/esm/perspective.cpp.wasm", compressed);
 } catch (e) {
     console.error(e);
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "html-loader": "^0.5.1",
         "html-loader-jest": "^0.2.1",
         "html-webpack-plugin": "^4.5.1",
+        "husky": "^7.0.4",
         "inquirer": "^7.0.0",
         "jest": "^25.1.0",
         "jest-junit": "^10.0.0",
@@ -67,7 +68,6 @@
         "npm-run-all": "^4.1.3",
         "postcss": "^7.0.19",
         "postcss-loader": "^4.3.0",
-        "pre-commit": "^1.2.2",
         "prettier": "^2.4.0",
         "puppeteer": "^10.2.0",
         "rimraf": "^2.6.2",
@@ -95,9 +95,6 @@
         "react-dom": "16.8.6",
         "autoprefixer": "9.7.0"
     },
-    "pre-commit": [
-        "precommit"
-    ],
     "scripts": {
         "postinstall": "node scripts/install_emsdk.js",
         "build,test": "npm run --silent build && npm run --silent test",
@@ -118,7 +115,8 @@
         "test_python": "node scripts/test_python.js",
         "clean": "node scripts/clean.js",
         "start": "lerna run start --stream --scope",
-        "precommit": "npm-run-all lint_js lint_python",
+        "prepush": "npm-run-all lint_js lint_python",
+        "prepare": "husky install",
         "lint_js": "npm-run-all lint:*",
         "lint:eslint": "eslint \"examples/**/*.js\" \"examples/**/*.ts\" \"examples/**/*.tsx\" \"scripts/*.js\" \"rust/**/*.ts\" \"rust/**/*.js\" \"packages/**/*.js\" \"packages/**/*.ts\" \"cpp/**/*.js\"",
         "lint_python": "node scripts/lint_python.js",

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -59,8 +59,8 @@
         "automock": false
     },
     "dependencies": {
-        "tslib": "^1.9.3",
-        "ws": "^6.1.2"
+        "ws": "^6.1.2",
+        "fflate": "^0.7.2"
     },
     "devDependencies": {
         "@finos/perspective-build": "^1.0.7",

--- a/rust/perspective-viewer/build.js
+++ b/rust/perspective-viewer/build.js
@@ -1,8 +1,8 @@
 const {lessLoader} = require("esbuild-plugin-less");
 const {execSync} = require("child_process");
 const util = require("util");
-const exec = util.promisify(require("child_process").exec);
 const fs = require("fs");
+const fflate = require("fflate");
 
 const {IgnoreCSSPlugin} = require("@finos/perspective-build/ignore_css");
 const {IgnoreFontsPlugin} = require("@finos/perspective-build/ignore_fonts");
@@ -119,6 +119,10 @@ async function build_all() {
         `CARGO_TARGET_DIR=./build wasm-pack build ${debug} --out-dir dist/pkg --target web`,
         INHERIT
     );
+
+    const wasm = fs.readFileSync("dist/pkg/perspective_viewer_bg.wasm");
+    const compressed = fflate.compressSync(wasm);
+    fs.writeFileSync("dist/pkg/perspective_viewer_bg.wasm", compressed);
 
     // Remove wasm-pack artifacts
     fs.rmSync("dist/pkg/package.json");

--- a/rust/perspective-viewer/package.json
+++ b/rust/perspective-viewer/package.json
@@ -55,7 +55,8 @@
     "dependencies": {
         "@finos/perspective": "^1.0.7",
         "mobile-drag-drop-shadow-dom": "3.0.0",
-        "monaco-editor": "0.24.0"
+        "monaco-editor": "0.24.0",
+        "fflate": "^0.7.2"
     },
     "optionalDependencies": {
         "monaco-editor-webpack-plugin": "3.1.0"

--- a/rust/perspective-viewer/src/ts/init.ts
+++ b/rust/perspective-viewer/src/ts/init.ts
@@ -8,7 +8,7 @@
  *
  */
 
-import {decompressSync} from "fflate";
+import {Decompress} from "fflate";
 
 import init_wasm from "@finos/perspective-viewer/dist/pkg/perspective_viewer.js";
 import wasm from "@finos/perspective-viewer/dist/pkg/perspective_viewer_bg.wasm";
@@ -22,27 +22,65 @@ window.addEventListener("unhandledrejection", (event) => {
     }
 });
 
+function is_gzip(buffer) {
+    return new Uint32Array(buffer.slice(0, 4))[0] == 559903;
+}
+
 async function load_wasm() {
     // Perform a silly dance to deal with the different ways webpack and esbuild
     // load binary
     const compressed = (await wasm) as unknown;
 
-    let buffer;
+    let parts = [];
+    let length = 0;
+    const decompressor = new Decompress((chunk) => {
+        if (chunk) {
+            length += chunk.byteLength;
+            parts.push(chunk);
+        }
+    });
+
     if (compressed instanceof URL || typeof compressed === "string") {
         const resp = await fetch(compressed.toString());
-        buffer = await resp.arrayBuffer();
+        const reader = resp.body.getReader();
+        let state = 0;
+        while (true) {
+            const {value, done} = await reader.read();
+            if (done) break;
+            if ((state === 0 && is_gzip(value.buffer)) || state === 1) {
+                state = 1;
+                decompressor.push(value, done);
+            } else {
+                state = 2;
+                length += value.byteLength;
+                parts.push(value);
+            }
+        }
     } else if (compressed instanceof Uint8Array) {
-        buffer = compressed.buffer;
+        if (is_gzip(compressed.buffer)) {
+            decompressor.push(compressed, true);
+        } else {
+            length = compressed.byteLength;
+            parts = [compressed];
+        }
     } else {
-        buffer = compressed as ArrayBuffer;
+        const array = new Uint8Array(compressed as ArrayBuffer);
+        if (is_gzip(compressed)) {
+            decompressor.push(array, true);
+        } else {
+            length = array.byteLength;
+            parts = [array];
+        }
     }
 
-    // Unzip if needed
-    if (new Uint32Array(buffer.slice(0, 4))[0] == 559903) {
-        return await init_wasm(decompressSync(new Uint8Array(buffer)));
-    } else {
-        return await init_wasm(buffer);
+    let offset = 0;
+    const buffer = new Uint8Array(length);
+    for (const part of parts) {
+        buffer.set(part, offset);
+        offset += part.byteLength;
     }
+
+    return await init_wasm(buffer);
 }
 
 export const WASM_MODULE = load_wasm();

--- a/tools/perspective-build/build.js
+++ b/tools/perspective-build/build.js
@@ -9,8 +9,8 @@ const DEFAULT_BUILD = {
     sourcemap: true,
     metafile: true,
     entryNames: "[name]",
-    chunkNames: "[name]-[hash]",
-    assetNames: "[name]-[hash]",
+    chunkNames: "[name]",
+    assetNames: "[name]",
 };
 
 exports.build = async function build(config) {

--- a/tools/perspective-build/wasm.js
+++ b/tools/perspective-build/wasm.js
@@ -33,9 +33,7 @@ exports.WasmPlugin = function WasmPlugin(inline) {
             contents: `
                 import wasm from ${JSON.stringify(args.path)};
                 async function get_wasm() {
-                    const req = await fetch(new URL(wasm, import.meta.url));
-                    const buffer = await req.arrayBuffer();
-                    return buffer;
+                    return new URL(wasm, import.meta.url);
                 }
 
                 export default get_wasm();

--- a/tools/perspective-build/worker.js
+++ b/tools/perspective-build/worker.js
@@ -22,7 +22,10 @@ exports.WorkerPlugin = function WorkerPlugin(inline) {
                     assetNames: "[name]",
                     minify: !process.env.PSP_DEBUG,
                     bundle: true,
-                    sourcemap: true,
+                    // // Unfortunately source maps don't work with blob
+                    // // workers, which we need to make cross-origin
+                    // // workers not a PITA ..
+                    // sourcemap: true,
                 });
 
                 return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5102,7 +5102,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@^1.5.2:
+concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -8819,6 +8819,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
+  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -12065,11 +12070,6 @@ os-name@^3.1.0:
     macos-release "^2.2.0"
     windows-release "^3.1.0"
 
-os-shim@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
-  integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
-
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -13188,15 +13188,6 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
-
-pre-commit@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
-  integrity sha1-287g7p3nI15X95xW186UZBpp7sY=
-  dependencies:
-    cross-spawn "^5.0.1"
-    spawn-sync "^1.0.15"
-    which "1.2.x"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -14768,14 +14759,6 @@ source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-
-spawn-sync@^1.0.15:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
-  integrity sha1-sAeZVX63+wyDdsKdROih6mfldHY=
-  dependencies:
-    concat-stream "^1.4.7"
-    os-shim "^0.1.2"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -16435,13 +16418,6 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-
-which@1.2.x:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
-  integrity sha1-mofEN48D6CfOyvGs31bHNsAcFOU=
-  dependencies:
-    isexe "^2.0.0"
 
 which@^1.2.9, which@^1.3.1:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7613,6 +7613,11 @@ feed@^4.0.0:
   dependencies:
     xml-js "^1.6.11"
 
+fflate@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.2.tgz#1db42c416d7b2845d2883050aa4eef516c63f246"
+  integrity sha512-h/YiXnc37yYaGe61h3A4ZdsBzBqKG5hhrmopFizTru8xrfOiJuYX5oLnatBwNEpf9biOJrZVscuEQsUzIUAhpQ==
+
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"


### PR DESCRIPTION
WASM assets gzip quite well when properly configured on your application's HTTP server via the `Content-Encoding: gzip` header, and you can even remove the on-the-fly gzip cost by pre-zipping the wasm and configuring your server appropriately, but
* `Content-Encoding: gzip` doesn't affect the perceived size of the perspective _inline_ (e.g. without the webpack-plugin) builds, especially in the developer's imagination (see #1655).  Also, the inlined base64 WASM payload as a string does not compress nearly as well as gzipping the original WASM.
* CDNs generally don't recognize pre-gzipped assets (as they likely shouldn't).
* Even with the build plugin, WASM assets sizes are large and perspective's build is complex enough without asking app developers to provide bespoke server support.

To mitigate this perception/complexity, this PR gzips Perspective's WASM assets during the build step, then uses `fflate`, a small (3kb) gzip Javascript library, to unzip the WASM content in Perspective's JavaScript client after downloading.  The result is nearly 80% reduction in Perspective WASM asset size without the use of `Content-Encoding`, at the cost of a few ms of additional startup time (with a margin of error at 400ms+ on my tests).

* `umd/perspective.js` inline single-JS build, `8.0mb` -> `1.7mb`
* `cdn/perspective.cpp.wasm` plugin build, `6.0mb` -> `1.3mb`
* `cdn/perspective-viewer.js` inline single-JS build, `4.2mb` -> `3.2mb` (most of this is monaco)
* `cdn/perspective_viewer_bg.wasm` plugin build, `1.2mb` -> `300kb`