### PR TITLE
Fix python memory leak in `table()`

### DIFF
--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -513,6 +513,7 @@ class Table(object):
         self._state_manager.remove_process(self._table.get_id())
         self._table.unregister_gnode(self._gnode_id)
         [cb() for cb in self._delete_callbacks]
+        self._table = None
 
     def _update_callback(self, port_id):
         """After `process` completes internally, this method is called by the

--- a/python/perspective/perspective/tests/table/test_leaks.py
+++ b/python/perspective/perspective/tests/table/test_leaks.py
@@ -1,0 +1,43 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+from perspective.table import Table
+import psutil
+import os
+
+
+class TestDelete(object):
+
+    # delete
+
+    def test_table_delete(self):
+        process = psutil.Process(os.getpid())
+        mem = process.memory_info().rss
+        for x in range(10000):
+            data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+            tbl = Table(data)
+            tbl.delete()
+        
+        mem2 = process.memory_info().rss
+
+        # assert 1 < (max2 / max) < 1.01
+        assert (mem2 - mem) < 2000000
+
+    def test_table_delete_with_view(self, sentinel):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+
+        process = psutil.Process(os.getpid())
+        mem = process.memory_info().rss
+        for x in range(10000):
+            view = tbl.view()
+            view.delete()
+        
+        tbl.delete()
+        mem2 = process.memory_info().rss
+        assert (mem2 - mem) < 2000000

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -52,6 +52,7 @@ requires_dev = [
     "flake8>=3.7.8",
     "flake8-black>=0.2.0",
     "mock",
+    "psutil",
     "pybind11>=2.4.0",
     "pyarrow>=0.16.0",
     "pytest>=4.3.0",

--- a/scripts/test_python.js
+++ b/scripts/test_python.js
@@ -63,7 +63,8 @@ const pytest_client_mode = (IS_DOCKER) => {
             perspective/tests/client_mode"`;
     } else {
         return bash`cd ${python_path} && PYTHONMALLOC=debug ${PYTHON} -m pytest \
-            ${VERBOSE ? "-vv --full-trace" : ""} --noconftest 
+            ${VERBOSE ? "-vv --full-trace" : ""} --noconftest
+            --disable-pytest-warnings
             perspective/tests/client_mode`;
     }
 };
@@ -77,11 +78,13 @@ const pytest = (IS_DOCKER) => {
             python/perspective && TZ=UTC PYTHONMALLOC=debug ${PYTHON} -m pytest \
             ${VERBOSE ? "-vv --full-trace" : ""} perspective \
             --ignore=perspective/tests/client_mode \
+            --disable-pytest-warnings
             --cov=perspective"`;
     } else {
         return bash`cd ${python_path} && PYTHONMALLOC=debug ${PYTHON} -m pytest \
             ${VERBOSE ? "-vv --full-trace" : ""} perspective \
             --ignore=perspective/tests/client_mode \
+            --disable-pytest-warnings
             ${COVERAGE ? "--cov=perspective" : ""}`;
     }
 };


### PR DESCRIPTION
Address the Python `table()` memory leak identified in #1723 (but do not close this issue it tracks dictionary "leak" behavior).