### PR TITLE
Update docusaurus footer with correct link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -101,7 +101,7 @@ const config = {
                         items: [
                             {
                                 label: "GitHub",
-                                href: "https://github.com/facebook/docusaurus",
+                                href: "https://github.com/finos/perspective",
                             },
                             {
                                 label: "FINOS",


### PR DESCRIPTION
I assume the link in the footer of https://perspective.finos.org/ is supposed to point to this repository, not Docusaurus'.