### PR TITLE
Fix bad filter when `.update()` contains missing string column value

### DIFF
--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -517,13 +517,16 @@ t_data_table::filter_cpp(
                     bool tval;
 
                     if (ft.m_use_interned) {
-                        cell_val.set(*(columns[cidx]->get_nth<t_uindex>(ridx)));
-                        tval = ft(cell_val);
+                        if (*(columns[cidx]->get_nth_status(ridx))
+                            == STATUS_VALID) {
+                            cell_val.set(
+                                *(columns[cidx]->get_nth<t_uindex>(ridx)));
+                        }
                     } else {
                         cell_val = columns[cidx]->get_scalar(ridx);
-                        tval = ft(cell_val);
                     }
 
+                    tval = ft(cell_val);
                     if ((ft.m_op != FILTER_OP_IS_NULL && !cell_val.is_valid())
                         || !tval) {
                         pass = false;

--- a/python/perspective/perspective/tests/table/test_table.py
+++ b/python/perspective/perspective/tests/table/test_table.py
@@ -104,6 +104,13 @@ class TestTable(object):
             "float": [None, 2.5, None]
         }
 
+    def test_table_string_column_with_nulls_update_and_filter(self):
+        tbl = Table([{'a': '1', 'b': 2, 'c': '3'}, {'a': '2', 'b': 3, 'c': '4'}, {'a': '3', 'b': 3, 'c': None}], index='a')
+        view = tbl.view(filter=[['c', '==', '4']])
+        records = view.to_records()
+        tbl.update([{'a': '4', 'b': 10}])
+        assert records == view.to_records()
+
     def test_table_int(self):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)


### PR DESCRIPTION
Fixes #1701 