### PR TITLE
fix bug in setup.js where extra set of quotes prevents initial build

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -40,7 +40,7 @@ const CONFIG = new Proxy(
         write() {
             fs.writeFileSync("./.perspectiverc", this.config.join("\n"));
             if (process.env.PSP_BUILD_IMMEDIATELY) {
-                execute`"node scripts/build.js"`;
+                execute`node scripts/build.js`;
             }
         }
     })(),


### PR DESCRIPTION
Fixes a bug in setup.js where extra set of quotes in the execution command prevents initial build (tries to execute contents of the double quotes as a single executable). 

Before:
<img width="987" alt="Screen Shot 2022-06-01 at 1 54 48 PM" src="https://user-images.githubusercontent.com/3105306/171471368-9206a8c3-0213-45f3-b2ff-9de2b7e551ea.png">


After:
<img width="533" alt="Screen Shot 2022-06-01 at 1 56 37 PM" src="https://user-images.githubusercontent.com/3105306/171471498-4bb3a30b-763b-4c8f-9eb6-b440348bd439.png">

