### PR TITLE
Fix Default Plugin Order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,13 +172,8 @@ python/perspective/README.md
 python/perspective/python_junit.xml
 python/perspective/coverage.xml
 python/perspective/bench/stresstest/results
-rust/perspective-viewer/target
+rust/perspective-viewer/target*
 rust/perspective-viewer/pkg
-rust/perspective-viewer/target2
-rust/perspective-viewer/pkg
-
-rust/perspective-viewer/target
-rust/perspective-viewer/target2
 
 .emsdk
 vcpkg

--- a/packages/perspective-viewer-datagrid/src/js/custom_elements/datagrid.js
+++ b/packages/perspective-viewer-datagrid/src/js/custom_elements/datagrid.js
@@ -55,6 +55,14 @@ export class HTMLPerspectiveViewerDatagridPluginElement extends HTMLElement {
         return undefined;
     }
 
+    /**
+     * Give the Datagrid a higher priority so it is loaded
+     * over the default charts by default.
+     */
+    get priority() {
+        return 1;
+    }
+
     async draw(view) {
         return await draw.call(this, view);
     }

--- a/rust/perspective-viewer/src/rust/js/plugin.rs
+++ b/rust/perspective-viewer/src/rust/js/plugin.rs
@@ -47,6 +47,9 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn config_column_names(this: &JsPerspectiveViewerPlugin) -> Option<js_sys::Array>;
 
+    #[wasm_bindgen(method, getter)]
+    pub fn priority(this: &JsPerspectiveViewerPlugin) -> Option<i32>;
+
     #[wasm_bindgen(method)]
     pub fn save(this: &JsPerspectiveViewerPlugin) -> JsValue;
 
@@ -58,7 +61,7 @@ extern "C" {
 
     #[wasm_bindgen(method, catch)]
     pub async fn restyle(
-        this: &JsPerspectiveViewerPlugin, 
+        this: &JsPerspectiveViewerPlugin,
         view: &JsPerspectiveView
     ) -> ApiResult<JsValue>;
 

--- a/rust/perspective-viewer/src/rust/renderer/registry.rs
+++ b/rust/perspective-viewer/src/rust/renderer/registry.rs
@@ -26,6 +26,7 @@ pub struct PluginRecord {
     name: String,
     category: String,
     tag_name: String,
+    priority: i32,
 }
 
 /// A global registry of all plugins that have been registered.
@@ -95,9 +96,11 @@ pub impl LocalKey<Rc<RefCell<Vec<PluginRecord>>>> {
                 category: plugin_inst
                     .category()
                     .unwrap_or_else(|| "Custom".to_owned()),
+                priority: plugin_inst.priority().unwrap_or_default(),
             };
-
-            plugin.borrow_mut().push(record);
+            let mut plugins = plugin.borrow_mut();
+            plugins.push(record);
+            plugins.sort_by(|a, b| Ord::cmp(&b.priority, &a.priority));
         });
     }
 
@@ -114,6 +117,7 @@ fn register_default() {
                 name: "Debug".to_owned(),
                 category: "Custom".to_owned(),
                 tag_name: "perspective-viewer-plugin".to_owned(),
+                priority: 0,
             })
         }
     })

--- a/rust/perspective-viewer/src/ts/plugin.ts
+++ b/rust/perspective-viewer/src/ts/plugin.ts
@@ -80,6 +80,18 @@ export interface IPerspectiveViewerPlugin {
     get config_column_names(): string[] | undefined;
 
     /**
+     * The load priority of the plugin. If the plugin shares priority with another,
+     * the first to load has a higher priority.
+     *
+     * A larger number has a higher priority.
+     *
+     * The plugin with the highest priority will be loaded by default by the Perspective viewer.
+     * If you would like to instead begin with a lower priority plugin, choose it explicitly with
+     * a `HTMLPerspectiveViewerPluginElement.restore` call.
+     */
+    get priority(): number | undefined;
+
+    /**
      * Render this plugin using the provided `View`.  While there is no
      * provision to cancel a render in progress per se, calling a method on
      * a `View` which has been deleted will throw an exception.
@@ -197,6 +209,10 @@ export class HTMLPerspectiveViewerPluginElement
 
     get config_column_names(): string[] | undefined {
         return undefined;
+    }
+
+    get priority(): number {
+        return 0;
     }
 
     async update(view: perspective.View): Promise<void> {

--- a/rust/perspective-viewer/test/html/plugin-priority-order.html
+++ b/rust/perspective-viewer/test/html/plugin-priority-order.html
@@ -1,0 +1,68 @@
+<!--
+
+   Copyright (c) 2017, the Perspective Authors.
+
+   This file is part of the Perspective library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="module" src="perspective.js"></script>
+        <script type="module" src="perspective-viewer.js"></script>
+
+        <link rel="stylesheet" href="demo.css" />
+    </head>
+
+    <body>
+        <script type="module">
+            import perspective from "./perspective.js";
+
+            class TestChartPluginHighPriority extends customElements.get(
+                "perspective-viewer-plugin"
+            ) {
+                get name() {
+                    return "HighPriority";
+                }
+
+                get priority() {
+                    return 10;
+                }
+            }
+
+            class TestChartPluginLowPriority extends customElements.get(
+                "perspective-viewer-plugin"
+            ) {
+                get name() {
+                    return "LowPriority";
+                }
+
+                get priority() {
+                    return -10;
+                }
+            }
+
+            const Viewer = customElements.get("perspective-viewer");
+            customElements.define("low-priority", TestChartPluginLowPriority);
+            customElements.define("high-priority", TestChartPluginHighPriority);
+            Viewer.registerPlugin("low-priority");
+            Viewer.registerPlugin("high-priority");
+
+            const viewer = document.createElement("perspective-viewer");
+            document.body.appendChild(viewer);
+
+            var xhr = new XMLHttpRequest();
+            xhr.open("GET", "superstore.csv", true);
+            xhr.onload = async function () {
+                window.__CSV__ = xhr.response;
+                window.__WORKER__ = perspective.worker();
+                const table = window.__WORKER__.table(xhr.response);
+                const t = await table;
+                await viewer.load(table);
+            };
+            xhr.send(null);
+        </script>
+    </body>
+</html>

--- a/rust/perspective-viewer/test/js/plugins.spec.js
+++ b/rust/perspective-viewer/test/js/plugins.spec.js
@@ -1,0 +1,71 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const utils = require("@finos/perspective-test");
+const path = require("path");
+
+utils.with_server({}, () => {
+    describe.page(
+        "plugin-priority-order.html",
+        () => {
+            test.capture(
+                "Elements are loaded in priority Order",
+                async (page) => {
+                    let viewer = await page.$("perspective-viewer");
+                    let saved = await page.evaluate(async (viewer) => {
+                        window.__TABLE__ = await viewer.getTable();
+                        await viewer.reset();
+
+                        return await viewer.save();
+                    }, viewer);
+
+                    const expected = {
+                        aggregates: {},
+                        columns: [
+                            "Row ID",
+                            "Order ID",
+                            "Order Date",
+                            "Ship Date",
+                            "Ship Mode",
+                            "Customer ID",
+                            "Segment",
+                            "Country",
+                            "City",
+                            "State",
+                            "Postal Code",
+                            "Region",
+                            "Product ID",
+                            "Category",
+                            "Sub-Category",
+                            "Sales",
+                            "Quantity",
+                            "Discount",
+                            "Profit",
+                        ],
+                        expressions: [],
+                        filter: [],
+                        group_by: [],
+                        plugin: "HighPriority",
+                        plugin_config: {},
+                        settings: false,
+                        sort: [],
+                        split_by: [],
+                        theme: null,
+                    };
+
+                    expect(saved).toEqual(expected);
+                },
+                { timeout: 120000 }
+            );
+        },
+        {
+            root: path.join(__dirname, "..", ".."),
+        }
+    );
+});

--- a/rust/perspective-viewer/test/results/results.json
+++ b/rust/perspective-viewer/test/results/results.json
@@ -3,7 +3,7 @@
     "superstore.html/doesn't leak elements.": "d0fd18b3d4d7c183c5ed155b4bf37972",
     "superstore.html/doesn't leak views when setting group by.": "54daaa4bbbe59f6ed4acc301ba871bab",
     "superstore.html/doesn't leak views when setting filters.": "6dfc1e505f1428424c3265f0236f22fc",
-    "__GIT_COMMIT__": "82f3e58191f6e05c750e4f3f10977d0b3a14ea4e",
+    "__GIT_COMMIT__": "9b8de02db52010e0ba8b8131390b93b992055020",
     "blank.html/Handles reloading with a schema.": "e58c62f6e0ff16dc4d753f99e0fc39c3",
     "superstore_shows_a_grid_without_any_settings_applied_": "ae1c4690d978598ca14c8669244ce604",
     "superstore_Responsive_Layout_shows_horizontal_columns_on_small_vertical_viewports_": "57ba3ad341cf8a0e4df6ab96715ff2a0",
@@ -86,5 +86,6 @@
     "superstore-all_migrate_restore__Plugin_config_color_mode_": "993e68451858d6e9cb85b6282445bae0",
     "superstore-all_migrate_restore__New_Datagrid_style_API_": "993e68451858d6e9cb85b6282445bae0",
     "superstore-all_migrate_restore__New_Datagrid_style_API_with_a_bar_and_gradient_": "52ba63f266aaaf22f896ed4784ac4210",
-    "superstore-all_migrate_restore__New_API,_reflexive_(new_API_is_unmodified)_": "8a158a3a29fd3a5f7884873aba12ed14"
+    "superstore-all_migrate_restore__New_API,_reflexive_(new_API_is_unmodified)_": "8a158a3a29fd3a5f7884873aba12ed14",
+    "plugin-priority-order_Elements_are_loaded_in_priority_Order": "313ffe98bbf4d005b54489937ed7f7ba"
 }


### PR DESCRIPTION
Now in environments with wonky loading (i.e. safari), the datagrid will come up first when loading all perspective plugins.

Fixes #2006