### PR TITLE
Pin `tornado` to 6.1 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,7 @@ jobs:
     ################
     # Python
     - name: Install python dependencies
-      run: python -m pip install --upgrade "jupyterlab>=3.2"
+      run: python -m pip install --upgrade "jupyterlab>=3.2" "tornado==6.1"
 
     ################
     # Linux
@@ -615,7 +615,7 @@ jobs:
     ################
     # Python
     - name: Install python dependencies
-      run: python -m pip install --upgrade "jupyterlab>=3.2"
+      run: python -m pip install --upgrade "jupyterlab>=3.2" "tornado==6.1"
 
     ################
     # Wasm
@@ -909,7 +909,7 @@ jobs:
     ################
     # Python
     - name: Install python dependencies
-      run: python -m pip install --upgrade pip wheel setuptools "jupyterlab>=3.2" numpy "pyarrow>=5"
+      run: python -m pip install --upgrade pip wheel setuptools "jupyterlab>=3.2" numpy "pyarrow>=5" "tornado==6.1"
       if: ${{ runner.os != 'Linux' }}  # skip on manylinux2014
 
     ################
@@ -1160,7 +1160,7 @@ jobs:
     ################
     # Python
     - name: Install python dependencies
-      run: python -m pip install --upgrade "jupyterlab>=3.2" ipywidgets ipykernel
+      run: python -m pip install --upgrade "jupyterlab>=3.2" ipywidgets ipykernel "tornado==6.1"
 
     # Download artifact
     - uses: actions/download-artifact@v3
@@ -1329,7 +1329,7 @@ jobs:
     ################
     # Python
     - name: Install python dependencies
-      run: python -m pip install --upgrade aiohttp Faker fastapi "jupyterlab>=3.2" mock numpy pip psutil "pyarrow>=5" pytest pytest-cov pytest-aiohttp pytest-asyncio pytest-tornado pytz setuptools wheel
+      run: python -m pip install --upgrade aiohttp Faker fastapi "jupyterlab>=3.2" mock numpy pip psutil "pyarrow>=5" pytest pytest-cov pytest-aiohttp pytest-asyncio pytest-tornado pytz setuptools wheel "tornado==6.1"
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
     #~~~~~~~~~ Build Pipelines ~~~~~~~~~#
@@ -1465,7 +1465,7 @@ jobs:
     ################
     # Python
     - name: Install python dependencies
-      run: python -m pip install --upgrade pip wheel setuptools "jupyterlab>=3.2" numpy "pyarrow>=5" pytest pytest-cov mock Faker psutil pytest-tornado pytz
+      run: python -m pip install --upgrade pip wheel setuptools "jupyterlab>=3.2" numpy "pyarrow>=5" pytest pytest-cov mock Faker psutil pytest-tornado pytz "tornado==6.1"
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
     #~~~~~~~~~ Build Pipelines ~~~~~~~~~#

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ parameters:
           architecture: "x64"
         displayName: "Use Python $(python.version)"
 
-      - bash: python -m pip install --upgrade pip wheel setuptools "jupyterlab>=3.0.14" numpy "pyarrow>=5" "black==20.8b1" flake8-black
+      - bash: python -m pip install --upgrade pip wheel setuptools "jupyterlab>=3.0.14" "tornado==6.1" numpy "pyarrow>=5" "black==20.8b1" flake8-black
         displayName: "Install Python base dependencies"
         condition: succeeded()
 


### PR DESCRIPTION
Perspective/Jupyterlab tests dump random errors coincident with the release of Tornado 6.2 today.  I don't yet know if this is an existing bug in Perspective that has been exposed, or in JupyterLab or Tornado, so I have not modified the `setup.py` bounds.

I'll be looking into removing the manual dependency installation from azure as well, as IMO it is unacceptable to have CI break when dependencies change. 

```bash
Exception in callback <TaskWakeupMethWrapper object at 0x10dd9f1c0>(<Future finis... GMT\r\n\r\n'>)
handle: <Handle <TaskWakeupMethWrapper object at 0x10dd9f1c0>(<Future finis... GMT\r\n\r\n'>)>
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
RuntimeError: Cannot enter into task <Task pending name='Task-13' coro=<HTTP1ServerConnection._server_request_loop() running at /usr/local/lib/python3.9/site-packages/tornado/http1connection.py:825> wait_for=<Future finished result=b'GET /static...7 GMT\r\n\r\n'> cb=[IOLoop.add_future.<locals>.<lambda>() at /usr/local/lib/python3.9/site-packages/tornado/ioloop.py:687]> while another task <Task pending name='Task-224' coro=<PeriodicCallback._run() running at /usr/local/lib/python3.9/site-packages/tornado/ioloop.py:921> cb=[IOLoop.add_future.<lo

```