### PR TITLE
fix cmake build error when install under virtualenv

### DIFF
--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -14,6 +14,7 @@ import platform
 import re
 import subprocess
 import sys
+import sysconfig
 from codecs import open
 from distutils.version import LooseVersion
 
@@ -129,6 +130,12 @@ class PSPBuild(build_ext):
             "-DPython_ADDITIONAL_VERSIONS={}".format(PYTHON_VERSION),
             "-DPython_FIND_VERSION={}".format(PYTHON_VERSION),
             "-DPython_EXECUTABLE={}".format(sys.executable).replace("\\", "/"),
+            "-DPYTHON_LIBRARY={}".format(sysconfig.get_config_var("LIBDIR")).replace(
+                "\\", "/"
+            ),
+            "-DPYTHON_INCLUDE_DIR={}".format(
+                sysconfig.get_config_var("INCLUDEPY")
+            ).replace("\\", "/"),
             "-DPython_ROOT_DIR={}".format(sys.prefix).replace("\\", "/"),
             "-DPython_ROOT={}".format(sys.prefix).replace("\\", "/"),
             "-DPSP_CMAKE_MODULE_PATH={folder}".format(


### PR DESCRIPTION
CMake's ```FindPythonLibs``` is not working very well under virtualenv. We need to set ```PYTHON_LIBRARY``` and ```PYTHON_INCLUDE_DIR``` to help CMake locate the relevant directories.

PS: This new one is created because I can't change the source branch of PR  https://github.com/finos/perspective/pull/1777