### PR TITLE
WIP: add fractional seconds digits to datetime fields in `perspective-viewer`

### DIFF
--- a/rust/perspective-viewer/package.json
+++ b/rust/perspective-viewer/package.json
@@ -60,5 +60,9 @@
     "devDependencies": {
         "@finos/perspective-esbuild-plugin": "^1.6.5",
         "@finos/perspective-test": "^1.6.5"
+        "esbuild": "^0.15.5",
+        "esbuild-plugin-less": "^1.1.9",
+        "node-fetch": "^2.6.7",
+        "tar": "^6.1.11"
     }
 }

--- a/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
@@ -100,7 +100,12 @@ impl DatetimeColumnStyle {
 
     /// Generate a color selector component for a specific `StringColorMode`
     /// variant.
-    fn color_select_row(&self, ctx: &Context<Self>, mode: &DatetimeColorMode, title: &str) -> Html {
+    fn color_select_row(
+        &self,
+        ctx: &Context<Self>,
+        mode: &DatetimeColorMode,
+        title: &str,
+    ) -> Html {
         let on_color = ctx.link().callback(DatetimeColumnStyleMsg::ColorChanged);
         let color = self
             .config
@@ -184,7 +189,8 @@ impl Component for DatetimeColumnStyle {
             }
             DatetimeColumnStyleMsg::ColorModeEnabled(enabled) => {
                 if enabled {
-                    self.config.datetime_color_mode = Some(DatetimeColorMode::default());
+                    self.config.datetime_color_mode =
+                        Some(DatetimeColorMode::default());
                 } else {
                     self.config.datetime_color_mode = None;
                     self.config.color = None;
@@ -230,8 +236,10 @@ impl Component for DatetimeColumnStyle {
             .link()
             .callback(|_| DatetimeColumnStyleMsg::TimezoneEnabled);
 
-        let on_date_reset = ctx.link().callback(|_| DatetimeColumnStyleMsg::DateEnabled);
-        let on_time_reset = ctx.link().callback(|_| DatetimeColumnStyleMsg::TimeEnabled);
+        let on_date_reset =
+            ctx.link().callback(|_| DatetimeColumnStyleMsg::DateEnabled);
+        let on_time_reset =
+            ctx.link().callback(|_| DatetimeColumnStyleMsg::TimeEnabled);
         let on_fractional_second_digits_reset = ctx
             .link()
             .callback(|_| DatetimeColumnStyleMsg::FractionalSecondsDigitsEnabled);

--- a/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
@@ -47,6 +47,7 @@ pub enum DatetimeColumnStyleMsg {
     TimezoneEnabled,
     DateEnabled,
     TimeEnabled,
+    FractionalSecondsDigitsEnabled,
     DateStyleChanged(DatetimeFormat),
     TimeStyleChanged(DatetimeFormat),
     TimezoneChanged(String),
@@ -156,6 +157,11 @@ impl Component for DatetimeColumnStyle {
                 self.dispatch_config(ctx);
                 true
             }
+            DatetimeColumnStyleMsg::FractionalSecondsDigitsEnabled => {
+                self.config.fractional_seconds_digits = None;
+                self.dispatch_config(ctx);
+                true
+            }
             DatetimeColumnStyleMsg::DateStyleChanged(format) => {
                 self.config.date_style = format;
                 self.dispatch_config(ctx);
@@ -226,6 +232,9 @@ impl Component for DatetimeColumnStyle {
 
         let on_date_reset = ctx.link().callback(|_| DatetimeColumnStyleMsg::DateEnabled);
         let on_time_reset = ctx.link().callback(|_| DatetimeColumnStyleMsg::TimeEnabled);
+        let on_fractional_second_digits_reset = ctx
+            .link()
+            .callback(|_| DatetimeColumnStyleMsg::FractionalSecondsDigitsEnabled);
 
         // TODO this checkbox should be disabled if the timezone is local but
         // can't set `checked=false`.
@@ -267,6 +276,17 @@ impl Component for DatetimeColumnStyle {
                                 on_select={ ctx.link().callback(DatetimeColumnStyleMsg::TimeStyleChanged) }
                                 values={ DatetimeFormat::values().iter().map(|x| SelectItem::Option(*x)).collect::<Vec<_>>() } >
                             </Select<DatetimeFormat>>
+                        </div>
+
+                        <div class="column-style-label">
+                            // TODO: Change this text to match the final feature
+                            <label class="indent">{ "Show microseconds (if available)" }</label>
+                        </div>
+                        <div class="section">
+                            <input
+                                type="checkbox"
+                                onchange={ on_fractional_second_digits_reset }
+                                cshecked={ !self.config.fractional_seconds_digits.is_some() } />
                         </div>
                     }
 

--- a/rust/perspective-viewer/src/rust/config/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/config/datetime_column_style.rs
@@ -122,6 +122,10 @@ fn time_style_default() -> DatetimeFormat {
     DatetimeFormat::Medium
 }
 
+/// TODO: note that this is a standard configuration object for the
+/// [`DateTimeFormat`] constructor.
+///
+/// [LINK]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat
 #[cfg_attr(test, derive(Debug))]
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct DatetimeColumnStyleConfig {
@@ -147,7 +151,13 @@ pub struct DatetimeColumnStyleConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fractional_seconds_digits: Option<FractionalSecondDigits>,
 }
+
+// TODO: need values b/w `0..=3`.
+pub type FractionalSecondDigits = bool;
 
 impl Default for DatetimeColumnStyleConfig {
     fn default() -> Self {
@@ -157,6 +167,7 @@ impl Default for DatetimeColumnStyleConfig {
             time_zone: Default::default(),
             datetime_color_mode: Default::default(),
             color: Default::default(),
+            fractional_seconds_digits: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This is very WIP work from a pairing session with @texodus that I'm leaving as a PR for the project to pick up. I doubt I'll be the one to push this PR specifically over the line; more details in commits.