### PR TITLE
Fix Python bug in `async` mode

### DIFF
--- a/python/perspective/perspective/tests/handlers/test_aiohttp_async_mode.py
+++ b/python/perspective/perspective/tests/handlers/test_aiohttp_async_mode.py
@@ -1,0 +1,85 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+import asyncio
+import threading
+import pytest
+import random
+
+from aiohttp import web
+from datetime import datetime
+
+from perspective import (
+    Table,
+    PerspectiveManager,
+    PerspectiveAIOHTTPHandler,
+    aiohttp_websocket as websocket,
+)
+
+
+data = {
+    "a": [i for i in range(10)],
+    "b": [i * 1.5 for i in range(10)],
+    "c": [str(i) for i in range(10)],
+    "d": [datetime(2020, 3, i, i, 30, 45) for i in range(1, 11)],
+}
+
+MANAGER = PerspectiveManager()
+
+
+def perspective_thread(manager):
+    psp_loop = asyncio.new_event_loop()
+    manager.set_loop_callback(psp_loop.call_soon_threadsafe)
+    psp_loop.run_forever()
+
+
+thread = threading.Thread(target=perspective_thread, args=(MANAGER,))
+thread.daemon = True
+thread.start()
+
+
+async def websocket_handler(request):
+    handler = PerspectiveAIOHTTPHandler(manager=MANAGER, request=request)
+    await handler.run()
+
+
+@pytest.fixture
+def app():
+    app = web.Application()
+    app.router.add_get("/websocket", websocket_handler)
+    return app
+
+
+class TestPerspectiveAIOHttpHandlerAsyncMode(object):
+    def setup_method(self):
+        """Flush manager state before each test method execution."""
+        MANAGER._tables = {}
+        MANAGER._views = {}
+
+    async def websocket_client(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        return await websocket(
+            "http://{}:{}/websocket".format(client.host, client.port), client.session
+        )
+
+    @pytest.mark.asyncio
+    async def test_aiohttp_handler_async_manager_thread(self, app, aiohttp_client):
+        table_name = str(random.random())
+        _table = Table(data)
+        MANAGER.host_table(table_name, _table)
+        client = await self.websocket_client(app, aiohttp_client)
+        table = client.open_table(table_name)
+        view = await table.view()
+        reqs = []
+        for x in range(10):
+            reqs.append(table.update(data))
+            reqs.append(view.to_arrow())
+
+        await asyncio.gather(*reqs)
+        records = await view.to_records()
+        assert len(records) == 110

--- a/python/perspective/perspective/tests/handlers/test_starlette_async_mode.py
+++ b/python/perspective/perspective/tests/handlers/test_starlette_async_mode.py
@@ -1,0 +1,86 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+import pytest
+import random
+import threading
+import asyncio
+
+from datetime import datetime
+
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+
+from perspective import (
+    Table,
+    PerspectiveManager,
+    PerspectiveStarletteHandler,
+    PerspectiveError,
+)
+
+from perspective.client.starlette_test import websocket
+
+data = {
+    "a": [i for i in range(10)],
+    "b": [i * 1.5 for i in range(10)],
+    "c": [str(i) for i in range(10)],
+    "d": [datetime(2020, 3, i, i, 30, 45) for i in range(1, 11)],
+}
+
+MANAGER = PerspectiveManager()
+
+
+def perspective_thread(manager):
+    psp_loop = asyncio.new_event_loop()
+    manager.set_loop_callback(psp_loop.call_soon_threadsafe)
+    psp_loop.run_forever()
+
+
+thread = threading.Thread(target=perspective_thread, args=(MANAGER,))
+thread.daemon = True
+thread.start()
+
+
+async def websocket_handler(websocket: WebSocket):
+    handler = PerspectiveStarletteHandler(manager=MANAGER, websocket=websocket)
+    await handler.run()
+
+
+APPLICATION = FastAPI()
+APPLICATION.add_api_websocket_route("/websocket", websocket_handler)
+
+CLIENT = TestClient(APPLICATION)
+
+
+class TestPerspectiveStarletteHandlerAsyncMode(object):
+    def setup_method(self):
+        """Flush manager state before each test method execution."""
+        MANAGER._tables = {}
+        MANAGER._views = {}
+
+    async def websocket_client(self):
+        return await websocket(CLIENT, "/websocket")
+
+    @pytest.mark.asyncio
+    async def test_starlette_handler_async_manager_thread(self):
+        table_name = str(random.random())
+        _table = Table(data)
+        MANAGER.host_table(table_name, _table)
+        client = await self.websocket_client()
+        table = client.open_table(table_name)
+        view = await table.view()
+        reqs = []
+        for x in range(10):
+            reqs.append(table.update(data))
+            reqs.append(view.to_arrow())
+
+        await asyncio.gather(*reqs)
+        records = await view.to_records()
+        assert len(records) == 110
+
+        await client.terminate()

--- a/python/perspective/perspective/tests/handlers/test_tornado_async_mode.py
+++ b/python/perspective/perspective/tests/handlers/test_tornado_async_mode.py
@@ -1,0 +1,119 @@
+################################################################################
+#
+# Copyright (c) 2019, the Perspective Authors.
+#
+# This file is part of the Perspective library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+
+# This test demonstrates the necessity of locks for server
+# responses to multiple clients
+
+# This test should be implemented for every new server handler, but
+# should otherwise never fail for existing locking implementations.
+
+# To demonstrate failing behavior, modify the tornado handler like so:
+# -        yield self._stream_lock.acquire()
+# +        # yield self._stream_lock.acquire()
+#          try:
+#              yield f(*args, **kwargs)
+#          except tornado.websocket.WebSocketClosedError:
+#              pass
+#          finally:
+# -            yield self._stream_lock.release()
+# +            ...
+# +            # yield self._stream_lock.release()
+
+
+import asyncio
+import pytest
+import random
+import threading
+import tornado
+from datetime import datetime
+
+from perspective import (
+    Table,
+    PerspectiveManager,
+    PerspectiveTornadoHandler,
+    tornado_websocket as websocket,
+)
+
+
+data = {
+    "a": [i for i in range(10)],
+    "b": [i * 1.5 for i in range(10)],
+    "c": [str(i) for i in range(10)],
+    "d": [datetime(2020, 3, i, i, 30, 45) for i in range(1, 11)],
+}
+
+MANAGER = PerspectiveManager()
+
+
+def perspective_thread(manager):
+    psp_loop = asyncio.new_event_loop()
+    manager.set_loop_callback(psp_loop.call_soon_threadsafe)
+    # with open(file_path, mode="rb") as file:
+    #     table = Table(file.read(), index="Row ID")
+    #     manager.host_table("data_source_one", table)
+    psp_loop.run_forever()
+
+
+thread = threading.Thread(target=perspective_thread, args=(MANAGER,))
+thread.daemon = True
+thread.start()
+
+
+APPLICATION = tornado.web.Application(
+    [
+        (
+            r"/websocket",
+            PerspectiveTornadoHandler,
+            {"manager": MANAGER, "check_origin": True, "chunk_size": 10},
+        )
+    ]
+)
+
+
+@pytest.fixture
+def app():
+    return APPLICATION
+
+
+class TestPerspectiveTornadoHandlerAsyncMode(object):
+    def setup_method(self):
+        """Flush manager state before each test method execution."""
+        MANAGER._tables = {}
+        MANAGER._views = {}
+
+    async def websocket_client(self, port):
+        """Connect and initialize a websocket client connection to the
+        Perspective tornado server.
+        """
+        client = await websocket("ws://127.0.0.1:{}/websocket".format(port))
+        return client
+
+    @pytest.mark.gen_test(run_sync=False)
+    async def test_tornado_handler_async_manager_thread(
+        self, app, http_client, http_port, sentinel
+    ):
+        table_name = str(random.random())
+        _table = Table(data)
+        MANAGER.host_table(table_name, _table)
+
+        client = await self.websocket_client(http_port)
+        table = client.open_table(table_name)
+        view = await table.view()
+        reqs = []
+        for x in range(10):
+            reqs.append(table.update(data))
+            reqs.append(view.to_arrow())
+
+        await asyncio.gather(*reqs)
+        # views = await asyncio.gather(*[table.view() for _ in range(5)])
+        # outputs = await asyncio.gather(*[view.to_arrow() for view in views])
+        expected = await table.schema()
+        records = await view.to_records()
+
+        assert len(records) == 110

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -272,7 +272,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/finos/perspective",
     author="Perspective Authors",
-    author_email="open_source@jpmorgan.com",
+    author_email="info@finos.org",
     license="Apache 2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Fixes a bug introduced in #1828.  Handler callbacks need to dispatch to the event loop from the framework in order to re-inject responses after `PerspectiveManager` is invoked, and this loop is captured by the top-level invoking thread via `get_event_loop()` (in this refactor).  However, due to a closure misapplication, this loop was exclusively being captured from the Perspective thread instead.

The impact of this can be seen in the `python-tornado-streaming` example within a few seconds of a client connecting, or in the trio of tests this PR adds.

```bash
ERROR:asyncio:Exception in callback None()
handle: <Handle cancelled>
Traceback (most recent call last):
  File "~/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "~/python3.9/site-packages/tornado/platform/asyncio.py", line 189, in _handle_events
    handler_func(fileobj, events)
  File "~/python3.9/site-packages/tornado/iostream.py", line 700, in _handle_events
    self._handle_write()
  File "~/python3.9/site-packages/tornado/iostream.py", line 974, in _handle_write
    self._write_buffer.advance(num_bytes)
  File "~/python3.9/site-packages/tornado/iostream.py", line 183, in advance
    assert 0 < size <= self._size
AssertionError
```