### PR TITLE
Rust lint+nightly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,5 @@ packages/perspective-jupyterlab/test/config/jupyter/lab
 packages/perspective-jupyterlab/test/config/jupyter/migrated
 docs/static/features
 results.debug.json
+
+tools/perspective-build/lib

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,12 @@ parameters:
       - bash: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         displayName: "Install wasm-pack"
 
+      - bash: rustup toolchain install nightly
+        displayName: "Install Rust nightly"
+
+      - bash: rustup component add rust-src --toolchain nightly
+        displayName: "Install rust-src"
+
   - name: linuxInitSteps
     type: stepList
     default:
@@ -119,6 +125,12 @@ parameters:
     default:
       - bash: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         displayName: "Install wasm-pack"
+
+      - bash: rustup toolchain install nightly
+        displayName: "Install Rust nightly"
+
+      - bash: rustup component add rust-src --toolchain nightly
+        displayName: "Install rust-src"
 
       - bash: yarn lint_js
         displayName: "Lint Javascript"

--- a/packages/perspective-viewer-d3fc/build.js
+++ b/packages/perspective-viewer-d3fc/build.js
@@ -45,6 +45,7 @@ const BUILD = [
         define: {
             global: "window",
         },
+        globalName: "perspective_viewer_d3fc",
         plugins: [InlineCSSPlugin(), UMDLoader()],
         format: "cjs",
         loader: {

--- a/rust/perspective-viewer/.cargo/config.toml
+++ b/rust/perspective-viewer/.cargo/config.toml
@@ -1,3 +1,4 @@
 
 [target.wasm32-unknown-unknown]
 rustflags = ["--cfg=web_sys_unstable_apis"]
+runner = 'wasm-bindgen-test-runner'

--- a/rust/perspective-viewer/Cargo.toml
+++ b/rust/perspective-viewer/Cargo.toml
@@ -130,6 +130,8 @@ version = "0.3"
 wasm-bindgen-test = "0.3.13"
 
 [profile.release]
+panic = "abort"
 opt-level = "z"
 codegen-units = 1
 lto = true
+strip = true

--- a/rust/perspective-viewer/rustfmt.toml
+++ b/rust/perspective-viewer/rustfmt.toml
@@ -1,0 +1,8 @@
+unstable_features = true
+wrap_comments = true
+use_field_init_shorthand = true
+format_code_in_doc_comments = true
+format_macro_bodies = true
+format_macro_matchers = true
+format_strings = true
+overflow_delimited_expr = true

--- a/rust/perspective-viewer/src/rust/components/active_column.rs
+++ b/rust/perspective-viewer/src/rust/components/active_column.rs
@@ -44,9 +44,7 @@ impl PartialEq for ActiveColumnProps {
 impl ActiveColumnProps {
     fn get_name(&self) -> Option<String> {
         match &self.name {
-            ActiveColumnState::DragOver(_) => {
-                Some(self.dragdrop.get_drag_column().unwrap())
-            }
+            ActiveColumnState::DragOver(_) => Some(self.dragdrop.get_drag_column().unwrap()),
             ActiveColumnState::Column(_, name) => Some(name.to_owned()),
             ActiveColumnState::Required(_) => None,
         }
@@ -73,12 +71,13 @@ impl From<ActiveColumnProps> for yew::Html {
 derive_session_renderer_model!(ActiveColumnProps);
 
 impl ActiveColumnProps {
-    /// Remove an active column from `columns`, or alternatively make this column
-    /// the only column in `columns` if the shift key is set (via the `shift` flag).
+    /// Remove an active column from `columns`, or alternatively make this
+    /// column the only column in `columns` if the shift key is set (via the
+    /// `shift` flag).
     ///
     /// # Arguments
-    /// - `name` The name of the column to de-activate, which is a unique ID with
-    ///   respect to `columns`.
+    /// - `name` The name of the column to de-activate, which is a unique ID
+    ///   with respect to `columns`.
     /// - `shift` whether to toggle or select this column.
     pub fn deactivate_column(&self, name: String, shift: bool) {
         let mut columns = self.session.borrow_view_config().columns.clone();
@@ -129,9 +128,9 @@ pub enum ActiveColumnMsg {
     DeactivateColumn(String, bool),
 }
 
-/// An `ActiveColumn` indicates a column which is part of the `columns` field of a
-/// `ViewConfig`.  It shows additional column details in context (like selected
-/// aggregate), and supports drag/drop and missing entries.
+/// An `ActiveColumn` indicates a column which is part of the `columns` field of
+/// a `ViewConfig`.  It shows additional column details in context (like
+/// selected aggregate), and supports drag/drop and missing entries.
 /// TODO Break this into "Active", "Hover" and "Empty"?
 pub struct ActiveColumn {
     add_expression_ref: NodeRef,
@@ -188,9 +187,7 @@ impl Component for ActiveColumn {
                     Some(ctx.props().dragdrop.get_drag_column().unwrap()),
                 )
             }
-            ActiveColumnState::Column(label, name) => {
-                (label.clone(), Some(name.to_owned()))
-            }
+            ActiveColumnState::Column(label, name) => (label.clone(), Some(name.to_owned())),
             ActiveColumnState::Required(label) => (label.clone(), None),
         };
 
@@ -240,13 +237,12 @@ impl Component for ActiveColumn {
                         event.data_transfer().unwrap().set_drag_image(&elem, 0, 0);
                         dragdrop.drag_start(
                             event_name.to_string(),
-                            DragEffect::Move(DropAction::Active),
+                            DragEffect::Move(DragTarget::Active),
                         )
                     }
                 });
 
-                let is_expression =
-                    ctx.props().session.metadata().is_column_expression(&name);
+                let is_expression = ctx.props().session.metadata().is_column_expression(&name);
 
                 let class = if self.is_required {
                     "is_column_active required"
@@ -327,8 +323,8 @@ impl Component for ActiveColumn {
                 // columns out until the new View forces a re-render (and the
                 // `change()` method on this component checks for this).
 
-                let class = Itertools::intersperse(classes.iter().cloned(), " ")
-                    .collect::<String>();
+                let class =
+                    Itertools::intersperse(classes.iter().cloned(), " ").collect::<String>();
 
                 html! {
                     <div

--- a/rust/perspective-viewer/src/rust/components/aggregate_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/aggregate_selector.rs
@@ -110,10 +110,7 @@ impl AggregateSelector {
         });
     }
 
-    pub fn get_dropdown_aggregates(
-        &self,
-        ctx: &Context<Self>,
-    ) -> Vec<SelectItem<Aggregate>> {
+    pub fn get_dropdown_aggregates(&self, ctx: &Context<Self>) -> Vec<SelectItem<Aggregate>> {
         let aggregates = ctx
             .props()
             .session

--- a/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
@@ -68,13 +68,14 @@ pub enum DragDropListMsg {
     Freeze(bool),
 }
 
-/// A sub-selector for a list-like component of a `JsViewConfig`, such as `filters`
-/// and `sort`.  `DragDropList` is parameterized by two `Component` types, the
-/// parent component `T` and the inner item compnent `U`, which must additionally
-/// implement `DragDropListItemProps` trait on its own `Properties` associated type.
+/// A sub-selector for a list-like component of a `JsViewConfig`, such as
+/// `filters` and `sort`.  `DragDropList` is parameterized by two `Component`
+/// types, the parent component `T` and the inner item compnent `U`, which must
+/// additionally implement `DragDropListItemProps` trait on its own `Properties`
+/// associated type.
 ///
-/// Before you ask:  yes, `frozen_size` needs to be a float64 since `flex` containers
-/// can have fractional dimensions.
+/// Before you ask:  yes, `frozen_size` needs to be a float64 since `flex`
+/// containers can have fractional dimensions.
 pub struct DragDropList<T, U, V>
 where
     T: Component,
@@ -192,9 +193,7 @@ where
                     .cloned();
 
                 if !ctx.props().allow_duplicates {
-                    columns.retain(|x| {
-                        x.1 .1.as_ref().unwrap().props.get_item() != *column
-                    });
+                    columns.retain(|x| x.1 .1.as_ref().unwrap().props.get_item() != *column);
                 }
 
                 // If inserting into the middle of the list, use

--- a/rust/perspective-viewer/src/rust/components/containers/dropdown_menu.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/dropdown_menu.rs
@@ -61,7 +61,6 @@ where
         }
     }
 
-
     fn view(&self, ctx: &Context<Self>) -> Html {
         let values = &ctx.props().values;
         let body = if !values.is_empty() {

--- a/rust/perspective-viewer/src/rust/components/containers/radio_list.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/radio_list.rs
@@ -81,8 +81,8 @@ impl<T> RadioListProps<T>
 where
     T: Clone + Display + FromStr + PartialEq + 'static,
 {
-    /// Validate a `RadioListProps`'s dimensions to make sure the no runtime errors
-    /// can occur when looking up values.
+    /// Validate a `RadioListProps`'s dimensions to make sure the no runtime
+    /// errors can occur when looking up values.
     fn validate(&self) {
         assert_eq!(self.children.len(), self.values.len());
         assert!(self.values.iter().any(|x| *x == self.selected));
@@ -176,14 +176,7 @@ where
             .iter()
             .enumerate()
             .map(|(idx, child)| {
-                self.render_item(
-                    ctx,
-                    idx,
-                    child,
-                    &class,
-                    on_change.clone(),
-                    &self.selected,
-                )
+                self.render_item(ctx, idx, child, &class, on_change.clone(), &self.selected)
             })
             .collect::<Html>()
     }

--- a/rust/perspective-viewer/src/rust/components/containers/select.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/select.rs
@@ -111,10 +111,11 @@ where
             "noselect".to_owned()
         };
 
-        let is_group_selected =
-            !ctx.props().values.iter().any(
-                |x| matches!(x, SelectItem::Option(y) if *y == ctx.props().selected),
-            );
+        let is_group_selected = !ctx
+            .props()
+            .values
+            .iter()
+            .any(|x| matches!(x, SelectItem::Option(y) if *y == ctx.props().selected));
 
         let select = html! {
             <select

--- a/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
@@ -16,8 +16,8 @@ use web_sys::HtmlElement;
 use yew::html::Scope;
 use yew::prelude::*;
 
-/// The state for the `Resizing` action, including the `MouseEvent` callbacks and
-/// panel starting dimensions.
+/// The state for the `Resizing` action, including the `MouseEvent` callbacks
+/// and panel starting dimensions.
 struct ResizingState {
     mousemove: Closure<dyn Fn(MouseEvent)>,
     mouseup: Closure<dyn Fn(MouseEvent)>,
@@ -32,9 +32,9 @@ struct ResizingState {
 }
 
 impl Drop for ResizingState {
-    /// On `drop`, we must remove these event listeners from the document `body`.
-    /// Without this, the `Closure` objects would not leak, but the document will
-    /// continue to call them, causing runtime exceptions.
+    /// On `drop`, we must remove these event listeners from the document
+    /// `body`. Without this, the `Closure` objects would not leak, but the
+    /// document will continue to call them, causing runtime exceptions.
     fn drop(&mut self) {
         let result: Result<(), JsValue> = maybe! {
             let document = web_sys::window().unwrap().document().unwrap();
@@ -53,8 +53,8 @@ impl Drop for ResizingState {
     }
 }
 
-/// When the instantiated, capture the initial dimensions and create the MouseEvent
-/// callbacks.
+/// When the instantiated, capture the initial dimensions and create the
+/// MouseEvent callbacks.
 impl ResizingState {
     pub fn new(
         index: usize,
@@ -141,13 +141,11 @@ impl ResizingState {
     /// occurring.
     fn capture_cursor(&mut self) -> Result<(), JsValue> {
         self.cursor = self.body_style.get_property_value("cursor")?;
-        self.body_style.set_property(
-            "cursor",
-            match self.orientation {
+        self.body_style
+            .set_property("cursor", match self.orientation {
                 Orientation::Horizontal => "col-resize",
                 Orientation::Vertical => "row-resize",
-            },
-        )
+            })
     }
 
     /// " but for release
@@ -217,8 +215,8 @@ pub enum SplitPanelMsg {
     Reset(usize),
 }
 
-/// A panel with 2 sub panels and a mouse-draggable divider which allows apportioning
-/// the panel's width.
+/// A panel with 2 sub panels and a mouse-draggable divider which allows
+/// apportioning the panel's width.
 ///
 /// # Examples
 ///
@@ -369,13 +367,10 @@ fn split_panel_divider(props: &SplitPanelDividerProps) -> Html {
     let i = props.i;
     let link = props.link.clone();
     let onmousedown = link.callback(move |event: MouseEvent| {
-        SplitPanelMsg::StartResizing(
-            i,
-            match orientation {
-                Orientation::Horizontal => event.client_x(),
-                Orientation::Vertical => event.client_y(),
-            },
-        )
+        SplitPanelMsg::StartResizing(i, match orientation {
+            Orientation::Horizontal => event.client_x(),
+            Orientation::Vertical => event.client_y(),
+        })
     });
 
     let ondblclick = props.link.callback(move |event: MouseEvent| {

--- a/rust/perspective-viewer/src/rust/components/copy_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/copy_dropdown.rs
@@ -72,10 +72,7 @@ fn get_menu_items(has_render: bool) -> Vec<CopyDropDownMenuItem> {
                 vec![ExportMethod::Csv, ExportMethod::Json]
             },
         ),
-        CopyDropDownMenuItem::OptGroup(
-            "All",
-            vec![ExportMethod::CsvAll, ExportMethod::JsonAll],
-        ),
+        CopyDropDownMenuItem::OptGroup("All", vec![ExportMethod::CsvAll, ExportMethod::JsonAll]),
         CopyDropDownMenuItem::OptGroup("Config", vec![ExportMethod::JsonConfig]),
     ]
 }

--- a/rust/perspective-viewer/src/rust/components/export_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/export_dropdown.rs
@@ -59,18 +59,12 @@ fn get_menu_items(name: &str, has_render: bool) -> Vec<ExportDropDownMenuItem> {
                 ]
             },
         ),
-        ExportDropDownMenuItem::OptGroup(
-            "All",
-            vec![
-                ExportMethod::CsvAll.new_file(name),
-                ExportMethod::JsonAll.new_file(name),
-                ExportMethod::ArrowAll.new_file(name),
-            ],
-        ),
-        ExportDropDownMenuItem::OptGroup(
-            "Config",
-            vec![ExportMethod::JsonConfig.new_file(name)],
-        ),
+        ExportDropDownMenuItem::OptGroup("All", vec![
+            ExportMethod::CsvAll.new_file(name),
+            ExportMethod::JsonAll.new_file(name),
+            ExportMethod::ArrowAll.new_file(name),
+        ]),
+        ExportDropDownMenuItem::OptGroup("Config", vec![ExportMethod::JsonConfig.new_file(name)]),
     ]
 }
 

--- a/rust/perspective-viewer/src/rust/components/expression_editor.rs
+++ b/rust/perspective-viewer/src/rust/components/expression_editor.rs
@@ -173,13 +173,13 @@ impl Component for ExpressionEditor {
     fn view(&self, ctx: &Context<Self>) -> Html {
         let reset = ctx.link().callback(|_| ExpressionEditorMsg::Reset);
         let save = ctx.link().callback_once(|_| ExpressionEditorMsg::SaveExpr);
-        let resize_horiz = ctx.link().callback(|(width, height)| {
-            ExpressionEditorMsg::Resize(width, height - 54)
-        });
+        let resize_horiz = ctx
+            .link()
+            .callback(|(width, height)| ExpressionEditorMsg::Resize(width, height - 54));
 
-        let resize_vert = ctx.link().callback(|(width, height)| {
-            ExpressionEditorMsg::Resize(width, height - 48)
-        });
+        let resize_vert = ctx
+            .link()
+            .callback(|(width, height)| ExpressionEditorMsg::Resize(width, height - 48));
 
         let reset_size = ctx.link().callback(|()| ExpressionEditorMsg::Resize(0, 0));
 
@@ -277,8 +277,9 @@ impl ExpressionEditorState {
         }))
     }
 
-    /// Initialize the `monaco-editor` for this `<perspective-expression-editor>`.
-    /// This method should only be called once per element.
+    /// Initialize the `monaco-editor` for this
+    /// `<perspective-expression-editor>`. This method should only be called
+    /// once per element.
     async fn init_monaco_editor(self) -> Result<JsValue, JsValue> {
         let monaco = init_monaco().await.into_jserror()?;
         if let Some(ref theme) = *self.theme.borrow() {

--- a/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
@@ -109,25 +109,25 @@ impl Component for FilterDropDown {
         let body = if let Some(ref values) = self.values {
             if !values.is_empty() {
                 values
-                .iter()
-                .enumerate()
-                .map(|(idx, value)| {
-                    let click = self.on_select.as_ref().unwrap().reform({
-                        let value = value.clone();
-                        move |_: MouseEvent| value.clone()
-                    });
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, value)| {
+                        let click = self.on_select.as_ref().unwrap().reform({
+                            let value = value.clone();
+                            move |_: MouseEvent| value.clone()
+                        });
 
-                    if idx == self.selected {
-                        html! {
-                            <span onmousedown={ click }class="selected">{ value }</span>
+                        if idx == self.selected {
+                            html! {
+                                <span onmousedown={ click }class="selected">{ value }</span>
+                            }
+                        } else {
+                            html! {
+                                <span onmousedown={ click }>{ value }</span>
+                            }
                         }
-                    } else {
-                        html! {
-                            <span onmousedown={ click }>{ value }</span>
-                        }
-                    }
-                })
-                .collect::<Html>()
+                    })
+                    .collect::<Html>()
             } else {
                 html! {
                     <span class="no-results">{ "No Completions" }</span>

--- a/rust/perspective-viewer/src/rust/components/filter_item.rs
+++ b/rust/perspective-viewer/src/rust/components/filter_item.rs
@@ -192,11 +192,9 @@ impl FilterItemProps {
                     }
                 }
                 Some(Type::Date) => match NaiveDate::parse_from_str(&val, "%Y-%m-%d") {
-                    Ok(ref posix) => posix.and_hms_opt(0, 0, 0).map(|x| {
-                        FilterTerm::Scalar(
-                            Scalar::DateTime(x.timestamp_millis() as f64),
-                        )
-                    }),
+                    Ok(ref posix) => posix
+                        .and_hms_opt(0, 0, 0)
+                        .map(|x| FilterTerm::Scalar(Scalar::DateTime(x.timestamp_millis() as f64))),
                     _ => None,
                 },
                 Some(Type::Datetime) => match str_to_utc_posix(&val) {
@@ -346,15 +344,13 @@ impl Component for FilterItem {
 
         let focus = ctx.link().callback({
             let input = self.input.clone();
-            move |_: FocusEvent| {
-                FilterItemMsg::FilterInput((idx, column.clone()), input.clone())
-            }
+            move |_: FocusEvent| FilterItemMsg::FilterInput((idx, column.clone()), input.clone())
         });
 
         let blur = ctx.link().callback(|_| FilterItemMsg::Close);
-        let keydown = ctx.link().callback(move |event: KeyboardEvent| {
-            FilterItemMsg::FilterKeyDown(event.key_code())
-        });
+        let keydown = ctx
+            .link()
+            .callback(move |event: KeyboardEvent| FilterItemMsg::FilterKeyDown(event.key_code()));
 
         let dragref = NodeRef::default();
         let dragstart = Callback::from({
@@ -364,10 +360,7 @@ impl Component for FilterItem {
             move |event: DragEvent| {
                 let elem = dragref.cast::<HtmlElement>().unwrap();
                 event.data_transfer().unwrap().set_drag_image(&elem, 0, 0);
-                dragdrop.drag_start(
-                    event_name.to_string(),
-                    DragEffect::Move(DropAction::Filter),
-                )
+                dragdrop.drag_start(event_name.to_string(), DragEffect::Move(DragTarget::Filter))
             }
         });
 

--- a/rust/perspective-viewer/src/rust/components/font_loader.rs
+++ b/rust/perspective-viewer/src/rust/components/font_loader.rs
@@ -32,10 +32,7 @@ pub struct FontLoaderProps {
 }
 
 impl Debug for FontLoaderProps {
-    fn fmt(
-        &self,
-        fmt: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         fmt.write_str("FontLoaderProps")
     }
 }
@@ -101,10 +98,7 @@ pub struct FontLoaderState {
 }
 
 impl FontLoaderProps {
-    pub fn new(
-        elem: &web_sys::HtmlElement,
-        on_update: Callback<()>,
-    ) -> FontLoaderProps {
+    pub fn new(elem: &web_sys::HtmlElement, on_update: Callback<()>) -> FontLoaderProps {
         let inner = FontLoaderState {
             status: Cell::new(FontLoaderStatus::Uninitialized),
             elem: elem.clone(),
@@ -138,8 +132,8 @@ impl FontLoaderProps {
         Ok(JsValue::UNDEFINED)
     }
 
-    /// Awaits loading of a required set of font/weight pairs, given an element with
-    /// a CSS variable of the format:
+    /// Awaits loading of a required set of font/weight pairs, given an element
+    /// with a CSS variable of the format:
     /// ```css
     /// perspective-viewer {
     ///     --preload-fonts: "Roboto Mono:200;Open Sans:300,400;Material Icons:400";
@@ -182,9 +176,7 @@ impl FontLoaderProps {
         }
 
         if block_promises.len() != preload_fonts.len() {
-            web_sys::console::warn_1(
-                &format!("Missing preload fonts {:?}", &preload_fonts).into(),
-            );
+            web_sys::console::warn_1(&format!("Missing preload fonts {:?}", &preload_fonts).into());
         }
 
         let res = join_all(block_promises)
@@ -201,10 +193,7 @@ impl FontLoaderProps {
 
 // An async task which times out.  Can be used to timeout an optional async task
 // by combinging with `Promise::any`.
-fn timeout_font_task(
-    family: &str,
-    weight: &str,
-) -> impl Future<Output = Result<JsValue, JsValue>> {
+fn timeout_font_task(family: &str, weight: &str) -> impl Future<Output = Result<JsValue, JsValue>> {
     let timeout_msg = format!("Timeout awaiting font \"{}:{}\"", family, weight);
     async {
         set_timeout(FONT_DOWNLOAD_TIMEOUT_MS).await?;

--- a/rust/perspective-viewer/src/rust/components/inactive_column.rs
+++ b/rust/perspective-viewer/src/rust/components/inactive_column.rs
@@ -33,8 +33,8 @@ pub struct InactiveColumnProps {
 }
 
 impl PartialEq for InactiveColumnProps {
-    /// Equality for `InactiveColumnProps` determines when it should re-render, which
-    /// is only when it has changed.
+    /// Equality for `InactiveColumnProps` determines when it should re-render,
+    /// which is only when it has changed.
     /// TODO Aggregates
     fn eq(&self, _rhs: &InactiveColumnProps) -> bool {
         false
@@ -44,12 +44,12 @@ impl PartialEq for InactiveColumnProps {
 derive_session_renderer_model!(InactiveColumnProps);
 
 impl InactiveColumnProps {
-    /// Add a column to the active columns, which corresponds to the `columns` field
-    /// of the `JsPerspectiveViewConfig`.
+    /// Add a column to the active columns, which corresponds to the `columns`
+    /// field of the `JsPerspectiveViewConfig`.
     ///
     /// # Arguments
-    /// - `name` The name of the column to de-activate, which is a unique ID with
-    ///   respect to `columns`.
+    /// - `name` The name of the column to de-activate, which is a unique ID
+    ///   with respect to `columns`.
     /// - `shift` whether to toggle or select this column.
     pub fn activate_column(&self, name: String, shift: bool) {
         let ViewConfig { mut columns, .. } = self.session.get_view_config();
@@ -137,9 +137,9 @@ impl Component for InactiveColumn {
             .get_column_table_type(&ctx.props().name)
             .expect("Unknown column");
 
-        let add_column = ctx.link().callback(|event: MouseEvent| {
-            InactiveColumnMsg::ActivateColumn(event.shift_key())
-        });
+        let add_column = ctx
+            .link()
+            .callback(|event: MouseEvent| InactiveColumnMsg::ActivateColumn(event.shift_key()));
 
         let noderef = NodeRef::default();
         let dragstart = Callback::from({

--- a/rust/perspective-viewer/src/rust/components/mod.rs
+++ b/rust/perspective-viewer/src/rust/components/mod.rs
@@ -6,8 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-//! `components` contains all Yew `Component` types, but only exports the 4 necessary
-//! for public Custom Elements.  The rest are internal components of these 4.
+//! `components` contains all Yew `Component` types, but only exports the 4
+//! necessary for public Custom Elements.  The rest are internal components of
+//! these 4.
 
 pub mod copy_dropdown;
 pub mod export_dropdown;

--- a/rust/perspective-viewer/src/rust/components/pivot_item.rs
+++ b/rust/perspective-viewer/src/rust/components/pivot_item.rs
@@ -19,7 +19,7 @@ pub struct PivotItem {}
 pub struct PivotItemProps {
     pub column: String,
     pub dragdrop: DragDrop,
-    pub action: DropAction,
+    pub action: DragTarget,
 }
 
 impl PartialEq for PivotItemProps {

--- a/rust/perspective-viewer/src/rust/components/plugin_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/plugin_selector.rs
@@ -46,7 +46,7 @@ impl Component for PluginSelector {
 
     fn create(ctx: &Context<Self>) -> Self {
         enable_weak_link_test!(ctx.props(), ctx.link());
-        let _plugin_sub = ctx.props().renderer.on_plugin_changed.add_listener({
+        let _plugin_sub = ctx.props().renderer.plugin_changed.add_listener({
             let link = ctx.link().clone();
             move |plugin: JsPerspectiveViewerPlugin| {
                 let name = plugin.name();
@@ -63,10 +63,9 @@ impl Component for PluginSelector {
             PluginSelectorMsg::ComponentSelectPlugin(plugin_name) => {
                 ctx.props().renderer.set_plugin(Some(&plugin_name)).unwrap();
                 let mut update = ViewConfigUpdate::default();
-                ctx.props().session.set_update_column_defaults(
-                    &mut update,
-                    &ctx.props().renderer.metadata(),
-                );
+                ctx.props()
+                    .session
+                    .set_update_column_defaults(&mut update, &ctx.props().renderer.metadata());
 
                 ctx.props().update_and_render(update);
                 false

--- a/rust/perspective-viewer/src/rust/components/render_warning.rs
+++ b/rust/perspective-viewer/src/rust/components/render_warning.rs
@@ -8,6 +8,7 @@
 
 use crate::renderer::*;
 use crate::session::*;
+use crate::*;
 
 use wasm_bindgen_futures::future_to_promise;
 use yew::prelude::*;
@@ -74,8 +75,7 @@ impl Component for RenderWarning {
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             RenderWarningMsg::DismissWarning => {
-                let renderer = ctx.props().renderer.clone();
-                let session = ctx.props().session.clone();
+                clone!(ctx.props().renderer, ctx.props().session);
                 let _promise = future_to_promise(async move {
                     renderer.disable_active_plugin_render_warning();
                     renderer.update(&session).await

--- a/rust/perspective-viewer/src/rust/components/sort_item.rs
+++ b/rust/perspective-viewer/src/rust/components/sort_item.rs
@@ -18,8 +18,8 @@ use super::containers::dragdrop_list::*;
 use web_sys::*;
 use yew::prelude::*;
 
-/// A `SortItem` includes the column name and `SortDir` arrow, a clickable button
-/// which cycles through the available `SortDir` states.
+/// A `SortItem` includes the column name and `SortDir` arrow, a clickable
+/// button which cycles through the available `SortDir` states.
 pub struct SortItem {}
 
 #[derive(Properties, Clone)]
@@ -65,8 +65,7 @@ impl Component for SortItem {
                 let ViewConfig {
                     mut sort, split_by, ..
                 } = ctx.props().session.get_view_config();
-                let sort_item =
-                    &mut sort.get_mut(ctx.props().idx).expect("Sort on no column");
+                let sort_item = &mut sort.get_mut(ctx.props().idx).expect("Sort on no column");
                 sort_item.1 = sort_item.1.cycle(!split_by.is_empty(), shift_key);
                 let update = ViewConfigUpdate {
                     sort: Some(sort),
@@ -91,10 +90,7 @@ impl Component for SortItem {
             move |event: DragEvent| {
                 let elem = noderef.cast::<HtmlElement>().unwrap();
                 event.data_transfer().unwrap().set_drag_image(&elem, 0, 0);
-                dragdrop.drag_start(
-                    event_name.to_string(),
-                    DragEffect::Move(DropAction::Sort),
-                )
+                dragdrop.drag_start(event_name.to_string(), DragEffect::Move(DragTarget::Sort))
             }
         });
 

--- a/rust/perspective-viewer/src/rust/components/status_bar_counter.rs
+++ b/rust/perspective-viewer/src/rust/components/status_bar_counter.rs
@@ -30,8 +30,8 @@ impl PartialEq for StatusBarRowsCounterProps {
     }
 }
 
-/// A label widget which displays a row count and a "projection" count, the number of
-/// rows in the `View` which includes aggregate rows.
+/// A label widget which displays a row count and a "projection" count, the
+/// number of rows in the `View` which includes aggregate rows.
 pub struct StatusBarRowsCounter {}
 
 impl Component for StatusBarRowsCounter {

--- a/rust/perspective-viewer/src/rust/components/string_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/string_column_style.rs
@@ -163,17 +163,14 @@ impl StringColumnStyle {
     }
 
     fn color_props(&self, ctx: &Context<Self>) -> ColorProps {
-        let color_oninput = ctx.link().callback(StringColumnStyleMsg::ColorChanged);
+        let on_color = ctx.link().callback(StringColumnStyleMsg::ColorChanged);
         let color = self
             .config
             .color
             .clone()
             .unwrap_or_else(|| ctx.props().default_config.color.to_owned());
 
-        props!(ColorProps {
-            color,
-            on_color: color_oninput.clone(),
-        })
+        props!(ColorProps { color, on_color })
     }
 }
 
@@ -261,8 +258,7 @@ impl Component for StringColumnStyle {
         let format_mode_selected = self.config.format.unwrap_or_default();
 
         // Format mode radio callback
-        let format_mode_changed =
-            ctx.link().callback(StringColumnStyleMsg::FormatChanged);
+        let format_mode_changed = ctx.link().callback(StringColumnStyleMsg::FormatChanged);
 
         // Color enabled/disabled oninput callback
         let color_enabled_oninput = ctx.link().callback(move |event: InputEvent| {
@@ -276,8 +272,7 @@ impl Component for StringColumnStyle {
         let selected_color_mode = self.config.string_color_mode.unwrap_or_default();
 
         // Color mode radio callback
-        let color_mode_changed =
-            ctx.link().callback(StringColumnStyleMsg::ColorModeChanged);
+        let color_mode_changed = ctx.link().callback(StringColumnStyleMsg::ColorModeChanged);
 
         let select_values = vec![
             StringColorMode::Foreground,
@@ -313,19 +308,18 @@ impl Component for StringColumnStyle {
                 }
             };
 
-        let series_controls =
-            if let Some(StringColorMode::Series) = self.config.string_color_mode {
-                html_template! {
-                    <span class="row">{ "Series" }</span>
-                    <div class="row section inner_section">
-                        <ColorSelector with self.color_props(ctx) />
-                    </div>
-                }
-            } else {
-                html! {
-                    <span class="row">{ "Series" }</span>
-                }
-            };
+        let series_controls = if let Some(StringColorMode::Series) = self.config.string_color_mode {
+            html_template! {
+                <span class="row">{ "Series" }</span>
+                <div class="row section inner_section">
+                    <ColorSelector with self.color_props(ctx) />
+                </div>
+            }
+        } else {
+            html! {
+                <span class="row">{ "Series" }</span>
+            }
+        };
 
         html_template! {
             <style>
@@ -345,7 +339,7 @@ impl Component for StringColumnStyle {
 
                     <RadioList<FormatMode>
                         class="indent"
-                        disabled={ !self.config.format.is_some() }
+                        disabled={ self.config.format.is_none() }
                         values={ vec!(FormatMode::Bold, FormatMode::Italics, FormatMode::Link) }
                         selected={ format_mode_selected }
                         on_change={ format_mode_changed } >
@@ -369,7 +363,7 @@ impl Component for StringColumnStyle {
                     <RadioList<StringColorMode>
                         class="indent"
                         name="color-radio-list"
-                        disabled={ !self.config.string_color_mode.is_some() }
+                        disabled={ self.config.string_color_mode.is_none() }
                         values={ select_values }
                         selected={ selected_color_mode }
                         on_change={ color_mode_changed } >

--- a/rust/perspective-viewer/src/rust/components/tests/plugin_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/tests/plugin_selector.rs
@@ -101,14 +101,13 @@ pub async fn test_plugin_selected() {
     PLUGIN_REGISTRY.register_plugin("perspective-viewer-debug4");
 
     let link: WeakScope<PluginSelector> = WeakScope::default();
-    let result: Rc<RefCell<Option<JsPerspectiveViewerPlugin>>> =
-        Rc::new(RefCell::new(None));
+    let result: Rc<RefCell<Option<JsPerspectiveViewerPlugin>>> = Rc::new(RefCell::new(None));
     let document = window().unwrap().document().unwrap();
     let elem: HtmlElement = document.create_element("div").unwrap().unchecked_into();
     let session = Session::default();
     session.set_table(get_mock_table().await).await.unwrap();
     let renderer = Renderer::new(elem, session.clone());
-    let _sub = renderer.on_plugin_changed.add_listener({
+    let _sub = renderer.plugin_changed.add_listener({
         clone!(result);
         move |val| {
             *result.borrow_mut() = Some(val);

--- a/rust/perspective-viewer/src/rust/components/tests/status_bar.rs
+++ b/rust/perspective-viewer/src/rust/components/tests/status_bar.rs
@@ -153,8 +153,6 @@ pub fn test_status_table_and_view_loaded() {
     assert_eq!(
         rows,
         "\
-<span>54,321 </span>\
-<span class=\"icon\">arrow_back</span>\
-<span> 12,345,678 rows</span>"
+<span>54,321 </span><span class=\"icon\">arrow_back</span><span> 12,345,678 rows</span>"
     );
 }

--- a/rust/perspective-viewer/src/rust/components/viewer.rs
+++ b/rust/perspective-viewer/src/rust/components/viewer.rs
@@ -95,13 +95,11 @@ impl Component for PerspectiveViewer {
                 false
             }
             Msg::Reset(all, sender) => {
-                let renderer = ctx.props().renderer.clone();
-                let session = ctx.props().session.clone();
+                clone!(ctx.props().renderer, ctx.props().session);
                 let _ = promisify_ignore_view_delete(async move {
                     session.reset(all);
                     renderer.reset().await;
-                    let result =
-                        renderer.draw(session.validate().await.create_view()).await;
+                    let result = renderer.draw(session.validate().await.create_view()).await;
 
                     if let Some(sender) = sender {
                         sender.send(()).unwrap();
@@ -158,14 +156,15 @@ impl Component for PerspectiveViewer {
         }
     }
 
-    /// This top-level component is mounted to the Custom Element, so it has no API
-    /// to provide props - but for sanity if needed, just return true on change.
+    /// This top-level component is mounted to the Custom Element, so it has no
+    /// API to provide props - but for sanity if needed, just return true on
+    /// change.
     fn changed(&mut self, _ctx: &Context<Self>) -> bool {
         true
     }
 
-    /// On rendered call notify_resize().  This also triggers any registered async
-    /// callbacks to the Custom Element API.
+    /// On rendered call notify_resize().  This also triggers any registered
+    /// async callbacks to the Custom Element API.
     fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
         ctx.props()
             .renderer
@@ -179,8 +178,9 @@ impl Component for PerspectiveViewer {
     }
 
     /// `PerspectiveViewer` has two basic UI modes - "open" and "closed".
-    // TODO these may be expensive to buil dbecause they will generate recursively from
-    // `JsPerspectiveConfig` - they may need caching as in the JavaScript version.
+    // TODO these may be expensive to buil dbecause they will generate recursively
+    // from `JsPerspectiveConfig` - they may need caching as in the JavaScript
+    // version.
     fn view(&self, ctx: &Context<Self>) -> Html {
         let settings = ctx.link().callback(|_| Msg::ToggleSettingsInit(None, None));
         if self.settings_open {
@@ -257,16 +257,19 @@ impl Component for PerspectiveViewer {
 }
 
 impl PerspectiveViewer {
-    /// Toggle the settings, or force the settings panel either open (true) or closed
-    /// (false) explicitly.  In order to reduce apparent screen-shear, `toggle_settings()`
-    /// uses a somewhat complex render order:  it first resize the plugin's `<div>`
-    /// without moving it, using `overflow: hidden` to hide the extra draw area;  then,
-    /// after the _async_ drawing of the plugin is complete, it will send a message to
-    /// complete the toggle action and re-render the element with the settings removed.
+    /// Toggle the settings, or force the settings panel either open (true) or
+    /// closed (false) explicitly.  In order to reduce apparent
+    /// screen-shear, `toggle_settings()` uses a somewhat complex render
+    /// order:  it first resize the plugin's `<div>` without moving it,
+    /// using `overflow: hidden` to hide the extra draw area;  then,
+    /// after the _async_ drawing of the plugin is complete, it will send a
+    /// message to complete the toggle action and re-render the element with
+    /// the settings removed.
     ///
     /// # Arguments
-    /// * `force` - Whether to explicitly set the settings panel state to Open/Close
-    ///   (`Some(true)`/`Some(false)`), or to just toggle the current state (`None`).
+    /// * `force` - Whether to explicitly set the settings panel state to
+    ///   Open/Close (`Some(true)`/`Some(false)`), or to just toggle the current
+    ///   state (`None`).
     fn init_toggle_settings_task(
         &mut self,
         ctx: &Context<Self>,
@@ -287,8 +290,7 @@ impl PerspectiveViewer {
                     Msg::ToggleSettingsComplete(update, resolve)
                 });
 
-                let renderer = ctx.props().renderer.clone();
-                let session = ctx.props().session.clone();
+                clone!(ctx.props().renderer, ctx.props().session);
                 drop(promisify_ignore_view_delete(async move {
                     let result = if session.js_get_table().is_some() {
                         renderer.presize(force, callback.emit_and_render()).await

--- a/rust/perspective-viewer/src/rust/config/aggregates.rs
+++ b/rust/perspective-viewer/src/rust/config/aggregates.rs
@@ -14,9 +14,7 @@ use serde::Serialize;
 use std::fmt::Display;
 use wasm_bindgen::*;
 
-#[derive(
-    Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
-)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde()]
 pub enum SingleAggregate {
     #[serde(rename = "sum")]
@@ -173,10 +171,7 @@ pub enum Aggregate {
 }
 
 impl Display for Aggregate {
-    fn fmt(
-        &self,
-        fmt: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         match self {
             Aggregate::SingleAggregate(x) => write!(fmt, "{}", x)?,
             Aggregate::MultiAggregate(MultiAggregate::WeightedMean, x) => {
@@ -192,10 +187,7 @@ impl FromStr for Aggregate {
     fn from_str(input: &str) -> std::result::Result<Self, JsValue> {
         Ok(
             if let Some(stripped) = input.strip_prefix("weighted mean by ") {
-                Aggregate::MultiAggregate(
-                    MultiAggregate::WeightedMean,
-                    stripped.to_owned(),
-                )
+                Aggregate::MultiAggregate(MultiAggregate::WeightedMean, stripped.to_owned())
             } else {
                 Aggregate::SingleAggregate(SingleAggregate::from_str(input)?)
             },
@@ -258,14 +250,12 @@ impl Type {
         }
     }
 
-    pub fn default_aggregate(&self) -> Aggregate {
+    pub const fn default_aggregate(&self) -> Aggregate {
         match self {
             Type::Bool | Type::Date | Type::Datetime | Type::String => {
                 Aggregate::SingleAggregate(SingleAggregate::Count)
             }
-            Type::Integer | Type::Float => {
-                Aggregate::SingleAggregate(SingleAggregate::Sum)
-            }
+            Type::Integer | Type::Float => Aggregate::SingleAggregate(SingleAggregate::Sum),
         }
     }
 }

--- a/rust/perspective-viewer/src/rust/config/column_type.rs
+++ b/rust/perspective-viewer/src/rust/config/column_type.rs
@@ -31,21 +31,14 @@ pub enum Type {
 }
 
 impl Display for Type {
-    fn fmt(
-        &self,
-        fmt: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
-        write!(
-            fmt,
-            "{}",
-            match self {
-                Type::String => "string",
-                Type::Integer => "integer",
-                Type::Float => "float",
-                Type::Bool => "boolean",
-                Type::Date => "date",
-                Type::Datetime => "datetime",
-            }
-        )
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(fmt, "{}", match self {
+            Type::String => "string",
+            Type::Integer => "integer",
+            Type::Float => "float",
+            Type::Bool => "boolean",
+            Type::Date => "date",
+            Type::Datetime => "datetime",
+        })
     }
 }

--- a/rust/perspective-viewer/src/rust/config/filters.rs
+++ b/rust/perspective-viewer/src/rust/config/filters.rs
@@ -26,10 +26,7 @@ pub enum Scalar {
 }
 
 impl Display for Scalar {
-    fn fmt(
-        &self,
-        fmt: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         match self {
             Scalar::Float(x) => write!(fmt, "{}", x),
             Scalar::String(x) => write!(fmt, "{}", x),
@@ -40,6 +37,7 @@ impl Display for Scalar {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Copy, Deserialize, Debug, PartialEq, Serialize)]
 #[serde()]
 pub enum FilterOp {
@@ -84,24 +82,21 @@ pub enum FilterOp {
 }
 
 impl Display for FilterOp {
-    fn fmt(
-        &self,
-        fmt: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         let op = match self {
-            FilterOp::Contains => "contains",
-            FilterOp::In => "in",
-            FilterOp::NotIn => "not in",
-            FilterOp::BeginsWith => "begins with",
-            FilterOp::EndsWith => "ends with",
-            FilterOp::IsNull => "is null",
-            FilterOp::IsNotNull => "is not null",
-            FilterOp::GT => ">",
-            FilterOp::LT => "<",
-            FilterOp::EQ => "==",
-            FilterOp::GTE => ">=",
-            FilterOp::LTE => "<=",
-            FilterOp::NE => "!=",
+            Self::Contains => "contains",
+            Self::In => "in",
+            Self::NotIn => "not in",
+            Self::BeginsWith => "begins with",
+            Self::EndsWith => "ends with",
+            Self::IsNull => "is null",
+            Self::IsNotNull => "is not null",
+            Self::GT => ">",
+            Self::LT => "<",
+            Self::EQ => "==",
+            Self::GTE => ">=",
+            Self::LTE => "<=",
+            Self::NE => "!=",
         };
 
         write!(fmt, "{}", op)
@@ -110,9 +105,7 @@ impl Display for FilterOp {
 
 impl FromStr for FilterOp {
     type Err = String;
-    fn from_str(
-        input: &str,
-    ) -> std::result::Result<Self, <Self as std::str::FromStr>::Err> {
+    fn from_str(input: &str) -> std::result::Result<Self, <Self as std::str::FromStr>::Err> {
         match input {
             "contains" => Ok(FilterOp::Contains),
             "in" => Ok(FilterOp::In),
@@ -140,10 +133,7 @@ pub enum FilterTerm {
 }
 
 impl Display for FilterTerm {
-    fn fmt(
-        &self,
-        fmt: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         match self {
             FilterTerm::Scalar(x) => {
                 write!(fmt, "{}", x)?;
@@ -151,11 +141,8 @@ impl Display for FilterTerm {
             FilterTerm::Array(xs) => write!(
                 fmt,
                 "{}",
-                Itertools::intersperse(
-                    xs.iter().map(|x| format!("{}", x)),
-                    ",".to_owned()
-                )
-                .collect::<String>()
+                Itertools::intersperse(xs.iter().map(|x| format!("{}", x)), ",".to_owned())
+                    .collect::<String>()
             )?,
         }
 

--- a/rust/perspective-viewer/src/rust/config/sort.rs
+++ b/rust/perspective-viewer/src/rust/config/sort.rs
@@ -46,25 +46,18 @@ pub enum SortDir {
 }
 
 impl Display for SortDir {
-    fn fmt(
-        &self,
-        fmt: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
-        write!(
-            fmt,
-            "{}",
-            match self {
-                SortDir::None => "none",
-                SortDir::Desc => "desc",
-                SortDir::Asc => "asc",
-                SortDir::ColDesc => "col desc",
-                SortDir::ColAsc => "col asc",
-                SortDir::DescAbs => "desc abs",
-                SortDir::AscAbs => "asc abs",
-                SortDir::ColDescAbs => "col desc abs",
-                SortDir::ColAscAbs => "col asc abs",
-            }
-        )
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(fmt, "{}", match self {
+            SortDir::None => "none",
+            SortDir::Desc => "desc",
+            SortDir::Asc => "asc",
+            SortDir::ColDesc => "col desc",
+            SortDir::ColAsc => "col asc",
+            SortDir::DescAbs => "desc abs",
+            SortDir::AscAbs => "asc abs",
+            SortDir::ColDescAbs => "col desc abs",
+            SortDir::ColAscAbs => "col asc abs",
+        })
     }
 }
 

--- a/rust/perspective-viewer/src/rust/config/view_config.rs
+++ b/rust/perspective-viewer/src/rust/config/view_config.rs
@@ -81,8 +81,8 @@ impl ViewConfig {
         std::mem::swap(self, &mut config);
     }
 
-    /// Apply `ViewConfigUpdate` to a `ViewConfig`, ignoring any fields in `update`
-    /// which were unset.
+    /// Apply `ViewConfigUpdate` to a `ViewConfig`, ignoring any fields in
+    /// `update` which were unset.
     pub fn apply_update(&mut self, update: ViewConfigUpdate) -> bool {
         let mut changed = false;
         changed = Self::_apply(&mut self.group_by, update.group_by) || changed;

--- a/rust/perspective-viewer/src/rust/custom_elements/copy_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/copy_dropdown.rs
@@ -25,7 +25,6 @@ use yew::prelude::*;
 #[derive(Clone)]
 pub struct CopyDropDownMenuElement {
     modal: ModalElement<CopyDropDownMenu>,
-    target: Rc<RefCell<Option<HtmlElement>>>,
 }
 
 impl ResizableMessage for <CopyDropDownMenu as Component>::Message {
@@ -42,8 +41,7 @@ impl CopyDropDownMenuElement {
             .unwrap()
             .unchecked_into::<HtmlElement>();
 
-        let modal_rc: Rc<RefCell<Option<ModalElement<CopyDropDownMenu>>>> =
-            Default::default();
+        let modal_rc: Rc<RefCell<Option<ModalElement<CopyDropDownMenu>>>> = Default::default();
 
         let callback = Callback::from({
             let modal_rc = modal_rc.clone();
@@ -54,10 +52,10 @@ impl CopyDropDownMenuElement {
                 let modal = modal_rc.borrow().clone().unwrap();
                 spawn_local(async move {
                     let result = copy_task.await;
-                    crate::js_log_maybe! {
+                    crate::js_log_maybe!({
                         result?;
                         modal.hide()?;
-                    }
+                    })
                 })
             }
         });
@@ -65,10 +63,7 @@ impl CopyDropDownMenuElement {
         let props = CopyDropDownMenuProps { renderer, callback };
         let modal = ModalElement::new(dropdown, props, true);
         *modal_rc.borrow_mut() = Some(modal.clone());
-        CopyDropDownMenuElement {
-            modal,
-            target: Default::default(),
-        }
+        CopyDropDownMenuElement { modal }
     }
 
     pub fn open(&self, target: HtmlElement) {

--- a/rust/perspective-viewer/src/rust/custom_elements/export_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/export_dropdown.rs
@@ -25,7 +25,6 @@ use yew::prelude::*;
 #[derive(Clone)]
 pub struct ExportDropDownMenuElement {
     modal: ModalElement<ExportDropDownMenu>,
-    target: Rc<RefCell<Option<HtmlElement>>>,
 }
 
 impl ResizableMessage for <ExportDropDownMenu as Component>::Message {
@@ -42,8 +41,7 @@ impl ExportDropDownMenuElement {
             .unwrap()
             .unchecked_into::<HtmlElement>();
 
-        let modal_rc: Rc<RefCell<Option<ModalElement<ExportDropDownMenu>>>> =
-            Default::default();
+        let modal_rc: Rc<RefCell<Option<ModalElement<ExportDropDownMenu>>>> = Default::default();
 
         let callback = Callback::from({
             let modal_rc = modal_rc.clone();
@@ -58,7 +56,7 @@ impl ExportDropDownMenuElement {
                             .export_method_to_jsvalue(x.method)
                             .await
                             .unwrap();
-                        download(&x.to_filename(), &val).unwrap();
+                        download(&x.as_filename(), &val).unwrap();
                         modal.hide().unwrap();
                     })
                 }
@@ -68,10 +66,7 @@ impl ExportDropDownMenuElement {
         let props = ExportDropDownMenuProps { renderer, callback };
         let modal = ModalElement::new(dropdown, props, true);
         *modal_rc.borrow_mut() = Some(modal.clone());
-        ExportDropDownMenuElement {
-            modal,
-            target: Default::default(),
-        }
+        ExportDropDownMenuElement { modal }
     }
 
     pub fn open(&self, target: HtmlElement) {

--- a/rust/perspective-viewer/src/rust/custom_elements/modal.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/modal.rs
@@ -18,13 +18,14 @@ use yew::prelude::*;
 
 type BlurHandlerType = Rc<RefCell<Option<Closure<dyn FnMut(FocusEvent)>>>>;
 
-/// A `ModalElement` wraps the parameterized yew `Component` in a Custom Element.
-/// Via the `open()` and `close()` methods, a `ModalElement` can be positioned next
-/// to any existing on-page elements, accounting for viewport, scroll position, etc.
+/// A `ModalElement` wraps the parameterized yew `Component` in a Custom
+/// Element. Via the `open()` and `close()` methods, a `ModalElement` can be
+/// positioned next to any existing on-page elements, accounting for viewport,
+/// scroll position, etc.
 ///
-///`#[derive(Clone)]` generates the trait bound `T: Clone`, which is not required
-/// because `Scope<T>` implements Clone without this bound;  thus `Clone`
-/// must be implemented by the `derivative` crate's
+///`#[derive(Clone)]` generates the trait bound `T: Clone`, which is not
+/// required because `Scope<T>` implements Clone without this bound;  thus
+/// `Clone` must be implemented by the `derivative` crate's
 /// [custom bounds](https://mcarton.github.io/rust-derivative/latest/Debug.html#custom-bound)
 /// support.
 #[derive(Derivative)]
@@ -58,7 +59,7 @@ impl Default for ModalAnchor {
 }
 
 impl ModalAnchor {
-    fn is_rev_vert(&self) -> bool {
+    const fn is_rev_vert(&self) -> bool {
         matches!(
             self,
             ModalAnchor::BottomLeftTopLeft
@@ -169,20 +170,14 @@ where
         let rect_width = self_rect.width() as i32;
 
         match self.anchor.get() {
-            ModalAnchor::BottomRightTopLeft => {
-                (top - rect_height, left - rect_width + 1)
-            }
+            ModalAnchor::BottomRightTopLeft => (top - rect_height, left - rect_width + 1),
             ModalAnchor::BottomRightBottomLeft => {
                 (top - rect_height + height, left - rect_width + 1)
             }
-            ModalAnchor::BottomRightTopRight => {
-                (top - rect_height + 1, left + width - rect_width)
-            }
+            ModalAnchor::BottomRightTopRight => (top - rect_height + 1, left + width - rect_width),
             ModalAnchor::BottomLeftTopLeft => (top - rect_height + 1, left),
             ModalAnchor::TopRightTopLeft => (top, left - rect_width + 1),
-            ModalAnchor::TopRightBottomRight => {
-                (top + height - 1, left + width - rect_width)
-            }
+            ModalAnchor::TopRightBottomRight => (top + height - 1, left + width - rect_width),
             ModalAnchor::TopLeftBottomLeft => ((top + height - 1), left),
         }
     }
@@ -225,8 +220,7 @@ where
         if self.own_focus {
             let mut this = Some(self.clone());
             *self.blurhandler.borrow_mut() = Some(
-                (move |_| this.take().and_then(|x| x.hide().ok()).unwrap_or(()))
-                    .into_closure_mut(),
+                (move |_| this.take().and_then(|x| x.hide().ok()).unwrap_or(())).into_closure_mut(),
             );
 
             self.custom_element.add_event_listener_with_callback(
@@ -257,13 +251,9 @@ where
     /// absolutely positioned relative to an alread-connected `target`
     /// element.
     ///
-    /// Because the Custom Element has a `blur` handler, we must invoke this before
-    /// attempting to re-parent the element.
-    pub fn open(
-        &self,
-        target: web_sys::HtmlElement,
-        resize_pubsub: Option<&PubSub<()>>,
-    ) {
+    /// Because the Custom Element has a `blur` handler, we must invoke this
+    /// before attempting to re-parent the element.
+    pub fn open(&self, target: web_sys::HtmlElement, resize_pubsub: Option<&PubSub<()>>) {
         if let Some(resize) = resize_pubsub {
             let this = self.clone();
             let target = target.clone();

--- a/rust/perspective-viewer/src/rust/custom_elements/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/number_column_style.rs
@@ -21,16 +21,13 @@ use crate::utils::WeakScope;
 #[derive(Clone)]
 pub struct PerspectiveNumberColumnStyleElement {
     modal: ModalElement<NumberColumnStyle>,
-    props: NumberColumnStyleProps,
 }
 
 fn on_change(elem: &web_sys::HtmlElement, config: &NumberColumnStyleConfig) {
     let mut event_init = web_sys::CustomEventInit::new();
     event_init.detail(&JsValue::from_serde(config).unwrap());
-    let event = CustomEvent::new_with_event_init_dict(
-        "perspective-column-style-change",
-        &event_init,
-    );
+    let event =
+        CustomEvent::new_with_event_init_dict("perspective-column-style-change", &event_init);
 
     elem.dispatch_event(&event.unwrap()).unwrap();
 }
@@ -64,8 +61,8 @@ impl PerspectiveNumberColumnStyleElement {
             weak_link: WeakScope::default(),
         };
 
-        let modal = ModalElement::new(elem, props.clone(), true);
-        PerspectiveNumberColumnStyleElement { modal, props }
+        let modal = ModalElement::new(elem, props, true);
+        PerspectiveNumberColumnStyleElement { modal }
     }
 
     /// Reset to a provided JSON config, to be used in place of `new()` when
@@ -101,7 +98,7 @@ impl PerspectiveNumberColumnStyleElement {
         self.modal.destroy()
     }
 
-    /// DOM lifecycle method when connected.  We don't use this, as it can fire during
-    /// innocuous events like re-parenting.
+    /// DOM lifecycle method when connected.  We don't use this, as it can fire
+    /// during innocuous events like re-parenting.
     pub fn connected_callback(&self) {}
 }

--- a/rust/perspective-viewer/src/rust/custom_elements/string_column_style.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/string_column_style.rs
@@ -18,16 +18,13 @@ use yew::prelude::*;
 #[derive(Clone)]
 pub struct PerspectiveStringColumnStyleElement {
     modal: ModalElement<StringColumnStyle>,
-    props: StringColumnStyleProps,
 }
 
 fn on_change(elem: &web_sys::HtmlElement, config: &StringColumnStyleConfig) {
     let mut event_init = web_sys::CustomEventInit::new();
     event_init.detail(&JsValue::from_serde(config).unwrap());
-    let event = CustomEvent::new_with_event_init_dict(
-        "perspective-column-style-change",
-        &event_init,
-    );
+    let event =
+        CustomEvent::new_with_event_init_dict("perspective-column-style-change", &event_init);
 
     elem.dispatch_event(&event.unwrap()).unwrap();
 }
@@ -41,11 +38,7 @@ impl ResizableMessage for <StringColumnStyle as Component>::Message {
 #[wasm_bindgen]
 impl PerspectiveStringColumnStyleElement {
     #[wasm_bindgen(constructor)]
-    pub fn new(
-        elem: web_sys::HtmlElement,
-        js_config: JsValue,
-        js_default_config: JsValue,
-    ) -> PerspectiveStringColumnStyleElement {
+    pub fn new(elem: web_sys::HtmlElement, js_config: JsValue, js_default_config: JsValue) -> Self {
         let config = js_config.into_serde().unwrap();
         let default_config = js_default_config.into_serde().unwrap();
         let on_change = {
@@ -59,8 +52,8 @@ impl PerspectiveStringColumnStyleElement {
             on_change,
         };
 
-        let modal = ModalElement::new(elem, props.clone(), true);
-        PerspectiveStringColumnStyleElement { modal, props }
+        let modal = ModalElement::new(elem, props, true);
+        Self { modal }
     }
 
     /// Reset to a provided JSON config, to be used in place of `new()` when
@@ -90,7 +83,7 @@ impl PerspectiveStringColumnStyleElement {
         self.modal.destroy()
     }
 
-    /// DOM lifecycle method when connected.  We don't use this, as it can fire during
-    /// innocuous events like re-parenting.
+    /// DOM lifecycle method when connected.  We don't use this, as it can fire
+    /// during innocuous events like re-parenting.
     pub fn connected_callback(&self) {}
 }

--- a/rust/perspective-viewer/src/rust/dragdrop.rs
+++ b/rust/perspective-viewer/src/rust/dragdrop.rs
@@ -6,19 +6,19 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use crate::js_log_maybe;
 use crate::utils::*;
 
 use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
-
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::*;
 use yew::prelude::*;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum DropAction {
+pub enum DragTarget {
     Active,
     GroupBy,
     SplitBy,
@@ -29,35 +29,60 @@ pub enum DropAction {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DragEffect {
     Copy,
-    Move(DropAction),
+    Move(DragTarget),
 }
 
-#[derive(Debug)]
-pub struct DragState {
+#[derive(Clone)]
+struct DragFrom {
     column: String,
     effect: DragEffect,
-    state: Option<(DropAction, usize)>,
+}
+
+struct DragOver {
+    target: DragTarget,
+    index: usize,
+}
+
+enum DragState {
+    NoDrag,
+    DragInProgress(DragFrom),
+    DragOverInProgress(DragFrom, DragOver),
+}
+
+impl Default for DragState {
+    fn default() -> Self {
+        Self::NoDrag
+    }
+}
+
+impl DragState {
+    fn take(&mut self) -> Self {
+        let mut new = Self::NoDrag;
+        std::mem::swap(self, &mut new);
+        new
+    }
+
+    const fn is_drag_in_progress(&self) -> bool {
+        !matches!(self, Self::NoDrag)
+    }
 }
 
 #[derive(Default)]
 pub struct DragDropState {
-    drag_state: Option<DragState>,
-    on_drop_action: PubSub<(String, DropAction, DragEffect, usize)>,
-    on_drag_action: PubSub<DragEffect>,
-    on_dragend_action: PubSub<()>,
+    drag_state: RefCell<DragState>,
+    pub drop_received: PubSub<(String, DragTarget, DragEffect, usize)>,
+    pub dragstart_received: PubSub<DragEffect>,
+    pub dragend_received: PubSub<()>,
 }
 
-/// The `<perspective-viewer>` drag-drop service, which manages drag/drop user
-/// interactions across components.  It is a component-level service, since only one
-/// drag/drop action can be executed by the user at a time, and has a 3 states:
-/// - `None` No drag/drop action is in effect.
-/// - `Some(DragDropState { state: None }` Drag is in effect.
-/// - `Some(DragDropState { state: Some(_) }` Drag and Hover are in effect.
+/// The `<perspective-viewer>` drag/drop service, which manages drag/drop user
+/// interactions across components.  It is a component-level service, since only
+/// one drag/drop action can be executed by the user at a time.
 #[derive(Clone, Default)]
-pub struct DragDrop(Rc<RefCell<DragDropState>>);
+pub struct DragDrop(Rc<DragDropState>);
 
 impl Deref for DragDrop {
-    type Target = Rc<RefCell<DragDropState>>;
+    type Target = Rc<DragDropState>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -70,71 +95,50 @@ impl PartialEq for DragDrop {
 }
 
 impl DragDrop {
-    pub fn add_on_drop_action(
-        &self,
-        callback: Callback<(String, DropAction, DragEffect, usize)>,
-    ) -> Subscription {
-        self.borrow().on_drop_action.add_listener(callback)
-    }
-
-    pub fn add_on_drag_action(&self, callback: Callback<DragEffect>) -> Subscription {
-        self.borrow().on_drag_action.add_listener(callback)
-    }
-
-    pub fn add_on_dragend_action(&self, callback: Callback<()>) -> Subscription {
-        self.borrow().on_dragend_action.add_listener(callback)
-    }
-
     pub fn notify_drop(&self) {
-        let action = match self.borrow_mut().drag_state.take() {
-            Some(DragState {
-                column,
-                state: Some((action, index)),
-                effect,
-            }) => Some((column, action, effect, index)),
+        let action = match self.drag_state.borrow_mut().take() {
+            DragState::DragOverInProgress(
+                DragFrom { column, effect },
+                DragOver { target, index },
+            ) => Some((column, target, effect, index)),
             _ => None,
         };
 
         if let Some(action) = action {
-            self.borrow().on_drop_action.emit_all(action);
+            self.drop_received.emit_all(action);
         }
     }
 
     /// Get the column name currently being drag/dropped.
     pub fn get_drag_column(&self) -> Option<String> {
-        match self.borrow().drag_state {
-            Some(DragState { ref column, .. }) => Some(column.clone()),
+        match *self.drag_state.borrow() {
+            DragState::DragInProgress(DragFrom { ref column, .. })
+            | DragState::DragOverInProgress(DragFrom { ref column, .. }, _) => Some(column.clone()),
             _ => None,
         }
     }
 
     /// Start the drag/drop action with the name of the column being dragged.
     pub fn drag_start(&self, column: String, effect: DragEffect) {
-        self.borrow_mut().drag_state = Some(DragState {
-            column,
-            effect,
-            state: None,
-        });
-
-        self.borrow().on_drag_action.emit_all(effect)
+        *self.drag_state.borrow_mut() = DragState::DragInProgress(DragFrom { column, effect });
+        self.dragstart_received.emit_all(effect)
     }
 
     /// End the drag/drop action by resetting the state to default.
     pub fn drag_end(&self) {
-        let should_notify = self.borrow_mut().drag_state.take().is_some();
+        let should_notify = self.drag_state.borrow_mut().take().is_drag_in_progress();
         if should_notify {
-            self.borrow().on_dragend_action.emit_all(());
+            self.dragend_received.emit_all(());
         }
     }
 
     /// Leave the `action` zone.
-    pub fn drag_leave(&self, action: DropAction) {
-        let reset = match self.borrow().drag_state {
-            Some(DragState {
-                ref column,
-                state: Some((a, _)),
-                effect,
-            }) if a == action => Some((column.clone(), effect)),
+    pub fn drag_leave(&self, drag_target: DragTarget) {
+        let reset = match *self.drag_state.borrow() {
+            DragState::DragOverInProgress(
+                DragFrom { ref column, effect },
+                DragOver { target, .. },
+            ) if target == drag_target => Some((column.clone(), effect)),
             _ => None,
         };
 
@@ -145,126 +149,127 @@ impl DragDrop {
 
     // Enter the `action` zone at `index`, which must be <= the number of children
     // in the container.
-    pub fn drag_enter(&self, action: DropAction, index: usize) -> bool {
-        let mut r = self.borrow_mut();
-        let should_render = match r.drag_state {
-            Some(DragState {
-                state: Some((a, x)),
-                ..
-            }) if a == action => x != index,
+    pub fn drag_enter(&self, target: DragTarget, index: usize) -> bool {
+        let mut drag_state = self.drag_state.borrow_mut();
+        let should_render = match &*drag_state {
+            DragState::DragOverInProgress(_, drag_to) => {
+                drag_to.target != target || drag_to.index != index
+            }
             _ => true,
         };
 
-        crate::js_log_maybe! {
-            r.drag_state
-                .as_mut()
-                .into_jserror()?
-                .state = Some((action, index))
+        *drag_state = match &*drag_state {
+            DragState::DragOverInProgress(drag_from, _) | DragState::DragInProgress(drag_from) => {
+                DragState::DragOverInProgress(drag_from.clone(), DragOver { target, index })
+            }
+            _ => DragState::NoDrag,
         };
 
         should_render
     }
 
     // Is the drag/drop state currently in `action`?
-    pub fn is_dragover(&self, action: DropAction) -> Option<(usize, String)> {
-        match self.borrow().drag_state {
-            Some(DragState {
-                ref column,
-                state: Some((a, index)),
-                ..
-            }) if a == action => Some((index, column.clone())),
+    pub fn is_dragover(&self, drag_target: DragTarget) -> Option<(usize, String)> {
+        match *self.drag_state.borrow() {
+            DragState::DragOverInProgress(
+                DragFrom { ref column, .. },
+                DragOver { target, index },
+            ) if target == drag_target => Some((index, column.clone())),
             _ => None,
         }
     }
 }
 
-/// Safari does not set `relatedTarget` on `"dragleave"`, which makes it impossible to
-/// determine whether a logical drag leave has happened with just this event, so use
-/// function on `"dragenter"` to capture the `relatedTarget`.
+/// Safari does not set `relatedTarget` on `"dragleave"`, which makes it
+/// impossible to determine whether a logical drag leave has happened with just
+/// this event, so use function on `"dragenter"` to capture the `relatedTarget`.
 pub fn dragenter_helper(event: DragEvent) {
-    event.stop_propagation();
-    event.prevent_default();
-    if event.related_target().is_none() {
-        event
-            .current_target()
-            .unwrap()
-            .unchecked_ref::<HtmlElement>()
-            .dataset()
-            .set("safaridragleave", "true")
-            .unwrap();
-    }
+    js_log_maybe!({
+        event.stop_propagation();
+        event.prevent_default();
+        if event.related_target().is_none() {
+            event
+                .current_target()
+                .into_jserror()?
+                .unchecked_ref::<HtmlElement>()
+                .dataset()
+                .set("safaridragleave", "true")?;
+        }
+    })
 }
 
 /// HTML drag/drop will fire a bubbling `dragleave` event over all children of a
-/// `dragleave`-listened-to element, so we need to filter out the events from the
-/// children elements with this esoteric DOM arcana.
+/// `dragleave`-listened-to element, so we need to filter out the events from
+/// the children elements with this esoteric DOM arcana.
 pub fn dragleave_helper(callback: impl Fn() + 'static) -> Callback<DragEvent> {
     Callback::from({
         move |event: DragEvent| {
-            event.stop_propagation();
-            event.prevent_default();
+            js_log_maybe!({
+                event.stop_propagation();
+                event.prevent_default();
 
-            let mut related_target = event
-                .related_target()
-                .or_else(|| Some(JsValue::UNDEFINED.unchecked_into::<EventTarget>()))
-                .and_then(|x| x.dyn_into::<Element>().ok());
+                let mut related_target = event
+                    .related_target()
+                    .or_else(|| Some(JsValue::UNDEFINED.unchecked_into::<EventTarget>()))
+                    .and_then(|x| x.dyn_into::<Element>().ok());
 
-            let current_target = event
-                .current_target()
-                .unwrap()
-                .unchecked_into::<HtmlElement>();
+                let current_target = event
+                    .current_target()
+                    .into_jserror()?
+                    .unchecked_into::<HtmlElement>();
 
-            // This is a wild chrome bug. `dragleave` can fire with the `relatedTarget`
-            // property set to an element inside the closed `ShadowRoot` hosted by a
-            // browser-native `<select>` tag, which fails the `.contains()` check
-            // below.  This mystery `ShadowRoot` has a structure that looks like this
-            // (tested in Chrome 92), which we try to detect as best we can below.
-            //
-            // ```html
-            // <div aria-hidden="true">Selected Text Here</siv>
-            // <slot name="user-agent-custom-assign-slot"></slot>
-            // ```
-            //
-            // This is pretty course though, since there is no guarantee this structure
-            // will be maintained in future Chrome versions; the `.expect()` in this
-            // method chain should at least warn us if this regresses.
-            //
-            // Wait - you don't believe me?  Throw a debugger statement inside this
-            // conditional and drag a column over a pivot-mode active columns list.
-            if related_target
-                .as_ref()
-                .map(|x| x.has_attribute("aria-hidden"))
-                .unwrap_or_default()
-            {
-                related_target = Some(
-                    related_target
-                        .unwrap()
-                        .parent_node()
-                        .unwrap()
-                        .dyn_ref::<ShadowRoot>()
-                        .expect("Chrome drag/drop bug detection failed")
-                        .host()
-                        .unchecked_into::<Element>(),
-                )
-            }
-
-            match related_target {
-                Some(ref related) => {
-                    if !current_target.contains(Some(related)) {
-                        callback();
-                    }
+                // This is a wild chrome bug. `dragleave` can fire with the `relatedTarget`
+                // property set to an element inside the closed `ShadowRoot` hosted by a
+                // browser-native `<select>` tag, which fails the `.contains()` check
+                // below.  This mystery `ShadowRoot` has a structure that looks like this
+                // (tested in Chrome 92), which we try to detect as best we can below.
+                //
+                // ```html
+                // <div aria-hidden="true">Selected Text Here</siv>
+                // <slot name="user-agent-custom-assign-slot"></slot>
+                // ```
+                //
+                // This is pretty course though, since there is no guarantee this structure
+                // will be maintained in future Chrome versions; the `.expect()` in this
+                // method chain should at least warn us if this regresses.
+                //
+                // Wait - you don't believe me?  Throw a debugger statement inside this
+                // conditional and drag a column over a pivot-mode active columns list.
+                if related_target
+                    .as_ref()
+                    .map(|x| x.has_attribute("aria-hidden"))
+                    .unwrap_or_default()
+                {
+                    related_target = Some(
+                        related_target
+                            .into_jserror()?
+                            .parent_node()
+                            .into_jserror()?
+                            .dyn_ref::<ShadowRoot>()
+                            .ok_or_else(|| JsValue::from("Chrome drag/drop bug detection failed"))?
+                            .host()
+                            .unchecked_into::<Element>(),
+                    )
                 }
-                None => {
-                    // Safari (OSX and iOS) don't set `relatedTarget`, so we need to
-                    // read a memoized value from the `"dragenter"` event.
-                    let dataset = current_target.dataset();
-                    if dataset.get("safaridragleave").is_some() {
-                        dataset.delete("safaridragleave");
-                    } else {
-                        callback();
+
+                match related_target {
+                    Some(ref related) => {
+                        if !current_target.contains(Some(related)) {
+                            callback();
+                        }
                     }
-                }
-            };
+                    None => {
+                        // Safari (OSX and iOS) don't set `relatedTarget`, so we need to
+                        // read a memoized value from the `"dragenter"` event.
+                        let dataset = current_target.dataset();
+                        if dataset.get("safaridragleave").is_some() {
+                            dataset.delete("safaridragleave");
+                        } else {
+                            callback();
+                        }
+                    }
+                };
+            })
         }
     })
 }

--- a/rust/perspective-viewer/src/rust/exprtk/completions.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/completions.rs
@@ -13,8 +13,8 @@ use super::language::*;
 use js_intern::*;
 use wasm_bindgen::prelude::*;
 
-/// This helper _must_ create the `JsValue` anew on each call, or it causes strange
-/// & subtle bugs in monaco.
+/// This helper _must_ create the `JsValue` anew on each call, or it causes
+/// strange & subtle bugs in monaco.
 /// https://github.com/microsoft/monaco-editor/issues/1510
 pub fn get_completions(
     model: JsMonacoModel,
@@ -22,8 +22,8 @@ pub fn get_completions(
     token: JsMonacoTriggerToken,
 ) -> JsValue {
     // Test the token stream until the cursor to distinguish opening from closing
-    // quotes - otherwise the column completion popup will occur at the end of a column
-    // name also.
+    // quotes - otherwise the column completion popup will occur at the end of a
+    // column name also.
     let tokens = model.get_line_tokens(position.line_number());
     let token_index = tokens.find_token_index_at_offset(position.column());
     let prev_token_type = tokens.get_class_name(token_index) == *js_intern!("mtk23");

--- a/rust/perspective-viewer/src/rust/exprtk/init.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/init.rs
@@ -56,8 +56,8 @@ pub fn init_theme(theme: &str, editor: &Editor) {
     editor.define_theme("exprtk-theme", theme_args)
 }
 
-/// Initializes the `MonacoEnvironment` global definition, which the monaco library
-/// uses to resolve its Web Workers and features.
+/// Initializes the `MonacoEnvironment` global definition, which the monaco
+/// library uses to resolve its Web Workers and features.
 pub async fn init_environment() -> Result<(), error::Error> {
     let worker = new_worker().await;
     let closure = Closure::once_into_js(move |_: JsValue| worker);

--- a/rust/perspective-viewer/src/rust/exprtk/mod.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/mod.rs
@@ -19,13 +19,13 @@ use wasm_bindgen::JsCast;
 
 pub use init::init_theme;
 
-/// Configure `monaco` for a set of column names, such that intellisense may complete
-/// available columns.  In the interest of simplification, this uses a static `RefCell`
-/// which must be set prior to completion events;  this is currently valid as
-/// an expression editor must have focus which is exclusive.  If we ever wanted to
-/// support multiple open expression editors at once on a page, this will need to
-/// become a struct, with a new language instance and expression editor custom element
-/// per viewer.
+/// Configure `monaco` for a set of column names, such that intellisense may
+/// complete available columns.  In the interest of simplification, this uses a
+/// static `RefCell` which must be set prior to completion events;  this is
+/// currently valid as an expression editor must have focus which is exclusive.
+/// If we ever wanted to support multiple open expression editors at once on a
+/// page, this will need to become a struct, with a new language instance and
+/// expression editor custom element per viewer.
 ///
 /// # Arguments
 /// * `names` - a vector of owned names for the `View()` with page focus.
@@ -35,7 +35,8 @@ pub fn set_global_completion_column_names(names: &[String]) {
     });
 }
 
-/// Initialize the `ExprTK` language in `monaco`.  This should only be done once.
+/// Initialize the `ExprTK` language in `monaco`.  This should only be done
+/// once.
 pub async fn init_monaco() -> Result<Editor, error::Error> {
     if IS_REGISTERED.with(|x| !x.get()) {
         init_environment().await?;

--- a/rust/perspective-viewer/src/rust/js/monaco.rs
+++ b/rust/perspective-viewer/src/rust/js/monaco.rs
@@ -176,9 +176,9 @@ extern "C" {
     pub fn trigger_character(this: &JsMonacoTriggerToken) -> String;
 }
 
-// Serde does not support closures and wasm_bindgen does not support anonymous object
-// construction without `Reflect`, so this signature is not possible and is instead
-// constructed manually.
+// Serde does not support closures and wasm_bindgen does not support anonymous
+// object construction without `Reflect`, so this signature is not possible and
+// is instead constructed manually.
 
 // #[derive(Serialize)]
 // #[serde(rename_all = "camelCase")]

--- a/rust/perspective-viewer/src/rust/js/perspective.rs
+++ b/rust/perspective-viewer/src/rust/js/perspective.rs
@@ -16,8 +16,8 @@ use wasm_bindgen::JsCast;
 // #[cfg(test)]
 // use wasm_bindgen_test::*;
 
-// `wasm-bindgen` only supports `JsValue` return types from `extern async fn`, so use
-// this macro to generate well-typed versions.
+// `wasm-bindgen` only supports `JsValue` return types from `extern async fn`,
+// so use this macro to generate well-typed versions.
 macro_rules! async_typed {
     (@jsvalue $sym:ident ()) => {{ $sym.await?; }};
     (@jsvalue $sym:ident f64) => { $sym.await?.as_f64().unwrap() };

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -8,25 +8,22 @@
 
 // Required by yew's `html` macro.
 #![recursion_limit = "1024"]
-#![warn(clippy::all)]
+#![warn(clippy::all, clippy::panic_in_result_fn)]
 
-pub mod components;
-pub mod config;
 pub mod custom_elements;
-pub mod custom_events;
-pub mod dragdrop;
-pub mod exprtk;
-pub mod js;
-pub mod model;
-pub mod renderer;
-pub mod session;
-pub mod utils;
+
+mod components;
+mod config;
+mod custom_events;
+mod dragdrop;
+mod exprtk;
+mod js;
+mod model;
+mod renderer;
+mod session;
+mod utils;
 
 use wasm_bindgen::prelude::*;
-
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen]
 pub fn register_plugin(name: &str) {

--- a/rust/perspective-viewer/src/rust/model.rs
+++ b/rust/perspective-viewer/src/rust/model.rs
@@ -25,11 +25,11 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use yew::prelude::*;
 
-/// A `SessionRendererModel` is any struct with `session` and `renderer` fields, as
-/// this method is boilerplate but has no other trait to live on currently.  As
-/// I'm too lazy to be bothered to implement a `proc-macro` crate, instead this
-/// trait can be conveniently derived via the `derive_session_renderer_model!()` macro
-/// on a suitable struct.
+/// A `SessionRendererModel` is any struct with `session` and `renderer` fields,
+/// as this method is boilerplate but has no other trait to live on currently.
+/// As I'm too lazy to be bothered to implement a `proc-macro` crate, instead
+/// this trait can be conveniently derived via the
+/// `derive_session_renderer_model!()` macro on a suitable struct.
 pub trait SessionRendererModel {
     fn session(&self) -> &'_ Session;
     fn renderer(&self) -> &'_ Renderer;
@@ -67,9 +67,7 @@ pub trait SessionRendererModel {
         });
     }
 
-    fn html_as_jsvalue(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = Result<web_sys::Blob, JsValue>>>> {
+    fn html_as_jsvalue(&self) -> Pin<Box<dyn Future<Output = Result<web_sys::Blob, JsValue>>>> {
         let view_config = self.get_viewer_config();
         let session = self.session().clone();
         Box::pin(async move {
@@ -112,9 +110,7 @@ window.viewer.restore(JSON.parse(window.layout.textContent));
         })
     }
 
-    fn get_viewer_config(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = Result<ViewerConfig, JsValue>>>> {
+    fn get_viewer_config(&self) -> Pin<Box<dyn Future<Output = Result<ViewerConfig, JsValue>>>> {
         let view_config = self.session().get_view_config();
         let js_plugin = self.renderer().get_active_plugin();
         let renderer = self.renderer().clone();
@@ -138,9 +134,7 @@ window.viewer.restore(JSON.parse(window.layout.textContent));
         })
     }
 
-    fn config_as_jsvalue(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = Result<web_sys::Blob, JsValue>>>> {
+    fn config_as_jsvalue(&self) -> Pin<Box<dyn Future<Output = Result<web_sys::Blob, JsValue>>>> {
         let viewer_config = self.get_viewer_config();
         Box::pin(async move {
             let config = viewer_config
@@ -193,10 +187,9 @@ window.viewer.restore(JSON.parse(window.layout.textContent));
                     let render = js_sys::Reflect::get(&plugin, js_intern!("render"))?;
                     let render_fun = render.unchecked_into::<js_sys::Function>();
                     let png = render_fun.call0(&plugin)?;
-                    let result =
-                        JsFuture::from(png.unchecked_into::<js_sys::Promise>())
-                            .await?
-                            .unchecked_into();
+                    let result = JsFuture::from(png.unchecked_into::<js_sys::Promise>())
+                        .await?
+                        .unchecked_into();
                     Ok(result)
                 })
             }
@@ -236,16 +229,8 @@ macro_rules! derive_session_renderer_model {
 pub trait ViewerModel: SessionRendererModel {
     fn dragdrop(&self) -> &'_ DragDrop;
 
-    fn column_selector_iter_set<'a>(
-        &'a self,
-        config: &'a ViewConfig,
-    ) -> ColumnsIteratorSet<'a> {
-        ColumnsIteratorSet::new(
-            config,
-            self.session(),
-            self.renderer(),
-            self.dragdrop(),
-        )
+    fn column_selector_iter_set<'a>(&'a self, config: &'a ViewConfig) -> ColumnsIteratorSet<'a> {
+        ColumnsIteratorSet::new(config, self.session(), self.renderer(), self.dragdrop())
     }
 }
 

--- a/rust/perspective-viewer/src/rust/model/columns_iter_set.rs
+++ b/rust/perspective-viewer/src/rust/model/columns_iter_set.rs
@@ -14,8 +14,8 @@ use crate::*;
 use itertools::Itertools;
 use std::collections::HashSet;
 
-/// The possible states of a column (row) in the active columns list, including the
-/// `Option<String>` label type.
+/// The possible states of a column (row) in the active columns list, including
+/// the `Option<String>` label type.
 #[derive(Clone, PartialEq)]
 pub enum ActiveColumnState {
     Column(Label, String),
@@ -43,7 +43,7 @@ impl<'a> ColumnsIteratorSet<'a> {
         renderer: &'a Renderer,
         dragdrop: &DragDrop,
     ) -> ColumnsIteratorSet<'a> {
-        let is_dragover_column = dragdrop.is_dragover(DropAction::Active);
+        let is_dragover_column = dragdrop.is_dragover(DragTarget::Active);
         ColumnsIteratorSet {
             config,
             session,
@@ -53,8 +53,8 @@ impl<'a> ColumnsIteratorSet<'a> {
         }
     }
 
-    /// Generate an iterator for active columns, which are represented as `Option`
-    /// for dragover and missing columns.
+    /// Generate an iterator for active columns, which are represented as
+    /// `Option` for dragover and missing columns.
     pub fn active(&'a self) -> impl Iterator<Item = ActiveColumnState> + 'a {
         let min_cols = self
             .renderer
@@ -85,17 +85,16 @@ impl<'a> ColumnsIteratorSet<'a> {
                     .unwrap_or_default();
 
                 if is_to_swap || is_from_required {
-                    let all_columns =
-                        self.config.columns.iter().filter_map(move |x| match x {
-                            Some(x) if x == from_column => {
-                                if is_to_empty && !is_from_swap {
-                                    None
-                                } else {
-                                    Some(to_column.unwrap_or(&None))
-                                }
+                    let all_columns = self.config.columns.iter().filter_map(move |x| match x {
+                        Some(x) if x == from_column => {
+                            if is_to_empty && !is_from_swap {
+                                None
+                            } else {
+                                Some(to_column.unwrap_or(&None))
                             }
-                            x => Some(x),
-                        });
+                        }
+                        x => Some(x),
+                    });
 
                     let before_cols = all_columns
                         .clone()
@@ -113,17 +112,16 @@ impl<'a> ColumnsIteratorSet<'a> {
                         _ => *to_index + 1,
                     };
 
-                    let all_columns =
-                        self.config.columns.iter().filter_map(move |x| match x {
-                            Some(x) if x == from_column => {
-                                if !is_from_swap {
-                                    None
-                                } else {
-                                    Some(&None)
-                                }
+                    let all_columns = self.config.columns.iter().filter_map(move |x| match x {
+                        Some(x) if x == from_column => {
+                            if !is_from_swap {
+                                None
+                            } else {
+                                Some(&None)
                             }
-                            x => Some(x),
-                        });
+                        }
+                        x => Some(x),
+                    });
 
                     let before_cols = all_columns
                         .clone()
@@ -137,8 +135,7 @@ impl<'a> ColumnsIteratorSet<'a> {
                     ))
                 }
             }
-            _ => self
-                .to_active_column_state(Box::new(self.config.columns.iter().map(Some))),
+            _ => self.to_active_column_state(Box::new(self.config.columns.iter().map(Some))),
         }
     }
 
@@ -146,13 +143,7 @@ impl<'a> ColumnsIteratorSet<'a> {
         &self,
         iter: Box<dyn Iterator<Item = Option<&'a Option<String>>> + 'a>,
     ) -> impl Iterator<Item = ActiveColumnState> + 'a {
-        let named_columns = self
-            .renderer
-            .metadata()
-            .names
-            .clone()
-            .unwrap_or_else(std::vec::Vec::new);
-
+        let named_columns = self.renderer.metadata().names.clone().unwrap_or_default();
         iter.pad_using(named_columns.len(), |_| Some(&None))
             .enumerate()
             .map(move |(idx, x)| {
@@ -170,8 +161,8 @@ impl<'a> ColumnsIteratorSet<'a> {
         self.order_columns(self.metadata.get_expression_columns())
     }
 
-    /// Generate an iterator for inactive columns, which also shows the columns in
-    /// sorted order by type, then name.
+    /// Generate an iterator for inactive columns, which also shows the columns
+    /// in sorted order by type, then name.
     pub fn inactive(&'a self) -> impl Iterator<Item = OrderedColumn<'a>> {
         self.order_columns(self.metadata.get_table_columns().into_iter().flatten())
     }
@@ -191,9 +182,7 @@ impl<'a> ColumnsIteratorSet<'a> {
         let col_set = self.config.columns.iter().collect::<HashSet<_>>();
 
         let mut filtered = values
-            .filter_map(move |name| {
-                self.to_ordered_column(name, is_drag_active, &col_set)
-            })
+            .filter_map(move |name| self.to_ordered_column(name, is_drag_active, &col_set))
             .collect::<Vec<_>>();
 
         filtered.sort();

--- a/rust/perspective-viewer/src/rust/model/export_method.rs
+++ b/rust/perspective-viewer/src/rust/model/export_method.rs
@@ -19,21 +19,18 @@ pub enum MimeType {
 
 impl Default for MimeType {
     fn default() -> Self {
-        MimeType::TextPlain
+        Self::TextPlain
     }
 }
 
 impl From<MimeType> for JsValue {
-    fn from(x: MimeType) -> JsValue {
-        JsValue::from(format!("{}", x))
+    fn from(x: MimeType) -> Self {
+        Self::from(format!("{}", x))
     }
 }
 
 impl Display for MimeType {
-    fn fmt(
-        &self,
-        fmt: &mut std::fmt::Formatter<'_>,
-    ) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         fmt.write_str(match self {
             MimeType::TextPlain => "text/plain",
             MimeType::ImagePng => "image/png",
@@ -55,32 +52,32 @@ pub enum ExportMethod {
 }
 
 impl ExportMethod {
-    pub fn to_filename(&self) -> &'static str {
+    pub const fn as_filename(&self) -> &'static str {
         match self {
-            ExportMethod::Csv => ".csv",
-            ExportMethod::CsvAll => ".all.csv",
-            ExportMethod::Json => ".json",
-            ExportMethod::JsonAll => ".all.json",
-            ExportMethod::Html => ".html",
-            ExportMethod::Png => ".png",
-            ExportMethod::Arrow => ".arrow",
-            ExportMethod::ArrowAll => ".all.arrow",
-            ExportMethod::JsonConfig => ".config.json",
+            Self::Csv => ".csv",
+            Self::CsvAll => ".all.csv",
+            Self::Json => ".json",
+            Self::JsonAll => ".all.json",
+            Self::Html => ".html",
+            Self::Png => ".png",
+            Self::Arrow => ".arrow",
+            Self::ArrowAll => ".all.arrow",
+            Self::JsonConfig => ".config.json",
         }
     }
 
-    pub fn mimetype(&self) -> MimeType {
+    pub const fn mimetype(&self) -> MimeType {
         match self {
-            ExportMethod::Png => MimeType::ImagePng,
+            Self::Png => MimeType::ImagePng,
             _ => MimeType::TextPlain,
         }
     }
 }
 
 impl From<ExportMethod> for Html {
-    fn from(x: ExportMethod) -> Html {
+    fn from(x: ExportMethod) -> Self {
         html! {
-            <code>{ x.to_filename() }</code>
+            <code>{ x.as_filename() }</code>
         }
     }
 }
@@ -101,8 +98,8 @@ pub struct ExportFile {
 }
 
 impl ExportFile {
-    pub fn to_filename(&self) -> String {
-        format!("{}{}", self.name, self.method.to_filename())
+    pub fn as_filename(&self) -> String {
+        format!("{}{}", self.name, self.method.as_filename())
     }
 }
 
@@ -117,7 +114,7 @@ impl From<ExportFile> for Html {
         html_template! {
             <code class={ class }>
                 { x.name }
-                { x.method.to_filename() }
+                { x.method.as_filename() }
             </code>
         }
     }

--- a/rust/perspective-viewer/src/rust/renderer/limits.rs
+++ b/rust/perspective-viewer/src/rust/renderer/limits.rs
@@ -81,8 +81,7 @@ mod tests {
             render_warning: true,
             ..ViewConfigRequirements::default()
         };
-        let (_, _, max_cols, max_rows) =
-            get_row_and_col_limits(&view, &reqs).await.unwrap();
+        let (_, _, max_cols, max_rows) = get_row_and_col_limits(&view, &reqs).await.unwrap();
         assert_eq!(max_cols, None);
         assert_eq!(max_rows, None);
     }
@@ -105,8 +104,7 @@ mod tests {
             ..ViewConfigRequirements::default()
         };
 
-        let (_, _, max_cols, max_rows) =
-            get_row_and_col_limits(&view, &reqs).await.unwrap();
+        let (_, _, max_cols, max_rows) = get_row_and_col_limits(&view, &reqs).await.unwrap();
         assert_eq!(max_cols, None);
         assert_eq!(max_rows, None);
     }
@@ -128,8 +126,7 @@ mod tests {
             render_warning: true,
             ..ViewConfigRequirements::default()
         };
-        let (_, _, max_cols, max_rows) =
-            get_row_and_col_limits(&view, &reqs).await.unwrap();
+        let (_, _, max_cols, max_rows) = get_row_and_col_limits(&view, &reqs).await.unwrap();
         assert_eq!(max_cols, Some(1));
         assert_eq!(max_rows, None);
     }
@@ -151,8 +148,7 @@ mod tests {
             render_warning: true,
             ..ViewConfigRequirements::default()
         };
-        let (_, _, max_cols, max_rows) =
-            get_row_and_col_limits(&view, &reqs).await.unwrap();
+        let (_, _, max_cols, max_rows) = get_row_and_col_limits(&view, &reqs).await.unwrap();
         assert_eq!(max_cols, Some(4));
         assert_eq!(max_rows, None);
     }
@@ -174,8 +170,7 @@ mod tests {
             render_warning: true,
             ..ViewConfigRequirements::default()
         };
-        let (_, _, max_cols, max_rows) =
-            get_row_and_col_limits(&view, &reqs).await.unwrap();
+        let (_, _, max_cols, max_rows) = get_row_and_col_limits(&view, &reqs).await.unwrap();
         assert_eq!(max_cols, None);
         assert_eq!(max_rows, Some(2));
     }
@@ -199,8 +194,7 @@ mod tests {
             ..ViewConfigRequirements::default()
         };
 
-        let (_, _, max_cols, max_rows) =
-            get_row_and_col_limits(&view, &reqs).await.unwrap();
+        let (_, _, max_cols, max_rows) = get_row_and_col_limits(&view, &reqs).await.unwrap();
         assert_eq!(max_cols, Some(2));
         assert_eq!(max_rows, Some(5));
     }

--- a/rust/perspective-viewer/src/rust/renderer/render_timer.rs
+++ b/rust/perspective-viewer/src/rust/renderer/render_timer.rs
@@ -39,9 +39,9 @@ impl Drop for RenderTimerType {
 }
 
 impl Default for RenderTimerType {
-    fn default() -> RenderTimerType {
+    fn default() -> Self {
         let deque: Rc<RefCell<Option<VecDeque<f64>>>> = Default::default();
-        RenderTimerType::Moving(register_on_visibility_change(deque.clone()), deque)
+        Self::Moving(register_on_visibility_change(deque.clone()), deque)
     }
 }
 
@@ -57,10 +57,7 @@ fn register_on_visibility_change(
     let closure = fun.into_closure();
     let document = window().unwrap().document().unwrap();
     document
-        .add_event_listener_with_callback(
-            "visibilitychange",
-            closure.as_ref().unchecked_ref(),
-        )
+        .add_event_listener_with_callback("visibilitychange", closure.as_ref().unchecked_ref())
         .unwrap();
 
     closure

--- a/rust/perspective-viewer/src/rust/renderer/theme_store.rs
+++ b/rust/perspective-viewer/src/rust/renderer/theme_store.rs
@@ -26,8 +26,8 @@ struct ThemeStoreData {
 }
 
 impl ThemeStore {
-    pub fn new(elem: &HtmlElement) -> ThemeStore {
-        ThemeStore(Rc::new(ThemeStoreData {
+    pub fn new(elem: &HtmlElement) -> Self {
+        Self(Rc::new(ThemeStoreData {
             viewer_elem: elem.clone(),
             themes: Default::default(), //RefCell::new(None),
         }))

--- a/rust/perspective-viewer/src/rust/session.rs
+++ b/rust/perspective-viewer/src/rust/session.rs
@@ -6,7 +6,10 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+mod column_defaults_update;
+mod drag_drop_update;
 mod metadata;
+mod replace_expression_update;
 mod view;
 mod view_subscription;
 
@@ -23,10 +26,8 @@ use crate::utils::*;
 use crate::*;
 
 use futures::channel::oneshot::*;
-use itertools::Itertools;
 use js_intern::*;
 use std::cell::{Ref, RefCell};
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::iter::IntoIterator;
 use std::ops::Deref;
@@ -36,9 +37,9 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
 use yew::prelude::*;
 
-/// The `Session` struct is the principal interface to the Perspective engine, the
-/// `Table` and `View` obejcts for this viewer, and all associated state including
-/// the `ViewConfig`.
+/// The `Session` struct is the principal interface to the Perspective engine,
+/// the `Table` and `View` objects for this viewer, and all associated state
+/// including the `ViewConfig`.
 #[derive(Clone, Default)]
 pub struct Session(Rc<SessionHandle>);
 
@@ -46,11 +47,11 @@ pub struct Session(Rc<SessionHandle>);
 #[derive(Default)]
 pub struct SessionHandle {
     session_data: RefCell<SessionData>,
-    pub on_update: PubSub<()>,
-    pub on_table_loaded: PubSub<()>,
-    pub on_view_created: PubSub<()>,
-    pub on_view_config_updated: PubSub<()>,
-    pub on_stats: PubSub<()>,
+    pub table_updated: PubSub<()>,
+    pub table_loaded: PubSub<()>,
+    pub view_created: PubSub<()>,
+    pub view_config_changed: PubSub<()>,
+    pub stats_changed: PubSub<()>,
 }
 
 /// Mutable state for `Session`.
@@ -104,9 +105,10 @@ impl Session {
         self.borrow_mut().config.reset(reset_expressions);
     }
 
-    /// Reset this (presumably shared) `Session` to its initial state, returning a
-    /// bool indicating whether this `Session` had a table which was deleted.
-    /// TODO Table should be an immutable constructor parameter to `Session`.
+    /// Reset this (presumably shared) `Session` to its initial state, returning
+    /// a bool indicating whether this `Session` had a table which was
+    /// deleted. TODO Table should be an immutable constructor parameter to
+    /// `Session`.
     pub fn delete(&self) -> bool {
         self.reset(false);
         self.borrow_mut().metadata = SessionMetadata::default();
@@ -117,16 +119,13 @@ impl Session {
     /// Reset this `Session`'s state with a new `Table`.  Implicitly clears the
     /// `ViewSubscription`, which will need to be re-initialized later via
     /// `create_view()`.
-    pub async fn set_table(
-        &self,
-        table: JsPerspectiveTable,
-    ) -> Result<JsValue, JsValue> {
+    pub async fn set_table(&self, table: JsPerspectiveTable) -> Result<JsValue, JsValue> {
         let metadata = SessionMetadata::from_table(&table).await?;
         self.borrow_mut().view_sub = None;
         self.borrow_mut().metadata = metadata;
         self.borrow_mut().table = Some(table);
 
-        self.on_table_loaded.emit_all(());
+        self.table_loaded.emit_all(());
         self.set_initial_stats().await?;
         Ok(JsValue::UNDEFINED)
     }
@@ -135,9 +134,9 @@ impl Session {
         if self.js_get_table().is_none() {
             let (sender, receiver) = channel::<()>();
             let sender = RefCell::new(Some(sender));
-            let _sub = self.on_table_loaded.add_listener(move |x| {
-                sender.borrow_mut().take().unwrap().send(x).unwrap()
-            });
+            let _sub = self
+                .table_loaded
+                .add_listener(move |x| sender.borrow_mut().take().unwrap().send(x).unwrap());
 
             receiver.await.into_jserror()?;
             let _ = self
@@ -167,147 +166,12 @@ impl Session {
         &self,
         column: String,
         index: usize,
-        drop: DropAction,
+        drop: DragTarget,
         drag: DragEffect,
         requirements: &ViewConfigRequirements,
     ) -> ViewConfigUpdate {
-        let mut config = self.get_view_config();
-        let mut update = ViewConfigUpdate::default();
-        let is_to_swap = requirements.is_swap(index);
-        let from_index = config
-            .columns
-            .iter()
-            .position(|x| x.as_ref() == Some(&column));
-
-        let is_from_required = from_index
-            .and_then(|x| requirements.min.map(|z| x < z))
-            .unwrap_or_default();
-
-        let is_from_swap = from_index
-            .map(|x| requirements.is_swap(x))
-            .unwrap_or_default();
-
-        let is_to_empty = config
-            .columns
-            .get(index)
-            .map(|x| x.is_none())
-            .unwrap_or_default();
-
-        match drag {
-            DragEffect::Copy => (),
-            DragEffect::Move(DropAction::Active) => {
-                let is_to_group_or_split =
-                    matches!(drop, DropAction::GroupBy | DropAction::SplitBy);
-
-                if ((!is_to_swap && is_from_swap)
-                    || (is_to_swap && !is_from_swap && is_to_empty)
-                    || is_to_group_or_split)
-                    && config.columns.len() > 1
-                    && !is_from_required
-                {
-                    // Is not a swap
-                    if !is_to_swap && !is_to_group_or_split {
-                        config.columns.iter_mut().for_each(|x| {
-                            if x.as_ref() == Some(&column) {
-                                *x = None;
-                            }
-                        });
-                    } else {
-                        config.columns.retain(|x| x.as_ref() != Some(&column));
-                    }
-
-                    update.columns = Some(config.columns.clone());
-                }
-            }
-            DragEffect::Move(DropAction::GroupBy) => {
-                config.group_by.retain(|x| x != &column);
-                update.group_by = Some(config.group_by.clone());
-            }
-            DragEffect::Move(DropAction::SplitBy) => {
-                config.split_by.retain(|x| x != &column);
-                update.split_by = Some(config.split_by.clone());
-            }
-            DragEffect::Move(DropAction::Sort) => {
-                config.sort.retain(|x| x.0 != column);
-                update.sort = Some(config.sort.clone());
-            }
-            DragEffect::Move(DropAction::Filter) => {
-                config.filter.retain(|x| x.0 != column);
-                update.filter = Some(config.filter.clone());
-            }
-        }
-
-        match drop {
-            DropAction::Active => {
-                if is_to_swap || is_from_required {
-                    let column = Some(column);
-                    config.columns.extend(std::iter::repeat(None).take({
-                        let fill_to = requirements
-                            .names
-                            .as_ref()
-                            .map(|x| std::cmp::max(x.len() - 1, index))
-                            .unwrap_or(index);
-
-                        if fill_to >= (config.columns.len() - 1) {
-                            fill_to + 1 - config.columns.len()
-                        } else {
-                            0
-                        }
-                    }));
-
-                    if let Some(prev) = config.columns.iter().position(|x| *x == column)
-                    {
-                        config.columns.swap(index, prev);
-                    } else {
-                        config.columns[index] = column;
-                    }
-                } else {
-                    config.columns.retain(|x| x.as_ref() != Some(&column));
-                    config.columns.extend(std::iter::repeat(None).take(
-                        if index >= config.columns.len() {
-                            index - config.columns.len()
-                        } else {
-                            0
-                        },
-                    ));
-
-                    if is_to_empty {
-                        config.columns[index] = Some(column)
-                    } else {
-                        config.columns.insert(index, Some(column));
-                    }
-                }
-
-                update.columns = Some(config.columns);
-            }
-            DropAction::GroupBy => {
-                config.group_by.retain(|x| x != &column);
-                let index = std::cmp::min(index as usize, config.group_by.len());
-                config.group_by.insert(index, column);
-                update.group_by = Some(config.group_by);
-            }
-            DropAction::SplitBy => {
-                config.split_by.retain(|x| x != &column);
-                let index = std::cmp::min(index as usize, config.split_by.len());
-                config.split_by.insert(index, column);
-                update.split_by = Some(config.split_by);
-            }
-            DropAction::Sort => {
-                let index = std::cmp::min(index as usize, config.sort.len());
-                config.sort.insert(index, Sort(column, SortDir::Asc));
-                update.sort = Some(config.sort);
-            }
-            DropAction::Filter => {
-                let index = std::cmp::min(index as usize, config.filter.len());
-                config.filter.insert(
-                    index,
-                    Filter(column, FilterOp::EQ, FilterTerm::Scalar(Scalar::Null)),
-                );
-                update.filter = Some(config.filter);
-            }
-        }
-
-        update
+        self.get_view_config()
+            .create_drag_drop_update(column, index, drop, drag, requirements)
     }
 
     /// An async task which replaces a `column` aliased expression with another.
@@ -323,104 +187,17 @@ impl Session {
             .unwrap();
 
         let expression = expression.as_string().unwrap();
-        let ViewConfig {
-            columns,
-            expressions,
-            group_by,
-            split_by,
-            sort,
-            filter,
-            aggregates,
-            ..
-        } = self.get_view_config();
-
-        let expressions = expressions
-            .into_iter()
-            .map(|x| {
-                if x == old_expression {
-                    expression.clone()
-                } else {
-                    x
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let aggregates = aggregates
-            .into_iter()
-            .map(|x| {
-                if x.0 == old_expression {
-                    (expression.clone(), x.1)
-                } else {
-                    x
-                }
-            })
-            .collect::<HashMap<_, _>>();
-
-        let columns = columns
-            .into_iter()
-            .map(|x| match x {
-                Some(x) if x == column => Some(new_name.clone()),
-                x => x,
-            })
-            .collect::<Vec<_>>();
-
-        let group_by = group_by
-            .into_iter()
-            .map(|x| if x == column { new_name.clone() } else { x })
-            .collect::<Vec<_>>();
-
-        let split_by = split_by
-            .into_iter()
-            .map(|x| if x == column { new_name.clone() } else { x })
-            .collect::<Vec<_>>();
-
-        let sort = sort
-            .into_iter()
-            .map(|x| {
-                if x.0 == column {
-                    Sort(new_name.clone(), x.1)
-                } else {
-                    x
-                }
-            })
-            .collect::<Vec<_>>();
-
-        // TODO expression editing can change type, which may invalidate filters
-        let filter = filter
-            .into_iter()
-            .map(|x| {
-                if x.0 == column {
-                    Filter(new_name.clone(), x.1, x.2)
-                } else {
-                    x
-                }
-            })
-            .collect::<Vec<_>>();
-
-        ViewConfigUpdate {
-            columns: Some(columns),
-            aggregates: Some(aggregates),
-            expressions: Some(expressions),
-            group_by: Some(group_by),
-            split_by: Some(split_by),
-            sort: Some(sort),
-            filter: Some(filter),
-        }
+        let view_config = self.get_view_config();
+        view_config.create_replace_expression_update(
+            column,
+            &old_expression,
+            &new_name,
+            &expression,
+        )
     }
 
-    async fn get_validated_expression_name(
-        &self,
-        expr: &JsValue,
-    ) -> Result<String, JsValue> {
-        let arr = [expr].iter().collect::<js_sys::Array>();
-        let table = self.borrow().table.as_ref().unwrap().clone();
-        let schema = table.validate_expressions(arr).await?.expression_schema();
-        let schema_keys = js_sys::Object::keys(&schema);
-        schema_keys.get(0).as_string().into_jserror()
-    }
-
-    /// Validate an expression string (as a JsValue since it comes from `monaco`),
-    /// and marshall the results.
+    /// Validate an expression string (as a JsValue since it comes from
+    /// `monaco`), and marshall the results.
     pub async fn validate_expr(
         &self,
         expr: JsValue,
@@ -444,19 +221,6 @@ impl Session {
         let bytes = csv_fut.await?;
         view.delete().await?;
         Ok(js_sys::Uint8Array::new(&bytes).to_vec())
-    }
-
-    async fn flat_as_jsvalue(&self, flat: bool) -> Result<View, JsValue> {
-        Ok(if flat {
-            let table = self.borrow().table.clone().into_jserror()?;
-            PerspectiveOwned::new(table.view(&js_object!().unchecked_into()).await?)
-        } else {
-            self.borrow()
-                .view_sub
-                .as_ref()
-                .map(|x| x.get_view().clone())
-                .into_jserror()?
-        })
     }
 
     pub async fn arrow_as_jsvalue(self, flat: bool) -> Result<web_sys::Blob, JsValue> {
@@ -520,18 +284,15 @@ impl Session {
 
     /// Get all unique column values for a given column name.
     ///
-    /// Use the `.to_csv()` method, as I suspected copying this large string once
-    /// was more efficient than copying many smaller strings, and string copying
-    /// shows up frequently when doing performance analysis.
+    /// Use the `.to_csv()` method, as I suspected copying this large string
+    /// once was more efficient than copying many smaller strings, and
+    /// string copying shows up frequently when doing performance analysis.
     ///
     /// TODO Does not work with expressions yet.
     ///
     /// # Arguments
     /// - `column` The name of the column (or expression).
-    pub async fn get_column_values(
-        &self,
-        column: String,
-    ) -> Result<Vec<String>, JsValue> {
+    pub async fn get_column_values(&self, column: String) -> Result<Vec<String>, JsValue> {
         let expressions = self.borrow().config.expressions.clone();
         let config = ViewConfig {
             group_by: vec![column],
@@ -566,131 +327,34 @@ impl Session {
             .skip(2)
             .collect::<Vec<String>>())
     }
-}
 
-impl Session {
     pub fn set_update_column_defaults(
         &self,
         config_update: &mut ViewConfigUpdate,
         requirements: &ViewConfigRequirements,
     ) {
-        if let (
-            None,
-            ViewConfigRequirements {
-                min: Some(min_cols),
-                names,
-                ..
-            },
-        ) = (&config_update.columns, &requirements)
-        {
-            // first try to take 2 numeric columns from existing config
-            let numeric_config_columns = self
-                .borrow()
-                .config
-                .columns
-                .iter()
-                .flatten()
-                .filter(|x| {
-                    matches!(
-                        self.metadata().get_column_table_type(x),
-                        Some(Type::Float) | Some(Type::Integer)
-                    )
-                })
-                .take(*min_cols)
-                .cloned()
-                .map(Some)
-                .collect::<Vec<_>>();
-
-            if numeric_config_columns.len() == *min_cols {
-                config_update.columns = Some(
-                    numeric_config_columns
-                        .into_iter()
-                        .pad_using(names.as_ref().map_or(0, |x| x.len()), |_| None)
-                        .collect::<Vec<_>>(),
-                );
-            } else {
-                // Append numeric columns from all columns and try again
-                let config_columns = numeric_config_columns
-                    .clone()
-                    .into_iter()
-                    .chain(
-                        self.metadata()
-                            .get_table_columns()
-                            .into_iter()
-                            .flatten()
-                            .filter(|x| {
-                                !numeric_config_columns
-                                    .iter()
-                                    .any(|y| y.as_ref().map_or(false, |z| z == *x))
-                            })
-                            .filter(|x| {
-                                matches!(
-                                    self.metadata().get_column_table_type(x),
-                                    Some(Type::Float) | Some(Type::Integer)
-                                )
-                            })
-                            .cloned()
-                            .map(Some),
-                    )
-                    .take(*min_cols)
-                    .collect::<Vec<_>>();
-
-                if config_columns.len() == *min_cols {
-                    config_update.columns = Some(
-                        config_columns
-                            .into_iter()
-                            .pad_using(names.as_ref().map_or(0, |x| x.len()), |_| None)
-                            .collect::<Vec<_>>(),
-                    );
-                } else {
-                    config_update.columns = Some(
-                        self.metadata()
-                            .get_table_columns()
-                            .into_iter()
-                            .flatten()
-                            .take(*min_cols)
-                            .cloned()
-                            .map(Some)
-                            .collect::<Vec<_>>(),
-                    );
-                }
-            }
-        } else if config_update.columns.is_none() {
-            let mut columns = self.borrow().config.columns.clone();
-            let initial_len = columns.len();
-            if let Some(last_filled) = columns.iter().rposition(|x| x.is_some()) {
-                columns.truncate(last_filled + 1);
-                if let ViewConfigRequirements {
-                    names: Some(names), ..
-                } = &requirements
-                {
-                    columns = columns
-                        .into_iter()
-                        .enumerate()
-                        .filter(|(idx, x)| *idx < names.len() || x.is_some())
-                        .map(|(_, x)| x)
-                        .pad_using(names.len(), |_| None)
-                        .collect::<Vec<_>>();
-                } else {
-                    columns = columns
-                        .into_iter()
-                        .filter(|x| x.is_some())
-                        .collect::<Vec<_>>();
-                }
-
-                if initial_len != columns.len() {
-                    config_update.columns = Some(columns);
-                }
-            }
-        }
+        config_update.set_update_column_defaults(
+            &self.metadata(),
+            &self.borrow().config.columns,
+            requirements,
+        )
     }
 
-    /// Update the config, setting the `columns` property to the plugin defaults if
-    /// provided.
+    /// Update the config, setting the `columns` property to the plugin defaults
+    /// if provided.
     pub fn update_view_config(&self, config_update: ViewConfigUpdate) {
         self.borrow_mut().view_sub = None;
         self.borrow_mut().config.apply_update(config_update);
-        self.on_view_config_updated.emit_all(());
+        self.view_config_changed.emit_all(());
+    }
+
+    pub fn reset_stats(&self) {
+        self.update_stats(TableStats::default());
+    }
+
+    #[cfg(test)]
+    pub fn set_stats(&self, stats: TableStats) {
+        self.update_stats(stats)
     }
 
     /// In order to create a new view in this session, the session must first be
@@ -709,56 +373,26 @@ impl Session {
 
         ValidSession(self)
     }
-}
 
-/// A newtype wrapper which only provides `create_view()`
-pub struct ValidSession<'a>(&'a Session);
-
-impl<'a> ValidSession<'a> {
-    /// Set a new `View` (derived from this `Session`'s `Table`), and create the
-    /// `update()` subscription, consuming this `ValidSession<'_>` and returning
-    /// the original `&Session`.
-    pub async fn create_view(&self) -> Result<&'a Session, JsValue> {
-        let js_config = self.0.borrow().config.as_jsvalue()?;
-        let table = self
-            .0
-            .borrow()
-            .table
-            .clone()
-            .ok_or("`restore()` called before `load()`")?;
-
-        let view = table.view(&js_config).await?;
-        let view_schema = view.schema().await?;
-        self.0.metadata_mut().update_view_schema(&view_schema)?;
-
-        let on_stats = Callback::from({
-            let this = self.0.clone();
-            move |stats| this.update_stats(stats)
-        });
-
-        let sub = {
-            let config = self.0.borrow().config.clone();
-            let on_update = self.0.on_update.callback();
-            ViewSubscription::new(table, view, config, on_stats, on_update)
-        };
-
-        // self.0.borrow_mut().metadata.as_mut().unwrap().view_schema = Some(view_schema);
-        self.0.borrow_mut().view_sub = Some(sub);
-        Ok(self.0)
+    async fn get_validated_expression_name(&self, expr: &JsValue) -> Result<String, JsValue> {
+        let arr = [expr].iter().collect::<js_sys::Array>();
+        let table = self.borrow().table.as_ref().unwrap().clone();
+        let schema = table.validate_expressions(arr).await?.expression_schema();
+        let schema_keys = js_sys::Object::keys(&schema);
+        schema_keys.get(0).as_string().into_jserror()
     }
-}
 
-impl<'a> Drop for ValidSession<'a> {
-    /// `ValidSession` is a guard for listeners of the `view_created` pubsub
-    /// event.
-    fn drop(&mut self) {
-        self.0.on_view_created.emit_all(());
-    }
-}
-
-impl Session {
-    pub fn reset_stats(&self) {
-        self.update_stats(TableStats::default());
+    async fn flat_as_jsvalue(&self, flat: bool) -> Result<View, JsValue> {
+        Ok(if flat {
+            let table = self.borrow().table.clone().into_jserror()?;
+            PerspectiveOwned::new(table.view(&js_object!().unchecked_into()).await?)
+        } else {
+            self.borrow()
+                .view_sub
+                .as_ref()
+                .map(|x| x.get_view().clone())
+                .into_jserror()?
+        })
     }
 
     /// Update the this `Session`'s `TableStats` data from the `Table`.
@@ -775,14 +409,9 @@ impl Session {
         Ok(JsValue::UNDEFINED)
     }
 
-    #[cfg(test)]
-    pub fn set_stats(&self, stats: TableStats) {
-        self.update_stats(stats)
-    }
-
     fn update_stats(&self, stats: TableStats) {
         self.borrow_mut().stats = Some(stats);
-        self.on_stats.emit_all(());
+        self.stats_changed.emit_all(());
     }
 
     async fn validate_view_config(&self) -> Result<(), JsValue> {
@@ -869,5 +498,51 @@ impl Session {
 
         self.borrow_mut().config = config;
         Ok(())
+    }
+}
+
+/// A newtype wrapper which only provides `create_view()`
+pub struct ValidSession<'a>(&'a Session);
+
+impl<'a> ValidSession<'a> {
+    /// Set a new `View` (derived from this `Session`'s `Table`), and create the
+    /// `update()` subscription, consuming this `ValidSession<'_>` and returning
+    /// the original `&Session`.
+    pub async fn create_view(&self) -> Result<&'a Session, JsValue> {
+        let js_config = self.0.borrow().config.as_jsvalue()?;
+        let table = self
+            .0
+            .borrow()
+            .table
+            .clone()
+            .ok_or("`restore()` called before `load()`")?;
+
+        let view = table.view(&js_config).await?;
+        let view_schema = view.schema().await?;
+        self.0.metadata_mut().update_view_schema(&view_schema)?;
+
+        let on_stats = Callback::from({
+            let this = self.0.clone();
+            move |stats| this.update_stats(stats)
+        });
+
+        let sub = {
+            let config = self.0.borrow().config.clone();
+            let on_update = self.0.table_updated.callback();
+            ViewSubscription::new(table, view, config, on_stats, on_update)
+        };
+
+        // self.0.borrow_mut().metadata.as_mut().unwrap().view_schema =
+        // Some(view_schema);
+        self.0.borrow_mut().view_sub = Some(sub);
+        Ok(self.0)
+    }
+}
+
+impl<'a> Drop for ValidSession<'a> {
+    /// `ValidSession` is a guard for listeners of the `view_created` pubsub
+    /// event.
+    fn drop(&mut self) {
+        self.0.view_created.emit_all(());
     }
 }

--- a/rust/perspective-viewer/src/rust/session/column_defaults_update.rs
+++ b/rust/perspective-viewer/src/rust/session/column_defaults_update.rs
@@ -1,0 +1,135 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018, the Perspective Authors.
+//
+// This file is part of the Perspective library, distributed under the terms
+// of the Apache License 2.0.  The full license can be found in the LICENSE
+// file.
+
+use super::metadata::*;
+use crate::config::*;
+use crate::js::plugin::*;
+
+use itertools::Itertools;
+use std::iter::IntoIterator;
+
+impl ViewConfigUpdate {
+    /// Appends additional columns to the `columns` field of this
+    /// `ViewConfigUpdate` by picking appropriate new columns from the
+    /// `SessionMetadata`, give the necessary column requirements of the plugin
+    /// provided by a `ViewConfigRequirements`.  For example, an "X/Y Scatter"
+    /// chart needs a minimum of 2 numeric columns to be drawable.
+    pub fn set_update_column_defaults(
+        &mut self,
+        metadata: &SessionMetadata,
+        columns: &[Option<String>],
+        requirements: &ViewConfigRequirements,
+    ) {
+        if let (
+            None,
+            ViewConfigRequirements {
+                min: Some(min_cols),
+                names,
+                ..
+            },
+        ) = (&self.columns, &requirements)
+        {
+            // first try to take 2 numeric columns from existing config
+            let numeric_config_columns = columns
+                .iter()
+                .flatten()
+                .filter(|x| {
+                    matches!(
+                        metadata.get_column_table_type(x),
+                        Some(Type::Float) | Some(Type::Integer)
+                    )
+                })
+                .take(*min_cols)
+                .cloned()
+                .map(Some)
+                .collect::<Vec<_>>();
+
+            if numeric_config_columns.len() == *min_cols {
+                self.columns = Some(
+                    numeric_config_columns
+                        .into_iter()
+                        .pad_using(names.as_ref().map_or(0, |x| x.len()), |_| None)
+                        .collect::<Vec<_>>(),
+                );
+            } else {
+                // Append numeric columns from all columns and try again
+                let config_columns = numeric_config_columns
+                    .clone()
+                    .into_iter()
+                    .chain(
+                        metadata
+                            .get_table_columns()
+                            .into_iter()
+                            .flatten()
+                            .filter(|x| {
+                                !numeric_config_columns
+                                    .iter()
+                                    .any(|y| y.as_ref().map_or(false, |z| z == *x))
+                            })
+                            .filter(|x| {
+                                matches!(
+                                    metadata.get_column_table_type(x),
+                                    Some(Type::Float) | Some(Type::Integer)
+                                )
+                            })
+                            .cloned()
+                            .map(Some),
+                    )
+                    .take(*min_cols)
+                    .collect::<Vec<_>>();
+
+                if config_columns.len() == *min_cols {
+                    self.columns = Some(
+                        config_columns
+                            .into_iter()
+                            .pad_using(names.as_ref().map_or(0, |x| x.len()), |_| None)
+                            .collect::<Vec<_>>(),
+                    );
+                } else {
+                    self.columns = Some(
+                        metadata
+                            .get_table_columns()
+                            .into_iter()
+                            .flatten()
+                            .take(*min_cols)
+                            .cloned()
+                            .map(Some)
+                            .collect::<Vec<_>>(),
+                    );
+                }
+            }
+        } else if self.columns.is_none() {
+            let mut columns = columns.to_vec();
+            let initial_len = columns.len();
+            if let Some(last_filled) = columns.iter().rposition(|x| x.is_some()) {
+                columns.truncate(last_filled + 1);
+                if let ViewConfigRequirements {
+                    names: Some(names), ..
+                } = &requirements
+                {
+                    columns = columns
+                        .into_iter()
+                        .enumerate()
+                        .filter(|(idx, x)| *idx < names.len() || x.is_some())
+                        .map(|(_, x)| x)
+                        .pad_using(names.len(), |_| None)
+                        .collect::<Vec<_>>();
+                } else {
+                    columns = columns
+                        .into_iter()
+                        .filter(|x| x.is_some())
+                        .collect::<Vec<_>>();
+                }
+
+                if initial_len != columns.len() {
+                    self.columns = Some(columns);
+                }
+            }
+        }
+    }
+}

--- a/rust/perspective-viewer/src/rust/session/drag_drop_update.rs
+++ b/rust/perspective-viewer/src/rust/session/drag_drop_update.rs
@@ -1,0 +1,162 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018, the Perspective Authors.
+//
+// This file is part of the Perspective library, distributed under the terms
+// of the Apache License 2.0.  The full license can be found in the LICENSE
+// file.
+
+use crate::config::*;
+use crate::dragdrop::DragEffect;
+use crate::dragdrop::DragTarget;
+use crate::js::plugin::ViewConfigRequirements;
+
+impl ViewConfig {
+    /// Create an update for this `ViewConfig` which applies a drag/drop action.
+    /// This method is designed to be called from `crate::session`.
+    pub(super) fn create_drag_drop_update(
+        &self,
+        column: String,
+        index: usize,
+        drop: DragTarget,
+        drag: DragEffect,
+        requirements: &ViewConfigRequirements,
+    ) -> ViewConfigUpdate {
+        let mut config = self.clone();
+        let mut update = ViewConfigUpdate::default();
+        let is_to_swap = requirements.is_swap(index);
+        let from_index = config
+            .columns
+            .iter()
+            .position(|x| x.as_ref() == Some(&column));
+
+        let is_from_required = from_index
+            .and_then(|x| requirements.min.map(|z| x < z))
+            .unwrap_or_default();
+
+        let is_from_swap = from_index
+            .map(|x| requirements.is_swap(x))
+            .unwrap_or_default();
+
+        let is_to_empty = config
+            .columns
+            .get(index)
+            .map(|x| x.is_none())
+            .unwrap_or_default();
+
+        match drag {
+            DragEffect::Copy => (),
+            DragEffect::Move(DragTarget::Active) => {
+                let is_to_group_or_split =
+                    matches!(drop, DragTarget::GroupBy | DragTarget::SplitBy);
+
+                if ((!is_to_swap && is_from_swap)
+                    || (is_to_swap && !is_from_swap && is_to_empty)
+                    || is_to_group_or_split)
+                    && config.columns.len() > 1
+                    && !is_from_required
+                {
+                    // Is not a swap
+                    if !is_to_swap && !is_to_group_or_split {
+                        config.columns.iter_mut().for_each(|x| {
+                            if x.as_ref() == Some(&column) {
+                                *x = None;
+                            }
+                        });
+                    } else {
+                        config.columns.retain(|x| x.as_ref() != Some(&column));
+                    }
+
+                    update.columns = Some(config.columns.clone());
+                }
+            }
+            DragEffect::Move(DragTarget::GroupBy) => {
+                config.group_by.retain(|x| x != &column);
+                update.group_by = Some(config.group_by.clone());
+            }
+            DragEffect::Move(DragTarget::SplitBy) => {
+                config.split_by.retain(|x| x != &column);
+                update.split_by = Some(config.split_by.clone());
+            }
+            DragEffect::Move(DragTarget::Sort) => {
+                config.sort.retain(|x| x.0 != column);
+                update.sort = Some(config.sort.clone());
+            }
+            DragEffect::Move(DragTarget::Filter) => {
+                config.filter.retain(|x| x.0 != column);
+                update.filter = Some(config.filter.clone());
+            }
+        }
+
+        match drop {
+            DragTarget::Active => {
+                if is_to_swap || is_from_required {
+                    let column = Some(column);
+                    config.columns.extend(std::iter::repeat(None).take({
+                        let fill_to = requirements
+                            .names
+                            .as_ref()
+                            .map(|x| std::cmp::max(x.len() - 1, index))
+                            .unwrap_or(index);
+
+                        if fill_to >= (config.columns.len() - 1) {
+                            fill_to + 1 - config.columns.len()
+                        } else {
+                            0
+                        }
+                    }));
+
+                    if let Some(prev) = config.columns.iter().position(|x| *x == column) {
+                        config.columns.swap(index, prev);
+                    } else {
+                        config.columns[index] = column;
+                    }
+                } else {
+                    config.columns.retain(|x| x.as_ref() != Some(&column));
+                    config.columns.extend(std::iter::repeat(None).take(
+                        if index >= config.columns.len() {
+                            index - config.columns.len()
+                        } else {
+                            0
+                        },
+                    ));
+
+                    if is_to_empty {
+                        config.columns[index] = Some(column)
+                    } else {
+                        config.columns.insert(index, Some(column));
+                    }
+                }
+
+                update.columns = Some(config.columns);
+            }
+            DragTarget::GroupBy => {
+                config.group_by.retain(|x| x != &column);
+                let index = std::cmp::min(index as usize, config.group_by.len());
+                config.group_by.insert(index, column);
+                update.group_by = Some(config.group_by);
+            }
+            DragTarget::SplitBy => {
+                config.split_by.retain(|x| x != &column);
+                let index = std::cmp::min(index as usize, config.split_by.len());
+                config.split_by.insert(index, column);
+                update.split_by = Some(config.split_by);
+            }
+            DragTarget::Sort => {
+                let index = std::cmp::min(index as usize, config.sort.len());
+                config.sort.insert(index, Sort(column, SortDir::Asc));
+                update.sort = Some(config.sort);
+            }
+            DragTarget::Filter => {
+                let index = std::cmp::min(index as usize, config.filter.len());
+                config.filter.insert(
+                    index,
+                    Filter(column, FilterOp::EQ, FilterTerm::Scalar(Scalar::Null)),
+                );
+                update.filter = Some(config.filter);
+            }
+        }
+
+        update
+    }
+}

--- a/rust/perspective-viewer/src/rust/session/replace_expression_update.rs
+++ b/rust/perspective-viewer/src/rust/session/replace_expression_update.rs
@@ -1,0 +1,125 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018, the Perspective Authors.
+//
+// This file is part of the Perspective library, distributed under the terms
+// of the Apache License 2.0.  The full license can be found in the LICENSE
+// file.
+
+use crate::config::*;
+
+use std::collections::HashMap;
+
+impl ViewConfig {
+    /// Create an update for this `ViewConfig` that replaces an expression
+    /// column with a new one, e.g. when a user edits an expression.  This may
+    /// changed either the expression alias, the expression itself, or both; as
+    /// well as any other fields that reference the expression column by alias.
+    ///
+    /// This method is designed to be called from `crate::session` which can
+    /// fill in `old_expression` and `new_alias`.
+    pub(super) fn create_replace_expression_update(
+        &self,
+        old_alias: &str,
+        old_expression: &str,
+        new_alias: &str,
+        new_expression: &str,
+    ) -> ViewConfigUpdate {
+        let expression = new_expression;
+        let ViewConfig {
+            columns,
+            expressions,
+            group_by,
+            split_by,
+            sort,
+            filter,
+            aggregates,
+            ..
+        } = self.clone();
+
+        let expressions = expressions
+            .into_iter()
+            .map(|x| {
+                if x == old_expression {
+                    expression.to_owned()
+                } else {
+                    x
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let aggregates = aggregates
+            .into_iter()
+            .map(|x| {
+                if x.0 == old_expression {
+                    (expression.to_owned(), x.1)
+                } else {
+                    x
+                }
+            })
+            .collect::<HashMap<_, _>>();
+
+        let columns = columns
+            .into_iter()
+            .map(|x| match x {
+                Some(x) if x == old_alias => Some(new_alias.to_owned()),
+                x => x,
+            })
+            .collect::<Vec<_>>();
+
+        let group_by = group_by
+            .into_iter()
+            .map(|x| {
+                if x == old_alias {
+                    new_alias.to_owned()
+                } else {
+                    x
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let split_by = split_by
+            .into_iter()
+            .map(|x| {
+                if x == old_alias {
+                    new_alias.to_owned()
+                } else {
+                    x
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let sort = sort
+            .into_iter()
+            .map(|x| {
+                if x.0 == old_alias {
+                    Sort(new_alias.to_owned(), x.1)
+                } else {
+                    x
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // TODO expression editing can change type, which may invalidate filters
+        let filter = filter
+            .into_iter()
+            .map(|x| {
+                if x.0 == old_alias {
+                    Filter(new_alias.to_owned(), x.1, x.2)
+                } else {
+                    x
+                }
+            })
+            .collect::<Vec<_>>();
+
+        ViewConfigUpdate {
+            columns: Some(columns),
+            aggregates: Some(aggregates),
+            expressions: Some(expressions),
+            group_by: Some(group_by),
+            split_by: Some(split_by),
+            sort: Some(sort),
+            filter: Some(filter),
+        }
+    }
+}

--- a/rust/perspective-viewer/src/rust/session/view.rs
+++ b/rust/perspective-viewer/src/rust/session/view.rs
@@ -16,22 +16,22 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 
-/// `PerspectiveOwned` is a newtype-ed `Rc` smart pointer which guarantees either a
-/// `JsPerspectiveView` or `JsPerspectiveTable` will have its `.delete()` method
-/// called when it is dropped.
+/// `PerspectiveOwned` is a newtype-ed `Rc` smart pointer which guarantees
+/// either a `JsPerspectiveView` or `JsPerspectiveTable` will have its
+/// `.delete()` method called when it is dropped.
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""))]
 pub struct PerspectiveOwned<T>(Rc<PerspectiveOwnedSession<T>>)
 where
     T: AsyncDelete + 'static;
 
-/// An owned `JsPerspectiveView` which calls its JavaScript `delete()` method when
-/// this struct is `drop()`-ed.
+/// An owned `JsPerspectiveView` which calls its JavaScript `delete()` method
+/// when this struct is `drop()`-ed.
 pub type View = PerspectiveOwned<JsPerspectiveView>;
 
 /// `<perspective-viewer>` does not currently take ownership of `Table`. objects
-/// so this is not currently needed, but it will be in the future and this polymorphism
-/// is th emotiviation behind the `PerspectiveOwned<T>` type.
+/// so this is not currently needed, but it will be in the future and this
+/// polymorphism is th emotiviation behind the `PerspectiveOwned<T>` type.
 #[allow(dead_code)]
 pub type Table = PerspectiveOwned<JsPerspectiveTable>;
 
@@ -40,12 +40,12 @@ where
     T: AsyncDelete + 'static + JsCast,
 {
     /// Take ownership of a `T` and construct a `PerspectiveOwned<T>`.
-    pub fn new(obj: T) -> PerspectiveOwned<T> {
-        PerspectiveOwned(Rc::new(PerspectiveOwnedSession(Some(obj))))
+    pub fn new(obj: T) -> Self {
+        Self(Rc::new(PerspectiveOwnedSession(Some(obj))))
     }
 
-    /// Get a reference to the owned object as a `JsValue`, which is necessary to
-    /// pass it back to other JavaScript APIs.
+    /// Get a reference to the owned object as a `JsValue`, which is necessary
+    /// to pass it back to other JavaScript APIs.
     pub fn as_jsvalue(&self) -> JsValue {
         self.0
              .0
@@ -70,8 +70,8 @@ where
 }
 
 /// `PerspectiveOwnedSession<T>` is a newtype wrapper for implementing `Drop`.
-/// Alternatively, we could just implement `Drop` directly on `JsPerspectiveView` and
-/// `JsPerspectiveTable`.
+/// Alternatively, we could just implement `Drop` directly on
+/// `JsPerspectiveView` and `JsPerspectiveTable`.
 struct PerspectiveOwnedSession<T: AsyncDelete + 'static>(Option<T>);
 
 #[async_trait(?Send)]

--- a/rust/perspective-viewer/src/rust/session/view_subscription.rs
+++ b/rust/perspective-viewer/src/rust/session/view_subscription.rs
@@ -17,8 +17,8 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
-/// Metadata snapshot of the current `Table()`/`View()` state which may be of interest
-/// to components.
+/// Metadata snapshot of the current `Table()`/`View()` state which may be of
+/// interest to components.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TableStats {
     pub is_pivot: bool,
@@ -67,9 +67,10 @@ impl ViewSubscriptionData {
 }
 
 impl ViewSubscription {
-    /// Create a new `ViewSubscription` with the provided Perspective `Table()` and
-    /// `View()` pair.  During initialization, any necessary Perspective API events
-    /// will be subscribed to and subsequently cleaned up via `Drop` trait.
+    /// Create a new `ViewSubscription` with the provided Perspective `Table()`
+    /// and `View()` pair.  During initialization, any necessary Perspective
+    /// API events will be subscribed to and subsequently cleaned up via
+    /// `Drop` trait.
     ///
     /// # Arguments
     /// * `table` - a Perspective `Table()`
@@ -82,7 +83,7 @@ impl ViewSubscription {
         config: ViewConfig,
         on_stats: Callback<TableStats>,
         on_update: Callback<()>,
-    ) -> ViewSubscription {
+    ) -> Self {
         let data = ViewSubscriptionData {
             table,
             view: View::new(view),
@@ -99,18 +100,18 @@ impl ViewSubscription {
         let closure = fun.into_closure();
         data.view.on_update(closure.as_ref().unchecked_ref());
         let _ = promisify_ignore_view_delete(data.clone().update_view_stats());
-        ViewSubscription { data, closure }
+        Self { data, closure }
     }
 
     /// Getter for the underlying `View()`.
-    pub fn get_view(&self) -> &View {
+    pub const fn get_view(&self) -> &View {
         &self.data.view
     }
 
     /// Getter for the underlying `Table()`.
     /// TODO this is un-used, but I'm leaving it as a reminder that the API
     /// intends this to be public.
-    pub fn _table(&self) -> &JsPerspectiveTable {
+    pub const fn _table(&self) -> &JsPerspectiveTable {
         &self.data.table
     }
 }

--- a/rust/perspective-viewer/src/rust/utils/closure.rs
+++ b/rust/perspective-viewer/src/rust/utils/closure.rs
@@ -13,9 +13,10 @@ use yew::prelude::*;
 pub trait ToClosure<T> {
     type Output;
 
-    /// Convert `self` to a `Closure`.  This is mostly just for code cleanliness,
-    /// as stable Rust does not yet supports specialization (which would support more
-    /// types) nor `Unsize<_>` (which would elide more explicit type annotations).
+    /// Convert `self` to a `Closure`.  This is mostly just for code
+    /// cleanliness, as stable Rust does not yet supports specialization
+    /// (which would support more types) nor `Unsize<_>` (which would elide
+    /// more explicit type annotations).
     fn into_closure(self) -> Self::Output;
 }
 
@@ -58,7 +59,7 @@ where
     }
 }
 
-impl<U> ToClosure<Callback<U>> for Callback<U>
+impl<U> ToClosure<Self> for Callback<U>
 where
     U: FromWasmAbi + 'static,
 {

--- a/rust/perspective-viewer/src/rust/utils/datetime.rs
+++ b/rust/perspective-viewer/src/rust/utils/datetime.rs
@@ -41,8 +41,7 @@ pub fn str_to_utc_posix(val: &str) -> Result<f64, JsValue> {
     let tz = get_local_tz();
     NaiveDateTime::parse_from_str(val, input_value_format(val)?)
         .map(|ref posix| {
-            DateTime::<Utc>::from(tz.from_local_datetime(posix).unwrap())
-                .timestamp_millis() as f64
+            DateTime::<Utc>::from(tz.from_local_datetime(posix).unwrap()).timestamp_millis() as f64
         })
         .into_jserror()
 }

--- a/rust/perspective-viewer/src/rust/utils/future_to_promise.rs
+++ b/rust/perspective-viewer/src/rust/utils/future_to_promise.rs
@@ -13,8 +13,8 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
 
 /// Same as `future_to_promise`, except this version will catch `"View is not
-/// initialzied"` errors thrown from disposed Perspective objects without causing Rust
-/// `abort()`s.
+/// initialzied"` errors thrown from disposed Perspective objects without
+/// causing Rust `abort()`s.
 ///
 /// # Arguments
 /// * `f` - a `Future` to convert to a `Promise` and execute.
@@ -40,9 +40,7 @@ pub fn ignore_view_delete(f: JsValue) -> Result<JsValue, JsValue> {
             }
         }
         _ => match f.as_string() {
-            Some(x) if x == "View method cancelled" => {
-                Ok(JsValue::from("View method cancelled"))
-            }
+            Some(x) if x == "View method cancelled" => Ok(JsValue::from("View method cancelled")),
             Some(_) => Err(f),
             _ => {
                 if js_sys::Reflect::get(&f, js_intern!("message"))

--- a/rust/perspective-viewer/src/rust/utils/pubsub.rs
+++ b/rust/perspective-viewer/src/rust/utils/pubsub.rs
@@ -73,9 +73,10 @@ where
     }
 }
 
-/// Manages the lifetime of a listener registered to a `PubSub<T>` by deregistering
-/// the associated listener when dropped.  The wrapped `Fn` of `Subscriptions` is
-/// the deregister closure provided by the issuing `PubSub<T>`.
+/// Manages the lifetime of a listener registered to a `PubSub<T>` by
+/// deregistering the associated listener when dropped.  The wrapped `Fn` of
+/// `Subscriptions` is the deregister closure provided by the issuing
+/// `PubSub<T>`.
 #[must_use]
 pub struct Subscription(Box<dyn Fn()>);
 

--- a/rust/perspective-viewer/src/rust/utils/request_animation_frame.rs
+++ b/rust/perspective-viewer/src/rust/utils/request_animation_frame.rs
@@ -39,7 +39,8 @@ pub async fn await_dom_loaded() -> Result<(), JsValue> {
     }
 }
 
-/// An `async` version of `set_timeout`, which resolves in `timeout` milliseconds
+/// An `async` version of `set_timeout`, which resolves in `timeout`
+/// milliseconds
 pub async fn set_timeout(timeout: i32) -> Result<(), JsValue> {
     let (sender, receiver) = channel::<()>();
     let jsfun = Closure::once_into_js(move || {
@@ -48,10 +49,7 @@ pub async fn set_timeout(timeout: i32) -> Result<(), JsValue> {
 
     web_sys::window()
         .unwrap()
-        .set_timeout_with_callback_and_timeout_and_arguments_0(
-            jsfun.unchecked_ref(),
-            timeout,
-        )?;
+        .set_timeout_with_callback_and_timeout_and_arguments_0(jsfun.unchecked_ref(), timeout)?;
 
     let x = receiver.await;
     x.into_jserror()

--- a/rust/perspective-viewer/src/rust/utils/testing.rs
+++ b/rust/perspective-viewer/src/rust/utils/testing.rs
@@ -30,8 +30,8 @@ extern "C" {
     fn worker() -> js_sys::Promise;
 }
 
-/// Generate a test `Table`, but only create teh webworker once or the tests will
-/// figuratively literally run forever.
+/// Generate a test `Table`, but only create teh webworker once or the tests
+/// will figuratively literally run forever.
 #[cfg(test)]
 pub async fn get_mock_table() -> JsPerspectiveTable {
     thread_local! {
@@ -58,10 +58,10 @@ pub async fn get_mock_table() -> JsPerspectiveTable {
         .unwrap()
 }
 
-/// A macro which set a property called `weak_link` on the container `Properties`
-/// when `cfg(test)`, such that unit tests may send messages to a component.
-/// This macro needs to be called in `create()` on any Component which needs to
-/// receive messages in a test.
+/// A macro which set a property called `weak_link` on the container
+/// `Properties` when `cfg(test)`, such that unit tests may send messages to a
+/// component. This macro needs to be called in `create()` on any Component
+/// which needs to receive messages in a test.
 #[macro_export]
 macro_rules! enable_weak_link_test {
     ($props:expr, $link:expr) => {

--- a/rust/perspective-viewer/src/rust/utils/tests/perspective.rs
+++ b/rust/perspective-viewer/src/rust/utils/tests/perspective.rs
@@ -19,7 +19,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 pub async fn test_table_size() {
     let table = get_mock_table().await;
     let size = table.size().await.unwrap();
-    assert_eq!(size, 3_f64);
+    assert!(size - 3_f64 < 0.01);
 }
 
 #[wasm_bindgen_test]
@@ -57,7 +57,7 @@ pub async fn test_view_num_rows() {
     let table = get_mock_table().await;
     let view = table.view(js_object!().unchecked_ref()).await.unwrap();
     let num_rows = view.num_rows().await.unwrap();
-    assert_eq!(num_rows, 3_f64);
+    assert!(num_rows - 3_f64 < 0.01);
 }
 
 // #[wasm_bindgen_test]

--- a/tools/perspective-build/rust_wasm.js
+++ b/tools/perspective-build/rust_wasm.js
@@ -1,0 +1,127 @@
+// Forked from https://github.com/MrRefactoring/wasm-opt
+// We need a specific version of `wasm-opt` due to regressions in the `-Os` and
+// `-Oz` optimization targets, and there is no published version of this
+// npm module for the `wasm-opt` version we want.
+
+const fs = require("fs");
+const tar = require("tar");
+const path = require("path");
+const fetch = require("node-fetch");
+const {promisify} = require("util");
+
+const mkdir = promisify(fs.mkdir);
+const copyFile = promisify(fs.copyFile);
+const rmdir = promisify(fs.rmdir);
+const unlink = promisify(fs.unlink);
+const writeFile = promisify(fs.writeFile);
+
+const {platform} = process;
+
+function getUrl() {
+    const {arch} = process;
+    const baseURL =
+        "https://github.com/WebAssembly/binaryen/releases/download/version_100";
+
+    switch (platform) {
+        case "win32":
+            if (arch === "x64") {
+                return `${baseURL}/binaryen-version_100-x86_64-windows.tar.gz`;
+            }
+            break;
+        case "darwin":
+            if (arch === "arm64") {
+                return `${baseURL}/binaryen-version_100-arm64-macos.tar.gz`;
+            }
+            if (arch === "x64") {
+                return `${baseURL}/binaryen-version_100-x86_64-macos.tar.gz`;
+            }
+            break;
+        case "linux":
+            if (arch === "x64") {
+                return `${baseURL}/binaryen-version_100-x86_64-linux.tar.gz`;
+            }
+            break;
+    }
+
+    throw new Error("\x1b[33mThis platform not supported\x1b[0m");
+}
+
+const EXECUTABLE_FILENAME = platform === "win32" ? "wasm-opt.exe" : "wasm-opt";
+
+exports.download_wasm_opt = async function download_wasm_opt() {
+    try {
+        const binariesOutputPath = path.resolve(__dirname, "binaries.tar");
+        const binaryUrl = getUrl();
+        const binaryResponse = await fetch(binaryUrl);
+        const binary = await binaryResponse.buffer();
+        await writeFile(binariesOutputPath, binary);
+
+        await tar.extract({
+            file: binariesOutputPath,
+            cwd: __dirname,
+            filter: (_path, stat) => {
+                const {path: filePath} = stat.header;
+
+                return [
+                    EXECUTABLE_FILENAME,
+                    "libbinaryen.dylib",
+                    "libbinaryen.a",
+                    "binaryen.lib",
+                ].some((filename) => filePath.endsWith(filename));
+            },
+        });
+
+        const libName = {
+            win32: "binaryen.lib",
+            linux: "libbinaryen.a",
+            darwin: "libbinaryen.dylib",
+        };
+
+        const libFolderName = {
+            win32: "lib",
+            linux: "lib64",
+            darwin: "lib",
+        };
+
+        const libFolder = "lib";
+
+        const unpackedFolder = path.resolve(__dirname, "binaryen-version_100");
+        const unpackedLibFolder = path.resolve(
+            unpackedFolder,
+            libFolderName[platform]
+        );
+        const unpackedBinFolder = path.resolve(unpackedFolder, "bin");
+        const downloadedWasmOpt = path.resolve(
+            unpackedBinFolder,
+            EXECUTABLE_FILENAME
+        );
+        const downloadedLibbinaryen = path.resolve(
+            unpackedLibFolder,
+            libName[platform]
+        );
+        const outputWasmOpt = path.resolve(
+            __dirname,
+            libFolder,
+            EXECUTABLE_FILENAME
+        );
+        const outputLibbinaryen = path.resolve(
+            __dirname,
+            `${libFolder}/${libName[platform]}`
+        );
+
+        try {
+            await mkdir(path.resolve(__dirname, `${libFolder}`));
+        } catch (e) {}
+
+        await copyFile(downloadedWasmOpt, outputWasmOpt);
+        await copyFile(downloadedLibbinaryen, outputLibbinaryen);
+        await unlink(binariesOutputPath);
+        await unlink(downloadedWasmOpt);
+        await unlink(downloadedLibbinaryen);
+        await rmdir(unpackedBinFolder);
+        await rmdir(unpackedLibFolder);
+        await rmdir(unpackedFolder);
+    } catch (e) {
+        throw new Error(`\x1b[31m${e}\x1b[0m`);
+    }
+};


### PR DESCRIPTION
The net effect of these changes is a ~12% code size reduction for `perspective-viewer`.

* Use nightly rust toolchain (but still rust stable language subset).
* Use updated `rustfmt` and `clippy` settings from nightly.
* Remove `wasm-pack` for build (still needed for tests for now due to chromedriver resolution ...)
* Refactor rust to correct new warnings/lint + cleanup.