### PR TITLE
Make toggle-menu more responsive under load

### DIFF
--- a/packages/perspective-workspace/src/js/workspace/workspace.js
+++ b/packages/perspective-workspace/src/js/workspace/workspace.js
@@ -728,8 +728,6 @@ export class PerspectiveWorkspace extends SplitPanel {
                         }
                     }
 
-                    console.log(this.viewers);
-
                     submenu.title.label = "New Table";
 
                     return submenu;


### PR DESCRIPTION
This PR adds a 500ms timeout to the settings toggle's plugin draw invocation.  Typically, opening/closing the settings menu will await a resized draw completion before removing the settings UI from the DOM, which reduces screen-shearing;  however, when the engine is very busy, this may create an unacceptable delay.  We now timeout this call, which creates some screen-shearing as the plugin later catches up and redraws at the new canvas size, but keeps the UI responsive even when the engine is under heavy load.