### PR TITLE
fix bad import in webpack example

### DIFF
--- a/examples/webpack-example/src/index.js
+++ b/examples/webpack-example/src/index.js
@@ -11,7 +11,7 @@ import perspective from "@finos/perspective";
 
 import "@finos/perspective-viewer";
 import "@finos/perspective-viewer-datagrid";
-import "@finos/perspective-viewer-d3fc/bar";
+import "@finos/perspective-viewer-d3fc";
 
 import "@finos/perspective-viewer/dist/css/material-dark.css";
 


### PR DESCRIPTION
CC https://github.com/finos/perspective/discussions/1842

presumably theres some way to just pull in bar but I figured this fixes it and thats not a super important feature to exhibit in this example.