### PR TITLE
fix: fire config-update evnt on perspective-viewer

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/plugin_menu.js
+++ b/packages/perspective-viewer-datagrid/src/js/plugin_menu.js
@@ -84,7 +84,7 @@ export function activate_plugin_menu(regularTable, target, column_max) {
         regularTable[PLUGIN_SYMBOL] = regularTable[PLUGIN_SYMBOL] || {};
         regularTable[PLUGIN_SYMBOL][column_name] = config;
         regularTable.draw({preserve_width: true});
-        regularTable.parentElement.dispatchEvent(
+        regularTable.parentElement.parentElement.dispatchEvent(
             new Event("perspective-config-update")
         );
     };
@@ -102,7 +102,7 @@ export function activate_plugin_menu(regularTable, target, column_max) {
         MENU.destroy();
         this._open_column_styles_menu.pop();
         await regularTable.draw({preserve_width: true});
-        regularTable.parentElement.dispatchEvent(
+        regularTable.parentElement.parentElement.dispatchEvent(
             new Event("perspective-config-update")
         );
     };


### PR DESCRIPTION
This PR resolves #1727 by firing the `perspective-config-update` event on `perspective-viewer` element.

This was tested manually. Is there a good place to add a test for this behavior?