### PR TITLE
fix group tree headers resize bug

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/plugin.js
+++ b/packages/perspective-viewer-datagrid/src/js/plugin.js
@@ -305,8 +305,7 @@ export class PerspectiveViewerDatagridPluginElement extends HTMLElement {
 
         const overrides = this.datagrid._column_sizes.override;
         const {group_by, columns} = this.model._config;
-        const tree_header_offset =
-            group_by?.length > 0 ? group_by.length + 1 : 0;
+        const tree_header_offset = group_by?.length > 0 ? group_by.length : 0;
 
         const old_sizes = {};
         for (const key of Object.keys(overrides)) {


### PR DESCRIPTION
This PR fixes a bug where tree group columns in a pivoted grid did not maintain any resize overrides between draws