### PR TITLE
Add labels to Scatter plot points.

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
@@ -66,6 +66,8 @@ function xyScatter(container, settings) {
         ? seriesLinearRange(settings, data, "size").range([10, 10000])
         : null;
 
+    const label = settings.realValues[4];
+
     const scale_factor = interpolate_scale([600, 0.1], [1600, 1])(container);
     const series = fc
         .seriesCanvasMulti()
@@ -77,6 +79,7 @@ function xyScatter(container, settings) {
                     series.key,
                     size,
                     color,
+                    label,
                     symbols,
                     scale_factor
                 )
@@ -139,7 +142,7 @@ xyScatter.plugin = {
     initial: {
         type: "number",
         count: 2,
-        names: ["X Axis", "Y Axis", "Color", "Size", "Tooltip"],
+        names: ["X Axis", "Y Axis", "Color", "Size", "Label", "Tooltip"],
     },
     selectMode: "toggle",
 };

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -10,12 +10,14 @@ import { seriesCanvasPoint } from "d3fc";
 import { withOpacity, withoutOpacity } from "./seriesColors";
 import { groupFromKey } from "./seriesKey";
 import { fromDomain } from "./seriesSymbols";
+import { toValue } from "../tooltip/selectionData";
 
 export function pointSeriesCanvas(
     settings,
     seriesKey,
     size,
     color,
+    label,
     symbols,
     scale_factor = 1
 ) {
@@ -35,6 +37,16 @@ export function pointSeriesCanvas(
             d.colorValue !== undefined ? d.colorValue : seriesKey
         );
         const opacity = settings.colorStyles && settings.colorStyles.opacity;
+
+        if (label) {
+            context.fillStyle = "#000"; // TODO;
+            context.font = "12px Open Sans";
+            const type = settings.mainValues.find(
+                (x) => x.name === label
+            )?.type;
+            const value = toValue(type, d.row[label]);
+            context.fillText(value, 0, -10);
+        }
 
         context.strokeStyle = withoutOpacity(colorValue);
         context.fillStyle = withOpacity(colorValue, opacity);

--- a/packages/perspective-viewer-d3fc/test/js/integration/scatter.spec.js
+++ b/packages/perspective-viewer-d3fc/test/js/integration/scatter.spec.js
@@ -35,31 +35,39 @@ utils.with_server({}, () => {
         () => {
             simple_tests.default(get_contents("xyscatter"));
 
-            // test.capture(
-            //     "tooltips with no color and size.",
-            //     async page => {
-            //         const viewer = await page.$("perspective-viewer");
-            //         await page.evaluate(async () => await document.querySelector("perspective-viewer").toggleConfig());
-            //         await page.evaluate(element => element.setAttribute("columns", '["Sales", "Profit", null, null, "Quantity"]'), viewer);
-            //         await page.waitForSelector("perspective-viewer:not([updating])");
-            //         const columns = JSON.parse(await page.evaluate(element => element.getAttribute("columns"), viewer));
-            //         expect(columns).toEqual(["Sales", "Profit", null, null, "Quantity"]);
-            //         await page.mouse.move(0, 0);
-            //         await page.mouse.move(500, 200);
-            //         await page.waitFor(
-            //             element => {
-            //                 const elem = element.children[0].shadowRoot.querySelector(".tooltip");
-            //                 if (elem) {
-            //                     return window.getComputedStyle(elem).opacity === "0.9";
-            //                 }
-            //                 return false;
-            //             },
-            //             {},
-            //             viewer
-            //         );
-            //     },
-            //     {preserve_hover: true}
-            // );
+            test.capture(
+                "Scatter charts with a 'label' field render the label",
+                async (page) => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(async () => {
+                        const viewer =
+                            document.querySelector("perspective-viewer");
+                        await viewer.restore({
+                            plugin: "X/Y Scatter",
+                            columns: ["Sales", "Quantity", null, null, "State"],
+                        });
+                    });
+                },
+                { preserve_hover: true }
+            );
+
+            test.capture(
+                "Scatter charts with a 'label' field render the label when a group by operation is applied",
+                async (page) => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(async () => {
+                        const viewer =
+                            document.querySelector("perspective-viewer");
+                        await viewer.restore({
+                            plugin: "X/Y Scatter",
+                            group_by: ["State"],
+                            columns: ["Sales", "Quantity", null, null, "City"],
+                            aggregates: { City: "dominant" },
+                        });
+                    });
+                },
+                { preserve_hover: true }
+            );
 
             // test.capture(
             //     "tooltip columns works",

--- a/packages/perspective-viewer-d3fc/test/results/results.json
+++ b/packages/perspective-viewer-d3fc/test/results/results.json
@@ -1,5 +1,5 @@
 {
-    "__GIT_COMMIT__": "82f3e58191f6e05c750e4f3f10977d0b3a14ea4e",
+    "__GIT_COMMIT__": "2790e08e20b79865b75dacd318452655ad120b96",
     "area_shows_a_grid_without_any_settings_applied": "67bab9ea6654cc7cf7c7b096824e610a",
     "area_displays_visible_columns_": "9c195f0f7bf184a4cb9e727f1b37b301",
     "area_pivot_by_a_row": "fbae982b73c9cbf91be40a767cbbd3df",
@@ -145,5 +145,7 @@
     "sunburst_filters_filters_with__in__comparator": "80705a191c3675ed34d3058874f09a00",
     "bar_rendering_bugs_correctly_render_when_a_bar_chart_has_non_equidistant_times_on_a_datetime_axis": "96a10ce528c635ca24fa509e899bbb09",
     "events_perspective-config-update_event_is_fired_when_series_axis_is_changed": "c0cf24c214ad730393fdd7d58c843a8d",
-    "events_perspective-config-update_event_is_fired_when_legend_position_is_changed": "9753be00c0d084dfbe592b46f6af6b08"
+    "events_perspective-config-update_event_is_fired_when_legend_position_is_changed": "9753be00c0d084dfbe592b46f6af6b08",
+    "scatter_Scatter_charts_with_a__label__field_render_the_label": "313ffe98bbf4d005b54489937ed7f7ba",
+    "scatter_Scatter_charts_with_a__label__field_render_the_label_when_a_group_by_operation_is_applied": "313ffe98bbf4d005b54489937ed7f7ba"
 }


### PR DESCRIPTION
Rebased version of #2032 with test fix.  Adds `label` field to X/Y Scatter charts, allowing individual scatter points to be labelled.  Fixes #2029

<img width="777" alt="Screen Shot 2022-12-05 at 7 55 59 PM" src="https://user-images.githubusercontent.com/60666/205779556-fe1c453b-528e-4db0-a2ad-fbc0e137a705.png">
