### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
         env:
           SKIP_CI: ${{ contains(github.event.head_commit.message, '[ci-skip]') }}
           SKIP_CACHE: ${{ contains(github.event.head_commit.message, '[ci-skip-cache]') }}
-          FULL_RUN: ${{ startsWith(github.ref, 'refs/heads/v') || contains(github.event.head_commit.message, '[ci-full]') }}
+          FULL_RUN: ${{ startsWith(github.ref_name, 'v') || contains(github.event.head_commit.message, '[ci-full]') }}
           SKIP_PYTHON: ${{ contains(github.event.head_commit.message, '[ci-skip-python]') }}
           INCLUDE_WINDOWS: ${{ contains(github.event.head_commit.message, '[ci-include-windows]') }}
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -706,7 +706,6 @@ jobs:
           - windows-2022 # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
           - windows-2019 # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
@@ -748,12 +747,6 @@ jobs:
           - os: ubuntu-20.04
             container: none
 
-          # Exclude windows Python 3.6
-          - os: windows-2022
-            python-version: 3.6
-          - os: windows-2019
-            python-version: 3.6
-
           ##############################################
           # Things to exclude if not a full matrix run #
           ##############################################
@@ -779,10 +772,7 @@ jobs:
           - is-full-run: false
             os: macos-10.11
 
-          # Exclude Python 3.6, 3.7, and 3.8 builds
-          - is-full-run: false
-            python-version: 3.6
-
+          # Exclude Python 3.7 and 3.8 builds
           - is-full-run: false
             python-version: 3.7
 
@@ -1229,7 +1219,6 @@ jobs:
           - windows-2022 # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
           - windows-2019 # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
@@ -1239,15 +1228,6 @@ jobs:
         include-windows-run:
           - ${{ needs.initialize.outputs.INCLUDE_WINDOWS == 'true' || needs.initialize.outputs.FULL_RUN == 'true' }}
         exclude:
-          ############################
-          # Things to always exclude #
-          ############################
-          # Exclude windows Python 3.6
-          - os: windows-2022
-            python-version: 3.6
-          - os: windows-2019
-            python-version: 3.6
-
           ##############################################
           # Things to exclude if not a full matrix run #
           ##############################################
@@ -1266,10 +1246,7 @@ jobs:
           - is-full-run: false
             os: macos-10.15
 
-          # Exclude Python 3.6, 3.7, and 3.8 builds
-          - is-full-run: false
-            python-version: 3.6
-
+          # Exclude Python 3.7 and 3.8 builds
           - is-full-run: false
             python-version: 3.7
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -351,18 +351,7 @@ jobs:
           artifact_name: "cp37-cp37m-manylinux2010_x86_64"
 
         ? ${{ if or(startsWith(variables['build.sourceBranch'], 'refs/tags/v'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual')) }}
-        : Python36ManyLinux2010:
-            python.version: "3.6"
-            python_flag: "--python36"
-            manylinux_flag: "--manylinux2010"
-            artifact_name: "cp36-cp36m-manylinux2010_x86_64"
-          Python36ManyLinux2014:
-            python.version: "3.6"
-            python_flag: "--python36"
-            manylinux_flag: "--manylinux2014"
-            artifact_name: "cp36-cp36m-manylinux2014_x86_64"
-          # Python37ManyLinux2010 is always built
-          Python37ManyLinux2014:
+        : Python37ManyLinux2014:
             python.version: "3.7"
             python_flag: ""
             manylinux_flag: "--manylinux2014"
@@ -472,11 +461,6 @@ jobs:
 
     strategy:
       matrix:
-          Python36:
-            python.version: "3.6"
-            python_flag: "--python36"
-            artifact_name: "cp36-cp36m-macosx_10_15_x86_64"
-
           Python37:
             python.version: "3.7"
             python_flag: ""

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -27,7 +27,7 @@ try:
 
     CPU_COUNT = os.cpu_count()
 except ImportError:
-    raise Exception("Requires Python 3.6 or later")
+    raise Exception("Requires Python 3.7 or later")
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -35,7 +35,7 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read().replace("\r\n", "\n")
 
 if sys.version_info.major < 3:
-    raise Exception("Requires Python 3.6 or later")
+    raise Exception("Requires Python 3.7 or later")
 
 
 def get_version(file, name="__version__"):
@@ -283,7 +283,7 @@ setup(
     packages=find_packages(exclude=["bench", "bench.*"]),
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=requires,
     extras_require={
         "aiohttp": requires_aiohttp,

--- a/scripts/build_python_azure.js
+++ b/scripts/build_python_azure.js
@@ -20,8 +20,6 @@ const fs = require("fs-extra");
 
 let PYTHON = getarg("--python38")
     ? "python3.8"
-    : getarg("--python36")
-    ? "python3.6"
     : getarg("--python37")
     ? "python3.7"
     : "python3";

--- a/scripts/publish_python.js
+++ b/scripts/publish_python.js
@@ -38,20 +38,17 @@ if (!process.env.COMMIT) {
 const dist_folders = [
     // https://github.com/actions/virtual-environments
     // Mac 10.15
-    "perspective-python-dist-macos-10.15-3.6",
     "perspective-python-dist-macos-10.15-3.7",
     "perspective-python-dist-macos-10.15-3.8",
     "perspective-python-dist-macos-10.15-3.9",
 
     // Mac 11
     // NOTE: use 10.15
-    // "perspective-python-dist-macos-11-3.6",
     // "perspective-python-dist-macos-11-3.7",
     // "perspective-python-dist-macos-11-3.8",
     // "perspective-python-dist-macos-11-3.9",
 
     // Ubuntu (Manylinux 2010 and 2014 docker images)
-    "perspective-python-dist-ubuntu-20.04-3.6",
     "perspective-python-dist-ubuntu-20.04-3.7",
     "perspective-python-dist-ubuntu-20.04-3.8",
     "perspective-python-dist-ubuntu-20.04-3.9",

--- a/scripts/publish_python_azure.js
+++ b/scripts/publish_python_azure.js
@@ -65,9 +65,6 @@ async function get(host, path, binary = false) {
 try {
     const build = process.env.AZURE_BUILD_ID;
     const artifacts = [
-        "cp36-cp36m-macosx_10_15_x86_64",
-        "cp36-cp36m-manylinux2010_x86_64",
-        "cp36-cp36m-manylinux2014_x86_64",
         "cp37-cp37m-macosx_10_15_x86_64",
         "cp37-cp37m-manylinux2010_x86_64",
         "cp37-cp37m-manylinux2014_x86_64",

--- a/scripts/script_utils.js
+++ b/scripts/script_utils.js
@@ -303,8 +303,6 @@ exports.python_version = function python_version() {
         return "python3.8";
     } else if (getarg("--python37")) {
         return "python3.7";
-    } else if (getarg("--python36")) {
-        return "python3.6";
     } else {
         return "python3";
     }


### PR DESCRIPTION
This PR is a fork of [tkp/py36cleanup](https://github.com/finos/perspective/tree/tkp/py36cleanup), which does not have its own PR but I've reviewed.  I've modified the last PR to remove the Docker changes (as per previous comments).