### PR TITLE
Add migrate support for datagrid `plugin_config` API

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/axis/ordinalAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/ordinalAxis.js
@@ -27,7 +27,7 @@ export const domain = () => {
     const _domain = (data) => {
         const flattenedData = flattenArray(data);
         return transformDomain([
-            ...new Set(flattenedData.map((d) => d[valueNames[0]])),
+            ...Array.from(new Set(flattenedData.map((d) => d[valueNames[0]]))),
         ]);
     };
 

--- a/packages/perspective/src/js/config/index.js
+++ b/packages/perspective/src/js/config/index.js
@@ -49,21 +49,21 @@ function mergeDeep(target, ...sources) {
     return mergeDeep(target, ...sources);
 }
 
-global.__PERSPECTIVE_CONFIG__ = undefined;
+globalThis.__PERSPECTIVE_CONFIG__ = undefined;
 
 module.exports.override_config = function (config) {
-    if (global.__PERSPECTIVE_CONFIG__) {
+    if (globalThis.__PERSPECTIVE_CONFIG__) {
         console.warn("Config already initialized!");
     }
-    global.__PERSPECTIVE_CONFIG__ = mergeDeep(DEFAULT_CONFIG, config);
+    globalThis.__PERSPECTIVE_CONFIG__ = mergeDeep(DEFAULT_CONFIG, config);
 };
 
 module.exports.get_config = function get_config() {
-    if (!global.__PERSPECTIVE_CONFIG__) {
-        global.__PERSPECTIVE_CONFIG__ = mergeDeep(
+    if (!globalThis.__PERSPECTIVE_CONFIG__) {
+        globalThis.__PERSPECTIVE_CONFIG__ = mergeDeep(
             DEFAULT_CONFIG,
-            global.__TEMPLATE_CONFIG__ || {}
+            globalThis.__TEMPLATE_CONFIG__ || {}
         );
     }
-    return global.__PERSPECTIVE_CONFIG__;
+    return globalThis.__PERSPECTIVE_CONFIG__;
 };

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -15,12 +15,6 @@ import {Server} from "./api/server.js";
 
 import formatters from "./view_formatters";
 
-// IE fix - chrono::steady_clock depends on performance.now() which does not
-// exist in IE workers
-if (global.performance === undefined) {
-    global.performance = {now: Date.now};
-}
-
 if (typeof self !== "undefined" && self.performance === undefined) {
     self.performance = {now: Date.now};
 }

--- a/packages/perspective/src/js/perspective.worker.js
+++ b/packages/perspective/src/js/perspective.worker.js
@@ -12,8 +12,8 @@ import perspective from "./perspective.js";
 
 let _perspective_instance;
 
-if (global.document !== undefined && typeof WebAssembly !== "undefined") {
-    _perspective_instance = global.perspective = perspective(
+if (globalThis.document !== undefined && typeof WebAssembly !== "undefined") {
+    _perspective_instance = globalThis.perspective = perspective(
         load_perspective({
             wasmJSMethod: "native-wasm",
             printErr: (x) => console.error(x),
@@ -21,7 +21,8 @@ if (global.document !== undefined && typeof WebAssembly !== "undefined") {
         })
     );
 } else {
-    _perspective_instance = global.perspective = perspective(load_perspective);
+    _perspective_instance = globalThis.perspective =
+        perspective(load_perspective);
 }
 
 export default _perspective_instance;

--- a/rust/perspective-viewer/build.js
+++ b/rust/perspective-viewer/build.js
@@ -126,8 +126,7 @@ const INHERIT = {
     stderr: "inherit",
 };
 
-async function build_all() {
-    await Promise.all(PREBUILD.map(build)).catch(() => process.exit(1));
+async function compile_rust() {
     const cargo_debug = IS_DEBUG ? "" : "--release";
 
     // Compile rust
@@ -184,6 +183,13 @@ async function build_all() {
     const wasm = fs.readFileSync("dist/pkg/perspective_viewer_bg.wasm");
     const compressed = fflate.compressSync(wasm, {level: 9});
     fs.writeFileSync("dist/pkg/perspective_viewer_bg.wasm", compressed);
+}
+
+async function build_all() {
+    await Promise.all(PREBUILD.map(build)).catch(() => process.exit(1));
+
+    // Rust
+    await compile_rust();
 
     // JavaScript
     execSync("yarn tsc --project tsconfig.json", INHERIT);

--- a/rust/perspective-viewer/src/ts/migrate.ts
+++ b/rust/perspective-viewer/src/ts/migrate.ts
@@ -414,12 +414,24 @@ function migrate_plugin_config(old, options) {
                 delete old.plugin_config[name];
 
                 if (typeof column.color_mode === "string") {
-                    column.number_color_mode = column.color_mode;
+                    if (column.color_mode === "foreground") {
+                        column.number_fg_mode = "color";
+                    } else if (column.color_mode === "bar") {
+                        column.number_fg_mode = "bar";
+                    } else if (column.color_mode === "background") {
+                        column.number_bg_mode = "color";
+                    } else if (column.color_mode === "gradient") {
+                        column.number_bg_mode = "gradient";
+                    } else {
+                        console.warn(`Unknown color_mode ${column.color_mode}`);
+                    }
+
+                    // column.number_color_mode = column.color_mode;
                     delete column["color_mode"];
 
                     if (options.warn) {
                         console.warn(
-                            `Deprecated perspective attribute "color_mode" renamed "number_color_mode"`
+                            `Deprecated perspective attribute "color_mode" renamed "number_bg_mode"`
                         );
                     }
                 }
@@ -431,6 +443,77 @@ function migrate_plugin_config(old, options) {
             if (options.replace_defaults) {
                 old.plugin_config.editable = false;
                 old.plugin_config.scroll_lock = true;
+            }
+        }
+
+        // Post 1.5, number columns have been split between `fg` and `bg`
+        // style param contexts.
+        for (const name of Object.keys(old.plugin_config.columns)) {
+            const column = old.plugin_config.columns[name];
+
+            if (typeof column.number_color_mode === "string") {
+                if (column.number_color_mode === "foreground") {
+                    column.number_fg_mode = "color";
+                } else if (column.number_color_mode === "bar") {
+                    column.number_fg_mode = "bar";
+                } else if (column.number_color_mode === "background") {
+                    column.number_bg_mode = "color";
+                } else if (column.number_color_mode === "gradient") {
+                    column.number_bg_mode = "gradient";
+                }
+
+                delete column["number_color_mode"];
+
+                if (options.warn) {
+                    console.warn(
+                        `Deprecated perspective attribute "number_color_mode" renamed "number_bg_mode"`
+                    );
+                }
+            }
+
+            if (column.gradient !== undefined) {
+                if (column.number_bg_mode === "gradient") {
+                    column.bg_gradient = column.gradient;
+                } else if (column.number_fg_mode === "bar") {
+                    column.fg_gradient = column.gradient;
+                }
+
+                delete column["gradient"];
+                if (options.warn) {
+                    console.warn(
+                        `Deprecated perspective attribute "gradient" renamed "bg_gradient"`
+                    );
+                }
+            }
+
+            if (column.pos_color !== undefined) {
+                if (column.number_bg_mode !== undefined) {
+                    column.pos_bg_color = column.pos_color;
+                } else if (column.number_fg_mode !== undefined) {
+                    column.pos_fg_color = column.pos_color;
+                }
+
+                delete column["pos_color"];
+                if (options.warn) {
+                    console.warn(
+                        `Deprecated perspective attribute "pos_color" renamed "pos_bg_color"`
+                    );
+                }
+            }
+
+            if (column.neg_color !== undefined) {
+                if (column.number_bg_mode !== undefined) {
+                    column.neg_bg_color = column.neg_color;
+                } else if (column.number_fg_mode !== undefined) {
+                    column.neg_fg_color = column.neg_color;
+                }
+
+                delete column["neg_color"];
+                if (options.warn) {
+                    console.warn(
+                        `Deprecated perspective attribute "neg_color" renamed "neg_bg_color"`
+                    );
+                }
             }
         }
     }

--- a/rust/perspective-viewer/test/js/migrate_viewer.spec.js
+++ b/rust/perspective-viewer/test/js/migrate_viewer.spec.js
@@ -72,7 +72,7 @@ const TESTS = [
             plugin: "Datagrid",
             plugin_config: {
                 columns: {
-                    Sales: {number_color_mode: "gradient", gradient: 10},
+                    Sales: {number_bg_mode: "gradient", bg_gradient: 10},
                 },
                 editable: false,
                 scroll_lock: true,
@@ -86,39 +86,215 @@ const TESTS = [
             aggregates: {},
         },
     ],
+    [
+        "New Datagrid style API",
+        {
+            plugin: "Datagrid",
+            plugin_config: {
+                columns: {
+                    Sales: {number_color_mode: "gradient", gradient: 10},
+                },
+                editable: false,
+                scroll_lock: true,
+            },
+            group_by: [],
+            split_by: [],
+            columns: ["Sales"],
+            filter: [],
+            sort: [],
+            expressions: [],
+            aggregates: {},
+        },
+        {
+            plugin: "Datagrid",
+            plugin_config: {
+                columns: {
+                    Sales: {
+                        bg_gradient: 10,
+                        number_bg_mode: "gradient",
+                    },
+                },
+                editable: false,
+                scroll_lock: true,
+            },
+            group_by: [],
+            split_by: [],
+            columns: ["Sales"],
+            filter: [],
+            sort: [],
+            expressions: [],
+            aggregates: {},
+        },
+    ],
+    [
+        "New Datagrid style API with a bar and gradient",
+        {
+            plugin: "Datagrid",
+            plugin_config: {
+                columns: {
+                    Sales: {
+                        number_color_mode: "bar",
+                        gradient: 10,
+                        pos_color: "#115599",
+                        neg_color: "#115599",
+                    },
+                },
+                editable: false,
+                scroll_lock: true,
+            },
+            group_by: [],
+            split_by: [],
+            columns: ["Sales"],
+            filter: [],
+            sort: [],
+            expressions: [],
+            aggregates: {},
+        },
+        {
+            plugin: "Datagrid",
+            plugin_config: {
+                columns: {
+                    Sales: {
+                        fg_gradient: 10,
+                        number_fg_mode: "bar",
+                        neg_fg_color: "#115599",
+                        pos_fg_color: "#115599",
+                    },
+                },
+                editable: false,
+                scroll_lock: true,
+            },
+            group_by: [],
+            split_by: [],
+            columns: ["Sales"],
+            filter: [],
+            sort: [],
+            expressions: [],
+            aggregates: {},
+        },
+    ],
+    [
+        "New API, reflexive (new API is unmodified)",
+        {
+            plugin: "Datagrid",
+            plugin_config: {
+                columns: {
+                    Discount: {
+                        neg_bg_color: "#780aff",
+                        number_bg_mode: "color",
+                        number_fg_mode: "disabled",
+                        pos_bg_color: "#f5ac0f",
+                    },
+                    Profit: {
+                        neg_bg_color: "#f50fed",
+                        number_bg_mode: "color",
+                        number_fg_mode: "disabled",
+                        pos_bg_color: "#32cd82",
+                    },
+                    Sales: {
+                        neg_bg_color: "#f5ac0f",
+                        number_bg_mode: "color",
+                        number_fg_mode: "disabled",
+                        pos_bg_color: "#780aff",
+                    },
+                },
+                editable: false,
+                scroll_lock: true,
+            },
+            columns: [
+                "Category",
+                "Sales",
+                "Discount",
+                "Profit",
+                "Sub-Category",
+                "Order Date",
+            ],
+            sort: [["Sub-Category", "desc"]],
+            aggregates: {},
+            filter: [],
+            group_by: [],
+            expressions: [],
+            split_by: [],
+        },
+        {
+            plugin: "Datagrid",
+            plugin_config: {
+                columns: {
+                    Discount: {
+                        neg_bg_color: "#780aff",
+                        number_bg_mode: "color",
+                        number_fg_mode: "disabled",
+                        pos_bg_color: "#f5ac0f",
+                    },
+                    Profit: {
+                        neg_bg_color: "#f50fed",
+                        number_bg_mode: "color",
+                        number_fg_mode: "disabled",
+                        pos_bg_color: "#32cd82",
+                    },
+                    Sales: {
+                        neg_bg_color: "#f5ac0f",
+                        number_bg_mode: "color",
+                        number_fg_mode: "disabled",
+                        pos_bg_color: "#780aff",
+                    },
+                },
+                editable: false,
+                scroll_lock: true,
+            },
+            columns: [
+                "Category",
+                "Sales",
+                "Discount",
+                "Profit",
+                "Sub-Category",
+                "Order Date",
+            ],
+            sort: [["Sub-Category", "desc"]],
+            aggregates: {},
+            filter: [],
+            group_by: [],
+            expressions: [],
+            split_by: [],
+        },
+    ],
 ];
 
 utils.with_server({}, () => {
     describe.page(
         "superstore-all.html",
         () => {
-            for (const [name, old, current] of TESTS) {
-                test.capture(`restore '${name}'`, async (page) => {
-                    const converted = convert(JSON.parse(JSON.stringify(old)));
-                    const config = await page.evaluate(async (old) => {
-                        const viewer =
-                            document.querySelector("perspective-viewer");
-                        await viewer.getTable();
-                        old.settings = true;
-                        await viewer.restore(old);
-                        const current = await viewer.save();
-                        current.settings = false;
-                        return current;
-                    }, converted);
+            describe("migrate", () => {
+                for (const [name, old, current] of TESTS) {
+                    test.capture(`restore '${name}'`, async (page) => {
+                        const converted = convert(
+                            JSON.parse(JSON.stringify(old))
+                        );
+                        const config = await page.evaluate(async (old) => {
+                            const viewer =
+                                document.querySelector("perspective-viewer");
+                            await viewer.getTable();
+                            old.settings = true;
+                            await viewer.restore(old);
+                            const current = await viewer.save();
+                            current.settings = false;
+                            return current;
+                        }, converted);
 
-                    expect(config.theme).toEqual("Material Light");
-                    delete config["theme"];
+                        expect(config.theme).toEqual("Material Light");
+                        delete config["theme"];
 
-                    expect(config.settings).toEqual(false);
-                    delete config.settings;
+                        expect(config.settings).toEqual(false);
+                        delete config.settings;
 
-                    expect(config).toEqual(current);
-                    expect(convert(old, {replace_defaults: true})).toEqual(
-                        current
-                    );
-                    return await get_contents(page);
-                });
-            }
+                        expect(config).toEqual(current);
+                        expect(convert(old, {replace_defaults: true})).toEqual(
+                            current
+                        );
+                        return await get_contents(page);
+                    });
+                }
+            });
         },
         {root: path.join(__dirname, "..", "..")}
     );

--- a/rust/perspective-viewer/test/results/results.json
+++ b/rust/perspective-viewer/test/results/results.json
@@ -3,7 +3,7 @@
     "superstore.html/doesn't leak elements.": "d0fd18b3d4d7c183c5ed155b4bf37972",
     "superstore.html/doesn't leak views when setting group by.": "54daaa4bbbe59f6ed4acc301ba871bab",
     "superstore.html/doesn't leak views when setting filters.": "6dfc1e505f1428424c3265f0236f22fc",
-    "__GIT_COMMIT__": "27eb13ab71df4ca304573492ff7b6e1782ca18e4",
+    "__GIT_COMMIT__": "4c1442210a01ef0e4eb1f2a2ea7ce9faadf7411c",
     "blank.html/Handles reloading with a schema.": "e58c62f6e0ff16dc4d753f99e0fc39c3",
     "superstore_shows_a_grid_without_any_settings_applied_": "ae1c4690d978598ca14c8669244ce604",
     "superstore_Responsive_Layout_shows_horizontal_columns_on_small_vertical_viewports_": "57ba3ad341cf8a0e4df6ab96715ff2a0",
@@ -81,5 +81,10 @@
     "dragdrop_column-selector-modes_dragover_from_named_to_required_columns_should_swap": "d9c2d859ecbf5c17a84e1cb7306d10c2",
     "dragdrop_column-selector-modes_dragover_from_optional_to_empty_columns_should_move": "d8bc0afae07bcad9a002a8ba75eddd1d",
     "dragdrop_column-selector-modes_dragover_from_optional_to_required_columns_should_swap": "e7d37d256b28d7ee2ff815f7e494a46c",
-    "dragdrop_column-selector-modes_dragover_filter_in_should_work": "d6a9d0eb28216e9a1da71fb350207fc6"
+    "dragdrop_column-selector-modes_dragover_filter_in_should_work": "d6a9d0eb28216e9a1da71fb350207fc6",
+    "superstore-all_migrate_restore__Bucket_by_year_": "e553e253c983516dea41eb584a889612",
+    "superstore-all_migrate_restore__Plugin_config_color_mode_": "e15272040eea436c123116c69c11a3e8",
+    "superstore-all_migrate_restore__New_Datagrid_style_API_": "e15272040eea436c123116c69c11a3e8",
+    "superstore-all_migrate_restore__New_Datagrid_style_API_with_a_bar_and_gradient_": "93078014b83a1364c39148e935471f1c",
+    "superstore-all_migrate_restore__New_API,_reflexive_(new_API_is_unmodified)_": "e034d0f8624ed40838ae85a84120eba5"
 }


### PR DESCRIPTION
* Fixes `@finos/perspective-viewer/dist/cjs/migrate` migration script to be compatible with the `plugin_config` API changes introduced in #1889
* Fixes various issues with disparities between ES6 and babel
    * Replace `global` with `globalThis`
    * Fix issues with spread operator + `Set()` e.g. `[...new Set()]`
    * Remove IE compat clock fix for missing emscripten API