### PR TITLE
Reduce CI: Turn off branch builds, only build on PRs to master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,29 @@
 trigger:
+  batch: true
   branches:
     include:
-      - "*" # must quote since "*" is a YAML reserved character; we want a string
+      - master
   tags:
     include:
       - "v*"
 
 pr:
+  autoCancel: true
   branches:
     include:
-      - "*" # must quote since "*" is a YAML reserved character; we want a string
+      - master
+  drafts: true
+  paths:
+    exclude:
+      - AUTHORS
+      - CHANGELOG.md
+      - CONTRIBUTING.md
+      - LICENSE
+      - README.md
+      - binder/
+      - docs/
+      - examples/
+      - python/perspective/README.md
 
 schedules:
   - cron: "0 0 * * 6"


### PR DESCRIPTION
reduce ci by only building on PRs to master branch, not building branches independent of PRs, and ommitting some paths