### PR TITLE
Split foreground and background numeric column color modes

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/plugin.js
+++ b/packages/perspective-viewer-datagrid/src/js/plugin.js
@@ -13,7 +13,6 @@ import {
     createModel,
     configureRegularTable,
     formatters,
-    create_color_record,
 } from "./regular_table_handlers.js";
 import MATERIAL_STYLE from "../less/regular_table.less";
 import TOOLBAR_STYLE from "../less/toolbar.less";
@@ -21,7 +20,7 @@ import {configureRowSelectable, deselect} from "./row_selection.js";
 import {configureClick} from "./click.js";
 import {configureEditable} from "./editing.js";
 import {configureSortable} from "./sorting.js";
-import {PLUGIN_SYMBOL} from "./plugin_menu.js";
+import {PLUGIN_SYMBOL, make_color_record} from "./plugin_menu.js";
 
 export class PerspectiveViewerDatagridPluginElement extends HTMLElement {
     constructor() {
@@ -208,9 +207,11 @@ export class PerspectiveViewerDatagridPluginElement extends HTMLElement {
 
             for (const col of Object.keys(datagrid[PLUGIN_SYMBOL] || {})) {
                 const config = Object.assign({}, datagrid[PLUGIN_SYMBOL][col]);
-                if (config?.pos_color) {
-                    config.pos_color = config.pos_color[0];
-                    config.neg_color = config.neg_color[0];
+                if (config?.pos_fg_color || config?.pos_bg_color) {
+                    config.pos_fg_color = config.pos_fg_color?.[0];
+                    config.neg_fg_color = config.neg_fg_color?.[0];
+                    config.pos_bg_color = config.pos_bg_color?.[0];
+                    config.neg_bg_color = config.neg_bg_color?.[0];
                 }
 
                 if (config?.color) {
@@ -247,17 +248,26 @@ export class PerspectiveViewerDatagridPluginElement extends HTMLElement {
                     delete col_config["column_size_override"];
                 }
 
-                if (col_config?.pos_color) {
-                    col_config.pos_color = create_color_record(
-                        col_config.pos_color
+                if (col_config?.pos_fg_color) {
+                    col_config.pos_fg_color = make_color_record(
+                        col_config.pos_fg_color
                     );
-                    col_config.neg_color = create_color_record(
-                        col_config.neg_color
+                    col_config.neg_fg_color = make_color_record(
+                        col_config.neg_fg_color
+                    );
+                }
+
+                if (col_config?.pos_bg_color) {
+                    col_config.pos_bg_color = make_color_record(
+                        col_config.pos_bg_color
+                    );
+                    col_config.neg_bg_color = make_color_record(
+                        col_config.neg_bg_color
                     );
                 }
 
                 if (col_config?.color) {
-                    col_config.color = create_color_record(col_config.color);
+                    col_config.color = make_color_record(col_config.color);
                 }
 
                 if (Object.keys(col_config).length === 0) {

--- a/packages/perspective-viewer-datagrid/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-datagrid/test/js/superstore.spec.js
@@ -78,7 +78,7 @@ utils.with_server({}, () => {
                             // Find the 'bar' button
                             const bar_button =
                                 style_menu.shadowRoot.querySelector(
-                                    "#radio-list-3"
+                                    '#radio-list-1[name="foreground-list"]'
                                 );
 
                             // Get its coords

--- a/rust/perspective-viewer/src/less/column-style.less
+++ b/rust/perspective-viewer/src/less/column-style.less
@@ -32,6 +32,8 @@
     }
 
     input#color-selected,
+    input#fore-selected,
+    input#back-selected,
     input#format-selected {
         float: left;
     }
@@ -105,7 +107,7 @@
     }
 
     div.section {
-        margin-bottom: 4px;
+        margin-bottom: 8px;
         flex: 1 1 100%;
     }
 
@@ -146,7 +148,15 @@
         white-space: pre;
     }
 
+    input[disabled]:after {
+        opacity: 0.5;
+    }
+
     input.parameter[disabled] {
         opacity: 0.5;
+    }
+
+    input[type=checkbox]:not(:disabled) {
+        cursor: pointer;
     }
 }


### PR DESCRIPTION
Part of the suggested refactoring of the UX from #1875, allowing both Foreground color and Background color to be specified on numeric datagrid columns at the same time.