### PR TITLE
Don't calculate unused `expressions`

### DIFF
--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1646,7 +1646,7 @@ namespace binding {
         auto filter_op = view_config->get_filter_op();
         auto fterm = view_config->get_fterm();
         auto sortspec = view_config->get_sortspec();
-        auto expressions = view_config->get_expressions();
+        auto expressions = view_config->get_used_expressions();
 
         auto cfg = t_config(columns, fterm, filter_op, expressions);
         auto ctx0 = std::make_shared<t_ctx0>(*(schema.get()), cfg);
@@ -1671,7 +1671,7 @@ namespace binding {
         auto fterm = view_config->get_fterm();
         auto sortspec = view_config->get_sortspec();
         auto row_pivot_depth = view_config->get_row_pivot_depth();
-        auto expressions = view_config->get_expressions();
+        auto expressions = view_config->get_used_expressions();
 
         auto cfg
             = t_config(row_pivots, aggspecs, fterm, filter_op, expressions);
@@ -1708,7 +1708,7 @@ namespace binding {
         auto col_sortspec = view_config->get_col_sortspec();
         auto row_pivot_depth = view_config->get_row_pivot_depth();
         auto column_pivot_depth = view_config->get_column_pivot_depth();
-        auto expressions = view_config->get_expressions();
+        auto expressions = view_config->get_used_expressions();
 
         t_totals total = sortspec.size() > 0 ? TOTALS_BEFORE : TOTALS_HIDDEN;
 

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -68,6 +68,11 @@ public:
     void validate(std::shared_ptr<t_schema> schema);
 
     /**
+     * @brief Retrieve only the used expressions.
+     */
+    std::vector<std::shared_ptr<t_computed_expression>> get_used_expressions();
+
+    /**
      * @brief Add filter terms manually, as the filter term must be calculated
      * from the value passed through the binding.
      *

--- a/python/perspective/perspective/src/context.cpp
+++ b/python/perspective/perspective/src/context.cpp
@@ -48,7 +48,7 @@ namespace binding {
         auto filter_op = view_config->get_filter_op();
         auto fterm = view_config->get_fterm();
         auto sortspec = view_config->get_sortspec();
-        auto expressions = view_config->get_expressions();
+        auto expressions = view_config->get_used_expressions();
 
         auto cfg = t_config(columns, fterm, filter_op, expressions);
         auto ctx0 = std::make_shared<t_ctx0>(*(schema.get()), cfg);
@@ -73,7 +73,7 @@ namespace binding {
         auto fterm = view_config->get_fterm();
         auto sortspec = view_config->get_sortspec();
         auto row_pivot_depth = view_config->get_row_pivot_depth();
-        auto expressions = view_config->get_expressions();
+        auto expressions = view_config->get_used_expressions();
 
         auto cfg
             = t_config(row_pivots, aggspecs, fterm, filter_op, expressions);
@@ -110,7 +110,7 @@ namespace binding {
         auto col_sortspec = view_config->get_col_sortspec();
         auto row_pivot_depth = view_config->get_row_pivot_depth();
         auto column_pivot_depth = view_config->get_column_pivot_depth();
-        auto expressions = view_config->get_expressions();
+        auto expressions = view_config->get_used_expressions();
 
         t_totals total = sortspec.size() > 0 ? TOTALS_BEFORE : TOTALS_HIDDEN;
 


### PR DESCRIPTION
`expressions` which are unused by `columns`/`group_by`/etc should not be calculated (but they do need to be maintained by the `View` instance as they are query-able metadata).  This is a _bug_ rather than an _enhancement_ because this behavior was a presumption of the UI already, as well as a property that was enforced by the previous iteration of `<perspective-viewer>` component (this PR moves the behavior to the `@finos/perspective` engine itself for consistency across languages/consumers).