### PR TITLE
More human-readable tick labels

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/axis/valueFormatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/valueFormatter.js
@@ -8,7 +8,7 @@
  */
 import * as d3 from "d3";
 
-const SI_MIN = 10000000;
+const SI_MIN = 100000;
 
 export default (d) =>
     Math.abs(d) >= SI_MIN


### PR DESCRIPTION
## Description
Humans tend to struggle with large number comprehension; this PR lowers SI_MIN to make the tick labels more easily readable at a glance

## Photos
<img width="1637" alt="legibleLabels_old" src="https://user-images.githubusercontent.com/55207313/193638057-92e4feb9-97b9-43d9-b183-9517f937d52d.png">
<img width="1637" alt="legibleLabels_new" src="https://user-images.githubusercontent.com/55207313/193638086-80f3d889-0eea-4638-9ed8-56b7c1982f04.png">
