### PR TITLE
Pin `flatc` to 1.12.1

### DIFF
--- a/scripts/install_tools.js
+++ b/scripts/install_tools.js
@@ -21,7 +21,7 @@ try {
         console.log("-- Installing Flatbuffers");
         execute`mkdir -p /usr/local`;
         process.chdir("/usr/local");
-        execute`git clone https://github.com/google/flatbuffers.git`;
+        execute`git clone --depth 1 --branch v1.12.1 https://github.com/google/flatbuffers.git`;
         process.chdir("/usr/local/flatbuffers");
         execute`cmake -G "Unix Makefiles"`;
         execute`make`;


### PR DESCRIPTION
Fixes CI build failure due to [regression in `flatbuffers`](https://github.com/google/flatbuffers/commit/a42e898979cc828a35aefcc469fec896175fa8e6) (just a guess).