### PR TITLE
Fix python `_requires_python` publish script on windows

### DIFF
--- a/scripts/_requires_python.js
+++ b/scripts/_requires_python.js
@@ -14,7 +14,7 @@ const {
 } = require("./script_utils.js");
 
 let PYTHON = python_version();
-const requires_script = `'import distutils.core; setup = distutils.core.run_setup("python/perspective/setup.py"); print(" ".join(["\\"" + requirement + "\\"" for requirement in setup.extras_require["dev"]]))'`;
+const requires_script = `"import distutils.core; setup = distutils.core.run_setup('python/perspective/setup.py'); print(' '.join(['\\\"' + requirement + '\\\"' for requirement in setup.extras_require['dev']]))"`;
 
 (async () => {
     try {


### PR DESCRIPTION
#1917 moved Python dependency population to a script, which is a huge improvement over the previos adhoc-`pip` approach.   However, this new script does not work on Windows, which prevented the release of `perspective-python` 1.6.2, fixed in this PR.