### PR TITLE
Fix webpack plugin compat with emsdk single-link build

### DIFF
--- a/packages/perspective-webpack-plugin/index.js
+++ b/packages/perspective-webpack-plugin/index.js
@@ -42,6 +42,17 @@ class PerspectiveWebpackPlugin {
         const moduleOptions =
             compilerOptions.module || (compilerOptions.module = {});
         const rules = [];
+
+        // Emscripten outputs require statements for these which are not called
+        // when loaded in browser.  It's not polite to delete these but ...
+        const resolveOptions =
+            compilerOptions.resolve || (compilerOptions.resolve = {});
+        const fallbackOptions =
+            resolveOptions.fallback || (resolveOptions.fallback = {});
+
+        fallbackOptions.path = false;
+        fallbackOptions.fs = false;
+
         rules.push({
             test: /perspective\.worker\.js$/,
             type: "javascript/auto",


### PR DESCRIPTION
Fixes a regression in `@finos/perspective-webpack-plugin` which caused unresolvable node.js imports `"fs"` and `"path"` to fail.