### PR TITLE
Fix gradient bounds calc

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
+++ b/packages/perspective-viewer-datagrid/src/js/regular_table_handlers.js
@@ -431,9 +431,14 @@ async function mousedownListener(regularTable, event) {
             regularTable.draw({preserve_width: true});
             activate_plugin_menu.call(this, regularTable, target);
         } else {
-            const [, max] = await this._view.get_min_max(column_name);
+            const [min, max] = await this._view.get_min_max(column_name);
             regularTable.draw({preserve_width: true});
-            activate_plugin_menu.call(this, regularTable, target, max);
+            let bound = Math.max(Math.abs(min), Math.abs(max));
+            if (bound > 1) {
+                bound = Math.round(bound * 100) / 100;
+            }
+
+            activate_plugin_menu.call(this, regularTable, target, bound);
         }
 
         event.preventDefault();

--- a/rust/perspective-viewer/src/less/column-style.less
+++ b/rust/perspective-viewer/src/less/column-style.less
@@ -49,6 +49,7 @@
     }
 
     input.parameter[type="number"] {
+        text-align:right;
         border-bottom-width: 1px;
         border-color: var(
             --input--border-color,


### PR DESCRIPTION
Fix gradient bounds calculation for gradient/bar numeric datagrid column styling, specifically for columns that contain negative values.  Additionally, applies rounding to 2 decimal digits for values exceeding one to make this value easier to read (though this will likely need more refinement).