### PR TITLE
accidentally copying license as readme when disting python

### DIFF
--- a/scripts/script_utils.js
+++ b/scripts/script_utils.js
@@ -297,7 +297,7 @@ exports.copy_files_to_python_folder = () => {
     const cpp = resolve`${__dirname}/../cpp/perspective/src`;
     const cmakelists = resolve`${__dirname}/../cpp/perspective/CMakeLists.txt`;
     const lic = resolve`${__dirname}/../LICENSE`;
-    const readme = resolve`${__dirname}/../LICENSE`;
+    const readme = resolve`${__dirname}/../README.md`;
 
     const cmake = resolve`${__dirname}/../cmake`;
     const dcmake = resolve`${dist}/cmake`;


### PR DESCRIPTION
I made a copy-pasta typo when writing the script, so the python README is actually the LICENSE. this fixes that.

<img width="1355" alt="Screen Shot 2022-10-08 at 16 05 46" src="https://user-images.githubusercontent.com/3105306/194726027-b56ca44a-00f4-47d0-9217-1171353c5313.png">
