### PR TITLE
Fix wrong label color bug

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/axis/splitterLabels.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/splitterLabels.js
@@ -24,16 +24,16 @@ export const splitterLabels = (settings) => {
             .dataJoin("span", "splitter-label")
             .key((d) => d);
 
-        const disabled = !alt && labels.length === 1;
+        const unMoveable = !alt && labels.length === 1;
         const coloured = color && settings.splitValues.length === 0;
         labelDataJoin(selection, labels)
-            .classed("disabled", disabled)
+            .classed("unMoveable", unMoveable)
             .text((d) => d.name)
             .style("color", (d) =>
                 coloured ? withoutOpacity(color(d.name)) : undefined
             )
             .on("click", (event, d) => {
-                if (disabled) return;
+                if (unMoveable) return;
 
                 if (alt) {
                     settings.splitMainValues = settings.splitMainValues.filter(

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -248,9 +248,9 @@
                 }
             }
 
-            &.disabled {
+            &.unMoveable {
                 &::after {
-                    color: rgba(80, 80, 80, 0.3);
+                    color: rgba(80, 80, 80, 0);
                 }
                 cursor: default;
             }


### PR DESCRIPTION
Resolves Issue #1869 

Keep labels the same color as their data, but hide the switch-axis arrow if the label is un-moveable

<img width="1552" alt="Screen Shot 2022-06-30 at 11 43 34 AM" src="https://user-images.githubusercontent.com/55207313/176732912-0a971180-715c-433c-bec3-b19275e52abc.png">


