### PR TITLE
Fix app export

### DIFF
--- a/packages/perspective-esbuild-plugin/index.js
+++ b/packages/perspective-esbuild-plugin/index.js
@@ -15,7 +15,10 @@ exports.PerspectiveEsbuildPlugin = function PerspectiveEsbuildPlugin(
     options = {}
 ) {
     const wasm_plugin = WasmPlugin(!!options.wasm?.inline);
-    const worker_plugin = WorkerPlugin(!!options.worker?.inline);
+    const worker_plugin = WorkerPlugin({
+        inline: !!options.worker?.inline,
+        targetdir: options.worker?.targetdir,
+    });
 
     // Rust outputs a `URL()` when an explicit path for the wasm
     // is not specified.  Esbuild ignores this, but webpack does not,

--- a/packages/perspective-esbuild-plugin/worker.js
+++ b/packages/perspective-esbuild-plugin/worker.js
@@ -3,13 +3,15 @@ const path = require("path");
 const esbuild = require("esbuild");
 const {EmptyPlugin} = require("./empty.js");
 
-exports.WorkerPlugin = function WorkerPlugin(inline) {
+exports.WorkerPlugin = function WorkerPlugin(options = {}) {
+    const inline = !!options.inline;
+    const targetdir = options.targetdir || "build/worker";
     function setup(build) {
         build.onResolve(
             {filter: /^(monaco-editor|\@finos\/perspective).+?worker\.js$/},
             (args) => {
                 if (args.namespace === "worker-stub") {
-                    const outfile = `build/worker/` + path.basename(args.path);
+                    const outfile = `${targetdir}/` + path.basename(args.path);
                     const subbuild = esbuild.build({
                         target: ["es2021"],
                         entryPoints: [require.resolve(args.path)],

--- a/packages/perspective-jupyterlab/build.js
+++ b/packages/perspective-jupyterlab/build.js
@@ -12,7 +12,12 @@ const TEST_BUILD = {
     define: {
         global: "window",
     },
-    plugins: [lessLoader(), WasmPlugin(true), WorkerPlugin(true), UMDLoader()],
+    plugins: [
+        lessLoader(),
+        WasmPlugin(true),
+        WorkerPlugin({inline: true}),
+        UMDLoader(),
+    ],
     globalName: "PerspectiveLumino",
     format: "cjs",
     loader: {
@@ -27,7 +32,7 @@ const PROD_BUILD = {
     define: {
         global: "window",
     },
-    plugins: [lessLoader(), WasmPlugin(true), WorkerPlugin(true)],
+    plugins: [lessLoader(), WasmPlugin(true), WorkerPlugin({inline: true})],
     external: ["@jupyter*", "@lumino*"],
     format: "esm",
     loader: {

--- a/packages/perspective-workspace/build.js
+++ b/packages/perspective-workspace/build.js
@@ -57,7 +57,7 @@ const BUILD = [
             IgnoreCSSPlugin(),
             IgnoreFontsPlugin(),
             WasmPlugin(true),
-            WorkerPlugin(true),
+            WorkerPlugin({inline: true}),
         ],
         format: "iife",
         loader: {
@@ -81,7 +81,7 @@ const BUILD = [
             IgnoreCSSPlugin(),
             IgnoreFontsPlugin(),
             WasmPlugin(false),
-            WorkerPlugin(false),
+            WorkerPlugin({inline: false}),
         ],
         format: "esm",
         splitting: true,

--- a/rust/perspective-viewer/Cargo.toml
+++ b/rust/perspective-viewer/Cargo.toml
@@ -14,6 +14,9 @@ path = "src/rust/lib.rs"
 define_custom_elements_async = []
 default = []
 
+[build-dependencies]
+serde_json = { version = "1.0.59", features = ["raw_value"] }
+
 [dependencies]
 # Provides async `Mutex` for locked sections such as `render`
 async-std = "1.9.0"

--- a/rust/perspective-viewer/build.rs
+++ b/rust/perspective-viewer/build.rs
@@ -1,0 +1,16 @@
+use std::{fs::File, io::BufReader};
+
+fn get_version_from_package() -> Option<String> {
+    let file = File::open("./package.json").ok()?;
+    let reader = BufReader::new(file);
+    let value: serde_json::Value = serde_json::from_reader(reader).ok()?;
+    let version = value.as_object().unwrap().get("version")?.as_str()?;
+    Some(version.to_owned())
+}
+
+fn main() {
+    println!(
+        "cargo:rustc-env=PKG_VERSION={}",
+        get_version_from_package().expect("Version not detected")
+    )
+}

--- a/rust/perspective-viewer/src/rust/model/export_app.rs
+++ b/rust/perspective-viewer/src/rust/model/export_app.rs
@@ -6,9 +6,22 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use itertools::Itertools;
+
 static VERSION: &str = env!("PKG_VERSION");
 
-pub fn render(data: &str, layout: &str) -> String {
+fn render_plugin(tag_name: impl AsRef<str>) -> String {
+    format!(
+        "import \"https://cdn.jsdelivr.net/npm/@finos/{0}@{1}/dist/cdn/{0}.js\";\n",
+        tag_name.as_ref(),
+        VERSION
+    )
+}
+
+pub fn render(data: &str, layout: &str, plugins: &[String]) -> String {
+    let stmts = plugins.iter().map(render_plugin);
+    let imports = Itertools::intersperse(stmts, " ".to_owned()).collect::<String>();
+
     format!("
 <!DOCTYPE html lang=\"en\">
 <html>
@@ -18,8 +31,7 @@ pub fn render(data: &str, layout: &str) -> String {
 <script type=\"module\">
 import perspective from \"https://cdn.jsdelivr.net/npm/@finos/perspective@{0}/dist/cdn/perspective.js\";
 import \"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer@{0}/dist/cdn/perspective-viewer.js\";
-import \"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid@{0}/dist/cdn/perspective-viewer-datagrid.js\";
-import \"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc@{0}/dist/cdn/perspective-viewer-d3fc.js\";
+{3}
 const worker = perspective.worker();
 const binary_string = window.atob(window.data.textContent);
 const len = binary_string.length;
@@ -38,5 +50,5 @@ window.viewer.restore(JSON.parse(window.layout.textContent));
 <perspective-viewer id='viewer'></perspective-viewer>
 </body>
 </html>
-", VERSION,  data, layout)
+", VERSION, data, layout, imports)
 }

--- a/rust/perspective-viewer/src/rust/model/export_app.rs
+++ b/rust/perspective-viewer/src/rust/model/export_app.rs
@@ -6,11 +6,20 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-static JS: &str = "
-import perspective from \"https://cdn.jsdelivr.net/npm/@finos/perspective@vlatest/dist/cdn/perspective.js\";
-import \"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer@vlatest/dist/cdn/perspective-viewer.js\";
-import \"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid@vlatest/dist/cdn/perspective-viewer-datagrid.js\";
-import \"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc@vlatest/dist/cdn/perspective-viewer-d3fc.js\";
+static VERSION: &str = env!("PKG_VERSION");
+
+pub fn render(data: &str, layout: &str) -> String {
+    format!("
+<!DOCTYPE html lang=\"en\">
+<html>
+<head>
+<meta name=\"viewport\" content=\"width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no\"/>
+<link rel=\"stylesheet\" crossorigin=\"anonymous\" href=\"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer@{0}/dist/css/themes.css\"/>
+<script type=\"module\">
+import perspective from \"https://cdn.jsdelivr.net/npm/@finos/perspective@{0}/dist/cdn/perspective.js\";
+import \"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer@{0}/dist/cdn/perspective-viewer.js\";
+import \"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid@{0}/dist/cdn/perspective-viewer-datagrid.js\";
+import \"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc@{0}/dist/cdn/perspective-viewer-d3fc.js\";
 const worker = perspective.worker();
 const binary_string = window.atob(window.data.textContent);
 const len = binary_string.length;
@@ -20,23 +29,14 @@ bytes[i] = binary_string.charCodeAt(i);
 }}
 window.viewer.load(worker.table(bytes.buffer));
 window.viewer.restore(JSON.parse(window.layout.textContent));
-";
-
-pub fn render(data: &str, layout: &str) -> String {
-    format!("
-<!DOCTYPE html lang=\"en\">
-<html>
-<head>
-<meta name=\"viewport\" content=\"width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no\"/>
-<link rel=\"stylesheet\" crossorigin=\"anonymous\" href=\"https://cdn.jsdelivr.net/npm/@finos/perspective-viewer@vlatest/dist/css/themes.css\"/>
-<script type=\"module\">{}</script>
+</script>
 <style>perspective-viewer{{position:absolute;top:0;left:0;right:0;bottom:0}}</style>
 </head>
 <body>
-<script id='data' type=\"application/octet-stream\">{}</script>
-<script id='layout' type=\"application/json\">{}</script>
+<script id='data' type=\"application/octet-stream\">{1}</script>
+<script id='layout' type=\"application/json\">{2}</script>
 <perspective-viewer id='viewer'></perspective-viewer>
 </body>
 </html>
-", JS.trim(), data, layout)
+", VERSION,  data, layout)
 }


### PR DESCRIPTION
When exporting as `.html`, `<perspective-viewer>` will now:
* Import the pinned version of the host `<perspective-viewer>`, rather than `@latest`.
* Import only the set of plugins the host `<perspective-viewer>` uses, rather than the default set (makes more sense now that `@finos/perspective-viewer-openlayers` is available).