### PR TITLE
Move default plugin to WASM

### DIFF
--- a/packages/perspective-esbuild-plugin/package.json
+++ b/packages/perspective-esbuild-plugin/package.json
@@ -20,5 +20,9 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/finos/perspective/packages/perspective-build"
+    },
+    "dependencies": {
+        "node-fetch": "^2.6.7",
+        "tar": "^6.1.11"
     }
 }

--- a/rust/perspective-viewer/src/rust/custom_elements/debug_plugin.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/debug_plugin.rs
@@ -1,0 +1,105 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018, the Perspective Authors.
+//
+// This file is part of the Perspective library, distributed under the terms
+// of the Apache License 2.0.  The full license can be found in the LICENSE
+// file.
+
+use wasm_bindgen::prelude::*;
+
+use crate::js::*;
+use crate::utils::*;
+use crate::*;
+
+/// The `<perspective-viewer-plugin>` element, the default perspective plugin
+/// which is registered and activated automcatically when a
+/// `<perspective-viewer>` is loaded without plugins.  While you will not
+/// typically instantiate this class directly, it is simple enough to function
+/// as a good "default" plugin implementation which can be extended to create
+/// custom plugins.
+///
+/// # Example
+/// ```javascript
+/// class MyPlugin extends customElements.get("perspective-viewer-plugin") {
+///    // Custom plugin overrides
+/// }
+/// ```
+#[wasm_bindgen]
+pub struct PerspectiveDebugPluginElement {
+    elem: web_sys::HtmlElement,
+}
+
+impl CustomElementMetadata for PerspectiveDebugPluginElement {
+    const CUSTOM_ELEMENT_NAME: &'static str = "perspective-viewer-plugin";
+}
+
+#[wasm_bindgen]
+impl PerspectiveDebugPluginElement {
+    #[wasm_bindgen(constructor)]
+    pub fn new(elem: web_sys::HtmlElement) -> PerspectiveDebugPluginElement {
+        PerspectiveDebugPluginElement { elem }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        "Debug".to_owned()
+    }
+
+    #[wasm_bindgen(getter, typescript_type = "'select' | 'toggle'")]
+    pub fn select_mode(&self) -> String {
+        "select".to_owned()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn min_config_columns(&self) -> JsValue {
+        JsValue::UNDEFINED
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn config_column_names(&self) -> JsValue {
+        JsValue::UNDEFINED
+    }
+
+    pub fn update(&self, view: JsPerspectiveView) -> ApiFuture<()> {
+        self.draw(view)
+    }
+
+    pub fn draw(&self, view: JsPerspectiveView) -> ApiFuture<()> {
+        let css = "margin:0;overflow:scroll;position:absolute;width:100%;height:100%";
+        clone!(self.elem);
+        ApiFuture::new(async move {
+            let csv = view.to_csv(json!({})).await?.as_string().into_apierror()?;
+            elem.style().set_property("background-color", "#fff")?;
+            elem.set_inner_html(&format!("<pre style='{}'>{}</pre>", css, csv));
+            Ok(())
+        })
+    }
+
+    pub fn clear(&self) -> ApiFuture<()> {
+        ApiFuture::default()
+    }
+
+    pub fn resize(&self) -> ApiFuture<()> {
+        ApiFuture::default()
+    }
+
+    pub fn restyle(&self) -> ApiFuture<()> {
+        ApiFuture::default()
+    }
+
+    pub fn save(&self) -> ApiFuture<()> {
+        ApiFuture::default()
+    }
+
+    pub fn restore(&self) -> ApiFuture<()> {
+        ApiFuture::default()
+    }
+
+    pub fn delete(&self) -> ApiFuture<()> {
+        ApiFuture::default()
+    }
+
+    #[wasm_bindgen(js_name = "connectedCallback")]
+    pub fn connected_callback(&self) {}
+}

--- a/rust/perspective-viewer/src/rust/custom_elements/mod.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/mod.rs
@@ -9,6 +9,7 @@
 pub mod copy_dropdown;
 pub mod date_column_style;
 pub mod datetime_column_style;
+pub mod debug_plugin;
 pub mod export_dropdown;
 pub mod expression_editor;
 mod filter_dropdown;

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -36,6 +36,7 @@ use wasm_bindgen::prelude::*;
 use crate::custom_elements::copy_dropdown::CopyDropDownMenuElement;
 use crate::custom_elements::date_column_style::PerspectiveDateColumnStyleElement;
 use crate::custom_elements::datetime_column_style::PerspectiveDatetimeColumnStyleElement;
+use crate::custom_elements::debug_plugin::PerspectiveDebugPluginElement;
 use crate::custom_elements::export_dropdown::ExportDropDownMenuElement;
 use crate::custom_elements::number_column_style::PerspectiveNumberColumnStyleElement;
 use crate::custom_elements::string_column_style::PerspectiveStringColumnStyleElement;
@@ -81,6 +82,7 @@ pub fn js_define_web_components() {
 pub fn bootstrap_web_components(psp: &JsValue) {
     if cfg!(feature = "define_custom_elements_async") {
         define_web_component::<PerspectiveViewerElement>(psp);
+        define_web_component::<PerspectiveDebugPluginElement>(psp);
     }
 
     define_web_component::<PerspectiveDateColumnStyleElement>(psp);

--- a/rust/perspective-viewer/src/rust/utils/custom_element.rs
+++ b/rust/perspective-viewer/src/rust/utils/custom_element.rs
@@ -34,11 +34,19 @@ pub trait CustomElementMetadata {
 
         const names = Object.getOwnPropertyNames(proto);
         for (const key of names) {
-            Object.defineProperty(x.prototype, key, {
-                value: function(...args) {
-                    return this._instance[key].call(this._instance, ...args);
-                }
-            });
+            if ('get' in Object.getOwnPropertyDescriptor(proto, key)) {
+                Object.defineProperty(x.prototype, key, {
+                    get: function() {
+                        return this._instance[key];
+                    }
+                });
+            } else {
+                Object.defineProperty(x.prototype, key, {
+                    value: function(...args) {
+                        return this._instance[key].call(this._instance, ...args);
+                    }
+                });
+            }
         }
 
         for (const key of statics) {

--- a/rust/perspective-viewer/src/rust/utils/futures.rs
+++ b/rust/perspective-viewer/src/rust/utils/futures.rs
@@ -50,6 +50,15 @@ where
     }
 }
 
+impl<T> Default for ApiFuture<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        ApiFuture::new(async { Ok(Default::default()) })
+    }
+}
+
 impl<T> From<ApiFuture<T>> for JsValue
 where
     Result<T, JsValue>: IntoJsResult + 'static,

--- a/rust/perspective-viewer/src/ts/plugin.ts
+++ b/rust/perspective-viewer/src/ts/plugin.ts
@@ -43,7 +43,7 @@ import type * as perspective from "@finos/perspective";
  * ```
  * @noInheritDoc
  */
-export interface IPerspectiveViewerPlugin extends HTMLElement {
+export interface IPerspectiveViewerPlugin {
     /**
      * The name for this plugin, which is used as both it's unique key for use
      * as a parameter for the `plugin` field of a `ViewerConfig`, and as the
@@ -57,7 +57,7 @@ export interface IPerspectiveViewerPlugin extends HTMLElement {
      * other columns.  `"toggle"` mode toggles the column on or off (dependent
      * on column state), leaving existing columns alone.
      */
-    get select_mode(): "select" | "toggle" | undefined;
+    get select_mode(): string | undefined;
 
     /**
      * The minimum number of columns required for this plugin to operate.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7020,6 +7020,11 @@ chownr@^1.1.1, chownr@^1.1.2:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 chroma-js@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-1.4.1.tgz#eb2d9c4d1ff24616be84b35119f4d26f8205f134"
@@ -10554,6 +10559,13 @@ fs-minipass@^1.2.5:
   integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
   dependencies:
     minipass "^2.6.0"
+
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
 
 fs-monkey@1.0.3:
   version "1.0.3"
@@ -14199,12 +14211,27 @@ minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^3.0.0:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.4.tgz#ca99f95dd77c43c7a76bf51e6d200025eee0ffae"
+  integrity sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==
+  dependencies:
+    yallist "^4.0.0"
+
 minizlib@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
   integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   dependencies:
     minipass "^2.9.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -14247,7 +14274,7 @@ mkdirp2@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp2/-/mkdirp2-1.0.4.tgz#56de1f8f5c93cf2199906362eba0f9f262ee4437"
   integrity sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw==
 
-mkdirp@*:
+mkdirp@*, mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -19114,6 +19141,18 @@ tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
+
+tar@^6.1.11:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 temp-dir@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
An internal API change which allows the default (debug) plugin to be optionally defined from Rust.