### PR TITLE
Disable OSX Python CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -462,60 +462,60 @@ jobs:
   #     - ${{ parameters.windowsInitSteps }}
   #     - ${{ parameters.pythonWindowsWheelVS2019Steps }}
 
-  - job: "MacOS_Catalina"
-    pool:
-      vmImage: "macos-10.15"
-    condition: or(startsWith(variables['build.sourceBranch'], 'refs/tags/v'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
+  # - job: "MacOS_Catalina"
+  #   pool:
+  #     vmImage: "macos-10.15"
+  #   condition: or(startsWith(variables['build.sourceBranch'], 'refs/tags/v'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
 
-    strategy:
-      matrix:
-          Python36:
-            python.version: "3.6"
-            python_flag: "--python36"
-            artifact_name: "cp36-cp36m-macosx_10_15_x86_64"
+  #   strategy:
+  #     matrix:
+  #         Python36:
+  #           python.version: "3.6"
+  #           python_flag: "--python36"
+  #           artifact_name: "cp36-cp36m-macosx_10_15_x86_64"
 
-          Python37:
-            python.version: "3.7"
-            python_flag: ""
-            artifact_name: "cp37-cp37m-macosx_10_15_x86_64"
+  #         Python37:
+  #           python.version: "3.7"
+  #           python_flag: ""
+  #           artifact_name: "cp37-cp37m-macosx_10_15_x86_64"
 
-          Python38:
-            python.version: "3.8"
-            python_flag: "--python38"
-            artifact_name: "cp38-cp38-macosx_10_15_x86_64"
+  #         Python38:
+  #           python.version: "3.8"
+  #           python_flag: "--python38"
+  #           artifact_name: "cp38-cp38-macosx_10_15_x86_64"
             
-          Python39:
-            python.version: "3.9"
-            python_flag: "--python39"
-            artifact_name: "cp39-cp39-macosx_10_15_x86_64"
+  #         Python39:
+  #           python.version: "3.9"
+  #           python_flag: "--python39"
+  #           artifact_name: "cp39-cp39-macosx_10_15_x86_64"
           
 
-    steps:
-      - ${{ parameters.initSteps }}
-      - ${{ parameters.pythonInitSteps }}
-      - ${{ parameters.macInitSteps }}
-      - ${{ parameters.pythonBuildSteps }}
-      - ${{ parameters.pythonCoverageSteps }}
-      - ${{ parameters.pythonMacWheelSteps }}
+  #   steps:
+  #     - ${{ parameters.initSteps }}
+  #     - ${{ parameters.pythonInitSteps }}
+  #     - ${{ parameters.macInitSteps }}
+  #     - ${{ parameters.pythonBuildSteps }}
+  #     - ${{ parameters.pythonCoverageSteps }}
+  #     - ${{ parameters.pythonMacWheelSteps }}
 
-  - job: "MacOS_BigSur"
-    pool:
-      vmImage: "macos-11"
+  # - job: "MacOS_BigSur"
+  #   pool:
+  #     vmImage: "macos-11"
 
-    strategy:
-      matrix:
-        Python39:
-          python.version: "3.9"
-          python_flag: "--python39"
-          artifact_name: "cp39-cp39-macosx_11_0_x86_64"
+  #   strategy:
+  #     matrix:
+  #       Python39:
+  #         python.version: "3.9"
+  #         python_flag: "--python39"
+  #         artifact_name: "cp39-cp39-macosx_11_0_x86_64"
 
-    steps:
-      - ${{ parameters.initSteps }}
-      - ${{ parameters.pythonInitSteps }}
-      - ${{ parameters.macInitSteps }}
-      - ${{ parameters.pythonBuildSteps }}
-      - ${{ parameters.pythonCoverageSteps }}
-      - ${{ parameters.pythonMacWheelSteps }}
+  #   steps:
+  #     - ${{ parameters.initSteps }}
+  #     - ${{ parameters.pythonInitSteps }}
+  #     - ${{ parameters.macInitSteps }}
+  #     - ${{ parameters.pythonBuildSteps }}
+  #     - ${{ parameters.pythonCoverageSteps }}
+  #     - ${{ parameters.pythonMacWheelSteps }}
 
   - job: "Jupyterlab"
     dependsOn: ["WebAssembly", "Linux"]


### PR DESCRIPTION
Homebrew now exclusively dists `flatbuffers@2.0.6` which is [incompatible with our arrow build](https://dev.azure.com/finosfoundation/perspective/_build/results?buildId=4064&view=logs&j=0e75fe71-fead-56f1-bee0-bc202d563d9d&t=59712ed9-8e00-5be3-1aeb-5e7d762b32ca).  I would spend more time attempting to fix this, but its already been 2 minor version JavaScript releases since a stable Python release due to #1741 (and list wouldn't hurt to add #1684 to the list).

What's one more tire on the eternally-burning apocalyptic tire-fire hellscape that is a cross-platform Python library with native extensions?