### PR TITLE
Add column-style-checkbox css variables

### DIFF
--- a/rust/perspective-viewer/src/less/column-style.less
+++ b/rust/perspective-viewer/src/less/column-style.less
@@ -64,13 +64,13 @@
     }
 
     input[type="checkbox"] {
-        appearance: none;
+        appearance: var(--column-style-checkbox--appearance, auto);
         font-family: var(--button--font-family, inherit);
         font-size: 16px;
         text-align: center;
 
         &:checked:after {
-            content: "\E834";
+            content: var(--column-style-checkbox-checked--content, none);
         }
 
         &:not([disabled]):checked:after {
@@ -78,7 +78,7 @@
         }
 
         &:after {
-            content: "\E835";
+            content: var(--column-style-checkbox-unchecked--content, none);
             color: var(--inactive--color, #999);
         }
     }

--- a/rust/perspective-viewer/src/themes/material.less
+++ b/rust/perspective-viewer/src/themes/material.less
@@ -41,6 +41,9 @@ perspective-expression-editor[theme="Material Light"],
     --column-style-radio--appearance: none;
     --column-style-radio-checked--content: "radio_button_checked";
     --column-style-radio-unchecked--content: "radio_button_unchecked";
+    --column-style-checkbox--appearance: none;
+    --column-style-checkbox-checked--content: "check_box";
+    --column-style-checkbox-unchecked--content: "check_box_outline_blank";
 }
 
 .perspective-viewer-material--dimensions {


### PR DESCRIPTION
As done with radio buttons, this PR allows `column style` checkbox icons to be provided by css variables with a native checkbox fallback. 

The original material checkbox icons have been moved to the material theme file.