### PR TITLE
build!: assume `emcc` already in `PATH` shouldn't source `emsdk_env.sh`

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "webpack": "^5.60.0",
         "webpack-cli": "^4.3.1",
         "webpack-dev-server": "^3.11.2",
+        "which": "^2.0.2",
         "worker-loader": "^3.0.7"
     },
     "resolutions": {

--- a/scripts/run_emsdk.js
+++ b/scripts/run_emsdk.js
@@ -9,13 +9,13 @@
 
 const {execute_throw} = require("./script_utils.js");
 const path = require("path");
-const which = require('which')
+const which = require("which");
 
 const cmd = process.argv.slice(2).join(" ");
 
-if (which.sync('emcc')) {
+if (which.sync("emcc")) {
     // Assume that the user has already configged what they need, let's just execute.
-    execute_throw`${cmd}`
+    execute_throw`${cmd}`;
 } else {
     try {
         const cwd = process.cwd();

--- a/scripts/run_emsdk.js
+++ b/scripts/run_emsdk.js
@@ -9,13 +9,20 @@
 
 const {execute_throw} = require("./script_utils.js");
 const path = require("path");
+const which = require('which')
 
-try {
-    const cwd = process.cwd();
-    const cmd = process.argv.slice(2).join(" ");
-    const emsdkdir = path.join(__dirname, "..", ".emsdk");
-    execute_throw`cd ${emsdkdir} && . ./emsdk_env.sh >/dev/null 2>&1 && cd ${cwd} && ${cmd}`;
-} catch (e) {
-    console.log(e.message);
-    process.exit(1);
+const cmd = process.argv.slice(2).join(" ");
+
+if (which.sync('emcc')) {
+    // Assume that the user has already configged what they need, let's just execute.
+    execute_throw`${cmd}`
+} else {
+    try {
+        const cwd = process.cwd();
+        const emsdkdir = path.join(__dirname, "..", ".emsdk");
+        execute_throw`cd ${emsdkdir} && . ./emsdk_env.sh >/dev/null 2>&1 && cd ${cwd} && ${cmd}`;
+    } catch (e) {
+        console.log(e.message);
+        process.exit(1);
+    }
 }


### PR DESCRIPTION
This allows us to avoid making assumptions on platforms where `emscripen` is more-or-less installed
correctly for our use, like with Chocolatey on Windows.

Signed off by @texodus while pairing.