### PR TITLE
Python parses period as seconds separators in string-formatted datetimes incorrectly

### DIFF
--- a/python/perspective/perspective/tests/table/test_datetimes.py
+++ b/python/perspective/perspective/tests/table/test_datetimes.py
@@ -1,0 +1,51 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+from pytest import raises
+import pytz
+import pandas as pd
+import perspective
+from datetime import date, datetime, timedelta
+
+TIMEZONE = pytz.timezone("America/New_York")
+
+
+class TestException(object):
+    def test_datetime_seconds_string_with_period_sep_parses_correctly(self):
+        dt = datetime(2022, 7, 8, 5, 15, 35).astimezone(TIMEZONE)
+        dt_str = dt.strftime("%m/%d/%Y %H:%M.%S %p")
+        df = pd.DataFrame(
+            [
+                {
+                    "datetime": dt,
+                    "datetime_str": dt_str,
+                }
+            ]
+        )
+
+        tbl = perspective.Table(df)
+        view = tbl.view()
+        result = view.to_records()
+        assert result[0]["datetime"].second == result[0]["datetime_str"].second
+
+    def test_datetime_seconds_string_with_colon_sep_parses_correctly(self):
+        dt = datetime(2022, 7, 8, 5, 15, 35).astimezone(TIMEZONE)
+        dt_str = dt.strftime("%m/%d/%Y %H:%M:%S %p")
+        df = pd.DataFrame(
+            [
+                {
+                    "datetime": dt,
+                    "datetime_str": dt_str,
+                }
+            ]
+        )
+
+        tbl = perspective.Table(df)
+        view = tbl.view()
+        result = view.to_records()
+        assert result[0]["datetime"].second == result[0]["datetime_str"].second


### PR DESCRIPTION
E.g., the time string `10:15.35` is parsed as 10 hours, 15 minutes and 35/100 seconds.

Currently this is just a failing test.  I'm not yet clear fixing this is unambiguous.