### PR TITLE
Remove unused watch commands from viewer-d3fc and viewer-datagrid, remove dependabot, dont trigger full build on merge to master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
         env:
           SKIP_CI: ${{ contains(github.event.head_commit.message, '[ci-skip]') }}
           SKIP_CACHE: ${{ contains(github.event.head_commit.message, '[ci-skip-cache]') }}
-          FULL_RUN: ${{ startsWith(github.ref, 'refs/heads/v') || contains(github.ref, 'master') || contains(github.event.head_commit.message, '[ci-full]') }}
+          FULL_RUN: ${{ startsWith(github.ref, 'refs/heads/v') || contains(github.event.head_commit.message, '[ci-full]') }}
           SKIP_PYTHON: ${{ contains(github.event.head_commit.message, '[ci-skip-python]') }}
           INCLUDE_WINDOWS: ${{ contains(github.event.head_commit.message, '[ci-include-windows]') }}
         if: ${{ github.event_name == 'push' }}

--- a/packages/perspective-viewer-d3fc/package.json
+++ b/packages/perspective-viewer-d3fc/package.json
@@ -37,7 +37,7 @@
         "prebuild": "mkdirp dist/esm",
         "build": "node ./build.js",
         "test:build": "cpy --cwd test \"html/*\" ../dist/umd",
-        "watch": "webpack --color --watch --config src/config/d3fc.watch.config.js",
+        "watch": ":",
         "test:run": "jest --rootDir=. --config=../../tools/perspective-test/jest.config.js --color",
         "test": "npm-run-all test:build test:run",
         "clean": "rimraf dist",

--- a/packages/perspective-viewer-datagrid/package.json
+++ b/packages/perspective-viewer-datagrid/package.json
@@ -26,7 +26,7 @@
         "test:build": "cpy \"test/html/*\" dist/umd",
         "test:run": "jest --rootDir=. --config=../../tools/perspective-test/jest.config.js --color",
         "test": "npm-run-all test:build test:run",
-        "watch": "npm-run-all -p watch:*",
+        "watch": ":",
         "clean": "rimraf dist",
         "clean:screenshots": "rimraf \"test/screenshots/**/*.@(failed|diff).png\""
     },


### PR DESCRIPTION
As discussed offline, removing the default dependabot upgrading, we will upgrade manually in response to features or bug fixes we want. Also removing the full build from merges to master, we can easily trigger manually and we will still build full on tags. 

Finally, removing some unused watch commands discovered during other development. 