### PR TITLE
Expand/collapse on entire group cell, rather than just button

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
+++ b/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
@@ -411,7 +411,7 @@ async function mousedownListener(regularTable, event) {
         }
     }
 
-    if (target.classList.contains("psp-tree-label") && event.offsetX < 26) {
+    if (target.classList.contains("psp-tree-label")) {
         expandCollapseHandler.call(this, regularTable, event);
         event.stopImmediatePropagation();
         return;


### PR DESCRIPTION
Fixes #1873 

Because the expand/collapse button is rendered via `::before` pseudo element, we can't declare separate hover rules for it, and the `click` handler used JavaScript to only respond to events in the appropriate region.  This PR simply removes the latter logic;  `click` now works on the entire group cell, just like the expand/collapse highlight indicator.