### PR TITLE
Fix `set_threadpool_size(n)` for `n == 1`

### DIFF
--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -617,13 +617,8 @@ t_ctx_grouped_pkey::rebuild() {
         aggindices[idx] = data[idx].m_idx;
     }
 
-#ifdef PSP_PARALLEL_FOR
-    parallel_for(int(naggs),
-        [&aggtable, &aggindices, &aggspecs, &tbl](int aggnum)
-#else
-    for (t_uindex aggnum = 0; aggnum < naggs; ++aggnum)
-#endif
-        {
+    parallel_for(
+        int(naggs), [&aggtable, &aggindices, &aggspecs, &tbl](int aggnum) {
             const t_aggspec& spec = aggspecs[aggnum];
             if (spec.agg() == AGGTYPE_IDENTITY) {
                 auto scol
@@ -632,10 +627,7 @@ t_ctx_grouped_pkey::rebuild() {
                     tbl->get_const_column(spec.get_first_depname()).get(),
                     aggindices, 1);
             }
-        }
-#ifdef PSP_PARALLEL_FOR
-    );
-#endif
+        });
 
     m_traversal = std::shared_ptr<t_traversal>(new t_traversal(m_tree));
 

--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -107,13 +107,13 @@ t_data_table::init(bool make_columns) {
     m_columns = std::vector<std::shared_ptr<t_column>>(m_schema.size());
 
     if (make_columns) {
-        parallel_for(int(m_schema.size()), [this](int idx) {
+        for (t_uindex idx = 0; idx < int(m_schema.size()); ++idx) {
             const std::string& colname = m_schema.m_columns[idx];
             t_dtype dtype = m_schema.m_types[idx];
             m_columns[idx]
                 = make_column(colname, dtype, m_schema.m_status_enabled[idx]);
             m_columns[idx]->init();
-        });
+        }
     }
 
     m_init = true;
@@ -443,9 +443,9 @@ t_data_table::append(const t_data_table& other) {
         }
     }
 
-    parallel_for(int(src_cols.size()), [&src_cols, dst_cols](int colidx) {
+    for (t_uindex colidx = 0; colidx < int(src_cols.size()); ++colidx) {
         dst_cols[colidx]->append(*(src_cols[colidx]));
-    });
+    }
 
     set_capacity(std::max(m_capacity, m_size + other.num_rows()));
     set_size(m_size + other.num_rows());

--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -107,23 +107,13 @@ t_data_table::init(bool make_columns) {
     m_columns = std::vector<std::shared_ptr<t_column>>(m_schema.size());
 
     if (make_columns) {
-#ifdef PSP_PARALLEL_FOR
-        parallel_for(int(m_schema.size()),
-            [this](int idx)
-#else
-        for (t_uindex idx = 0, loop_end = m_schema.size(); idx < loop_end;
-             ++idx)
-#endif
-            {
-                const std::string& colname = m_schema.m_columns[idx];
-                t_dtype dtype = m_schema.m_types[idx];
-                m_columns[idx] = make_column(
-                    colname, dtype, m_schema.m_status_enabled[idx]);
-                m_columns[idx]->init();
-            }
-#ifdef PSP_PARALLEL_FOR
-        );
-#endif
+        parallel_for(int(m_schema.size()), [this](int idx) {
+            const std::string& colname = m_schema.m_columns[idx];
+            t_dtype dtype = m_schema.m_types[idx];
+            m_columns[idx]
+                = make_column(colname, dtype, m_schema.m_status_enabled[idx]);
+            m_columns[idx]->init();
+        });
     }
 
     m_init = true;
@@ -453,17 +443,10 @@ t_data_table::append(const t_data_table& other) {
         }
     }
 
-#ifdef PSP_PARALLEL_FOR
-    parallel_for(int(src_cols.size()),
-        [&src_cols, dst_cols](int colidx)
-#else
-    for (t_uindex colidx = 0, loop_end = src_cols.size(); colidx < loop_end;
-         ++colidx)
-#endif
-        { dst_cols[colidx]->append(*(src_cols[colidx])); }
-#ifdef PSP_PARALLEL_FOR
-    );
-#endif
+    parallel_for(int(src_cols.size()), [&src_cols, dst_cols](int colidx) {
+        dst_cols[colidx]->append(*(src_cols[colidx]));
+    });
+
     set_capacity(std::max(m_capacity, m_size + other.num_rows()));
     set_size(m_size + other.num_rows());
 }

--- a/cpp/perspective/src/cpp/expression_tables.cpp
+++ b/cpp/perspective/src/cpp/expression_tables.cpp
@@ -53,13 +53,8 @@ t_expression_tables::calculate_transitions(
 
     auto num_cols = column_names.size();
 
-#ifdef PSP_PARALLEL_FOR
-    parallel_for(int(num_cols),
-        [&column_names, &existed_column, this](int cidx)
-#else
-    for (t_uindex cidx = 0; cidx < num_cols; ++cidx)
-#endif
-        {
+    parallel_for(
+        int(num_cols), [&column_names, &existed_column, this](int cidx) {
             const std::string& cname = column_names[cidx];
             const t_column& prev_column = *(m_prev->get_const_column(cname));
             const t_column& current_column
@@ -106,10 +101,7 @@ t_expression_tables::calculate_transitions(
 
                 transition_column->set_nth<std::uint8_t>(ridx, transition);
             }
-        }
-#ifdef PSP_PARALLEL_FOR
-    );
-#endif
+        });
 }
 
 void

--- a/cpp/perspective/src/cpp/gnode.cpp
+++ b/cpp/perspective/src/cpp/gnode.cpp
@@ -21,10 +21,10 @@
 #include <perspective/expression_vocab.h>
 
 #include <perspective/utils.h>
+#include <perspective/parallel_for.h>
 
 #ifdef PSP_ENABLE_PYTHON
 #include <perspective/pyutils.h>
-#include <perspective/parallel_for.h>
 #endif
 
 namespace perspective {
@@ -348,13 +348,8 @@ t_gnode::_process_table(t_uindex port_id) {
         = get_output_schema().m_columns;
     t_uindex ncols = column_names.size();
 
-#ifdef PSP_PARALLEL_FOR
-    parallel_for(int(ncols),
-        [&_process_state, &column_names, this](int colidx)
-#else
-    for (t_uindex colidx = 0; colidx < ncols; ++colidx)
-#endif
-        {
+    parallel_for(
+        int(ncols), [&_process_state, &column_names, this](int colidx) {
             const std::string& cname = column_names[colidx];
             auto fcolumn
                 = _process_state.m_flattened_data_table->get_column(cname)
@@ -438,10 +433,7 @@ t_gnode::_process_table(t_uindex port_id) {
                     PSP_COMPLAIN_AND_ABORT("Unsupported column dtype");
                 }
             }
-        }
-#ifdef PSP_PARALLEL_FOR
-    );
-#endif
+        });
 
     /**
      * After all columns have been processed (transitional tables written into),
@@ -774,16 +766,9 @@ t_gnode::_update_contexts_from_state(std::shared_ptr<t_data_table> tbl) {
         }
     };
 
-#ifdef PSP_PARALLEL_FOR
-    parallel_for(int(num_contexts),
-        [&update_contexts_helper](int ctx_idx)
-#else
-    for (t_index ctx_idx = 0; ctx_idx < num_contexts; ++ctx_idx)
-#endif
-        { update_contexts_helper(ctx_idx); }
-#ifdef PSP_PARALLEL_FOR
-    );
-#endif
+    parallel_for(int(num_contexts), [&update_contexts_helper](int ctx_idx) {
+        update_contexts_helper(ctx_idx);
+    });
 }
 
 /**
@@ -997,16 +982,9 @@ t_gnode::notify_contexts(std::shared_ptr<t_data_table> flattened) {
               }
           };
 
-#ifdef PSP_PARALLEL_FOR
-    parallel_for(int(num_contexts),
-        [&notify_context_helper](int ctx_idx)
-#else
-    for (t_index ctx_idx = 0; ctx_idx < num_contexts; ++ctx_idx)
-#endif
-        { notify_context_helper(ctx_idx); }
-#ifdef PSP_PARALLEL_FOR
-    );
-#endif
+    parallel_for(int(num_contexts), [&notify_context_helper](int ctx_idx) {
+        notify_context_helper(ctx_idx);
+    });
 }
 
 /******************************************************************************

--- a/cpp/perspective/src/include/perspective/expression_tables.h
+++ b/cpp/perspective/src/include/perspective/expression_tables.h
@@ -11,10 +11,7 @@
 #include <perspective/base.h>
 #include <perspective/computed_expression.h>
 #include <perspective/data_table.h>
-
-#ifdef PSP_PARALLEL_FOR
 #include <perspective/parallel_for.h>
-#endif
 
 namespace perspective {
 

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -25,9 +25,9 @@
 #include <perspective/expression_tables.h>
 #include <perspective/regex.h>
 #include <tsl/ordered_map.h>
+#include <perspective/parallel_for.h>
 #ifdef PSP_PARALLEL_FOR
 #include <thread>
-#include <perspective/parallel_for.h>
 #endif
 #include <chrono>
 

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -208,7 +208,7 @@ public:
     std::shared_ptr<t_expression_vocab> get_expression_vocab() const;
     std::shared_ptr<t_regex_mapping> get_expression_regex_mapping() const;
 
-#ifdef PSP_PARALLEL_FOR
+#ifdef PSP_ENABLE_PYTHON
     void set_event_loop_thread_id(std::thread::id id);
 #endif
 

--- a/cpp/perspective/src/include/perspective/parallel_for.h
+++ b/cpp/perspective/src/include/perspective/parallel_for.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef PSP_ENABLE_PYTHON
+#ifdef PSP_PARALLEL_FOR
 #include <arrow/util/parallel.h>
 #include <arrow/status.h>
 #endif
@@ -19,10 +19,16 @@ namespace perspective {
 template <class FUNCTION>
 void
 parallel_for(int num_tasks, FUNCTION&& func) {
+#ifdef PSP_PARALLEL_FOR
     auto status = arrow::internal::ParallelFor(num_tasks, func);
     if (!status.ok()) {
         PSP_COMPLAIN_AND_ABORT("ParallelFor failed");
     }
+#else
+    for (t_uindex aggnum = 0; aggnum < num_tasks; ++aggnum) {
+        func(aggnum);
+    }
+#endif
 }
 
 } // namespace perspective

--- a/python/perspective/docs/perspective.core.rst
+++ b/python/perspective/docs/perspective.core.rst
@@ -5,6 +5,8 @@ Additionally, ``perspective.core`` defines several enums that provide easy acces
 
 For usage of ``PerspectiveWidget`` and ``PerspectiveTornadoHandler``, see the User Guide in the sidebar.
 
+.. autofunction:: perspective.set_threadpool_size
+
 .. automodule:: perspective.core
    :members:
    :show-inheritance:

--- a/python/perspective/perspective/libpsp.py
+++ b/python/perspective/perspective/libpsp.py
@@ -30,8 +30,11 @@ try:
 
     def set_threadpool_size(nthreads):
         """Sets the size of the global Perspective thread pool, up to the
-        total number of available cores, which can be set explicity by
-        setting `nthreads` to `None`.
+        total number of available cores.  Passing an explicit
+        `None` sets this limit to the detected hardware concurrency from the
+        environment, which is also the default if this method is never called.
+        `set_threadpool_size()` must be called before any other
+        `perspective-python` API calls, and cannot be changed after such a call.
         """
         os.environ["OMP_THREAD_LIMIT"] = "0" if nthreads is None else str(nthreads)
 

--- a/python/perspective/perspective/tests/single_threaded/test_single_threaded.py
+++ b/python/perspective/perspective/tests/single_threaded/test_single_threaded.py
@@ -1,0 +1,56 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+import pandas as pd
+from perspective import Table, set_threadpool_size
+
+set_threadpool_size(1)
+
+
+class TestThreadPoolOne:
+    def test_threadpool_one_does_not_block_view(self):
+        t = Table(
+            {"id": int, "symbol": str, "valid": bool, "value": int, "value2": int},
+            index="id",
+        )
+        t.update(
+            [
+                {"id": 1, "symbol": "A", "valid": False, "value": 5, "value2": 15},
+                {"id": 2, "symbol": "A", "valid": True, "value": 10, "value2": 20},
+            ]
+        )
+
+        v = t.view(
+            columns=["symbol", "value", "value3"],
+            expressions=["""//value3\n"value" + "value2\""""],
+        )
+
+        v_agg = t.view(
+            columns=["symbol", "value", "value3"],
+            expressions=["""//value3\n"value" + "value2\""""],
+            group_by=["symbol"],
+            aggregates={"symbol": "first", "value": "sum", "value2": "sum"},
+        )
+
+        assert v.to_df().to_dict("records") == [
+            {"symbol": "A", "value": 5, "value3": 20.0},
+            {"symbol": "A", "value": 10, "value3": 30.0},
+        ]
+
+        assert v_agg.to_df().to_dict("records") == [
+            {"__ROW_PATH__": [], "symbol": "A", "value": 15, "value3": 50.0},
+            {"__ROW_PATH__": ["A"], "symbol": "A", "value": 15, "value3": 50.0},
+        ]


### PR DESCRIPTION
* Fixes a deadlock condition when `set_threadpool_size(1)` was called in Python.
* Add documentation to `set_threadpool_size()` to note that it must be called before the global thread pool is instantiated.
* Removed sloppy `parallel_for()` API in C++.  Confirmed that this generates nearly identical bytecode in wasm/release, and confirmed no benchmark regressions in single- or mult- threaded runtimes.
* Cherrypick #1851 