### PR TITLE
Fix "inline mode" build

### DIFF
--- a/packages/perspective/src/js/perspective.browser.js
+++ b/packages/perspective/src/js/perspective.browser.js
@@ -19,11 +19,7 @@ import wasm_worker from "@finos/perspective/src/js/perspective.worker.js";
 import wasm from "@finos/perspective/dist/pkg/esm/perspective.cpp.wasm";
 
 // eslint-disable-next-line max-len
-const INLINE_WARNING = `Perspective has been compiled in "inline" mode.  While \
-Perspective's runtime performance is not affected, you may see smaller assets \
-size and faster engine initial load time using \
-"@finos/perspective-webpack-plugin" to build your application.
-https://perspective.finos.org/docs/md/js.html`;
+const INLINE_WARNING = `Perspective has been compiled in "inline" mode.`;
 
 function is_gzip(buffer) {
     return new Uint32Array(buffer.slice(0, 4))[0] == 559903;
@@ -54,7 +50,7 @@ const _override = /* @__PURE__ */ (function () {
                     });
 
                     if (_wasm.buffer && _wasm.buffer instanceof ArrayBuffer) {
-                        console.warn(INLINE_WARNING);
+                        console.info(INLINE_WARNING);
                         if (is_gzip(_wasm.buffer)) {
                             decompressor.push(_wasm, true);
                         } else {

--- a/packages/perspective/src/js/perspective.worker.js
+++ b/packages/perspective/src/js/perspective.worker.js
@@ -10,19 +10,4 @@
 import load_perspective from "@finos/perspective/dist/pkg/esm/perspective.cpp.js";
 import perspective from "./perspective.js";
 
-let _perspective_instance;
-
-if (globalThis.document !== undefined && typeof WebAssembly !== "undefined") {
-    _perspective_instance = globalThis.perspective = perspective(
-        load_perspective({
-            wasmJSMethod: "native-wasm",
-            printErr: (x) => console.error(x),
-            print: (x) => console.log(x),
-        })
-    );
-} else {
-    _perspective_instance = globalThis.perspective =
-        perspective(load_perspective);
-}
-
-export default _perspective_instance;
+export default globalThis.perspective = perspective(load_perspective);


### PR DESCRIPTION
In some circumstances, it is useful to run Perspective without a WebWorker, e.g. when using `file://` protocol where WebWorkers are disallowed by security policy in Chrome.  The code which enabled this runtime mode was updated incorrectly #1914, which this PR fixes.