### PR TITLE
Fix jupyterlab test timeouts

### DIFF
--- a/packages/perspective-jupyterlab/test/jupyter/utils.js
+++ b/packages/perspective-jupyterlab/test/jupyter/utils.js
@@ -108,12 +108,21 @@ module.exports = {
         await page.waitForSelector(".jp-NotebookPanel-toolbar", {
             visible: true,
         });
-        await page.waitForTimeout(1000);
+
+        // wait for a cell to be active
+        await page.waitForSelector(
+            '.jp-Notebook-ExecutionIndicator:not([data-status="idle"])',
+            {timeout: 3000}
+        );
+
+        await page.waitForSelector(
+            '.jp-Notebook-ExecutionIndicator[data-status="idle"]',
+            {timeout: 3000}
+        );
 
         // Use our custom keyboard shortcut to run all cells
         await page.keyboard.press("R");
         await page.keyboard.press("R");
-
         await page.evaluate(() => (document.scrollTop = 0));
     },
 };

--- a/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
+++ b/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
@@ -15,13 +15,13 @@ const default_body = async (page) => {
     await execute_all_cells(page);
     const viewer = await page.waitForSelector(
         ".jp-OutputArea-output perspective-viewer",
-        {visible: true, timeout: 1200000}
+        {visible: true, timeout: 30000}
     );
     await viewer.evaluate(async (viewer) => await viewer.flush());
     return viewer;
 };
 
-jest.setTimeout(1200000);
+jest.setTimeout(30000);
 
 utils.with_jupyterlab(process.env.__JUPYTERLAB_PORT__, () => {
     describe.jupyter(


### PR DESCRIPTION
I _believe_ this fixes the persistent Jupyter test failures which have plagued our CI recently, though the nature of intermittent test failures on CI means I cannot be _certain_.

Replaces an arbitrary timeout with a `waitForSelector()` that tests for the presence of an `"idle"` kernel before executing a keyboard command to run Jupyter cells.  Though I am not sure this was the source of the timeout on CI, removing this 1000ms timeout consistently failed these tests, and in non-headless mode I observed instances of the keyboard commands firing before the kernel reported `"idle"`. 