### PR TITLE
Fix jlab tests to use local packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1177,8 +1177,8 @@ jobs:
     - name: Install wheel (local)
       run: python -m pip install -U *manylinux2014*.whl --target python/perspective
 
-    - name: Install puppeteer
-      run: yarn add -W --dev puppeteer@13.1.3
+    - name: Install perspective-jupyterlab extension dependencies
+      run: yarn jlab_link
 
     - name: Install perspective-jupyterlab labextension
       run: jupyter labextension install packages/perspective-jupyterlab --dev-build=True --no-minimize

--- a/python/perspective/perspective/tests/table/test_view.py
+++ b/python/perspective/perspective/tests/table/test_view.py
@@ -12,7 +12,7 @@ import numpy as np
 from perspective import PerspectiveCppError
 from perspective.table import Table
 from datetime import date, datetime
-from pytest import approx, mark, raises, skip
+from pytest import approx, mark, raises
 
 
 def compare_delta(received, expected):
@@ -2040,7 +2040,7 @@ class TestView(object):
 
     # TODO collapse/espand should be no-ops on column only contexts, but
     # the concept of "column only" is not yet implemented in C++
-    @skip
+    @mark.skip
     def test_view_collapse_two_column_only(self):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)


### PR DESCRIPTION
Jupyterlab CI tests have been running against e.g. `@finos/perspective-viewer-datagrid` from NPM instead of locally since #1808, which is fixed by this PR