### PR TITLE
Allow `@finos/perspective` to run in single-threaded mode

### DIFF
--- a/packages/perspective/src/js/perspective.browser.js
+++ b/packages/perspective/src/js/perspective.browser.js
@@ -127,9 +127,7 @@ class WebWorkerClient extends Client {
         let _worker;
         const msg = {cmd: "init", config: get_config()};
         if (typeof WebAssembly === "undefined") {
-            throw new Error(
-                "WebAssembly not supported. Support for ASM.JS has been removed as of 0.3.1."
-            );
+            throw new Error("WebAssembly not supported.");
         } else {
             [_worker, msg.buffer] = await Promise.all([
                 _override().worker(),


### PR DESCRIPTION
In 2022, there are still some contexts where Web Workers are not allowed, but (somehow) Web Assembly is.  This PR adds single-threaded mode to `@finos/perspective`, such that the Web Assembly engine will run synchronously on the main browser thread when Web Worker instantiation fails.