### PR TITLE
remove separate mock dependency, now part of unittest

### DIFF
--- a/docker/python/manylinux2010/Dockerfile
+++ b/docker/python/manylinux2010/Dockerfile
@@ -39,10 +39,10 @@ RUN cp -arf /opt/python/cp39-cp39/* /usr/local/
 ENV PATH=/usr/local/bin:$PATH
 
 # Install dependencies
-RUN python3.6 -m pip install numpy scipy pybind11 cython codecov mock black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
-RUN python3.7 -m pip install numpy scipy pybind11 cython codecov mock black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
-RUN python3.8 -m pip install numpy scipy pybind11 cython codecov mock black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
-RUN python3.9 -m pip install numpy scipy pybind11 cython codecov mock black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
+RUN python3.6 -m pip install numpy scipy pybind11 cython black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
+RUN python3.7 -m pip install numpy scipy pybind11 cython black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
+RUN python3.8 -m pip install numpy scipy pybind11 cython black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
+RUN python3.9 -m pip install numpy scipy pybind11 cython black>=20 flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
 
 # Install Auditwheel - not available on Python 2
 RUN python3.6 -m pip install --ignore-installed auditwheel

--- a/docker/python/manylinux2014/Dockerfile
+++ b/docker/python/manylinux2014/Dockerfile
@@ -38,10 +38,10 @@ RUN cp -arf /opt/python/cp39-cp39/* /usr/local/
 ENV PATH=/usr/local/bin:$PATH
 
 # Install dependencies
-RUN python3.6 -m pip install numpy scipy pybind11 cython codecov mock "black==20.8b1" flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
-RUN python3.7 -m pip install numpy scipy pybind11 cython codecov mock "black==20.8b1" flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
-RUN python3.8 -m pip install numpy scipy pybind11 cython codecov mock "black==20.8b1" flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
-RUN python3.9 -m pip install numpy scipy pybind11 cython codecov mock "black==20.8b1" flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
+RUN python3.6 -m pip install numpy scipy pybind11 cython "black==20.8b1" flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
+RUN python3.7 -m pip install numpy scipy pybind11 cython "black==20.8b1" flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
+RUN python3.8 -m pip install numpy scipy pybind11 cython "black==20.8b1" flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
+RUN python3.9 -m pip install numpy scipy pybind11 cython "black==20.8b1" flake8-black pytest pytest-cov traitlets ipywidgets faker psutil
 
 # Install Auditwheel - not available on Python 2
 RUN python3.6 -m pip install --ignore-installed auditwheel

--- a/python/perspective/perspective/tests/core/test_layout.py
+++ b/python/perspective/perspective/tests/core/test_layout.py
@@ -7,7 +7,7 @@
 #
 
 import pandas as pd
-from mock import patch
+from unittest.mock import patch
 from perspective import PerspectiveWidget, Plugin, PerspectiveError
 
 

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -51,7 +51,6 @@ requires_dev = [
     "Faker>=1.0.0",
     "flake8>=3.7.8",
     "flake8-black>=0.2.0",
-    "mock",
     "psutil",
     "pybind11>=2.4.0",
     "pytest>=4.3.0",


### PR DESCRIPTION
Just a small PR top remove the separate `mock` dependency. 