### PR TITLE
Update `emsdk` to `3.1.14`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ on:
       - docs/
       - examples/
       - python/perspective/README.md
-  pull_request:
   workflow_dispatch:
     inputs:
       ci-full:
@@ -765,12 +764,12 @@ jobs:
           - is-full-run: false
             os: windows-2019
 
-          # Exclude Macos 10.11 bulds
+          # Exclude Macos bulds
           - is-full-run: false
             os: macos-10.15
 
           - is-full-run: false
-            os: macos-10.11
+            os: macos-11
 
           # Exclude Python 3.7 and 3.8 builds
           - is-full-run: false
@@ -1247,6 +1246,9 @@ jobs:
             os: macos-10.15
 
           # Exclude Python 3.7 and 3.8 builds
+          - is-full-run: false
+            os: macos-11
+
           - is-full-run: false
             python-version: 3.7
 

--- a/cmake/arrow/CMakeLists.txt
+++ b/cmake/arrow/CMakeLists.txt
@@ -18,6 +18,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 set(ARROW_SRCS
+
     # Base
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/array/array_base.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/array/array_binary.cc
@@ -57,6 +58,7 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/table.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/table_builder.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/tensor.cc
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/tensor/coo_converter.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/tensor/csf_converter.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/tensor/csx_converter.cc
@@ -66,6 +68,7 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/io/buffered.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/io/caching.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/io/compressed.cc
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/io/file.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/io/interfaces.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/io/memory.cc
@@ -119,6 +122,7 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/vendored/double-conversion/fixed-dtoa.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/vendored/double-conversion/diy-fp.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/vendored/double-conversion/strtod.cc
+
     # CSV
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/csv/converter.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/csv/chunker.cc
@@ -128,6 +132,7 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/csv/parser.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/csv/reader.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/csv/writer.cc
+
     # IPC
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/dictionary.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/feather.cc
@@ -136,15 +141,18 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/options.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/reader.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/writer.cc
+
     # Compute
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/api_aggregate.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/api_scalar.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/api_vector.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/cast.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec.cc
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/aggregate_node.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/exec_plan.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/expression.cc
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/filter_node.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/project_node.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/source_node.cc
@@ -153,6 +161,7 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/function.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/function_internal.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernel.cc
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/registry.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/aggregate_basic.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -160,6 +169,7 @@ set(ARROW_SRCS
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/codegen_internal.cc
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/hash_aggregate.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_boolean.cc
@@ -170,6 +180,7 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_compare.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_nested.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -179,11 +190,13 @@ set(ARROW_SRCS
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_validity.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/scalar_if_else.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/util_internal.cc
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/vector_array_sort.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/vector_hash.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/vector_nested.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/vector_replace.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/vector_selection.cc
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/vector_sort.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/row_encoder.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/union_node.cc
@@ -196,15 +209,16 @@ set(ARROW_SRCS
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/hash_join.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/hash_join_node.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/task_util.cc
-    )
+)
 
-if (PSP_PYTHON_BUILD)
+if(PSP_PYTHON_BUILD)
     set(ARROW_SRCS
         ${ARROW_SRCS}
         ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/io/file.cc
         ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/tensor/coo_converter.cc
         ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/tensor/csf_converter.cc
         ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/tensor/csx_converter.cc
+
         # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/util/time.cc
         # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/vendored/double-conversion/bignum-dtoa.cc
         # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/vendored/double-conversion/fast-dtoa.cc
@@ -219,8 +233,8 @@ if (PSP_PYTHON_BUILD)
 endif()
 
 set_property(SOURCE util/io_util.cc
-           APPEND_STRING
-           PROPERTY COMPILE_FLAGS " -Wno-unused-macros -stdlib=libc++")
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-unused-macros -stdlib=libc++")
 
 # # make clean will delete the generated file
 # set_source_files_properties(${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/Message_generated.h PROPERTIES GENERATED TRUE)
@@ -231,26 +245,26 @@ set_property(SOURCE util/io_util.cc
 # set_source_files_properties(${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/feather_generated.h PROPERTIES GENERATED TRUE)
 
 # set(FBS_OUTPUT_FILES
-#     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/Message_generated.h
-#     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/File_generated.h
-#     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/Schema_generated.h
-#     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/Tensor_generated.h
-#     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/SparseTensor_generated.h
-#     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/feather_generated.h)
+# ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/Message_generated.h
+# ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/File_generated.h
+# ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/Schema_generated.h
+# ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/Tensor_generated.h
+# ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/SparseTensor_generated.h
+# ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/feather_generated.h)
 
 # set(FBS_SRC
-#     ${CMAKE_BINARY_DIR}/arrow-src/format/Message.fbs
-#     ${CMAKE_BINARY_DIR}/arrow-src/format/File.fbs
-#     ${CMAKE_BINARY_DIR}/arrow-src/format/Schema.fbs
-#     ${CMAKE_BINARY_DIR}/arrow-src/format/Tensor.fbs
-#     ${CMAKE_BINARY_DIR}/arrow-src/format/SparseTensor.fbs
-#     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/feather.fbs)
-
+# ${CMAKE_BINARY_DIR}/arrow-src/format/Message.fbs
+# ${CMAKE_BINARY_DIR}/arrow-src/format/File.fbs
+# ${CMAKE_BINARY_DIR}/arrow-src/format/Schema.fbs
+# ${CMAKE_BINARY_DIR}/arrow-src/format/Tensor.fbs
+# ${CMAKE_BINARY_DIR}/arrow-src/format/SparseTensor.fbs
+# ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/feather.fbs)
 include_directories(src)
 
 # Build Arrow as a static library
 set(ARROW_BUILD_STATIC ON)
-if (PSP_WASM_BUILD)
+
+if(PSP_WASM_BUILD)
     set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
 elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -272,14 +286,13 @@ target_link_libraries(arrow
 # find_package(Flatbuffers)
 
 # add_custom_command(OUTPUT ${FBS_OUTPUT_FILES}
-#                    COMMAND ${FLATBUFFERS_COMPILER}
-#                            -c
-#                            -o
-#                            ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/
-#                            ${FBS_SRC}
-#                    DEPENDS ${FLATBUFFERS_COMPILER}
-#                    COMMENT "Running flatc compiler on ${FBS_SRC}"
-#                    VERBATIM)
-
+# COMMAND ${FLATBUFFERS_COMPILER}
+# -c
+# -o
+# ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/
+# ${FBS_SRC}
+# DEPENDS ${FLATBUFFERS_COMPILER}
+# COMMENT "Running flatc compiler on ${FBS_SRC}"
+# VERBATIM)
 add_custom_target(arrow_fb_files DEPENDS ${FBS_OUTPUT_FILES})
 add_dependencies(arrow arrow_fb_files)

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -259,8 +259,8 @@ if(PSP_WASM_BUILD)
     # ###################
     execute_process(COMMAND which emcc OUTPUT_VARIABLE EMCC)
     execute_process(COMMAND which em++ OUTPUT_VARIABLE EMPP)
-    string(STRIP ${EMCC} EMCC)
-    string(STRIP ${EMPP} EMPP)
+    string(STRIP "${EMCC}" EMCC)
+    string(STRIP "${EMPP}" EMPP)
     set(CMAKE_C_COMPILER ${EMCC})
     set(CMAKE_CXX_COMPILER ${EMPP})
     set(CMAKE_TOOLCHAIN_FILE "$ENV{EMSCRIPTEN_ROOT}/cmake/Modules/Platform/Emscripten.cmake")
@@ -622,6 +622,7 @@ if(PSP_WASM_BUILD)
         --bind \
         --source-map-base \"\" \
         --memory-init-file 0 \
+        --no-entry \
         -s EXPORT_ES6=1 \
         -s NO_EXIT_RUNTIME=1 \
         -s NO_FILESYSTEM=1 \
@@ -630,7 +631,6 @@ if(PSP_WASM_BUILD)
         -s EXPORT_NAME=\"load_perspective\" \
         -s MAXIMUM_MEMORY=4gb \
         -s USE_ES6_IMPORT_META=0 \
-        -s EXPORTED_FUNCTIONS=\"['_main']\" \
         -s ERROR_ON_UNDEFINED_SYMBOLS=1 \
     ")
 

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -639,20 +639,11 @@ if(PSP_WASM_BUILD)
     set_target_properties(psp PROPERTIES COMPILE_FLAGS "")
     target_link_libraries(psp arrow re2)
 
-    # "esm/perspective.cpp.js" from CMAKE_EXECUTABLE_SYNTAX
-    add_executable(perspective_esm src/cpp/emscripten.cpp)
-    target_link_libraries(perspective_esm psp)
-    target_link_options(perspective_esm PRIVATE -s ENVIRONMENT=worker)
-    target_compile_definitions(perspective_esm PRIVATE PSP_ENABLE_WASM=1)
-    set_target_properties(perspective_esm PROPERTIES RUNTIME_OUTPUT_DIRECTORY "./esm/")
-    set_target_properties(perspective_esm PROPERTIES OUTPUT_NAME "perspective.cpp")
-
     # "cjs/perspective.cpp.js" from CMAKE_EXECUTABLE_SYNTAX
     add_executable(perspective_cjs src/cpp/emscripten.cpp)
     target_link_libraries(perspective_cjs psp)
-    target_link_options(perspective_cjs PRIVATE -s ENVIRONMENT=node)
     target_compile_definitions(perspective_cjs PRIVATE PSP_ENABLE_WASM=1)
-    set_target_properties(perspective_cjs PROPERTIES RUNTIME_OUTPUT_DIRECTORY "./cjs/")
+    set_target_properties(perspective_cjs PROPERTIES RUNTIME_OUTPUT_DIRECTORY "./esm/")
     set_target_properties(perspective_cjs PROPERTIES OUTPUT_NAME "perspective.cpp")
 elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
     if(NOT WIN32)

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_policy(SET CMP0077 NEW)
 #
 # - https://github.com/actions/virtual-environments/issues/687
 # - https://github.com/actions/virtual-environments/issues/319
-# 
+#
 # `BOOST_ROOT` must be set in the environment, and policy CMP0074
 # must be set to `NEW` to allow BOOST_ROOT to be defined by env var
 cmake_policy(SET CMP0074 NEW)
@@ -26,6 +26,7 @@ cmake_policy(SET CMP0094 NEW)
 if(NOT DEFINED PSP_CMAKE_MODULE_PATH)
     set(PSP_CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake/")
 endif()
+
 set(CMAKE_MODULE_PATH "${PSP_CMAKE_MODULE_PATH}/modules" ${CMAKE_MODULE_PATH})
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -42,9 +43,10 @@ else()
     set(LINUX ON)
 endif()
 
-## Helper function
+# # Helper function
 function(string_starts_with str search)
     string(FIND "${str}" "${search}" out)
+
     if("${out}" EQUAL 0)
         return(true)
     endif()
@@ -52,14 +54,15 @@ function(string_starts_with str search)
 endfunction()
 
 set(BUILD_MESSAGE "")
-function (psp_build_message message)
+
+function(psp_build_message message)
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${message}")
 endfunction()
 
-###################################################
+# ##################################################
 # Helper to grab dependencies from remote sources #
-###################################################
-function (psp_build_dep name cmake_file)
+# ##################################################
+function(psp_build_dep name cmake_file)
     if(EXISTS ${CMAKE_BINARY_DIR}/${name}-build)
         psp_build_message("${Cyan}Dependency found - not rebuilding - ${CMAKE_BINARY_DIR}/${name}-build${ColorReset}")
     else()
@@ -67,7 +70,7 @@ function (psp_build_dep name cmake_file)
 
         execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
             RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${name}-download )
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${name}-download)
 
         if(result)
             message(FATAL_ERROR "CMake step for ${name} failed: ${result}")
@@ -75,7 +78,7 @@ function (psp_build_dep name cmake_file)
 
         execute_process(COMMAND ${CMAKE_COMMAND} --build .
             RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${name}-download )
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${name}-download)
 
         if(result)
             message(FATAL_ERROR "Build step for ${name} failed: ${result}")
@@ -112,12 +115,12 @@ function (psp_build_dep name cmake_file)
         include_directories(${CMAKE_BINARY_DIR}/${name}-src)
     endif()
 endfunction()
-##############################
 
+# #############################
 
-#######################
+# ######################
 # BUILD CONFIGURATION #
-#######################
+# ######################
 find_package(Color)
 
 # OPTIONS
@@ -127,21 +130,20 @@ option(PSP_CPP_BUILD "Build the C++ Project" OFF)
 option(PSP_PYTHON_BUILD "Build the Python Bindings" OFF)
 option(PSP_CPP_BUILD_STRICT "Build the C++ with strict warnings" OFF)
 
-if (NOT DEFINED PSP_WASM_BUILD)
+if(NOT DEFINED PSP_WASM_BUILD)
     set(PSP_WASM_BUILD ON)
     set(PSP_CPP_BUILD OFF)
     set(PSP_PYTHON_BUILD OFF)
 endif()
 
-if (PSP_WASM_BUILD AND PSP_CPP_BUILD)
+if(PSP_WASM_BUILD AND PSP_CPP_BUILD)
     message(FATAL_ERROR "${Red}CPP and Emscripten builds must be done separately${ColorReset}")
 endif()
-
 
 if(DEFINED ENV{PSP_DEBUG})
     set(CMAKE_BUILD_TYPE DEBUG)
 else()
-    if (NOT DEFINED CMAKE_BUILD_TYPE)
+    if(NOT DEFINED CMAKE_BUILD_TYPE)
         set(CMAKE_BUILD_TYPE RELEASE)
     endif()
 endif()
@@ -157,24 +159,24 @@ if(DEFINED ENV{PSP_USE_CCACHE})
     set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
 endif()
 
-if (NOT DEFINED PSP_CPP_BUILD)
+if(NOT DEFINED PSP_CPP_BUILD)
     set(PSP_CPP_BUILD ON)
 endif()
 
-if (NOT DEFINED PSP_PYTHON_BUILD)
+if(NOT DEFINED PSP_PYTHON_BUILD)
     set(PSP_PYTHON_BUILD OFF)
 elseif(PSP_PYTHON_BUILD)
     # PSP_PYTHON_BUILD will always run PSP_CPP_BUILD
     set(PSP_CPP_BUILD ON)
+
     if(NOT DEFINED PSP_PYTHON_VERSION)
         set(PSP_PYTHON_VERSION 3.7)
     endif()
 endif()
 
-if (NOT DEFINED PSP_CPP_BUILD_STRICT)
+if(NOT DEFINED PSP_CPP_BUILD_STRICT)
     set(PSP_CPP_BUILD_STRICT OFF)
 endif()
-
 
 if(PSP_WASM_BUILD)
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Cyan}Building WASM binding${ColorReset}")
@@ -185,28 +187,31 @@ endif()
 if(NOT DEFINED PSP_CPP_SRC)
     set(PSP_CPP_SRC "${CMAKE_SOURCE_DIR}")
 endif()
+
 if(PSP_CPP_BUILD)
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Cyan}Building C++ binding${ColorReset}")
 else()
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Yellow}Skipping C++ binding${ColorReset}")
 endif()
 
-if (PSP_PYTHON_BUILD)
+if(PSP_PYTHON_BUILD)
     if(NOT DEFINED PSP_PYTHON_SRC)
         set(PSP_PYTHON_SRC "${CMAKE_SOURCE_DIR}/../../python/perspective/perspective")
     endif()
+
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Cyan}Building Python ${Red}${PSP_PYTHON_VERSION}${Cyan} binding${ColorReset}")
 else()
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Yellow}Skipping Python binding${ColorReset}")
 endif()
 
-if (PSP_CPP_BUILD AND NOT PSP_CPP_BUILD_STRICT)
+if(PSP_CPP_BUILD AND NOT PSP_CPP_BUILD_STRICT)
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Yellow}Building C++ without strict warnings${ColorReset}")
 else()
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Cyan}Building C++ with strict warnings${ColorReset}")
 endif()
 
-string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER )
+string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
+
 if(CMAKE_BUILD_TYPE_LOWER STREQUAL debug)
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Red}Building DEBUG${ColorReset}")
     add_definitions(-DPSP_DEBUG)
@@ -214,9 +219,8 @@ else()
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Cyan}Building RELEASE${ColorReset}")
 endif()
 
-
-if (PSP_PYTHON_BUILD AND MACOS)
-    # fix for threads on osx 
+if(PSP_PYTHON_BUILD AND MACOS)
+    # fix for threads on osx
     # assume built-in pthreads on MacOS
     set(CMAKE_THREAD_LIBS_INIT "-lpthread")
     set(CMAKE_HAVE_THREADS_LIBRARY 1)
@@ -242,19 +246,17 @@ if (PSP_PYTHON_BUILD AND MACOS)
     endif()
 endif()
 
-
-#######################
+# ######################
 include_directories("${CMAKE_SOURCE_DIR}/src/include")
 
 # if(NOT WIN32)
-#     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
-#     set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
+# set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+# set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
 # endif()
-
-if (PSP_WASM_BUILD)
-    ####################
+if(PSP_WASM_BUILD)
+    # ###################
     # EMSCRIPTEN BUILD #
-    ####################
+    # ###################
     execute_process(COMMAND which emcc OUTPUT_VARIABLE EMCC)
     execute_process(COMMAND which em++ OUTPUT_VARIABLE EMPP)
     string(STRIP ${EMCC} EMCC)
@@ -325,6 +327,7 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
                 ")
         endif()
     endif()
+
     set(ASYNC_MODE_FLAGS "")
 
     # Boost is a system dependency and must be present and built on the system.
@@ -334,9 +337,9 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         message(FATAL_ERROR "${Red}Boost could not be located${ColorReset}")
     else()
         psp_build_message("${Cyan}Found Boost: `Boost_INCLUDE_DIRS`: ${Boost_INCLUDE_DIRS}, `Boost_LIBRARY_DIRS` - ${Boost_LIBRARY_DIRS} ${ColorReset}")
-        include_directories( ${Boost_INCLUDE_DIRS} )
+        include_directories(${Boost_INCLUDE_DIRS})
 
-        if (WIN32) 
+        if(WIN32)
             add_definitions(-DBOOST_UUID_FORCE_AUTO_LINK)
         endif()
     endif()
@@ -345,18 +348,19 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         foreach(warning 4244 4251 4267 4275 4290 4786 4305 4996)
             SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd${warning}")
         endforeach(warning)
-        # When linking against Boost on Azure, bcrypt fails to link:
-        # - https://github.com/microsoft/vcpkg/issues/4481
-        # - https://github.com/boostorg/uuid/issues/68
-        #add_definitions("-DBOOST_UUID_FORCE_AUTO_LINK")
+
+    # When linking against Boost on Azure, bcrypt fails to link:
+    # - https://github.com/microsoft/vcpkg/issues/4481
+    # - https://github.com/boostorg/uuid/issues/68
+    # add_definitions("-DBOOST_UUID_FORCE_AUTO_LINK")
     else()
         include_directories("/usr/local/include")
     endif()
 
     if(PSP_PYTHON_BUILD)
-        #########################
+        # ########################
         # PYTHON BINDINGS BUILD #
-        #########################
+        # ########################
         set(CMAKE_POSITION_INDEPENDENT_CODE ON)
         include_directories("${PSP_PYTHON_SRC}/perspective/include")
 
@@ -375,20 +379,22 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
             find_package(PythonInterp ${PSP_PYTHON_VERSION} EXACT REQUIRED)
         else()
             psp_build_message("${Cyan}Use python shared libraries${ColorReset}")
-            find_package( Python ${PSP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
+            find_package(Python ${PSP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
 
             # Run with exact version so its cached for pybind
             find_package(PythonInterp ${PSP_PYTHON_VERSION} EXACT REQUIRED)
             find_package(PythonLibs ${PSP_PYTHON_VERSION} EXACT REQUIRED)
 
-            link_directories( ${Python_LIBRARY_DIRS} )
+            link_directories(${Python_LIBRARY_DIRS})
         endif()
+
         psp_build_message("${Cyan}Using Python ${Python_VERSION}, \nPython_INCLUDE_DIRS: ${Python_INCLUDE_DIRS}, \nPython_LIBRARIES: ${Python_LIBRARIES}, \nPython_EXECUTABLE: ${Python_EXECUTABLE} ${ColorReset}")
-        include_directories( ${Python_INCLUDE_DIRS} )
+        include_directories(${Python_INCLUDE_DIRS})
 
         if(MACOS)
             # on mac, use the vanilla pybind11 finder
             find_package(pybind11)
+
             if(pybind11_FOUND)
                 # Found PyBind installed by Homebrew
                 set(PYTHON_PYBIND_FOUND pybind11_FOUND)
@@ -406,17 +412,19 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
             psp_build_dep("pybind11" "${PSP_CMAKE_MODULE_PATH}/Pybind.txt.in")
         else()
             psp_build_message("${Cyan}Found PyBind11 in ${PYTHON_PYBIND_INCLUDE_DIR}${ColorReset}")
-            include_directories( ${PYTHON_PYBIND_INCLUDE_DIR} )
+            include_directories(${PYTHON_PYBIND_INCLUDE_DIR})
         endif()
 
         find_package(NumPy)
+
         if(NOT PYTHON_NUMPY_FOUND)
             message(FATAL_ERROR "${Red}Numpy could not be located${ColorReset}")
         else()
             psp_build_message("${Cyan}Numpy found: ${PYTHON_NUMPY_INCLUDE_DIR}${ColorReset}")
-            include_directories( ${PYTHON_NUMPY_INCLUDE_DIR})
+            include_directories(${PYTHON_NUMPY_INCLUDE_DIR})
         endif()
-        #####################
+
+        # ####################
     endif()
 endif()
 
@@ -436,12 +444,13 @@ psp_build_dep("double-conversion" "${PSP_CMAKE_MODULE_PATH}/double-conversion.tx
 # headers accessible. The actual flatc executable is installed using
 # Chocolatey for our Azure Windows job.
 find_package(Flatbuffers)
+
 if(NOT FLATBUFFERS_FOUND)
     psp_build_message("${Cyan}Could not find Flatbuffers${ColorReset}")
     psp_build_dep("flatbuffers" "${PSP_CMAKE_MODULE_PATH}/flatbuffers.txt.in")
 else()
     psp_build_message("${Cyan}Found Flatbuffers in ${FLATBUFFERS_INCLUDE_DIR}${ColorReset}")
-    include_directories( ${FLATBUFFERS_INCLUDE_DIR} )
+    include_directories(${FLATBUFFERS_INCLUDE_DIR})
 endif()
 
 # Build minimal arrow itself
@@ -449,28 +458,30 @@ psp_build_dep("arrow" "${PSP_CMAKE_MODULE_PATH}/arrow.txt.in")
 
 # Build re2 as our regex library
 find_package(re2)
+
 if(NOT re2_FOUND)
     psp_build_message("${Cyan}Could not find Re2${ColorReset}")
+
     # this is a workaround for some re2-specific weirdness
     add_definitions(-DTARGET_OS_OSX=1)
     psp_build_dep("re2" "${PSP_CMAKE_MODULE_PATH}/re2.txt.in")
 else()
     psp_build_message("${Cyan}Found re2 in ${RE2_INCLUDE_DIR}${ColorReset}")
-    include_directories( ${RE2_INCLUDE_DIR} )
+    include_directories(${RE2_INCLUDE_DIR})
 endif()
 
 # Build exprtk for expression parsing
 find_package(exprtk)
+
 if(NOT exprtk_FOUND)
     psp_build_message("${Cyan}Could not find exprtk${ColorReset}")
     psp_build_dep("exprtk" "${PSP_CMAKE_MODULE_PATH}/exprtk.txt.in")
 else()
     psp_build_message("${Cyan}Found exprtk in ${EXPRTK_INCLUDE_DIR}${ColorReset}")
-    include_directories( ${EXPRTK_INCLUDE_DIR} )
+    include_directories(${EXPRTK_INCLUDE_DIR})
 endif()
 
-#####################
-
+# ####################
 set(CMAKE_C_FLAGS_RELEASE " \
     ${CMAKE_C_FLAGS} \
     ${EXTENDED_FLAGS} \
@@ -487,7 +498,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c++1y")
 endif()
 
-set (SOURCE_FILES
+set(SOURCE_FILES
     ${PSP_CPP_SRC}/src/cpp/vendor/arrow_compute_registry.cpp
     ${PSP_CPP_SRC}/src/cpp/aggregate.cpp
     ${PSP_CPP_SRC}/src/cpp/aggspec.cpp
@@ -500,6 +511,7 @@ set (SOURCE_FILES
     ${PSP_CPP_SRC}/src/cpp/base_impl_wasm.cpp
     ${PSP_CPP_SRC}/src/cpp/base_impl_win.cpp
     ${PSP_CPP_SRC}/src/cpp/binding.cpp
+
     # ${PSP_CPP_SRC}/src/cpp/build_filter.cpp
     # ${PSP_CPP_SRC}/src/cpp/calc_agg_dtype.cpp
     ${PSP_CPP_SRC}/src/cpp/column.cpp
@@ -574,7 +586,7 @@ set (SOURCE_FILES
     ${PSP_CPP_SRC}/src/cpp/view_config.cpp
     ${PSP_CPP_SRC}/src/cpp/vocab.cpp
     ${PSP_CPP_SRC}/src/cpp/arrow_csv.cpp
-    )
+)
 
 set(PYTHON_SOURCE_FILES ${SOURCE_FILES}
     ${PSP_PYTHON_SRC}/src/column.cpp
@@ -584,7 +596,7 @@ set(WASM_SOURCE_FILES ${SOURCE_FILES}
     ${PSP_CPP_SRC}/src/cpp/vendor/arrow_single_threaded_reader.cpp
 )
 
-set (PYTHON_BINDING_SOURCE_FILES
+set(PYTHON_BINDING_SOURCE_FILES
     ${PSP_PYTHON_SRC}/src/accessor.cpp
     ${PSP_PYTHON_SRC}/src/context.cpp
     ${PSP_PYTHON_SRC}/src/expressions.cpp
@@ -597,7 +609,7 @@ set (PYTHON_BINDING_SOURCE_FILES
     ${PSP_PYTHON_SRC}/src/view.cpp
 )
 
-if (WIN32)
+if(WIN32)
     set(CMAKE_CXX_FLAGS " /EHsc /MP /bigobj")
 else()
     set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS}")
@@ -605,8 +617,8 @@ endif()
 
 message("${BUILD_MESSAGE}\n")
 
-if (PSP_WASM_BUILD)
-    set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} \
+if(PSP_WASM_BUILD)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
         --bind \
         --source-map-base \"\" \
         --memory-init-file 0 \
@@ -645,6 +657,7 @@ if (PSP_WASM_BUILD)
 elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
     if(NOT WIN32)
         set(CMAKE_SHARED_LIBRARY_SUFFIX .so)
+
         # Look for the binary using @loader_path (relative to binary location)
         set(CMAKE_MACOSX_RPATH TRUE)
         set(CMAKE_SKIP_BUILD_RPATH FALSE)
@@ -663,9 +676,9 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
     endif()
 
     if(PSP_PYTHON_BUILD)
-        ########################
+        # #######################
         # Python extra targets #
-        ########################
+        # #######################
         add_library(psp SHARED ${PYTHON_SOURCE_FILES})
         add_library(binding SHARED ${PYTHON_BINDING_SOURCE_FILES})
 
@@ -674,13 +687,13 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         target_compile_definitions(psp PRIVATE PSP_ENABLE_PYTHON=1)
         target_compile_definitions(binding PRIVATE PSP_ENABLE_PYTHON=1)
 
-        if (WIN32)
+        if(WIN32)
             target_compile_definitions(binding PRIVATE WIN32=1)
             target_compile_definitions(binding PRIVATE _WIN32=1)
 
             # .dll not importable
             set_property(TARGET binding PROPERTY SUFFIX .pyd)
-        elseif (MACOS OR NOT MANYLINUX)
+        elseif(MACOS OR NOT MANYLINUX)
             target_compile_options(binding PRIVATE -Wdeprecated-declarations)
             set_property(TARGET psp PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${module_origin_path})
             set_property(TARGET binding PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${module_origin_path})
@@ -700,7 +713,7 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         add_custom_command(TARGET psp POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:psp> ${PSP_PYTHON_SRC}/table/)
         add_custom_command(TARGET binding POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:binding> ${PSP_PYTHON_SRC}/table/)
 
-        ########################
+    # #######################
     else()
         add_library(psp SHARED ${WASM_SOURCE_FILES})
         target_link_libraries(psp arrow)
@@ -709,6 +722,7 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
     if(PSP_CPP_BUILD_STRICT AND NOT WIN32)
         target_compile_options(psp PRIVATE -Wall -Werror)
         target_compile_options(psp PRIVATE $<$<CONFIG:DEBUG>:-fPIC -O0>)
+
         if(PSP_PYTHON_BUILD)
             target_compile_options(binding PRIVATE $<$<CONFIG:DEBUG>:-fPIC -O0>)
         endif()

--- a/cpp/perspective/build.js
+++ b/cpp/perspective/build.js
@@ -22,7 +22,6 @@ try {
         stdio,
     });
     execSync(`cpy esm/**/* ../esm`, {cwd, stdio});
-    execSync(`cpy cjs/**/* ../cjs`, {cwd, stdio});
 
     const wasm = fs.readFileSync("dist/esm/perspective.cpp.wasm");
     const compressed = fflate.compressSync(wasm);

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1846,27 +1846,12 @@ using namespace perspective::binding;
 /**
  * Main
  */
-int
-main(int argc, char** argv) {
+void
+init() {
     t_computed_expression_parser::init();
 
     // clang-format off
-EM_ASM({
 
-    if (typeof self !== "undefined") {
-        try {
-            if (self.dispatchEvent && !self._perspective_initialized && self.document !== null) {
-                self._perspective_initialized = true;
-                var event = self.document.createEvent("Event");
-                event.initEvent("perspective-ready", false, true);
-                self.dispatchEvent(event);
-            } else if (!self.document && self.postMessage) {                
-                self.postMessage({});
-            }
-        } catch (e) {}
-    }
-
-});
     // clang-format on
 }
 
@@ -2308,4 +2293,5 @@ EMSCRIPTEN_BINDINGS(perspective) {
     function("scalar_to_val", &scalar_to_val);
     function("validate_expressions", &validate_expressions<t_val>);
     function("is_valid_datetime", &is_valid_datetime);
+    function("init", &init);
 }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1843,18 +1843,6 @@ namespace binding {
 
 using namespace perspective::binding;
 
-/**
- * Main
- */
-void
-init() {
-    t_computed_expression_parser::init();
-
-    // clang-format off
-
-    // clang-format on
-}
-
 /******************************************************************************
  *
  * Embind
@@ -2293,5 +2281,5 @@ EMSCRIPTEN_BINDINGS(perspective) {
     function("scalar_to_val", &scalar_to_val);
     function("validate_expressions", &validate_expressions<t_val>);
     function("is_valid_datetime", &is_valid_datetime);
-    function("init", &init);
+    function("init", &t_computed_expression_parser::init);
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
             "internal": "Internal"
         }
     },
-    "emscripten": "2.0.29",
+    "emscripten": "3.1.14",
     "engines": {
         "node": ">=14.18.2"
     },

--- a/packages/perspective/build.js
+++ b/packages/perspective/build.js
@@ -48,7 +48,6 @@ const BUILD = [
 
 async function build_all() {
     await cpy(["../../cpp/perspective/dist/esm"], "dist/pkg/esm");
-    await cpy(["../../cpp/perspective/dist/cjs"], "dist/pkg/cjs");
     await Promise.all(BUILD.map(build)).catch(() => process.exit(1));
 }
 

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -2267,6 +2267,8 @@ export default function (Module) {
                     wasmJSMethod: "native-wasm",
                 }).then((mod) => {
                     __MODULE__ = mod;
+                    __MODULE__.init();
+                    notify_main_thread();
                     super.init(msg);
                 });
             }
@@ -2282,4 +2284,23 @@ export default function (Module) {
     }
 
     return perspective;
+}
+
+function notify_main_thread() {
+    if (typeof self !== "undefined") {
+        try {
+            if (
+                self.dispatchEvent &&
+                !self._perspective_initialized &&
+                self.document !== null
+            ) {
+                self._perspective_initialized = true;
+                const event = self.document.createEvent("Event");
+                event.initEvent("perspective-ready", false, true);
+                self.dispatchEvent(event);
+            } else if (!self.document && self.postMessage) {
+                self.postMessage({});
+            }
+        } catch (e) {}
+    }
 }

--- a/packages/perspective/src/js/perspective.node.js
+++ b/packages/perspective/src/js/perspective.node.js
@@ -38,6 +38,7 @@ const SYNC_SERVER = new (class extends Server {
                 })
             )
             .then((core) => {
+                core.init();
                 this.perspective = perspective(core);
                 super.init(msg);
             });

--- a/packages/perspective/src/js/perspective.node.js
+++ b/packages/perspective/src/js/perspective.node.js
@@ -20,23 +20,44 @@ const http = require("http");
 const WebSocket = require("ws");
 const process = require("process");
 const path = require("path");
+const {Decompress} = require("fflate");
 
 const load_perspective =
-    require("../../dist/pkg/cjs/perspective.cpp.js").default;
+    require("../../dist/pkg/esm/perspective.cpp.js").default;
 
 const LOCAL_PATH = path.join(process.cwd(), "node_modules");
 const buffer =
-    require("@finos/perspective/dist/pkg/cjs/perspective.cpp.wasm").default;
+    require("@finos/perspective/dist/pkg/esm/perspective.cpp.wasm").default;
 
+function deflate(buffer) {
+    let parts = [];
+    let length = 0;
+    const decompressor = new Decompress((chunk) => {
+        if (chunk) {
+            length += chunk.byteLength;
+            parts.push(chunk);
+        }
+    });
+
+    decompressor.push(buffer, true);
+    let offset = 0;
+    const buffer2 = new Uint8Array(length);
+    for (const part of parts) {
+        buffer2.set(part, offset);
+        offset += part.byteLength;
+    }
+
+    return buffer2.buffer;
+}
 const SYNC_SERVER = new (class extends Server {
     init(msg) {
         buffer
-            .then((buffer) =>
-                load_perspective({
-                    wasmBinary: buffer,
+            .then((buffer) => {
+                return load_perspective({
+                    wasmBinary: deflate(buffer),
                     wasmJSMethod: "native-wasm",
-                })
-            )
+                });
+            })
             .then((core) => {
                 core.init();
                 this.perspective = perspective(core);

--- a/rust/perspective-viewer/build.js
+++ b/rust/perspective-viewer/build.js
@@ -164,11 +164,13 @@ async function build_all() {
         // Optimize wasm
         const OPT_PATH = `dist/pkg/perspective_viewer_bg.wasm`;
         const WASM_OPT_OPTIONS = [
-            `-lmu`,
-            `--dce`,
-            `--strip-producers`,
-            `--strip-target-features`,
-            `--strip-debug`,
+            `--low-memory-unused`,
+            `--converge`,
+
+            // This commit to `binaryen/wasm-opt` adds 50k to wasm asset, this
+            // is ths old settings.
+            // https://github.com/WebAssembly/binaryen/commit/1a6efdb4233a077bc6e5e8a340baf5672bb5bced
+            `--one-caller-inline-max-function-size=15`,
         ].join(" ");
 
         execSync(

--- a/rust/perspective-viewer/src/rust/components/containers/select.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/select.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum SelectItem<T> {
     Option(T),
     OptGroup(&'static str, Vec<T>),

--- a/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
@@ -154,7 +154,7 @@ impl ResizingState {
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Orientation {
     Horizontal,
     Vertical,

--- a/rust/perspective-viewer/src/rust/components/modal.rs
+++ b/rust/perspective-viewer/src/rust/components/modal.rs
@@ -15,7 +15,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use yew::{prelude::*, virtual_dom::VChild};
 
-#[derive(Default, Clone, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
 pub struct ModalOrientation(Rc<Cell<bool>>);
 
 impl From<ModalOrientation> for bool {

--- a/rust/perspective-viewer/src/rust/components/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/number_column_style.rs
@@ -22,7 +22,7 @@ use yew::*;
 
 pub static CSS: &str = include_str!("../../../build/css/column-style.css");
 
-#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum NumberColorMode {
     #[serde(rename = "disabled")]
     Disabled,

--- a/rust/perspective-viewer/src/rust/components/string_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/string_column_style.rs
@@ -22,7 +22,7 @@ use yew::*;
 
 pub static CSS: &str = include_str!("../../../build/css/column-style.css");
 
-#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum StringColorMode {
     #[serde(rename = "foreground")]
     Foreground,
@@ -64,7 +64,7 @@ impl FromStr for StringColorMode {
     }
 }
 
-#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum FormatMode {
     #[serde(rename = "link")]
     Link,
@@ -112,7 +112,7 @@ impl FromStr for FormatMode {
 }
 
 #[cfg_attr(test, derive(Debug))]
-#[derive(Serialize, Deserialize, Clone, Default, PartialEq)]
+#[derive(Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StringColumnStyleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<FormatMode>,
@@ -124,7 +124,7 @@ pub struct StringColumnStyleConfig {
     pub color: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Default, PartialEq)]
+#[derive(Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StringColumnStyleDefaultConfig {
     pub color: String,
 }

--- a/rust/perspective-viewer/src/rust/config/filters.rs
+++ b/rust/perspective-viewer/src/rust/config/filters.rs
@@ -38,7 +38,7 @@ impl Display for Scalar {
 }
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Clone, Copy, Deserialize, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Deserialize, Debug, Eq, PartialEq, Serialize)]
 #[serde()]
 pub enum FilterOp {
     #[serde(rename = "contains")]

--- a/rust/perspective-viewer/src/rust/config/sort.rs
+++ b/rust/perspective-viewer/src/rust/config/sort.rs
@@ -10,11 +10,11 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::fmt::Display;
 
-#[derive(Clone, Deserialize, Debug, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Debug, Eq, PartialEq, Serialize)]
 #[serde()]
 pub struct Sort(pub String, pub SortDir);
 
-#[derive(Clone, Copy, Deserialize, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Deserialize, Debug, Eq, PartialEq, Serialize)]
 #[serde()]
 pub enum SortDir {
     #[serde(rename = "none")]

--- a/rust/perspective-viewer/src/rust/dragdrop.rs
+++ b/rust/perspective-viewer/src/rust/dragdrop.rs
@@ -17,7 +17,7 @@ use wasm_bindgen::JsCast;
 use web_sys::*;
 use yew::prelude::*;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DragTarget {
     Active,
     GroupBy,
@@ -26,7 +26,7 @@ pub enum DragTarget {
     Filter,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DragEffect {
     Copy,
     Move(DragTarget),

--- a/rust/perspective-viewer/src/rust/js/mimetype.rs
+++ b/rust/perspective-viewer/src/rust/js/mimetype.rs
@@ -9,7 +9,7 @@
 use std::fmt::Display;
 use wasm_bindgen::prelude::*;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum MimeType {
     TextPlain,
     ImagePng,

--- a/rust/perspective-viewer/src/rust/js/plugin.rs
+++ b/rust/perspective-viewer/src/rust/js/plugin.rs
@@ -85,7 +85,7 @@ extern "C" {
     pub async fn resize(this: &JsPerspectiveViewerPlugin) -> Result<JsValue, JsValue>;
 }
 
-#[derive(Clone, Copy, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum ColumnSelectMode {
     Toggle,
@@ -98,7 +98,7 @@ impl Default for ColumnSelectMode {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ViewConfigRequirements {
     pub min: Option<usize>,
     pub names: Option<Vec<String>>,

--- a/rust/perspective-viewer/src/rust/model/columns_iter_set.rs
+++ b/rust/perspective-viewer/src/rust/model/columns_iter_set.rs
@@ -18,7 +18,7 @@ use std::fmt::Display;
 
 /// The possible states of a column (row) in the active columns list, including
 /// the `Option<String>` label type.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum ActiveColumnState {
     Column(Label, String),
     Required(Label),

--- a/rust/perspective-viewer/src/rust/model/export_method.rs
+++ b/rust/perspective-viewer/src/rust/model/export_method.rs
@@ -12,7 +12,7 @@ use crate::*;
 use std::rc::Rc;
 use yew::prelude::*;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum ExportMethod {
     Csv,
     CsvAll,
@@ -65,7 +65,7 @@ impl ExportMethod {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct ExportFile {
     pub name: Rc<String>,
     pub method: ExportMethod,

--- a/rust/perspective-viewer/src/rust/session/view_subscription.rs
+++ b/rust/perspective-viewer/src/rust/session/view_subscription.rs
@@ -19,7 +19,7 @@ use yew::prelude::*;
 
 /// Metadata snapshot of the current `Table()`/`View()` state which may be of
 /// interest to components.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct TableStats {
     pub is_pivot: bool,
     pub num_rows: Option<u32>,

--- a/tools/perspective-bench/package.json
+++ b/tools/perspective-bench/package.json
@@ -24,6 +24,7 @@
         "microtime": "^3.0.0"
     },
     "dependencies": {
+        "perspective-1-4-0": "npm:@finos/perspective@1.4.0",
         "perspective-1-3-0": "npm:@finos/perspective@1.3.0",
         "perspective-1-2-0": "npm:@finos/perspective@1.2.0",
         "perspective-1-1-0": "npm:@finos/perspective@1.1.0",

--- a/tools/perspective-build/empty.js
+++ b/tools/perspective-build/empty.js
@@ -1,0 +1,31 @@
+exports.EmptyPlugin = function EmptyPlugin(options) {
+    return {
+        name: "empty",
+        setup: (build) => {
+            for (const moduleName of options) {
+                const filter = new RegExp(moduleName);
+                build.onResolve({filter}, async (args) => {
+                    if (args.resolveDir === "") {
+                        return;
+                    }
+
+                    return {
+                        path: args.path,
+                        namespace: "empty",
+                        pluginData: {
+                            resolveDir: args.resolveDir,
+                            moduleName,
+                        },
+                    };
+                });
+
+                build.onLoad({filter, namespace: "empty"}, async (args) => {
+                    return {
+                        contents: "",
+                        resolveDir: args.pluginData.resolveDir,
+                    };
+                });
+            }
+        },
+    };
+};

--- a/tools/perspective-build/rust_wasm.js
+++ b/tools/perspective-build/rust_wasm.js
@@ -20,25 +20,25 @@ const {platform} = process;
 function getUrl() {
     const {arch} = process;
     const baseURL =
-        "https://github.com/WebAssembly/binaryen/releases/download/version_100";
+        "https://github.com/WebAssembly/binaryen/releases/download/version_109";
 
     switch (platform) {
         case "win32":
             if (arch === "x64") {
-                return `${baseURL}/binaryen-version_100-x86_64-windows.tar.gz`;
+                return `${baseURL}/binaryen-version_109-x86_64-windows.tar.gz`;
             }
             break;
         case "darwin":
             if (arch === "arm64") {
-                return `${baseURL}/binaryen-version_100-arm64-macos.tar.gz`;
+                return `${baseURL}/binaryen-version_109-arm64-macos.tar.gz`;
             }
             if (arch === "x64") {
-                return `${baseURL}/binaryen-version_100-x86_64-macos.tar.gz`;
+                return `${baseURL}/binaryen-version_109-x86_64-macos.tar.gz`;
             }
             break;
         case "linux":
             if (arch === "x64") {
-                return `${baseURL}/binaryen-version_100-x86_64-linux.tar.gz`;
+                return `${baseURL}/binaryen-version_109-x86_64-linux.tar.gz`;
             }
             break;
     }
@@ -79,13 +79,13 @@ exports.download_wasm_opt = async function download_wasm_opt() {
 
         const libFolderName = {
             win32: "lib",
-            linux: "lib64",
+            linux: "lib",
             darwin: "lib",
         };
 
         const libFolder = "lib";
 
-        const unpackedFolder = path.resolve(__dirname, "binaryen-version_100");
+        const unpackedFolder = path.resolve(__dirname, "binaryen-version_109");
         const unpackedLibFolder = path.resolve(
             unpackedFolder,
             libFolderName[platform]

--- a/tools/perspective-build/worker.js
+++ b/tools/perspective-build/worker.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const esbuild = require("esbuild");
+const {EmptyPlugin} = require("./empty.js");
 
 exports.WorkerPlugin = function WorkerPlugin(inline) {
     function setup(build) {
@@ -14,6 +15,7 @@ exports.WorkerPlugin = function WorkerPlugin(inline) {
                     define: {
                         global: "self",
                     },
+                    plugins: [EmptyPlugin(["fs", "path"])],
                     entryNames: "[name]",
                     chunkNames: "[name]",
                     assetNames: "[name]",


### PR DESCRIPTION
A set of internal changes which make Perspective compatible with Emscripten's `STANDALONE_WASM` output mode, and otherwise reduce the complexity/redundancy of the CI process.
* Update emscripten to `3.1.14`
* Update wasm-opt to `109`
* Remove `main()` from emscripten bindings, switch to `--no-entry` compilation mode.
* Removes double-linking (for node and browser) portion of emscripten build.