### PR TITLE
Eliminate custom wheel code / build universal2 wheels for mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - tkp/universal2
     tags:
       - v*
     paths-ignore:
@@ -143,7 +144,6 @@ jobs:
           SKIP_PYTHON: ${{ contains(github.event.pull_request.title, '[ci-skip-python]') || contains(env.COMMIT_MSG, '[ci-skip-python]') }}
           INCLUDE_WINDOWS: ${{ contains(github.event.pull_request.title, '[ci-include-windows]') || contains(env.COMMIT_MSG, '[ci-include-windows]') }}
         if: ${{ github.event_name == 'pull_request' }}
-
 
       - name: Display and Setup Build Args (Manual)
         id: setupmanual
@@ -769,8 +769,9 @@ jobs:
           - is-full-run: false
             os: macos-10.15
 
-          - is-full-run: false
-            os: macos-11
+          # TODO remove when done
+          # - is-full-run: false
+          #   os: macos-11
 
           # Exclude Python 3.7 and 3.8 builds
           - is-full-run: false
@@ -960,7 +961,6 @@ jobs:
       env:
         PYTHON_VERSION: ${{ matrix.python-version }}
         MANYLINUX: ${{ matrix.container }}
-        PSP_DOCKER: 1
       if: ${{ matrix.os == 'ubuntu-20.04' }}
 
     ########
@@ -1242,14 +1242,15 @@ jobs:
           - is-full-run: false
             os: windows-2019
 
-          # Exclude Macos 10.15 bulds
+          # Exclude Macos
           - is-full-run: false
             os: macos-10.15
 
-          # Exclude Python 3.7 and 3.8 builds
-          - is-full-run: false
-            os: macos-11
+          # TODO remove when done
+          # - is-full-run: false
+          #   os: macos-11
 
+          # Exclude Python 3.7 and 3.8 builds
           - is-full-run: false
             python-version: 3.7
 

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -221,6 +221,12 @@ class PSPBuild(build_ext):
             ]
 
         env["PSP_ENABLE_PYTHON"] = "1"
+
+        # Relevant mac env vars:
+        # _PYTHON_HOST_PLATFORM: macosx-11.0-arm64,
+        #                        macosx-10.9-x86_64,
+        #                        macosx-10.9-universal2,
+        # ARCHFLAGS: -arch arm64 -arch x86_64
         env["OSX_DEPLOYMENT_TARGET"] = os.environ.get(
             "PSP_OSX_DEPLOYMENT_TARGET", "10.9"
         )

--- a/scripts/script_utils.js
+++ b/scripts/script_utils.js
@@ -328,6 +328,31 @@ exports.python_version = function python_version(manylinux) {
 };
 
 /**
+ * Get the python tag to use from env/arguments.
+ * NOTE: we only support cpython builds.
+ * 
+ * ref: https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
+ *
+ * @returns {string} The python tag to use
+ */
+ exports.python_tag = function python_tag(manylinux) {
+     if (process.env.PYTHON_VERSION) {
+         const v = process.env.PYTHON_VERSION.replace(".", "");
+         return `cp${v}`;
+    } else if (getarg("--python310")) {
+        return "cp310";
+    } else if (getarg("--python39")) {
+        return "cp39";
+    } else if (getarg("--python38")) {
+        return "cp38";
+    } else if (getarg("--python37")) {
+        return "cp37";
+    } else {
+        return "cp39";
+    }
+};
+
+/**
  * Get the docker image to use for the given image/python combination
  *
  * @param {string} image The Docker image name.


### PR DESCRIPTION
Takes https://github.com/finos/perspective/pull/1893 even further by removing any custom wheel management code (including building inside of manylinux wheels via docker directly, running `delocate` / `auditwheel` directly, etc) and offloading all this work to the very widely used and officially endorsed [`cibuildwheel`](https://github.com/pypa/cibuildwheel/) project. 