### PR TITLE
Fix scrolling in Chrome 102

### DIFF
--- a/rust/perspective-viewer/src/themes/material-dark.less
+++ b/rust/perspective-viewer/src/themes/material-dark.less
@@ -84,7 +84,7 @@ perspective-expression-editor[theme="Material Dark"],
         }
     }
 
-    regular-table::-webkit-scrollbar-thumb {
+    regular-table:hover::-webkit-scrollbar-thumb {
         background-color: @grey500;
     }
 

--- a/rust/perspective-viewer/src/themes/material.less
+++ b/rust/perspective-viewer/src/themes/material.less
@@ -190,27 +190,41 @@ perspective-expression-editor[theme="Material Light"],
     --toolbar-edit-mode--content: "edit_off";
     --toolbar-edit-mode-active--content: "edit";
 
+    // // This no long works on Chrome 102.x/canary.
+    // // `-webkit-mask-image` causes scroll events to be surpressed for some
+    // // ****** reason.
+
+    // regular-table::-webkit-scrollbar-thumb {
+    //     background-color: #e0e4e9;
+    // }
+
+    // regular-table {
+    //     mask-image: ~"linear-gradient(black, black)",
+    //         ~"linear-gradient(to top, transparent 10%, black 90%)",
+    //         ~"linear-gradient(to left, transparent 10%, black 90%)";
+    //     -webkit-mask-image: ~"linear-gradient(black, black)",
+    //         ~"linear-gradient(to top, transparent 10%, black 90%)",
+    //         ~"linear-gradient(to left, transparent 10%, black 90%)";
+    //     mask-position: ~"-12px -12px", ~"bottom right", ~"bottom right";
+    //     -webkit-mask-position: ~"-12px -12px", ~"bottom right", ~"bottom right";
+    //     mask-size: ~"100% 100%", ~"12px 1000%", ~"1000% 12px";
+    //     -webkit-mask-size: ~"100% 100%", ~"12px 1000%", ~"1000% 12px";
+    //     mask-repeat: no-repeat;
+    //     -webkit-mask-repeat: no-repeat;
+    //     transition: -webkit-mask-position 0.3s, mask-position 0.3s;
+    //     &:hover {
+    //         mask-position: ~"-12px -12px", ~"top right", ~"bottom left";
+    //         -webkit-mask-position: ~"-12px -12px", ~"top right", ~"bottom left";
+    //     }
+    // }
+
+    // // Instead just change the `background-color`.
+
     regular-table::-webkit-scrollbar-thumb {
-        background-color: #e0e4e9;
+        background-color: transparent;
     }
 
-    regular-table {
-        mask-image: ~"linear-gradient(black, black)",
-            ~"linear-gradient(to top, transparent 10%, black 90%)",
-            ~"linear-gradient(to left, transparent 10%, black 90%)";
-        -webkit-mask-image: ~"linear-gradient(black, black)",
-            ~"linear-gradient(to top, transparent 10%, black 90%)",
-            ~"linear-gradient(to left, transparent 10%, black 90%)";
-        mask-position: ~"-12px -12px", ~"bottom right", ~"bottom right";
-        -webkit-mask-position: ~"-12px -12px", ~"bottom right", ~"bottom right";
-        mask-size: ~"100% 100%", ~"12px 1000%", ~"1000% 12px";
-        -webkit-mask-size: ~"100% 100%", ~"12px 1000%", ~"1000% 12px";
-        mask-repeat: no-repeat;
-        -webkit-mask-repeat: no-repeat;
-        transition: -webkit-mask-position 0.3s, mask-position 0.3s;
-        &:hover {
-            mask-position: ~"-12px -12px", ~"top right", ~"bottom left";
-            -webkit-mask-position: ~"-12px -12px", ~"top right", ~"bottom left";
-        }
+    regular-table:hover::-webkit-scrollbar-thumb {
+        background-color: #e0e4e9;  
     }
 }

--- a/rust/perspective-viewer/src/themes/solarized-dark.less
+++ b/rust/perspective-viewer/src/themes/solarized-dark.less
@@ -58,7 +58,7 @@ perspective-expression-editor[theme="Solarized Dark"],
         border-top-color: #586e75;
     }
 
-    regular-table::-webkit-scrollbar-thumb {
+    regular-table:hover::-webkit-scrollbar-thumb {
         background-color: var(--inactive--color, #586e75);
     }
 


### PR DESCRIPTION
In the recent release of Chrome 102, scroll events to `perspective-viewer-datagrid` behave differently; in previous versions, "inertia" scroll would trigger events, where-as in version 102.0.5005.61, there additional scroll events would frequently not fire, causing a slow, stuttering scroll experience.  This was observed in versions as far bask as perspective 1.0.0.

In testing, the previous behavior can be restored by removing the `-webkit-mask-image` CSS rules from the scroll container, which simulated fade-in on hover for the custom scrollbars.  This PR removes these rules, reverting this animation to pop-in on hover instead, restoring scroll behavior to mirror pre-102 Chrome.