### PR TITLE
Fix Sunburst chart infinite loop bug

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
@@ -237,16 +237,18 @@ export function register(...plugins) {
                     }
 
                     async draw(view, end_col, end_row) {
-                        if (!this.isConnected) {
+                        if (this.offsetParent === null) {
+                            this._staged_view = [view, end_col, end_row];
                             return;
                         }
 
+                        this._staged_view = undefined;
                         this.config = await this.parentElement.save();
                         await this.update(view, end_col, end_row, true);
                     }
 
                     async update(view, end_col, end_row, clear = false) {
-                        if (!this.isConnected) {
+                        if (this.offsetParent === null) {
                             return;
                         }
 
@@ -409,7 +411,7 @@ export function register(...plugins) {
                     }
 
                     _draw() {
-                        if (this._settings.data && this.isConnected) {
+                        if (this.offsetParent !== null) {
                             const containerDiv = d3.select(this._container);
                             const chartClass = `chart ${name}`;
                             this._settings.size =
@@ -434,9 +436,16 @@ export function register(...plugins) {
                      * causes non-cleared redraws duplicate column labels when calculating column name
                      * resize/repositions - see `treemapLabel.js`.
                      */
-                    async resize() {
-                        if (this.isConnected) {
-                            this._draw();
+                    async resize(view) {
+                        if (this.offsetParent !== null) {
+                            if (this._settings?.data !== undefined) {
+                                this._draw();
+                            } else {
+                                const [view, end_col, end_row] =
+                                    this._staged_view;
+                                this._staged_view = undefined;
+                                this.draw(view, end_col, end_row);
+                            }
                         }
                     }
 

--- a/packages/perspective-workspace/test/html/index.html
+++ b/packages/perspective-workspace/test/html/index.html
@@ -13,6 +13,7 @@
         <script type="module" src="perspective.js"></script>
         <script type="module" src="perspective-workspace.js"></script>
         <script type="module" src="perspective-viewer-datagrid.js"></script>
+        <script type="module" src="perspective-viewer-d3fc.js"></script>
 
         <link rel="stylesheet" href="material.css" />
         <link rel="stylesheet" href="index.css" />

--- a/packages/perspective-workspace/test/js/integration/visibility.spec.js
+++ b/packages/perspective-workspace/test/js/integration/visibility.spec.js
@@ -1,0 +1,156 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const utils = require("@finos/perspective-test");
+const path = require("path");
+
+const TEST_ROOT = path.join(__dirname, "..", "..", "..");
+const PATHS = [
+    path.join(TEST_ROOT, "dist", "umd"),
+    path.join(TEST_ROOT, "dist", "theme"),
+    path.join(TEST_ROOT, "test", "html"),
+    path.join(TEST_ROOT, "test", "css"),
+    path.join(TEST_ROOT, "test", "csv"),
+];
+
+utils.with_server({paths: PATHS}, () => {
+    describe.page(
+        "index.html",
+        () => {
+            describe("Light DOM", () => {
+                tests((page) =>
+                    page.evaluate(
+                        async () =>
+                            document.getElementById("workspace").outerHTML
+                    )
+                );
+            });
+
+            describe("Shadow DOM", () => {
+                tests((page) =>
+                    page.evaluate(
+                        async () =>
+                            document
+                                .getElementById("workspace")
+                                .shadowRoot.querySelector("#container")
+                                .innerHTML
+                    )
+                );
+            });
+        },
+        {root: TEST_ROOT}
+    );
+});
+
+const BAD_LAYOUT = {
+    sizes: [1],
+    detail: {
+        main: {
+            type: "tab-area",
+            widgets: [
+                "PERSPECTIVE_GENERATED_ID_0",
+                "PERSPECTIVE_GENERATED_ID_1",
+            ],
+            currentIndex: 1,
+        },
+    },
+    mode: "globalFilters",
+    viewers: {
+        PERSPECTIVE_GENERATED_ID_0: {
+            plugin: "Sunburst",
+            plugin_config: {},
+            settings: true,
+            theme: null,
+            group_by: ["State"],
+            split_by: [],
+            columns: ["Quantity", null, null],
+            filter: [],
+            sort: [],
+            expressions: [],
+            aggregates: {},
+            master: false,
+            name: "My Data",
+            table: "myData",
+            linked: false,
+        },
+        PERSPECTIVE_GENERATED_ID_1: {
+            plugin: "Sunburst",
+            plugin_config: {},
+            settings: true,
+            theme: null,
+            group_by: ["State"],
+            split_by: [],
+            columns: ["Sales", null, null],
+            filter: [],
+            sort: [],
+            expressions: [],
+            aggregates: {},
+            master: false,
+            name: "My Data",
+            table: "myData",
+            linked: false,
+        },
+    },
+};
+
+function tests(extract) {
+    describe("visibility", () => {
+        test.capture(
+            "Sunburst charts do not loop forever when disconnected from DOM",
+            async (page) => {
+                await page.waitForFunction(() => !!window.__TABLE__);
+                await page.evaluate(async (layout) => {
+                    // const viewer = document.createElement("perspective-viewer");
+                    // viewer.setAttribute("table", "superstore");
+                    // viewer.setAttribute("name", "one");
+                    // viewer.setAttribute("slot", "one");
+                    // const viewer2 =
+                    //     document.createElement("perspective-viewer");
+                    // viewer2.setAttribute("table", "superstore");
+                    // viewer2.setAttribute("name", "two");
+                    // viewer2.setAttribute("slot", "two");
+                    // const workspace = document.getElementById("workspace");
+                    // workspace.appendChild(viewer);
+                    // workspace.appendChild(viewer2);
+                    // await workspace.flush();
+
+                    // const datasource = async () => {
+                    //     const worker = window.perspective.worker();
+                    //     const data = [
+                    //         {country: "United States", age: 1},
+                    //         {country: "China", age: 1},
+                    //         {country: "Russia", age: 2},
+                    //         {country: "Germany", age: 3},
+                    //         {country: "Canada", age: 2},
+                    //         {country: "Australia", age: 3},
+                    //         {country: "Great Britain", age: 4},
+                    //         {country: "South Korea", age: 1},
+                    //     ];
+                    //     return worker.table(data);
+                    // };
+
+                    // window.addEventListener("load", async () => {
+                    window.workspace.tables.set("myData", window.__TABLE__);
+                    await window.workspace.restore(layout);
+                }, BAD_LAYOUT);
+
+                // await page.evaluate(async () => {
+                //     const viewer = document.body.querySelector(
+                //         'perspective-viewer[name="one"]'
+                //     );
+                //     const workspace = document.getElementById("workspace");
+                //     workspace.removeChild(viewer);
+                //     await workspace.flush();
+                // });
+
+                return extract(page);
+            }
+        );
+    });
+}

--- a/packages/perspective-workspace/test/results/results.json
+++ b/packages/perspective-workspace/test/results/results.json
@@ -1,5 +1,5 @@
 {
-    "__GIT_COMMIT__": "c744efa438393bf46bf0d0801d9807fd86b64f51",
+    "__GIT_COMMIT__": "67e6675f87a1b57d6e34de57ae6a839d78a4364e",
     "index_restore_workspace_with_detail_only": "d24f601369fbf86c853d4dd2894506e3",
     "index_Light_DOM_restore_workspace_with_detail_only": "e23bd42ed74c5efc2d067301b449027d",
     "index_Shadow_DOM_restore_workspace_with_detail_only": "aa44cdf6689ff93f68d4a4cffe292e09",
@@ -16,5 +16,7 @@
     "index_Shadow_DOM_Create_Multiple": "4d88faf666989a462633244ece20f2c8",
     "index_Shadow_DOM_Create_multiple_with_names": "391266f09bb098827941e474f3733680",
     "workspace-all_Light_DOM_Restore_workspace_\"Bucket_by_year": "c0bc13512d1449e3cde3f1a4c5963a70",
-    "workspace-all_Shadow_DOM_Restore_workspace_\"Bucket_by_year": "aa44cdf6689ff93f68d4a4cffe292e09"
+    "workspace-all_Shadow_DOM_Restore_workspace_\"Bucket_by_year": "aa44cdf6689ff93f68d4a4cffe292e09",
+    "index_Light_DOM_visibility_Sunburst_charts_do_not_loop_forever_when_disconnected_from_DOM": "cd6a7a559b0b7b8cd050c00b8fbdbba3",
+    "index_Shadow_DOM_visibility_Sunburst_charts_do_not_loop_forever_when_disconnected_from_DOM": "b2658306ddd05fe57a00e76bc6770be3"
 }


### PR DESCRIPTION
Within sunburst charts, labels must be calculated (or not) depending on whether they will _physically fit_ in their respective slices, and this can only practically be done by measuring the text _after_ its been rendered.  When a sunburst chart is drawn but not visible, e.g. in the case of a `<perspective-workspace>` panel that is "unselected" but still _connected" from the perspective of the Shadow DOM, this can result in an infinite loop, as most geometry calculations e.g. `getBoundingClientRect()` will not return the correct values when they're not "visible".  This PR changes the initialization logic for charts, only rendering them fully when their `offsetParent` is non-null.

Fixes #1938 and adds a test case derived from the repro in this issue.