### PR TITLE
Fix `perspective-workspace` webpack compat

### DIFF
--- a/packages/perspective-workspace/build.js
+++ b/packages/perspective-workspace/build.js
@@ -29,7 +29,9 @@ const BUILD = [
             InlineCSSPlugin(),
             IgnoreCSSPlugin(),
             IgnoreFontsPlugin(),
-            NodeModulesExternal(),
+
+            // Inlining `lumino` and importing the `.ts` source saves _50kb_
+            NodeModulesExternal("@lumino"),
         ],
         loader: {
             ".html": "text",

--- a/tools/perspective-build/external.js
+++ b/tools/perspective-build/external.js
@@ -1,11 +1,13 @@
-exports.NodeModulesExternal = function NodeModulesExternal() {
+exports.NodeModulesExternal = function NodeModulesExternal(whitelist) {
     function setup(build) {
         build.onResolve({filter: /^[A-Za-z0-9\@]/}, (args) => {
-            return {
-                path: args.path,
-                external: true,
-                namespace: "skip-node-modules",
-            };
+            if (!whitelist || !args.path.startsWith(whitelist)) {
+                return {
+                    path: args.path,
+                    external: true,
+                    namespace: "skip-node-modules",
+                };
+            }
         });
     }
 


### PR DESCRIPTION
Tree-shaking for neither `esbuild` nor `webpack` live up to the kb discount of importing the implementation source `.ts` files rather than the pre-compiled es6 `dist/` versions, ~50kb of difference in `perspective-workspace`.  However, `webpack` requires yet another custom loader for `perspective-webpack-plugin` to selectively compile the TypeScript.  Rather than add this, this PR instead inlines the `@lumino` includes in `@finos/perspective-workspce/dist/esm`.

TL;DR `@finos/perspective-workspce` works and is 50kb smaller.