### PR TITLE
remove separate mock dependency, now part of unittest - fixes #1821

### DIFF
--- a/python/perspective/perspective/tests/core/test_layout.py
+++ b/python/perspective/perspective/tests/core/test_layout.py
@@ -7,7 +7,7 @@
 #
 
 import pandas as pd
-from mock import patch
+from unittest.mock import patch
 from perspective import PerspectiveWidget, Plugin, PerspectiveError
 
 

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -72,7 +72,6 @@ requires_dev = (
         "Faker>=1.0.0",
         "flake8>=3.7.8",
         "flake8-black>=0.2.0",
-        "mock",
         "psutil",
         "pybind11>=2.4.0",
         "pyarrow>=0.16.0",


### PR DESCRIPTION
redo of https://github.com/finos/perspective/pull/1827 now that the docker images are gone