### PR TITLE
Add `settings` and `theme` to `perspective-config-update` DOM event and `PerspectiveWidget` python class

### DIFF
--- a/packages/perspective-jupyterlab/src/js/model.js
+++ b/packages/perspective-jupyterlab/src/js/model.js
@@ -34,6 +34,7 @@ export class PerspectiveModel extends DOMWidgetModel {
             filter: [],
             expressions: [],
             plugin_config: {},
+            settings: true,
             theme: "Material Light",
             editable: false,
             server: false,

--- a/packages/perspective-jupyterlab/src/js/psp_widget.js
+++ b/packages/perspective-jupyterlab/src/js/psp_widget.js
@@ -49,6 +49,8 @@ export class PerspectiveWidget extends Widget {
         const expressions = options.expressions || options.expressions || [];
         const plugin_config = options.plugin_config || {};
         const theme = options.theme || "Material Light";
+        const settings =
+            typeof options.settings === "boolean" ? options.settings : true;
         const editable = options.editable || false;
         const server = options.server || false;
         const client = options.client || false;
@@ -66,6 +68,7 @@ export class PerspectiveWidget extends Widget {
             aggregates,
             expressions,
             filter,
+            settings,
             theme,
         };
         // this.plugin_config = plugin_config;

--- a/packages/perspective-jupyterlab/src/js/renderer.js
+++ b/packages/perspective-jupyterlab/src/js/renderer.js
@@ -343,7 +343,7 @@ function activate(app, restorer, themeManager) {
                 ? themeManager.isLight(themeManager.theme)
                 : true;
 
-        const theme = is_light ? "Material Light" : "Material Dark";
+        const theme = isLight ? "Material Light" : "Material Dark";
         trackercsv.forEach((pspDocWidget) => {
             pspDocWidget.psp.theme = theme;
         });

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -53,6 +53,8 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         "plugin",
         "editable",
         "plugin_config",
+        "theme",
+        "settings",
     )
 
     def __init__(
@@ -66,6 +68,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         filter=None,
         expressions=None,
         plugin_config=None,
+        settings=True,
         theme=None,
         editable=False,
     ):
@@ -96,6 +99,8 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
                 select by default.
             plugin_config (:obj:`dict`): A configuration for the plugin, i.e.
                 the datagrid plugin or a chart plugin.
+            settings(:obj:`bool`): Whether the perspective query settings
+                panel should be open.
             theme (:obj:`str`): The color theme to use.
             editable (:obj:`bool`): Whether to allow editability using the grid.
 
@@ -128,6 +133,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         self.filter = validate_filter(filter) or []
         self.expressions = validate_expressions(expressions) or []
         self.plugin_config = validate_plugin_config(plugin_config) or {}
+        self.settings = settings
         self.theme = theme
         self.editable = editable
 

--- a/python/perspective/perspective/viewer/viewer_traitlets.py
+++ b/python/perspective/perspective/viewer/viewer_traitlets.py
@@ -44,6 +44,7 @@ class PerspectiveTraitlets(HasTraits):
     filter = List(default_value=[]).tag(sync=True)
     expressions = List(default_value=[]).tag(sync=True)
     plugin_config = Dict(default_value={}).tag(sync=True)
+    settings = Bool(True).tag(sync=True)
     theme = Unicode("Material Light", allow_none=True).tag(sync=True)
     editable = Bool(False).tag(sync=True)
     server = Bool(False).tag(sync=True)

--- a/rust/perspective-viewer/src/rust/components/tests/viewer.rs
+++ b/rust/perspective-viewer/src/rust/components/tests/viewer.rs
@@ -69,12 +69,17 @@ pub fn test_settings_closed() {
 pub async fn test_settings_open() {
     let (link, root, _) = set_up_html();
     let viewer = link.borrow().clone().unwrap();
-    viewer.send_message(Msg::ToggleSettings(
+    viewer.send_message(Msg::ToggleSettingsInit(
         Some(SettingsUpdate::Update(true)),
         None,
     ));
+
     let (sender, receiver) = channel::<()>();
-    viewer.send_message(Msg::ToggleSettingsFinished(sender));
+    viewer.send_message(Msg::ToggleSettingsComplete(
+        SettingsUpdate::Update(true),
+        sender,
+    ));
+
     receiver.await.unwrap();
     for selector in ["#app_panel", "slot", "#settings_button", "#status_bar"].iter() {
         assert!(root
@@ -90,7 +95,7 @@ pub async fn test_load_table() {
     let (link, root, session) = set_up_html();
     let table = get_mock_table().await;
     let viewer = link.borrow().clone().unwrap();
-    viewer.send_message(Msg::ToggleSettings(
+    viewer.send_message(Msg::ToggleSettingsInit(
         Some(SettingsUpdate::Update(true)),
         None,
     ));

--- a/rust/perspective-viewer/src/rust/config/view_config.rs
+++ b/rust/perspective-viewer/src/rust/config/view_config.rs
@@ -25,8 +25,7 @@ use {crate::*, js_sys::Array};
 #[cfg(test)]
 use wasm_bindgen_test::*;
 
-#[derive(Clone, Debug, Deserialize, Default, Serialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Clone, Debug, Deserialize, Default, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ViewConfig {
     #[serde(default)]

--- a/rust/perspective-viewer/src/rust/custom_events.rs
+++ b/rust/perspective-viewer/src/rust/custom_events.rs
@@ -1,0 +1,142 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018, the Perspective Authors.
+//
+// This file is part of the Perspective library, distributed under the terms
+// of the Apache License 2.0.  The full license can be found in the LICENSE
+// file.
+
+use crate::config::*;
+use crate::js::plugin::JsPerspectiveViewerPlugin;
+use crate::renderer::*;
+use crate::session::Session;
+use crate::utils::*;
+use crate::*;
+use std::ops::Deref;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::future_to_promise;
+use web_sys::*;
+
+#[derive(Clone)]
+pub struct CustomEvents(Rc<(CustomEventsDataRc, [Subscription; 4])>);
+
+#[derive(Clone)]
+struct CustomEventsDataRc(Rc<CustomEventsData>);
+
+impl Deref for CustomEventsDataRc {
+    type Target = CustomEventsData;
+    fn deref(&self) -> &CustomEventsData {
+        &*self.0
+    }
+}
+
+struct CustomEventsData {
+    elem: HtmlElement,
+    session: Session,
+    renderer: Renderer,
+    last_dispatched: RefCell<Option<ViewerConfig>>,
+}
+
+derive_renderable_props!(CustomEventsData);
+
+impl CustomEvents {
+    pub fn new(
+        elem: &HtmlElement,
+        session: &Session,
+        renderer: &Renderer,
+    ) -> CustomEvents {
+        let data = CustomEventsDataRc(Rc::new(CustomEventsData {
+            elem: elem.clone(),
+            session: session.clone(),
+            renderer: renderer.clone(),
+            last_dispatched: Default::default(),
+        }));
+
+        let theme_sub = renderer.on_theme_config_updated.add_listener({
+            clone!(data);
+            move |_| {
+                data.clone().dispatch_config_update();
+            }
+        });
+
+        let settings_sub = renderer.on_settings_open_changed.add_listener({
+            clone!(data);
+            move |open| {
+                data.dispatch_settings_open_changed(open);
+                data.clone().dispatch_config_update();
+            }
+        });
+
+        let plugin_sub = renderer.on_plugin_changed.add_listener({
+            clone!(data);
+            move |plugin| {
+                data.dispatch_plugin_changed(&plugin);
+                data.clone().dispatch_config_update();
+            }
+        });
+
+        let view_sub = session.on_view_created.add_listener({
+            clone!(data);
+            move |_| {
+                data.clone().dispatch_config_update();
+            }
+        });
+
+        CustomEvents(Rc::new((
+            data,
+            [theme_sub, settings_sub, plugin_sub, view_sub],
+        )))
+    }
+}
+
+impl CustomEventsDataRc {
+    fn dispatch_settings_open_changed(&self, open: bool) {
+        let mut event_init = web_sys::CustomEventInit::new();
+        event_init.detail(&JsValue::from(open));
+        let event = web_sys::CustomEvent::new_with_event_init_dict(
+            "perspective-toggle-settings",
+            &event_init,
+        );
+
+        self.elem
+            .toggle_attribute_with_force("settings", open)
+            .unwrap();
+        self.elem.dispatch_event(&event.unwrap()).unwrap();
+    }
+
+    fn dispatch_plugin_changed(&self, plugin: &JsPerspectiveViewerPlugin) {
+        let mut event_init = web_sys::CustomEventInit::new();
+        event_init.detail(plugin);
+        let event = web_sys::CustomEvent::new_with_event_init_dict(
+            "perspective-plugin-update",
+            &event_init,
+        );
+
+        self.elem.dispatch_event(&event.unwrap()).unwrap();
+    }
+
+    fn dispatch_config_update(self) {
+        let _ = future_to_promise(async move {
+            let viewer_config = self.get_viewer_config().await?;
+            if viewer_config.view_config != Default::default()
+                && Some(&viewer_config) != self.last_dispatched.borrow().as_ref()
+            {
+                let json_config = JsValue::from_serde(&viewer_config).into_jserror()?;
+                let mut event_init = web_sys::CustomEventInit::new();
+                event_init.detail(&json_config);
+                let event = web_sys::CustomEvent::new_with_event_init_dict(
+                    "perspective-config-update",
+                    &event_init,
+                );
+
+                *self.last_dispatched.borrow_mut() = Some(viewer_config);
+                self.elem.dispatch_event(&event.unwrap()).unwrap();
+            }
+
+            Ok(JsValue::UNDEFINED)
+        });
+    }
+}

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -13,6 +13,7 @@
 pub mod components;
 pub mod config;
 pub mod custom_elements;
+pub mod custom_events;
 pub mod dragdrop;
 pub mod exprtk;
 pub mod js;

--- a/rust/perspective-viewer/test/js/events.spec.js
+++ b/rust/perspective-viewer/test/js/events.spec.js
@@ -55,8 +55,12 @@ utils.with_server({}, () => {
                         columns: ["Profit", "Sales"],
                         expressions: [],
                         filter: [],
+                        plugin: "Debug",
+                        plugin_config: {},
                         row_pivots: ["State"],
+                        settings: true,
                         sort: [],
+                        theme: null,
                     });
 
                     return await get_contents(page);


### PR DESCRIPTION
This PR updates the `perspective-config-update` event fired from `<perspective-viewer>` custom element in two ways:

1) `perspective-config-update` is now fired when either the `settings` or `theme` property are changed, in addition to the other properties it fires for currently.
2) Then `event.detail` property now includes `theme`, `settings`, `plugin` and `plugin_config`, mirroring the object returned from the `.save()` method.

In addition, Python `traitlets` have been added for `settings` and `theme`, allowing them to be manipulated programmatically from the `PerspectiveWidget` JupyterLab interface.

Fixes #1499 