### PR TITLE
Expression Editor autocomplete bug fixes

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,0 @@
-max_width = 88

--- a/rust/perspective-viewer/.rustfmt.toml
+++ b/rust/perspective-viewer/.rustfmt.toml
@@ -1,0 +1,14 @@
+# normalize_comments = true
+
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+newline_style = "Unix"
+normalize_doc_attributes = true
+overflow_delimited_expr = true
+reorder_impl_items = true
+use_field_init_shorthand = true
+wrap_comments = true
+format_code_in_doc_comments = true
+format_macro_matchers = true
+format_strings = true
+condense_wildcard_suffixes = true

--- a/rust/perspective-viewer/build.rs
+++ b/rust/perspective-viewer/build.rs
@@ -1,4 +1,5 @@
-use std::{fs::File, io::BufReader};
+use std::fs::File;
+use std::io::BufReader;
 
 fn get_version_from_package() -> Option<String> {
     let file = File::open("./package.json").ok()?;

--- a/rust/perspective-viewer/src/less/function-dropdown.less
+++ b/rust/perspective-viewer/src/less/function-dropdown.less
@@ -38,8 +38,7 @@
         background-color: transparent;
     }
 
-    span:hover,
-    span.selected:hover {
+    .selected:hover {
         background-color: rgba(0, 0, 0, 0.05);
     }
 }

--- a/rust/perspective-viewer/src/rust/components/column_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector.rs
@@ -11,6 +11,14 @@ mod aggregate_selector;
 mod expression_toolbar;
 mod inactive_column;
 
+use std::iter::*;
+use std::rc::Rc;
+
+use extend::ext;
+use wasm_bindgen::prelude::*;
+use web_sys::*;
+use yew::prelude::*;
+
 use self::active_column::*;
 use self::inactive_column::*;
 use super::containers::scroll_panel::*;
@@ -23,12 +31,6 @@ use crate::renderer::*;
 use crate::session::*;
 use crate::utils::*;
 use crate::*;
-use extend::ext;
-use std::iter::*;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use web_sys::*;
-use yew::prelude::*;
 
 #[derive(Properties)]
 pub struct ColumnSelectorProps {
@@ -208,7 +210,7 @@ impl Component for ColumnSelector {
                 true
             }
             Drop((_, _, DragEffect::Move(DragTarget::Active), _)) => true,
-            Drop((_, _, _, _)) => true,
+            Drop((..)) => true,
             SaveExpression(expression) => {
                 let task = ctx.props().save_expr(&expression);
                 let expr = self.expression_editor.clone();

--- a/rust/perspective-viewer/src/rust/components/column_selector/active_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/active_column.rs
@@ -6,8 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use super::expression_toolbar::*;
+use itertools::Itertools;
+use web_sys::*;
+use yew::prelude::*;
+
 use super::aggregate_selector::*;
+use super::expression_toolbar::*;
 use crate::config::*;
 use crate::dragdrop::*;
 use crate::js::plugin::*;
@@ -16,10 +20,6 @@ use crate::renderer::*;
 use crate::session::*;
 use crate::utils::ApiFuture;
 use crate::*;
-
-use itertools::Itertools;
-use web_sys::*;
-use yew::prelude::*;
 
 #[derive(Properties, Clone)]
 pub struct ActiveColumnProps {

--- a/rust/perspective-viewer/src/rust/components/column_selector/aggregate_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/aggregate_selector.rs
@@ -6,6 +6,8 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use yew::prelude::*;
+
 use crate::components::containers::select::*;
 use crate::components::style::LocalStyle;
 use crate::config::*;
@@ -14,7 +16,6 @@ use crate::renderer::*;
 use crate::session::*;
 use crate::utils::ApiFuture;
 use crate::*;
-use yew::prelude::*;
 
 #[derive(Properties)]
 pub struct AggregateSelectorProps {

--- a/rust/perspective-viewer/src/rust/components/column_selector/expression_toolbar.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/expression_toolbar.rs
@@ -6,6 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::*;
+use yew::prelude::*;
+
 use crate::config::*;
 use crate::custom_elements::expression_editor::ExpressionEditorElement;
 use crate::dragdrop::*;
@@ -14,11 +19,6 @@ use crate::renderer::*;
 use crate::session::*;
 use crate::utils::ApiFuture;
 use crate::*;
-
-use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::spawn_local;
-use web_sys::*;
-use yew::prelude::*;
 
 #[derive(Properties, Clone)]
 pub struct ExpressionToolbarProps {

--- a/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
@@ -6,6 +6,10 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use itertools::Itertools;
+use web_sys::*;
+use yew::prelude::*;
+
 use super::expression_toolbar::*;
 use crate::config::*;
 use crate::dragdrop::*;
@@ -15,10 +19,6 @@ use crate::renderer::*;
 use crate::session::*;
 use crate::utils::ApiFuture;
 use crate::*;
-
-use itertools::Itertools;
-use web_sys::*;
-use yew::prelude::*;
 
 #[derive(Properties, Clone)]
 pub struct InactiveColumnProps {

--- a/rust/perspective-viewer/src/rust/components/config_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/config_selector.rs
@@ -10,6 +10,10 @@ mod filter_item;
 mod pivot_item;
 mod sort_item;
 
+use std::rc::Rc;
+
+use yew::prelude::*;
+
 use self::filter_item::*;
 use self::pivot_item::*;
 use self::sort_item::*;
@@ -23,8 +27,6 @@ use crate::renderer::*;
 use crate::session::*;
 use crate::utils::*;
 use crate::*;
-use std::rc::Rc;
-use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
 pub struct ConfigSelectorProps {
@@ -206,7 +208,7 @@ impl Component for ConfigSelector {
                 ApiFuture::spawn(ctx.props().update_and_render(config));
                 true
             }
-            ConfigSelectorMsg::Close(_, _) => false,
+            ConfigSelectorMsg::Close(..) => false,
             ConfigSelectorMsg::Drop(column, action, effect, index)
                 if action != DragTarget::Active =>
             {
@@ -225,7 +227,7 @@ impl Component for ConfigSelector {
             {
                 true
             }
-            ConfigSelectorMsg::Drop(_, _, _, _) => false,
+            ConfigSelectorMsg::Drop(..) => false,
             ConfigSelectorMsg::TransposePivots => {
                 let mut view_config = ctx.props().session.get_view_config().clone();
                 std::mem::swap(&mut view_config.group_by, &mut view_config.split_by);

--- a/rust/perspective-viewer/src/rust/components/config_selector/filter_item.rs
+++ b/rust/perspective-viewer/src/rust/components/config_selector/filter_item.rs
@@ -6,6 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use chrono::{NaiveDate, TimeZone, Utc};
+use wasm_bindgen::JsCast;
+use web_sys::*;
+use yew::prelude::*;
+
 use crate::components::containers::dragdrop_list::*;
 use crate::components::containers::select::*;
 use crate::components::style::LocalStyle;
@@ -15,13 +20,8 @@ use crate::dragdrop::*;
 use crate::model::*;
 use crate::renderer::*;
 use crate::session::*;
-use crate::utils::ApiFuture;
-use crate::utils::{posix_to_utc_str, str_to_utc_posix};
+use crate::utils::{posix_to_utc_str, str_to_utc_posix, ApiFuture};
 use crate::*;
-use chrono::{NaiveDate, TimeZone, Utc};
-use wasm_bindgen::JsCast;
-use web_sys::*;
-use yew::prelude::*;
 
 /// A control for a single filter condition.
 pub struct FilterItem {

--- a/rust/perspective-viewer/src/rust/components/config_selector/pivot_item.rs
+++ b/rust/perspective-viewer/src/rust/components/config_selector/pivot_item.rs
@@ -6,10 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::containers::dragdrop_list::*;
-use crate::dragdrop::*;
 use web_sys::*;
 use yew::prelude::*;
+
+use crate::components::containers::dragdrop_list::*;
+use crate::dragdrop::*;
 
 pub struct PivotItem {}
 

--- a/rust/perspective-viewer/src/rust/components/config_selector/sort_item.rs
+++ b/rust/perspective-viewer/src/rust/components/config_selector/sort_item.rs
@@ -6,6 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use web_sys::*;
+use yew::prelude::*;
+
 use crate::components::containers::dragdrop_list::*;
 use crate::config::*;
 use crate::dragdrop::*;
@@ -14,8 +17,6 @@ use crate::renderer::*;
 use crate::session::*;
 use crate::utils::ApiFuture;
 use crate::*;
-use web_sys::*;
-use yew::prelude::*;
 
 /// A `SortItem` includes the column name and `SortDir` arrow, a clickable
 /// button which cycles through the available `SortDir` states.

--- a/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
@@ -6,13 +6,14 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::dragdrop::*;
+use std::marker::PhantomData;
 
 use derivative::Derivative;
-use std::marker::PhantomData;
 use web_sys::*;
 use yew::html::Scope;
 use yew::prelude::*;
+
+use crate::dragdrop::*;
 
 /// Must be implemented by `Properties` of children of `DragDropList`, returning
 /// the value a DragDropItem represents.

--- a/rust/perspective-viewer/src/rust/components/containers/dropdown_menu.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/dropdown_menu.rs
@@ -6,13 +6,15 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use web_sys::*;
+use yew::prelude::*;
+
 use super::select::SelectItem;
 use crate::components::style::LocalStyle;
 use crate::*;
-use std::marker::PhantomData;
-use std::rc::Rc;
-use web_sys::*;
-use yew::prelude::*;
 
 pub type DropDownMenuItem<T> = SelectItem<T>;
 

--- a/rust/perspective-viewer/src/rust/components/containers/radio_list.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/radio_list.rs
@@ -6,16 +6,17 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use super::radio_list_item::*;
-use crate::components::style::LocalStyle;
-use crate::*;
 use std::fmt::Display;
 use std::str::FromStr;
+
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
+use super::radio_list_item::*;
+use crate::components::style::LocalStyle;
 #[cfg(test)]
 use crate::utils::WeakScope;
+use crate::*;
 
 // The type constraints on this component are boilerplate and will be alias-able
 // in a [future rust version](https://doc.rust-lang.org/nightly/unstable-book/language-features/trait-alias.html)

--- a/rust/perspective-viewer/src/rust/components/containers/radio_list_item.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/radio_list_item.rs
@@ -6,10 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use derivative::Derivative;
 use std::fmt::Display;
 use std::marker::PhantomData;
 use std::str::FromStr;
+
+use derivative::Derivative;
 use yew::prelude::*;
 
 #[derive(Derivative)]

--- a/rust/perspective-viewer/src/rust/components/containers/scroll_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/scroll_panel.rs
@@ -9,15 +9,16 @@
 // Forked from https://github.com/AircastDev/yew-virtual-scroller (Apache 2.0)
 // Adds support for Yew 0.19, auto-width and a simplified message structure.
 
-use crate::components::style::LocalStyle;
-use crate::utils::*;
-use crate::*;
-
 use std::marker::PhantomData;
 use std::ops::Range;
 use std::rc::Rc;
+
 use web_sys::Element;
 use yew::prelude::*;
+
+use crate::components::style::LocalStyle;
+use crate::utils::*;
+use crate::*;
 
 pub struct ScrollPanel<T>
 where

--- a/rust/perspective-viewer/src/rust/components/containers/select.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/select.rs
@@ -6,9 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use std::borrow::Borrow;
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 use std::fmt::Display;
+
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 

--- a/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
@@ -6,16 +6,17 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::style::LocalStyle;
-use crate::utils::*;
-use crate::*;
-
 use std::cmp::max;
+
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::HtmlElement;
 use yew::html::Scope;
 use yew::prelude::*;
+
+use crate::components::style::LocalStyle;
+use crate::utils::*;
+use crate::*;
 
 /// The state for the `Resizing` action, including the `MouseEvent` callbacks
 /// and panel starting dimensions.

--- a/rust/perspective-viewer/src/rust/components/copy_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/copy_dropdown.rs
@@ -6,16 +6,17 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::rc::Rc;
+
+use js_intern::*;
+use yew::prelude::*;
+
 use super::containers::dropdown_menu::*;
 use super::modal::*;
 use super::style::StyleProvider;
 use crate::model::*;
 use crate::renderer::*;
 use crate::utils::*;
-
-use js_intern::*;
-use std::rc::Rc;
-use yew::prelude::*;
 
 pub type CopyDropDownMenuMsg = DropDownMenuMsg;
 pub type CopyDropDownMenuItem = DropDownMenuItem<ExportMethod>;

--- a/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
@@ -6,6 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use lazy_static::*;
+use wasm_bindgen::*;
+use web_sys::*;
+use yew::prelude::*;
+use yew::*;
+
 use super::containers::radio_list::RadioList;
 use super::containers::radio_list_item::RadioListItem;
 use super::containers::select::*;
@@ -15,11 +21,6 @@ use super::style::{LocalStyle, StyleProvider};
 use crate::config::*;
 use crate::utils::WeakScope;
 use crate::*;
-use lazy_static::*;
-use wasm_bindgen::*;
-use web_sys::*;
-use yew::prelude::*;
-use yew::*;
 
 #[wasm_bindgen]
 extern "C" {

--- a/rust/perspective-viewer/src/rust/components/export_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/export_dropdown.rs
@@ -6,18 +6,18 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::rc::Rc;
+
+use js_intern::*;
+use yew::prelude::*;
+
 use super::containers::dropdown_menu::*;
-use super::modal::ModalLink;
-use super::modal::SetModalLink;
+use super::modal::{ModalLink, SetModalLink};
 use super::style::StyleProvider;
 use crate::model::*;
 use crate::renderer::*;
 use crate::utils::*;
 use crate::*;
-
-use js_intern::*;
-use std::rc::Rc;
-use yew::prelude::*;
 
 pub type ExportDropDownMenuItem = DropDownMenuItem<ExportFile>;
 
@@ -81,8 +81,8 @@ fn get_menu_items(name: &str, has_render: bool) -> Vec<ExportDropDownMenuItem> {
 }
 
 impl Component for ExportDropDownMenu {
-    type Properties = ExportDropDownMenuProps;
     type Message = ExportDropDownMenuMsg;
+    type Properties = ExportDropDownMenuProps;
 
     fn view(&self, ctx: &Context<Self>) -> yew::virtual_dom::VNode {
         let callback = ctx.link().callback(|_| ExportDropDownMenuMsg::TitleChange);

--- a/rust/perspective-viewer/src/rust/components/expression_editor.rs
+++ b/rust/perspective-viewer/src/rust/components/expression_editor.rs
@@ -6,18 +6,19 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use yew::prelude::*;
+
 use super::containers::split_panel::*;
 use super::form::code_editor::*;
 use super::modal::*;
-use super::style::LocalStyle;
-use super::style::StyleProvider;
+use super::style::{LocalStyle, StyleProvider};
 use crate::js::PerspectiveValidationError;
 use crate::session::Session;
 use crate::utils::*;
 use crate::*;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use yew::prelude::*;
 
 #[derive(Debug)]
 pub enum ExpressionEditorMsg {

--- a/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
@@ -6,12 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use web_sys::*;
+use yew::prelude::*;
+
 use super::modal::*;
 use crate::utils::WeakScope;
 use crate::*;
-
-use web_sys::*;
-use yew::prelude::*;
 
 static CSS: &str = include_str!("../../../build/css/filter-dropdown.css");
 

--- a/rust/perspective-viewer/src/rust/components/font_loader.rs
+++ b/rust/perspective-viewer/src/rust/components/font_loader.rs
@@ -6,17 +6,20 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::{html_template, utils::*};
-use futures::future::{join_all, select_all};
-use js_intern::*;
 use std::cell::{Cell, Ref, RefCell};
 use std::future::Future;
 use std::iter::{repeat_with, Iterator};
 use std::rc::Rc;
+
+use futures::future::{join_all, select_all};
+use js_intern::*;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use yew::prelude::*;
+
+use crate::html_template;
+use crate::utils::*;
 
 const FONT_DOWNLOAD_TIMEOUT_MS: i32 = 1000;
 const FONT_TEST_SAMPLE: &str = "ABCD";
@@ -39,8 +42,8 @@ impl PartialEq for FontLoaderProps {
 pub struct FontLoader {}
 
 impl Component for FontLoader {
-    type Properties = FontLoaderProps;
     type Message = ();
+    type Properties = FontLoaderProps;
 
     fn create(_ctx: &Context<Self>) -> Self {
         FontLoader {}

--- a/rust/perspective-viewer/src/rust/components/form/code_editor.rs
+++ b/rust/perspective-viewer/src/rust/components/form/code_editor.rs
@@ -83,7 +83,9 @@ fn autocomplete(
     if let Some(x) = token {
         let elem = target.cast::<HtmlElement>().unwrap();
         if elem.is_connected() {
-            filter_dropdown.autocomplete(x.clone(), elem, Callback::from(|_| ()));
+            filter_dropdown
+                .autocomplete(x.clone(), elem, Callback::from(|_| ()))
+                .unwrap();
         } else {
             filter_dropdown.hide().unwrap();
         }

--- a/rust/perspective-viewer/src/rust/components/form/code_editor.rs
+++ b/rust/perspective-viewer/src/rust/components/form/code_editor.rs
@@ -6,6 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use wasm_bindgen::JsCast;
+use web_sys::*;
+use yew::prelude::*;
+
 use super::super::LocalStyle;
 use crate::components::form::highlight::highlight;
 use crate::custom_elements::FunctionDropDownElement;
@@ -13,11 +20,6 @@ use crate::exprtk::{tokenize, Cursor};
 use crate::js::PerspectiveValidationError;
 use crate::utils::*;
 use crate::*;
-use std::cell::RefCell;
-use std::rc::Rc;
-use wasm_bindgen::JsCast;
-use web_sys::*;
-use yew::prelude::*;
 
 #[derive(Debug, Properties, PartialEq)]
 pub struct CodeEditorProps {

--- a/rust/perspective-viewer/src/rust/components/form/color_range_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/form/color_range_selector.rs
@@ -6,11 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::*;
-
 use wasm_bindgen::JsCast;
 use web_sys::*;
 use yew::prelude::*;
+
+use crate::*;
 
 #[derive(Properties, PartialEq)]
 pub struct ColorRangeProps {

--- a/rust/perspective-viewer/src/rust/components/form/highlight.rs
+++ b/rust/perspective-viewer/src/rust/components/form/highlight.rs
@@ -6,8 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::exprtk::{Cursor, Token};
 use yew::prelude::*;
+
+use crate::exprtk::{Cursor, Token};
 
 /// Highlight a token if the cursor overlaps an error.  This is not a
 /// `Component` because of the the lifetimes associated with `Cursor<'a>` etc.

--- a/rust/perspective-viewer/src/rust/components/form/number_input.rs
+++ b/rust/perspective-viewer/src/rust/components/form/number_input.rs
@@ -6,10 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::*;
 use wasm_bindgen::*;
 use web_sys::*;
 use yew::prelude::*;
+
+use crate::*;
 
 #[derive(Properties, PartialEq)]
 pub struct NumberInputProps {

--- a/rust/perspective-viewer/src/rust/components/function_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/function_dropdown.rs
@@ -6,13 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use web_sys::*;
+use yew::prelude::*;
+
 use super::modal::*;
 use crate::exprtk::CompletionItemSuggestion;
 use crate::utils::WeakScope;
 use crate::*;
-
-use web_sys::*;
-use yew::prelude::*;
 
 static CSS: &str = include_str!("../../../build/css/function-dropdown.css");
 

--- a/rust/perspective-viewer/src/rust/components/modal.rs
+++ b/rust/perspective-viewer/src/rust/components/modal.rs
@@ -6,16 +6,17 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::WeakScope;
-use crate::*;
-
-use derivative::Derivative;
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::rc::Rc;
+
+use derivative::Derivative;
 use yew::html::*;
 use yew::prelude::*;
 use yew::virtual_dom::VChild;
+
+use crate::utils::WeakScope;
+use crate::*;
 
 #[derive(Clone, Default, Eq, PartialEq)]
 pub struct ModalOrientation(Rc<Cell<bool>>);

--- a/rust/perspective-viewer/src/rust/components/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/number_column_style.rs
@@ -6,6 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use wasm_bindgen::*;
+use web_sys::*;
+use yew::prelude::*;
+use yew::*;
+
 use super::containers::radio_list::RadioList;
 use super::containers::radio_list_item::RadioListItem;
 use super::form::color_range_selector::*;
@@ -15,10 +20,6 @@ use super::style::{LocalStyle, StyleProvider};
 use crate::config::*;
 use crate::utils::WeakScope;
 use crate::*;
-use wasm_bindgen::*;
-use web_sys::*;
-use yew::prelude::*;
-use yew::*;
 
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub enum Side {

--- a/rust/perspective-viewer/src/rust/components/plugin_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/plugin_selector.rs
@@ -6,6 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use yew::prelude::*;
+
+use super::containers::select::*;
 use crate::config::*;
 use crate::js::*;
 use crate::model::*;
@@ -13,10 +16,6 @@ use crate::renderer::*;
 use crate::session::*;
 use crate::utils::*;
 use crate::*;
-
-use super::containers::select::*;
-
-use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
 pub struct PluginSelectorProps {

--- a/rust/perspective-viewer/src/rust/components/render_warning.rs
+++ b/rust/perspective-viewer/src/rust/components/render_warning.rs
@@ -6,12 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use yew::prelude::*;
+
 use super::style::LocalStyle;
 use crate::renderer::*;
 use crate::session::*;
 use crate::utils::*;
 use crate::*;
-use yew::prelude::*;
 
 #[derive(Properties)]
 pub struct RenderWarningProps {

--- a/rust/perspective-viewer/src/rust/components/status_bar.rs
+++ b/rust/perspective-viewer/src/rust/components/status_bar.rs
@@ -6,6 +6,10 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use web_sys::*;
+use yew::prelude::*;
+
+use super::style::LocalStyle;
 use crate::components::containers::select::*;
 use crate::components::status_bar_counter::StatusBarRowsCounter;
 use crate::custom_elements::copy_dropdown::*;
@@ -13,15 +17,10 @@ use crate::custom_elements::export_dropdown::*;
 use crate::renderer::*;
 use crate::session::*;
 use crate::theme::Theme;
-use crate::utils::*;
-use crate::*;
-use web_sys::*;
-use yew::prelude::*;
-
 #[cfg(test)]
 use crate::utils::WeakScope;
-
-use super::style::LocalStyle;
+use crate::utils::*;
+use crate::*;
 
 #[derive(Properties)]
 pub struct StatusBarProps {

--- a/rust/perspective-viewer/src/rust/components/status_bar_counter.rs
+++ b/rust/perspective-viewer/src/rust/components/status_bar_counter.rs
@@ -6,14 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::session::TableStats;
-use crate::*;
-
-#[cfg(test)]
-use crate::utils::*;
-
 use num_format::{Locale, ToFormattedString};
 use yew::prelude::*;
+
+use crate::session::TableStats;
+#[cfg(test)]
+use crate::utils::*;
+use crate::*;
 
 #[derive(Properties)]
 pub struct StatusBarRowsCounterProps {

--- a/rust/perspective-viewer/src/rust/components/string_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/string_column_style.rs
@@ -6,6 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use wasm_bindgen::*;
+use web_sys::*;
+use yew::prelude::*;
+use yew::*;
+
 use super::containers::radio_list::RadioList;
 use super::containers::radio_list_item::RadioListItem;
 use super::form::color_selector::*;
@@ -14,10 +19,6 @@ use super::style::{LocalStyle, StyleProvider};
 use crate::config::*;
 use crate::utils::WeakScope;
 use crate::*;
-use wasm_bindgen::*;
-use web_sys::*;
-use yew::prelude::*;
-use yew::*;
 
 pub enum StringColumnStyleMsg {
     Reset(StringColumnStyleConfig),

--- a/rust/perspective-viewer/src/rust/components/style/local_style.rs
+++ b/rust/perspective-viewer/src/rust/components/style/local_style.rs
@@ -6,8 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use super::style_cache::*;
 use yew::prelude::*;
+
+use super::style_cache::*;
 
 #[derive(Properties)]
 pub struct LocalStyleProps {

--- a/rust/perspective-viewer/src/rust/components/style/style_cache.rs
+++ b/rust/perspective-viewer/src/rust/components/style/style_cache.rs
@@ -6,13 +6,15 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::*;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::rc::Rc;
+
 use wasm_bindgen::JsCast;
 use web_sys::HtmlStyleElement;
+
+use crate::*;
 
 type CSSResource = (&'static str, &'static str);
 
@@ -28,6 +30,7 @@ pub struct StyleCache(Rc<StyleCacheData>);
 
 impl Deref for StyleCache {
     type Target = StyleCacheData;
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/rust/perspective-viewer/src/rust/components/style/style_provider.rs
+++ b/rust/perspective-viewer/src/rust/components/style/style_provider.rs
@@ -6,11 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use super::style_cache::StyleCache;
-use crate::*;
 use web_sys::HtmlStyleElement;
 use yew::prelude::*;
 use yew::virtual_dom::VNode;
+
+use super::style_cache::StyleCache;
+use crate::*;
 
 #[derive(Properties, PartialEq)]
 pub struct StyleProviderProps {

--- a/rust/perspective-viewer/src/rust/components/tests/column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/tests/column_style.rs
@@ -6,15 +6,18 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::number_column_style::*;
-use crate::config::*;
-use crate::utils::{await_animation_frame, WeakScope};
-use crate::*;
-use std::{cell::RefCell, rc::Rc};
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 use web_sys::*;
 use yew::prelude::*;
+
+use crate::components::number_column_style::*;
+use crate::config::*;
+use crate::utils::{await_animation_frame, WeakScope};
+use crate::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 

--- a/rust/perspective-viewer/src/rust/components/tests/plugin_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/tests/plugin_selector.rs
@@ -6,20 +6,21 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+use web_sys::*;
+use yew::prelude::*;
+
 use crate::components::plugin_selector::*;
 use crate::js::*;
 use crate::renderer::*;
 use crate::session::*;
 use crate::utils::*;
 use crate::*;
-
-use std::cell::RefCell;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use wasm_bindgen_test::*;
-use web_sys::*;
-use yew::prelude::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 

--- a/rust/perspective-viewer/src/rust/components/tests/status_bar.rs
+++ b/rust/perspective-viewer/src/rust/components/tests/status_bar.rs
@@ -6,19 +6,20 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::cell::Cell;
+use std::rc::Rc;
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+use web_sys::*;
+use yew::prelude::*;
+
 use crate::components::status_bar::*;
 use crate::renderer::*;
 use crate::session::*;
 use crate::theme::Theme;
 use crate::utils::*;
 use crate::*;
-
-use std::cell::Cell;
-use std::rc::Rc;
-use wasm_bindgen::JsCast;
-use wasm_bindgen_test::*;
-use web_sys::*;
-use yew::prelude::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 

--- a/rust/perspective-viewer/src/rust/components/tests/viewer.rs
+++ b/rust/perspective-viewer/src/rust/components/tests/viewer.rs
@@ -6,6 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+use web_sys::*;
+use yew::prelude::*;
+
 use crate::components::viewer::*;
 use crate::config::*;
 use crate::dragdrop::*;
@@ -15,11 +20,6 @@ use crate::session::*;
 use crate::theme::Theme;
 use crate::utils::*;
 use crate::*;
-
-use wasm_bindgen::JsCast;
-use wasm_bindgen_test::*;
-use web_sys::*;
-use yew::prelude::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 

--- a/rust/perspective-viewer/src/rust/components/viewer.rs
+++ b/rust/perspective-viewer/src/rust/components/viewer.rs
@@ -6,6 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::rc::Rc;
+
+use futures::channel::oneshot::*;
+use wasm_bindgen::prelude::*;
+use yew::prelude::*;
+
 use super::column_selector::ColumnSelector;
 use super::config_selector::ConfigSelector;
 use super::containers::split_panel::SplitPanel;
@@ -14,7 +20,6 @@ use super::plugin_selector::PluginSelector;
 use super::render_warning::RenderWarning;
 use super::status_bar::StatusBar;
 use super::style::{LocalStyle, StyleProvider};
-
 use crate::config::*;
 use crate::dragdrop::*;
 use crate::model::*;
@@ -23,11 +28,6 @@ use crate::session::*;
 use crate::theme::Theme;
 use crate::utils::*;
 use crate::*;
-
-use futures::channel::oneshot::*;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use yew::prelude::*;
 
 #[derive(Properties)]
 pub struct PerspectiveViewerProps {
@@ -71,6 +71,7 @@ pub struct PerspectiveViewer {
 impl Component for PerspectiveViewer {
     type Message = Msg;
     type Properties = PerspectiveViewerProps;
+
     fn create(ctx: &Context<Self>) -> Self {
         *ctx.props().weak_link.borrow_mut() = Some(ctx.link().clone());
         let elem = ctx.props().elem.clone();

--- a/rust/perspective-viewer/src/rust/config/aggregates.rs
+++ b/rust/perspective-viewer/src/rust/config/aggregates.rs
@@ -6,14 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::{ApiError, ApiResult};
-
-use super::column_type::*;
+use std::fmt::Display;
 use std::str::FromStr;
 
-use serde::Deserialize;
-use serde::Serialize;
-use std::fmt::Display;
+use serde::{Deserialize, Serialize};
+
+use super::column_type::*;
+use crate::utils::{ApiError, ApiResult};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde()]
@@ -126,6 +125,7 @@ impl Display for SingleAggregate {
 
 impl FromStr for SingleAggregate {
     type Err = ApiError;
+
     fn from_str(value: &str) -> ApiResult<Self> {
         match value {
             "sum" => Ok(SingleAggregate::Sum),
@@ -185,6 +185,7 @@ impl Display for Aggregate {
 
 impl FromStr for Aggregate {
     type Err = ApiError;
+
     fn from_str(input: &str) -> ApiResult<Self> {
         Ok(
             if let Some(stripped) = input.strip_prefix("weighted mean by ") {

--- a/rust/perspective-viewer/src/rust/config/column_type.rs
+++ b/rust/perspective-viewer/src/rust/config/column_type.rs
@@ -6,8 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use serde::Deserialize;
 use std::fmt::Display;
+
+use serde::Deserialize;
 
 #[derive(Deserialize, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub enum Type {

--- a/rust/perspective-viewer/src/rust/config/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/config/datetime_column_style.rs
@@ -6,10 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::*;
-use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::*;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum DatetimeColorMode {
@@ -39,6 +41,7 @@ impl Display for DatetimeColorMode {
 
 impl FromStr for DatetimeColorMode {
     type Err = String;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "foreground" => Ok(DatetimeColorMode::Foreground),
@@ -102,6 +105,7 @@ impl Display for DatetimeFormat {
 
 impl FromStr for DatetimeFormat {
     type Err = String;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "full" => Ok(DatetimeFormat::Full),

--- a/rust/perspective-viewer/src/rust/config/filters.rs
+++ b/rust/perspective-viewer/src/rust/config/filters.rs
@@ -6,11 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use itertools::Itertools;
-use serde::Deserialize;
-use serde::Serialize;
 use std::fmt::Display;
 use std::str::FromStr;
+
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Debug, PartialEq, Serialize)]
 #[serde(untagged)]
@@ -105,6 +105,7 @@ impl Display for FilterOp {
 
 impl FromStr for FilterOp {
     type Err = String;
+
     fn from_str(input: &str) -> std::result::Result<Self, <Self as std::str::FromStr>::Err> {
         match input {
             "contains" => Ok(FilterOp::Contains),

--- a/rust/perspective-viewer/src/rust/config/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/config/number_column_style.rs
@@ -6,10 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::*;
-use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::*;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum NumberForegroundMode {
@@ -46,6 +48,7 @@ impl Display for NumberForegroundMode {
 
 impl FromStr for NumberForegroundMode {
     type Err = String;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "color" => Ok(Self::Color),
@@ -105,6 +108,7 @@ impl Display for NumberBackgroundMode {
 
 impl FromStr for NumberBackgroundMode {
     type Err = String;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "color" => Ok(Self::Color),

--- a/rust/perspective-viewer/src/rust/config/sort.rs
+++ b/rust/perspective-viewer/src/rust/config/sort.rs
@@ -6,9 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use serde::Deserialize;
-use serde::Serialize;
 use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Debug, Eq, PartialEq, Serialize)]
 #[serde()]

--- a/rust/perspective-viewer/src/rust/config/string_column_style.rs
+++ b/rust/perspective-viewer/src/rust/config/string_column_style.rs
@@ -6,9 +6,10 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum StringColorMode {
@@ -42,6 +43,7 @@ impl Display for StringColorMode {
 
 impl FromStr for StringColorMode {
     type Err = String;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "foreground" => Ok(StringColorMode::Foreground),
@@ -88,6 +90,7 @@ impl Display for FormatMode {
 
 impl FromStr for FormatMode {
     type Err = String;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "link" => Ok(FormatMode::Link),

--- a/rust/perspective-viewer/src/rust/config/view_config.rs
+++ b/rust/perspective-viewer/src/rust/config/view_config.rs
@@ -6,24 +6,21 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::js::perspective::JsPerspectiveViewConfig;
-use crate::utils::*;
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+#[cfg(test)]
+use wasm_bindgen_test::*;
+#[cfg(test)]
+use {crate::*, js_sys::Array};
 
 use super::aggregates::*;
 use super::filters::*;
 use super::sort::*;
-
-use serde::Deserialize;
-use serde::Serialize;
-use std::collections::HashMap;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-
-#[cfg(test)]
-use {crate::*, js_sys::Array};
-
-#[cfg(test)]
-use wasm_bindgen_test::*;
+use crate::js::perspective::JsPerspectiveViewConfig;
+use crate::utils::*;
 
 #[derive(Clone, Debug, Deserialize, Default, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/rust/perspective-viewer/src/rust/config/viewer_config.rs
+++ b/rust/perspective-viewer/src/rust/config/viewer_config.rs
@@ -6,21 +6,19 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use super::view_config::*;
-use crate::utils::*;
+use std::io::{Read, Write};
+use std::str::FromStr;
 
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
-use serde::Deserialize;
-use serde::Deserializer;
-use serde::Serialize;
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use std::io::Read;
-use std::io::Write;
-use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+
+use super::view_config::*;
+use crate::utils::*;
 
 pub enum ViewerConfigEncoding {
     Json,

--- a/rust/perspective-viewer/src/rust/custom_elements/copy_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/copy_dropdown.rs
@@ -6,20 +6,21 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::*;
+use yew::*;
+
 use super::modal::*;
 use super::viewer::PerspectiveViewerElement;
 use crate::components::{CopyDropDownMenu, CopyDropDownMenuProps};
 use crate::js::*;
 use crate::model::*;
 use crate::utils::*;
-
-use std::cell::RefCell;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::spawn_local;
-use web_sys::*;
-use yew::*;
 
 #[wasm_bindgen]
 #[derive(Clone)]

--- a/rust/perspective-viewer/src/rust/custom_elements/date_column_style.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/date_column_style.rs
@@ -6,15 +6,15 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::datetime_column_style::*;
-use crate::config::*;
-use crate::custom_elements::modal::*;
-use crate::utils::CustomElementMetadata;
-use crate::utils::*;
-use crate::*;
 use wasm_bindgen::prelude::*;
 use web_sys::*;
 use yew::*;
+
+use crate::components::datetime_column_style::*;
+use crate::config::*;
+use crate::custom_elements::modal::*;
+use crate::utils::{CustomElementMetadata, *};
+use crate::*;
 
 #[wasm_bindgen]
 #[derive(Clone)]

--- a/rust/perspective-viewer/src/rust/custom_elements/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/datetime_column_style.rs
@@ -6,15 +6,15 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::datetime_column_style::*;
-use crate::config::*;
-use crate::custom_elements::modal::*;
-use crate::utils::CustomElementMetadata;
-use crate::utils::*;
-use crate::*;
 use wasm_bindgen::prelude::*;
 use web_sys::*;
 use yew::*;
+
+use crate::components::datetime_column_style::*;
+use crate::config::*;
+use crate::custom_elements::modal::*;
+use crate::utils::{CustomElementMetadata, *};
+use crate::*;
 
 #[wasm_bindgen]
 #[derive(Clone)]

--- a/rust/perspective-viewer/src/rust/custom_elements/export_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/export_dropdown.rs
@@ -6,14 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::export_dropdown::*;
-use crate::custom_elements::modal::*;
-use crate::model::*;
-use crate::utils::*;
-use crate::*;
-
 use std::cell::RefCell;
 use std::rc::Rc;
+
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
@@ -21,6 +16,11 @@ use web_sys::*;
 use yew::*;
 
 use super::viewer::PerspectiveViewerElement;
+use crate::components::export_dropdown::*;
+use crate::custom_elements::modal::*;
+use crate::model::*;
+use crate::utils::*;
+use crate::*;
 
 #[wasm_bindgen]
 #[derive(Clone)]

--- a/rust/perspective-viewer/src/rust/custom_elements/expression_editor.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/expression_editor.rs
@@ -6,16 +6,18 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::*;
+use yew::*;
+
 use crate::components::expression_editor::*;
 use crate::custom_elements::modal::*;
 use crate::session::Session;
 use crate::utils::*;
 use crate::*;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use web_sys::*;
-use yew::*;
 
 #[wasm_bindgen]
 #[derive(Clone)]

--- a/rust/perspective-viewer/src/rust/custom_elements/filter_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/filter_dropdown.rs
@@ -6,19 +6,20 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::filter_dropdown::*;
-use crate::custom_elements::modal::*;
-use crate::session::Session;
-use crate::utils::ApiFuture;
-use crate::*;
-
 use std::cell::RefCell;
 use std::rc::Rc;
+
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::*;
 use yew::html::ImplicitClone;
 use yew::*;
+
+use crate::components::filter_dropdown::*;
+use crate::custom_elements::modal::*;
+use crate::session::Session;
+use crate::utils::ApiFuture;
+use crate::*;
 
 #[wasm_bindgen]
 #[derive(Clone)]

--- a/rust/perspective-viewer/src/rust/custom_elements/function_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/function_dropdown.rs
@@ -50,14 +50,20 @@ impl FunctionDropDownElement {
         input: String,
         target: HtmlElement,
         callback: Callback<CompletionItemSuggestion>,
-    ) {
+    ) -> ApiResult<()> {
         let values = filter_values(&input);
-        self.modal.send_message_batch(vec![
-            FunctionDropDownMsg::SetCallback(callback),
-            FunctionDropDownMsg::SetValues(values),
-        ]);
+        if values.is_empty() {
+            self.modal.hide()?;
+        } else {
+            self.modal.send_message_batch(vec![
+                FunctionDropDownMsg::SetCallback(callback),
+                FunctionDropDownMsg::SetValues(values),
+            ]);
 
-        ApiFuture::spawn(self.modal.clone().open(target, None));
+            ApiFuture::spawn(self.modal.clone().open(target, None));
+        }
+
+        Ok(())
     }
 
     pub fn item_select(&self) {

--- a/rust/perspective-viewer/src/rust/custom_elements/function_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/function_dropdown.rs
@@ -6,19 +6,20 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::function_dropdown::*;
-use crate::custom_elements::modal::*;
-use crate::exprtk::CompletionItemSuggestion;
-use crate::exprtk::COMPLETIONS;
-use crate::utils::ApiFuture;
-use crate::*;
 use std::cell::RefCell;
 use std::rc::Rc;
+
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::*;
 use yew::html::ImplicitClone;
 use yew::*;
+
+use crate::components::function_dropdown::*;
+use crate::custom_elements::modal::*;
+use crate::exprtk::{CompletionItemSuggestion, COMPLETIONS};
+use crate::utils::ApiFuture;
+use crate::*;
 
 #[wasm_bindgen]
 #[derive(Clone)]

--- a/rust/perspective-viewer/src/rust/custom_elements/modal.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/modal.rs
@@ -303,14 +303,11 @@ where
             }));
         };
 
-        if !self.is_open() {
-            // self.custom_element.blur().unwrap();
-            target.class_list().add_1("modal-target").unwrap();
-            let theme = get_theme(&target);
-            self.open_within_viewport(target).await.unwrap();
-            if let Some(theme) = theme {
-                self.custom_element.set_attribute("theme", &theme).unwrap();
-            }
+        target.class_list().add_1("modal-target").unwrap();
+        let theme = get_theme(&target);
+        self.open_within_viewport(target).await.unwrap();
+        if let Some(theme) = theme {
+            self.custom_element.set_attribute("theme", &theme).unwrap();
         }
 
         Ok(())

--- a/rust/perspective-viewer/src/rust/custom_elements/modal.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/modal.rs
@@ -6,15 +6,17 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::*;
-use crate::utils::*;
-use derivative::Derivative;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+
+use derivative::Derivative;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::*;
 use yew::prelude::*;
+
+use crate::components::*;
+use crate::utils::*;
 
 type BlurHandlerType = Rc<RefCell<Option<Closure<dyn FnMut(FocusEvent)>>>>;
 

--- a/rust/perspective-viewer/src/rust/custom_elements/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/number_column_style.rs
@@ -6,15 +6,15 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::number_column_style::*;
-use crate::config::*;
-use crate::custom_elements::modal::*;
-use crate::utils::CustomElementMetadata;
-use crate::utils::*;
-use crate::*;
 use wasm_bindgen::prelude::*;
 use web_sys::*;
 use yew::*;
+
+use crate::components::number_column_style::*;
+use crate::config::*;
+use crate::custom_elements::modal::*;
+use crate::utils::{CustomElementMetadata, *};
+use crate::*;
 
 #[wasm_bindgen]
 #[derive(Clone)]

--- a/rust/perspective-viewer/src/rust/custom_elements/string_column_style.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/string_column_style.rs
@@ -6,15 +6,15 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::components::string_column_style::*;
-use crate::config::*;
-use crate::custom_elements::modal::*;
-use crate::utils::CustomElementMetadata;
-use crate::utils::*;
-use crate::*;
 use wasm_bindgen::prelude::*;
 use web_sys::*;
 use yew::*;
+
+use crate::components::string_column_style::*;
+use crate::config::*;
+use crate::custom_elements::modal::*;
+use crate::utils::{CustomElementMetadata, *};
+use crate::*;
 
 #[wasm_bindgen]
 #[derive(Clone)]

--- a/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
@@ -6,6 +6,18 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::str::FromStr;
+
+use gloo::utils::document;
+use js_sys::*;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::*;
+use yew::prelude::*;
+
 use crate::components::{Msg, PerspectiveViewer, PerspectiveViewerProps};
 use crate::config::*;
 use crate::custom_events::*;
@@ -17,16 +29,6 @@ use crate::session::Session;
 use crate::theme::*;
 use crate::utils::*;
 use crate::*;
-use gloo::utils::document;
-use js_sys::*;
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::str::FromStr;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::JsFuture;
-use web_sys::*;
-use yew::prelude::*;
 
 struct ResizeObserverHandle {
     elem: HtmlElement,

--- a/rust/perspective-viewer/src/rust/custom_events.rs
+++ b/rust/perspective-viewer/src/rust/custom_events.rs
@@ -6,6 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::cell::RefCell;
+use std::ops::Deref;
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use web_sys::*;
+
 use crate::config::*;
 use crate::js::JsPerspectiveViewerPlugin;
 use crate::model::*;
@@ -14,12 +21,6 @@ use crate::session::Session;
 use crate::theme::Theme;
 use crate::utils::*;
 use crate::*;
-
-use std::cell::RefCell;
-use std::ops::Deref;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use web_sys::*;
 
 /// A collection of `Subscription` which should trigger an event on the
 /// JavaScript Custom Element as a `CustomEvent`.  There are no public methods
@@ -33,6 +34,7 @@ struct CustomEventsDataRc(Rc<CustomEventsData>);
 
 impl Deref for CustomEventsDataRc {
     type Target = CustomEventsData;
+
     fn deref(&self) -> &CustomEventsData {
         &self.0
     }

--- a/rust/perspective-viewer/src/rust/dragdrop.rs
+++ b/rust/perspective-viewer/src/rust/dragdrop.rs
@@ -6,17 +6,18 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::*;
-use crate::*;
-
 use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
+
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::*;
 use yew::html::ImplicitClone;
 use yew::prelude::*;
+
+use crate::utils::*;
+use crate::*;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DragTarget {
@@ -84,6 +85,7 @@ pub struct DragDrop(Rc<DragDropState>);
 
 impl Deref for DragDrop {
     type Target = Rc<DragDropState>;
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/rust/perspective-viewer/src/rust/exprtk/cursor.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/cursor.rs
@@ -6,8 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::js::PerspectiveValidationError;
 use yew::prelude::*;
+
+use crate::js::PerspectiveValidationError;
 
 /// Because ExprTK reports errors in column/row coordinates and visually needs
 /// to be applied to an entire token rather than a single character, we need

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -6,8 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use serde::Serialize;
 use std::cell::RefCell;
+
+use serde::Serialize;
 
 #[derive(Serialize, Clone, Copy)]
 pub struct CompletionItemSuggestion {

--- a/rust/perspective-viewer/src/rust/exprtk/tokenize.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/tokenize.rs
@@ -11,16 +11,17 @@ mod number;
 mod string;
 mod symbol;
 
-use self::comment::*;
-use self::number::*;
-use self::string::*;
-use self::symbol::*;
 use nom::branch::alt;
 use nom::bytes::complete::{is_a, is_not};
 use nom::character::complete::{line_ending, space1};
 use nom::combinator::map;
 use nom::multi::many0;
 use yew::prelude::*;
+
+use self::comment::*;
+use self::number::*;
+use self::string::*;
+use self::symbol::*;
 
 /// Syntax-highlightable ExprTK tokens. We had the option of implemnting this
 /// alternatively as `pub struct Token(TokenType, &'a str);`, but I felt this
@@ -119,8 +120,9 @@ pub fn tokenize(input: &str) -> Vec<Token<'_>> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use wasm_bindgen_test::*;
+
+    use super::*;
 
     #[wasm_bindgen_test]
     fn test_simple() {

--- a/rust/perspective-viewer/src/rust/js/clipboard.rs
+++ b/rust/perspective-viewer/src/rust/js/clipboard.rs
@@ -6,16 +6,17 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::cell::RefCell;
+use std::future::Future;
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
 use super::mimetype::*;
 use crate::js::clipboard_item::*;
 use crate::utils::*;
 use crate::*;
-
-use std::cell::RefCell;
-use std::future::Future;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 
 /// Copy a `JsPerspectiveView` to the clipboard as a CSV.
 pub fn copy_to_clipboard(

--- a/rust/perspective-viewer/src/rust/js/mimetype.rs
+++ b/rust/perspective-viewer/src/rust/js/mimetype.rs
@@ -7,6 +7,7 @@
 // file.
 
 use std::fmt::Display;
+
 use wasm_bindgen::prelude::*;
 
 #[derive(Clone, Copy, Eq, PartialEq)]

--- a/rust/perspective-viewer/src/rust/js/mod.rs
+++ b/rust/perspective-viewer/src/rust/js/mod.rs
@@ -27,6 +27,5 @@ pub use self::perspective::*;
 pub use self::plugin::*;
 pub use self::resize_observer::*;
 // pub use self::testing::enable_weak_link_test;
-
 #[cfg(test)]
 pub use self::testing::*;

--- a/rust/perspective-viewer/src/rust/js/perspective.rs
+++ b/rust/perspective-viewer/src/rust/js/perspective.rs
@@ -6,11 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::{ApiError, ApiResult};
 use js_sys::Array;
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+
+use crate::utils::{ApiError, ApiResult};
 
 // #[cfg(test)]
 // use wasm_bindgen_test::*;
@@ -146,26 +147,39 @@ extern "C" {
 
 impl JsPerspectiveWorker {
     async_typed!(_delete, delete(&self) -> ());
+
     async_typed!(_table, table(&self, data: js_sys::Object) -> JsPerspectiveTable);
 }
 
 impl JsPerspectiveTable {
     async_typed!(_columns, columns(&self) -> js_sys::Array);
+
     async_typed!(_delete, delete(self) -> ());
+
     async_typed!(_make_port, make_port(&self) -> f64);
+
     async_typed!(_validate_expressions, validate_expressions(&self, exprs: Array) -> JsPerspectiveValidatedExpressions);
+
     async_typed!(_schema, schema(&self) -> JsPerspectiveTableSchema);
+
     async_typed!(_view, view(&self, config: &JsPerspectiveViewConfig) -> JsPerspectiveView);
+
     async_typed!(_size, size(&self) -> f64);
 }
 
 impl JsPerspectiveView {
     async_typed!(_to_csv, to_csv(&self, options: js_sys::Object) -> js_sys::JsString);
+
     async_typed!(_to_arrow, to_arrow(&self) -> js_sys::ArrayBuffer);
+
     async_typed!(_to_columns, to_columns(&self) -> js_sys::Object);
+
     async_typed!(_num_rows, num_rows(&self) -> f64);
+
     async_typed!(_num_columns, num_columns(&self) -> f64);
+
     async_typed!(_schema, schema(&self) -> JsPerspectiveViewSchema);
+
     async_typed!(_delete, delete(self) -> ());
     // async_typed!(_get_config, get_config(&self) -> JsPerspectiveViewConfig);
 }

--- a/rust/perspective-viewer/src/rust/js/plugin.rs
+++ b/rust/perspective-viewer/src/rust/js/plugin.rs
@@ -6,12 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::*;
-
 use serde::*;
 use wasm_bindgen::prelude::*;
 
 use super::perspective::JsPerspectiveView;
+use crate::utils::*;
 
 /// Perspective FFI
 #[wasm_bindgen]

--- a/rust/perspective-viewer/src/rust/js/tests/perspective.rs
+++ b/rust/perspective-viewer/src/rust/js/tests/perspective.rs
@@ -6,12 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use super::super::testing::*;
-use crate::*;
-
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
+
+use super::super::testing::*;
+use crate::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -29,6 +29,10 @@ mod session;
 mod theme;
 pub mod utils;
 
+#[cfg(feature = "define_custom_elements_async")]
+pub use components::{LocalStyle, StyleProvider};
+use wasm_bindgen::prelude::*;
+
 use crate::custom_elements::copy_dropdown::CopyDropDownMenuElement;
 use crate::custom_elements::date_column_style::PerspectiveDateColumnStyleElement;
 use crate::custom_elements::datetime_column_style::PerspectiveDatetimeColumnStyleElement;
@@ -36,13 +40,7 @@ use crate::custom_elements::export_dropdown::ExportDropDownMenuElement;
 use crate::custom_elements::number_column_style::PerspectiveNumberColumnStyleElement;
 use crate::custom_elements::string_column_style::PerspectiveStringColumnStyleElement;
 use crate::custom_elements::viewer::PerspectiveViewerElement;
-
-use crate::utils::define_web_component;
-use crate::utils::ApiResult;
-use wasm_bindgen::prelude::*;
-
-#[cfg(feature = "define_custom_elements_async")]
-pub use components::{LocalStyle, StyleProvider};
+use crate::utils::{define_web_component, ApiResult};
 
 /// Register a plugin globally.
 #[wasm_bindgen(js_name = "registerPlugin")]

--- a/rust/perspective-viewer/src/rust/model/columns_iter_set.rs
+++ b/rust/perspective-viewer/src/rust/model/columns_iter_set.rs
@@ -6,15 +6,16 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::collections::HashSet;
+use std::fmt::Display;
+
+use itertools::Itertools;
+
 use crate::config::*;
 use crate::dragdrop::*;
 use crate::renderer::*;
 use crate::session::*;
 use crate::*;
-
-use itertools::Itertools;
-use std::collections::HashSet;
-use std::fmt::Display;
 
 /// The possible states of a column (row) in the active columns list, including
 /// the `Option<String>` label type.

--- a/rust/perspective-viewer/src/rust/model/copy_export.rs
+++ b/rust/perspective-viewer/src/rust/model/copy_export.rs
@@ -6,6 +6,14 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::collections::HashSet;
+
+use futures::join;
+use itertools::Itertools;
+use js_intern::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+
 use super::export_app;
 use super::export_method::*;
 use super::get_viewer_config::*;
@@ -13,13 +21,6 @@ use super::structural::*;
 use crate::config::*;
 use crate::js::JsPerspectiveViewerPlugin;
 use crate::utils::*;
-
-use futures::join;
-use itertools::Itertools;
-use js_intern::*;
-use std::collections::HashSet;
-use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::JsFuture;
 
 fn tag_name_to_package(plugin: &JsPerspectiveViewerPlugin) -> String {
     let tag_name = plugin.unchecked_ref::<web_sys::HtmlElement>().tag_name();

--- a/rust/perspective-viewer/src/rust/model/export_method.rs
+++ b/rust/perspective-viewer/src/rust/model/export_method.rs
@@ -6,11 +6,12 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::rc::Rc;
+
+use yew::prelude::*;
+
 use crate::js::*;
 use crate::*;
-
-use std::rc::Rc;
-use yew::prelude::*;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub enum ExportMethod {

--- a/rust/perspective-viewer/src/rust/model/get_viewer_config.rs
+++ b/rust/perspective-viewer/src/rust/model/get_viewer_config.rs
@@ -6,6 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::future::Future;
+use std::pin::Pin;
+
 use super::columns_iter_set::*;
 use super::structural::*;
 use crate::config::*;
@@ -14,9 +17,6 @@ use crate::session::*;
 use crate::theme::Theme;
 use crate::utils::*;
 use crate::*;
-
-use std::future::Future;
-use std::pin::Pin;
 
 /// A `ViewerConfig` is constructed from various properties acrosss the
 /// application state, including the current `Plugin`, `ViewConfig`, and

--- a/rust/perspective-viewer/src/rust/model/update_and_render.rs
+++ b/rust/perspective-viewer/src/rust/model/update_and_render.rs
@@ -6,13 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.der;
 
+use yew::prelude::*;
+
 use super::structural::*;
 use crate::renderer::Renderer;
 use crate::session::Session;
 use crate::utils::*;
 use crate::*;
-
-use yew::prelude::*;
 
 /// While `Renderer` manages the plugin and thus the render call itself, the
 /// current `View` is handled by the `Session` which must be validated and

--- a/rust/perspective-viewer/src/rust/renderer.rs
+++ b/rust/perspective-viewer/src/rust/renderer.rs
@@ -19,6 +19,19 @@ mod plugin_store;
 mod registry;
 mod render_timer;
 
+use std::cell::{Ref, RefCell};
+use std::collections::HashMap;
+use std::future::Future;
+use std::ops::Deref;
+use std::pin::Pin;
+use std::rc::Rc;
+
+use futures::future::{join_all, select_all};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::*;
+use yew::html::ImplicitClone;
+
 use self::activate::*;
 use self::limits::*;
 use self::plugin_store::*;
@@ -30,19 +43,6 @@ use crate::js::plugin::*;
 use crate::session::*;
 use crate::utils::*;
 use crate::*;
-
-use futures::future::join_all;
-use futures::future::select_all;
-use std::cell::{Ref, RefCell};
-use std::collections::HashMap;
-use std::future::Future;
-use std::ops::Deref;
-use std::pin::Pin;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use web_sys::*;
-use yew::html::ImplicitClone;
 
 #[derive(Clone)]
 pub struct Renderer(Rc<RendererData>);
@@ -70,6 +70,7 @@ type RenderLimits = (usize, usize, Option<usize>, Option<usize>);
 
 impl Deref for Renderer {
     type Target = RendererData;
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -85,6 +86,7 @@ impl ImplicitClone for Renderer {}
 
 impl Deref for RendererData {
     type Target = RefCell<RendererMutData>;
+
     fn deref(&self) -> &Self::Target {
         &self.plugin_data
     }

--- a/rust/perspective-viewer/src/rust/renderer/activate.rs
+++ b/rust/perspective-viewer/src/rust/renderer/activate.rs
@@ -6,11 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::js::plugin::JsPerspectiveViewerPlugin;
-use crate::utils::ApiResult;
 use std::future::Future;
+
 use wasm_bindgen::JsCast;
 use web_sys::*;
+
+use crate::js::plugin::JsPerspectiveViewerPlugin;
+use crate::utils::ApiResult;
 
 /// Given an async `task` which draws `plugin`, activates the plugin in stages
 /// to prevent screen shearing.  First, and plugin is appended ot the DOM with

--- a/rust/perspective-viewer/src/rust/renderer/limits.rs
+++ b/rust/perspective-viewer/src/rust/renderer/limits.rs
@@ -6,17 +6,15 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::js::perspective::*;
-use crate::js::plugin::*;
-
-#[cfg(test)]
-use crate::*;
-
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-
 #[cfg(test)]
 use {crate::utils::*, wasm_bindgen_futures::future_to_promise, wasm_bindgen_test::*};
+
+use crate::js::perspective::*;
+use crate::js::plugin::*;
+#[cfg(test)]
+use crate::*;
 
 pub async fn get_row_and_col_limits(
     view: &JsPerspectiveView,

--- a/rust/perspective-viewer/src/rust/renderer/plugin_store.rs
+++ b/rust/perspective-viewer/src/rust/renderer/plugin_store.rs
@@ -6,9 +6,10 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::collections::HashMap;
+
 use super::registry::*;
 use crate::js::plugin::*;
-use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct PluginStore {

--- a/rust/perspective-viewer/src/rust/renderer/registry.rs
+++ b/rust/perspective-viewer/src/rust/renderer/registry.rs
@@ -6,16 +6,17 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::js::plugin::*;
-
-use extend::ext;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::thread::LocalKey;
+
+use extend::ext;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::*;
+
+use crate::js::plugin::*;
 
 thread_local! {
     pub static PLUGIN_REGISTRY: Rc<RefCell<Vec<PluginRecord>>> = Rc::new(RefCell::new(vec![]));

--- a/rust/perspective-viewer/src/rust/renderer/render_timer.rs
+++ b/rust/perspective-viewer/src/rust/renderer/render_timer.rs
@@ -6,15 +6,16 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::*;
-
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::future::Future;
 use std::rc::Rc;
+
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::*;
+
+use crate::utils::*;
 
 #[derive(Default, Clone)]
 pub struct MovingWindowRenderTimer(Rc<RefCell<RenderTimerType>>);
@@ -68,7 +69,7 @@ impl MovingWindowRenderTimer {
         let perf = window().unwrap().performance().unwrap();
         let start = match *self.0.borrow() {
             RenderTimerType::Constant(_) => 0_f64,
-            RenderTimerType::Moving(_, _) => perf.now(),
+            RenderTimerType::Moving(..) => perf.now(),
         };
 
         let result = f.await;

--- a/rust/perspective-viewer/src/rust/session.rs
+++ b/rust/perspective-viewer/src/rust/session.rs
@@ -13,9 +13,19 @@ mod replace_expression_update;
 mod view;
 mod view_subscription;
 
+use std::cell::{Ref, RefCell};
+use std::collections::HashSet;
+use std::iter::IntoIterator;
+use std::ops::Deref;
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use yew::html::ImplicitClone;
+use yew::prelude::*;
+
 use self::metadata::*;
-use self::view::PerspectiveOwned;
-use self::view::View;
+use self::view::{PerspectiveOwned, View};
 pub use self::view_subscription::TableStats;
 use self::view_subscription::*;
 use crate::config::*;
@@ -24,15 +34,6 @@ use crate::js::perspective::*;
 use crate::js::plugin::*;
 use crate::utils::*;
 use crate::*;
-use std::cell::{Ref, RefCell};
-use std::collections::HashSet;
-use std::iter::IntoIterator;
-use std::ops::Deref;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use yew::html::ImplicitClone;
-use yew::prelude::*;
 
 /// The `Session` struct is the principal interface to the Perspective engine,
 /// the `Table` and `View` objects for this viewer, and all associated state
@@ -65,6 +66,7 @@ pub struct SessionData {
 
 impl Deref for Session {
     type Target = SessionHandle;
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -78,6 +80,7 @@ impl PartialEq for Session {
 
 impl Deref for SessionHandle {
     type Target = RefCell<SessionData>;
+
     fn deref(&self) -> &Self::Target {
         &self.session_data
     }

--- a/rust/perspective-viewer/src/rust/session/column_defaults_update.rs
+++ b/rust/perspective-viewer/src/rust/session/column_defaults_update.rs
@@ -6,12 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::iter::IntoIterator;
+
+use itertools::Itertools;
+
 use super::metadata::*;
 use crate::config::*;
 use crate::js::plugin::*;
-
-use itertools::Itertools;
-use std::iter::IntoIterator;
 
 impl ViewConfigUpdate {
     /// Appends additional columns to the `columns` field of this

--- a/rust/perspective-viewer/src/rust/session/drag_drop_update.rs
+++ b/rust/perspective-viewer/src/rust/session/drag_drop_update.rs
@@ -7,8 +7,7 @@
 // file.
 
 use crate::config::*;
-use crate::dragdrop::DragEffect;
-use crate::dragdrop::DragTarget;
+use crate::dragdrop::{DragEffect, DragTarget};
 use crate::js::plugin::ViewConfigRequirements;
 
 impl ViewConfig {

--- a/rust/perspective-viewer/src/rust/session/metadata.rs
+++ b/rust/perspective-viewer/src/rust/session/metadata.rs
@@ -6,16 +6,14 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use std::collections::{HashMap, HashSet};
+use std::iter::IntoIterator;
+use std::ops::{Deref, DerefMut};
+
 use crate::config::*;
 use crate::js::perspective::*;
 use crate::utils::*;
 use crate::*;
-
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::iter::IntoIterator;
-use std::ops::Deref;
-use std::ops::DerefMut;
 
 struct SessionViewExpressionMetadata {
     schema: HashMap<String, Type>,
@@ -32,6 +30,7 @@ pub struct SessionMetadata(Option<SessionMetadataState>);
 
 impl Deref for SessionMetadata {
     type Target = Option<SessionMetadataState>;
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/rust/perspective-viewer/src/rust/session/replace_expression_update.rs
+++ b/rust/perspective-viewer/src/rust/session/replace_expression_update.rs
@@ -6,9 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::config::*;
-
 use std::collections::HashMap;
+
+use crate::config::*;
 
 impl ViewConfig {
     /// Create an update for this `ViewConfig` that replaces an expression

--- a/rust/perspective-viewer/src/rust/session/view.rs
+++ b/rust/perspective-viewer/src/rust/session/view.rs
@@ -6,16 +6,17 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::js::perspective::*;
-use crate::utils::ApiResult;
+use std::ops::Deref;
+use std::rc::Rc;
 
 use async_trait::async_trait;
 use derivative::Derivative;
-use std::ops::Deref;
-use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
+
+use crate::js::perspective::*;
+use crate::utils::ApiResult;
 
 /// `PerspectiveOwned` is a newtype-ed `Rc` smart pointer which guarantees
 /// either a `JsPerspectiveView` or `JsPerspectiveTable` will have its

--- a/rust/perspective-viewer/src/rust/session/view_subscription.rs
+++ b/rust/perspective-viewer/src/rust/session/view_subscription.rs
@@ -6,16 +6,15 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use yew::prelude::*;
+
+use super::view::*;
 use crate::config::*;
 use crate::js::perspective::*;
 use crate::utils::*;
 use crate::*;
-
-use super::view::*;
-
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use yew::prelude::*;
 
 /// Metadata snapshot of the current `Table()`/`View()` state which may be of
 /// interest to components.

--- a/rust/perspective-viewer/src/rust/theme.rs
+++ b/rust/perspective-viewer/src/rust/theme.rs
@@ -6,14 +6,16 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::*;
-use async_std::sync::Mutex;
 use std::ops::Deref;
 use std::rc::Rc;
+
+use async_std::sync::Mutex;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::*;
 use yew::html::ImplicitClone;
+
+use crate::utils::*;
 
 /// The available themes as detected in the browser environment or set
 /// explicitly when CORS prevents detection.  Detection is expensive and
@@ -24,6 +26,7 @@ pub struct Theme(Rc<ThemeData>);
 
 impl Deref for Theme {
     type Target = ThemeData;
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/rust/perspective-viewer/src/rust/utils/browser/download.rs
+++ b/rust/perspective-viewer/src/rust/utils/browser/download.rs
@@ -6,8 +6,9 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::ApiResult;
 use wasm_bindgen::JsCast;
+
+use crate::utils::ApiResult;
 
 pub fn download(name: &str, value: &web_sys::Blob) -> ApiResult<()> {
     let window = web_sys::window().unwrap();

--- a/rust/perspective-viewer/src/rust/utils/browser/request_animation_frame.rs
+++ b/rust/perspective-viewer/src/rust/utils/browser/request_animation_frame.rs
@@ -6,11 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::*;
-
 use ::futures::channel::oneshot::*;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::*;
+
+use crate::utils::*;
 
 /// An `async` version of `request_animation_frame`, which resolves on the next
 /// animation frame.

--- a/rust/perspective-viewer/src/rust/utils/browser/selection.rs
+++ b/rust/perspective-viewer/src/rust/utils/browser/selection.rs
@@ -6,11 +6,10 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::*;
-
-use crate::utils::ApiResult;
-use crate::utils::ToApiError;
 use wasm_bindgen::JsCast;
+
+use crate::utils::{ApiResult, ToApiError};
+use crate::*;
 
 /// Utilities for caret position.  DOM elements have different APIs for this
 /// but `Deref` makes them fall through, so it is important that this method

--- a/rust/perspective-viewer/src/rust/utils/browser/tests/debounce.rs
+++ b/rust/perspective-viewer/src/rust/utils/browser/tests/debounce.rs
@@ -6,15 +6,16 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use super::super::request_animation_frame::set_timeout;
-use crate::utils::debounce::*;
+use std::cell::Cell;
+use std::rc::Rc;
 
 use futures::channel::oneshot::*;
 use futures::future::join_all;
-use std::cell::Cell;
-use std::rc::Rc;
 use wasm_bindgen_futures::spawn_local;
 use wasm_bindgen_test::*;
+
+use super::super::request_animation_frame::set_timeout;
+use crate::utils::debounce::*;
 
 #[wasm_bindgen_test]
 pub async fn test_lock() {

--- a/rust/perspective-viewer/src/rust/utils/closure.rs
+++ b/rust/perspective-viewer/src/rust/utils/closure.rs
@@ -27,6 +27,7 @@ where
     V: IntoWasmAbi + 'static,
 {
     type Output = Closure<dyn Fn(U) -> V>;
+
     fn into_closure(self) -> Closure<dyn Fn(U) -> V + 'static> {
         Closure::wrap(Box::new(self) as Box<dyn Fn(U) -> V>)
     }
@@ -40,6 +41,7 @@ where
     W: IntoWasmAbi + 'static,
 {
     type Output = Closure<dyn Fn(U, V) -> W>;
+
     fn into_closure(self) -> Closure<dyn Fn(U, V) -> W + 'static> {
         Closure::wrap(Box::new(self) as Box<dyn Fn(U, V) -> W>)
     }
@@ -54,6 +56,7 @@ where
     X: IntoWasmAbi + 'static,
 {
     type Output = Closure<dyn Fn(U, V, W) -> X>;
+
     fn into_closure(self) -> Closure<dyn Fn(U, V, W) -> X + 'static> {
         Closure::wrap(Box::new(self) as Box<dyn Fn(U, V, W) -> X>)
     }
@@ -64,6 +67,7 @@ where
     U: FromWasmAbi + 'static,
 {
     type Output = Closure<dyn Fn(U)>;
+
     fn into_closure(self) -> Closure<dyn Fn(U)> {
         Closure::wrap(Box::new(move |x: U| {
             self.emit(x);

--- a/rust/perspective-viewer/src/rust/utils/datetime.rs
+++ b/rust/perspective-viewer/src/rust/utils/datetime.rs
@@ -6,10 +6,10 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::*;
-
 use chrono::{DateTime, FixedOffset, NaiveDateTime, TimeZone, Utc};
 use wasm_bindgen::prelude::*;
+
+use crate::utils::*;
 
 fn input_value_format(x: &str) -> Result<&str, JsValue> {
     match x.len() {

--- a/rust/perspective-viewer/src/rust/utils/debounce.rs
+++ b/rust/perspective-viewer/src/rust/utils/debounce.rs
@@ -6,10 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use async_std::sync::Mutex;
 use std::cell::Cell;
 use std::future::Future;
 use std::rc::Rc;
+
+use async_std::sync::Mutex;
 
 use crate::utils::ApiResult;
 

--- a/rust/perspective-viewer/src/rust/utils/futures.rs
+++ b/rust/perspective-viewer/src/rust/utils/futures.rs
@@ -6,22 +6,21 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use super::errors::*;
-use js_intern::*;
 use std::future::Future;
 use std::pin::Pin;
-use wasm_bindgen::convert::FromWasmAbi;
-use wasm_bindgen::convert::IntoWasmAbi;
+
+use js_intern::*;
+use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi};
 use wasm_bindgen::describe::WasmDescribe;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::future_to_promise;
-use wasm_bindgen_futures::JsFuture;
-
 // TODO This is risky to rely on, but it is currently impossible to implement
 // this trait locally due to the orphan instance restriction.  Using this trait
 // removes alow of boilerplate required by `async` when casting to `Promise`.
 use wasm_bindgen::__rt::IntoJsResult;
+use wasm_bindgen_futures::{future_to_promise, JsFuture};
+
+use super::errors::*;
 
 /// A newtype wrapper for a `Future` trait object which supports being
 /// marshalled to a `JsPromise`, avoiding an API which requires type casting to
@@ -84,6 +83,7 @@ where
     Result<T, JsValue>: IntoJsResult + 'static,
 {
     type Abi = <js_sys::Promise as IntoWasmAbi>::Abi;
+
     #[inline]
     fn into_abi(self) -> Self::Abi {
         js_sys::Promise::from(self).into_abi()
@@ -96,6 +96,7 @@ where
     T: From<JsValue> + Into<JsValue>,
 {
     type Abi = <js_sys::Promise as IntoWasmAbi>::Abi;
+
     #[inline]
     unsafe fn from_abi(js: Self::Abi) -> Self {
         ApiFuture::new(async move {
@@ -110,6 +111,7 @@ where
     Result<T, JsValue>: IntoJsResult + 'static,
 {
     type Output = ApiResult<T>;
+
     fn poll(
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,

--- a/rust/perspective-viewer/src/rust/utils/mod.rs
+++ b/rust/perspective-viewer/src/rust/utils/mod.rs
@@ -29,7 +29,6 @@ mod weak_scope;
 #[cfg(test)]
 mod tests;
 
-pub use self::futures::*;
 pub use browser::*;
 pub use clone::*;
 pub use closure::*;
@@ -43,6 +42,8 @@ pub use scope::*;
 pub use tee::*;
 pub use wasm_abi::*;
 pub use weak_scope::*;
+
+pub use self::futures::*;
 
 #[macro_export]
 macro_rules! maybe {

--- a/rust/perspective-viewer/src/rust/utils/pubsub.rs
+++ b/rust/perspective-viewer/src/rust/utils/pubsub.rs
@@ -6,10 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use derivative::Derivative;
-use futures::channel::oneshot::*;
 use std::cell::RefCell;
 use std::rc::Rc;
+
+use derivative::Derivative;
+use futures::channel::oneshot::*;
 use yew::prelude::*;
 
 /// A simple pub/sub struct which allows many listeners to subscribe to a single

--- a/rust/perspective-viewer/src/rust/utils/scope.rs
+++ b/rust/perspective-viewer/src/rust/utils/scope.rs
@@ -6,12 +6,13 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use super::ApiResult;
 use async_trait::async_trait;
 use extend::ext;
 use futures::channel::oneshot::*;
 use yew::html::Scope;
 use yew::prelude::*;
+
+use super::ApiResult;
 
 #[ext]
 pub impl<T> Scope<T>

--- a/rust/perspective-viewer/src/rust/utils/tests/pubsub.rs
+++ b/rust/perspective-viewer/src/rust/utils/tests/pubsub.rs
@@ -9,8 +9,9 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::super::pubsub::*;
 use wasm_bindgen_test::*;
+
+use super::super::pubsub::*;
 
 #[wasm_bindgen_test]
 pub async fn test_pub_sub() {

--- a/rust/perspective-viewer/src/rust/utils/tests/request_animation_frame.rs
+++ b/rust/perspective-viewer/src/rust/utils/tests/request_animation_frame.rs
@@ -6,13 +6,14 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use crate::utils::*;
-use crate::*;
-
 use std::cell::*;
 use std::rc::*;
+
 use wasm_bindgen_futures::spawn_local;
 use wasm_bindgen_test::*;
+
+use crate::utils::*;
+use crate::*;
 
 #[wasm_bindgen_test]
 async fn test_request_animation_frame_async() {

--- a/rust/perspective-viewer/src/rust/utils/weak_scope.rs
+++ b/rust/perspective-viewer/src/rust/utils/weak_scope.rs
@@ -6,10 +6,11 @@
 // of the Apache License 2.0.  The full license can be found in the LICENSE
 // file.
 
-use derivative::Derivative;
 use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
+
+use derivative::Derivative;
 use yew::html::Scope;
 use yew::prelude::*;
 


### PR DESCRIPTION
* Adds better rustfmt defaults, specifically the ones related to imports which I'm a huge fan of but are disabled by default.
* Fixes expression editor to reposition when in "above" position, and the potential completions shrinks below the maximum dropdown size.
* Fixes expression editor visibility when there are no valid completions.
* Fixe expression editor hover CSS to be less confusing.