### PR TITLE
Vec3 functions for ExprTK and new example "Ray Casting"

### DIFF
--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -45,6 +45,18 @@ computed_function::min_fn t_computed_expression_parser::MIN_FN
 computed_function::max_fn t_computed_expression_parser::MAX_FN
     = computed_function::max_fn();
 
+computed_function::diff3 t_computed_expression_parser::diff3
+    = computed_function::diff3();
+
+computed_function::norm3 t_computed_expression_parser::norm3
+    = computed_function::norm3();
+
+computed_function::cross_product3 t_computed_expression_parser::cross_product3
+    = computed_function::cross_product3();
+
+computed_function::dot_product3 t_computed_expression_parser::dot_product3
+    = computed_function::dot_product3();
+
 computed_function::length t_computed_expression_parser::LENGTH_FN
     = computed_function::length();
 
@@ -457,6 +469,14 @@ t_computed_function_store::register_computed_functions(
         "min", t_computed_expression_parser::MIN_FN);
     sym_table.add_reserved_function(
         "max", t_computed_expression_parser::MAX_FN);
+    sym_table.add_reserved_function(
+        "diff3", t_computed_expression_parser::diff3);
+    sym_table.add_reserved_function(
+        "norm3", t_computed_expression_parser::norm3);
+    sym_table.add_reserved_function(
+        "cross_product3", t_computed_expression_parser::cross_product3);
+    sym_table.add_reserved_function(
+        "dot_product3", t_computed_expression_parser::dot_product3);        
     sym_table.add_function(
         "percent_of", t_computed_expression_parser::PERCENT_OF_FN);
     sym_table.add_function("is_null", t_computed_expression_parser::IS_NULL_FN);

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <perspective/computed_function.h>
+#include <math.h>
 
 namespace perspective {
 
@@ -1669,6 +1670,112 @@ namespace computed_function {
             }
         }
 
+        return rval;
+    }
+
+    diff3::diff3()
+        : exprtk::igeneric_function<t_tscalar>("VVV") {}
+
+    diff3::~diff3() {}
+
+    t_tscalar
+    diff3::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+        rval.m_type = DTYPE_BOOL;
+
+        t_vector_view v1(parameters[0]);
+        t_vector_view v2(parameters[1]);
+        t_vector_view out(parameters[2]);
+
+        t_tscalar o1;
+        o1.set(v1[0] - v2[0]);
+
+        t_tscalar o2;
+        o2.set(v1[1] - v2[1]);
+
+        t_tscalar o3;
+        o3.set(v1[2] - v2[2]);
+
+        out[0] = o1;
+        out[1] = o2;
+        out[2] = o3;
+
+        rval.set(true);
+        return rval;
+    }
+
+    norm3::norm3()
+        : exprtk::igeneric_function<t_tscalar>("V") {}
+
+    norm3::~norm3() {}
+
+    t_tscalar
+    norm3::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+        rval.m_type = DTYPE_FLOAT64;
+        t_vector_view v1(parameters[0]);
+        double a = v1[0].to_double();
+        double b = v1[1].to_double();
+        double c = v1[2].to_double();
+        rval.set(sqrt(pow(a, 2) + pow(b, 2) + pow(c, 2)));
+        return rval;
+    }
+
+    cross_product3::cross_product3()
+        : exprtk::igeneric_function<t_tscalar>("VVV") {}
+
+    cross_product3::~cross_product3() {}
+
+    t_tscalar
+    cross_product3::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+        rval.m_type = DTYPE_BOOL;
+
+        // Parameters already validated
+        t_vector_view v1(parameters[0]);
+        t_vector_view v2(parameters[1]);
+        t_vector_view out(parameters[2]);
+
+        // a2 * b3 - a3 * b2
+        t_tscalar o1;
+        o1.set(v1[1] * v2[2] - v1[2] * v2[1]);
+
+        // a3 * b1 - a1 * b3,
+        t_tscalar o2;
+        o2.set(v1[2] * v2[0] - v1[0] * v2[2]);
+
+        // a1 * b2 - a2 * b1
+        t_tscalar o3;
+        o3.set(v1[0] * v2[1] - v1[1] * v2[0]);
+
+        out[0] = o1;
+        out[1] = o2;
+        out[2] = o3;
+
+
+        rval.set(true);
+        return rval;
+    }
+
+    dot_product3::dot_product3()
+        : exprtk::igeneric_function<t_tscalar>("VV") {}
+
+    dot_product3::~dot_product3() {}
+
+    t_tscalar
+    dot_product3::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+        rval.m_type = DTYPE_FLOAT64;
+
+        // Parameters already validated
+        t_vector_view v1(parameters[0]);
+        t_vector_view v2(parameters[1]);
+
+        rval.set(v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2]);
         return rval;
     }
 

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -137,6 +137,10 @@ public:
     static computed_function::inrange_fn INRANGE_FN;
     static computed_function::min_fn MIN_FN;
     static computed_function::max_fn MAX_FN;
+    static computed_function::diff3 diff3;
+    static computed_function::norm3 norm3;
+    static computed_function::cross_product3 cross_product3;
+    static computed_function::dot_product3 dot_product3;
     static computed_function::length LENGTH_FN;
     static computed_function::is_null IS_NULL_FN;
     static computed_function::is_not_null IS_NOT_NULL_FN;

--- a/cpp/perspective/src/include/perspective/computed_function.h
+++ b/cpp/perspective/src/include/perspective/computed_function.h
@@ -271,6 +271,26 @@ namespace computed_function {
     FUNCTION_HEADER(max_fn)
 
     /**
+     * @brief Get the cross product of two vec3s
+     */
+    FUNCTION_HEADER(diff3)
+
+    /**
+     * @brief Get the cross product of two vec3s
+     */
+    FUNCTION_HEADER(norm3)
+
+    /**
+     * @brief Get the cross product of two vec3s
+     */
+    FUNCTION_HEADER(cross_product3)
+
+    /**
+     * @brief Get the dot product of two vec3s
+     */
+    FUNCTION_HEADER(dot_product3)
+
+    /**
      * @brief Get a as percent of b.
      *
      */

--- a/examples/blocks/gists.json
+++ b/examples/blocks/gists.json
@@ -10,5 +10,6 @@
     "citibike": "bc8d7e6f72e09c9dbd7424b4332cacad",
     "movies": "6b4dcebf65db4ebe4fe53a6de5ea0b48",
     "fractal": "5485f6b630b08d38218822e507f09f21",
-    "covid": "e074d7d9e5783e680d35f565d2b4b32e"
+    "covid": "e074d7d9e5783e680d35f565d2b4b32e",
+    "raycasting": "be354157591f5cac606dc35aad93e82b"
 }

--- a/examples/blocks/src/raycasting/.block
+++ b/examples/blocks/src/raycasting/.block
@@ -1,0 +1,2 @@
+license: apache-2.0
+height: 800

--- a/examples/blocks/src/raycasting/README.md
+++ b/examples/blocks/src/raycasting/README.md
@@ -1,0 +1,4 @@
+Demo of [Perspective](https://github.com/finos/perspective).
+
+A ray-tracing engine written as an [ExprTK](https://github.com/ArashPartow/exprtk)
+Expression within [Perspective](https://github.com/finos/perspective).

--- a/examples/blocks/src/raycasting/index.css
+++ b/examples/blocks/src/raycasting/index.css
@@ -1,0 +1,28 @@
+perspective-viewer {
+    overflow: visible;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+perspective-viewer[theme="Material Light"],
+perspective-viewer[theme="Material Dark"] {
+    --d3fc-positive--gradient: linear-gradient(
+        #94d0ff,
+        #8795e8,
+        #966bff,
+        #ad8cff,
+        #c774e8,
+        #c774a9,
+        #ff6ad5,
+        #ff6a8b,
+        #ff8b8b,
+        #ffa58b,
+        #ffde8b,
+        #cdde8b,
+        #8bde8b,
+        #20de8b
+    );
+}

--- a/examples/blocks/src/raycasting/index.html
+++ b/examples/blocks/src/raycasting/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta
+            name="viewport"
+            content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"
+        />
+
+        <script type="module" src="/node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js"></script>
+
+        <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
+
+        <link rel="preload" href="/node_modules/@finos/perspective/dist/cdn/perspective.cpp.wasm" as="fetch" type="application/wasm" crossorigin="anonymous" />
+        <link rel="preload" href="/node_modules/@finos/perspective-viewer/dist/cdn/perspective_bg.wasm" as="fetch" type="application/wasm" crossorigin="anonymous" />
+        <link rel="preload" href="/node_modules/@finos/perspective/dist/cdn/perspective.worker.js" as="fetch" type="application/javascript" crossorigin="anonymous" />
+
+        <script type="module" src="index.js"></script>
+        <link rel="stylesheet" href="index.css" />
+    </head>
+    <body>
+        <perspective-viewer id="viewer"></perspective-viewer>
+    </body>
+</html>

--- a/examples/blocks/src/raycasting/index.js
+++ b/examples/blocks/src/raycasting/index.js
@@ -1,0 +1,192 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import perspective from "/node_modules/@finos/perspective/dist/cdn/perspective.js";
+
+const WIDTH = 200;
+const HEIGHT = 200;
+
+const vertices = [
+    [-100, -100, -100],
+    [-100, -100, 100],
+    [-100, 100, 100],
+
+    [100, 100, -100],
+    [-100, -100, -100],
+    [-100, 100, -100],
+
+    [100, -100, 100],
+    [-100, -100, -100],
+    [100, -100, -100],
+
+    [100, 100, -100],
+    [100, -100, -100],
+    [-100, -100, -100],
+
+    [-100, -100, -100],
+    [-100, 100, 100],
+    [-100, 100, -100],
+
+    [100, -100, 100],
+    [-100, -100, 100],
+    [-100, -100, -100],
+
+    [-100, 100, 100],
+    [-100, -100, 100],
+    [100, -100, 100],
+
+    [100, 100, 100],
+    [100, -100, -100],
+    [100, 100, -100],
+
+    [100, -100, -100],
+    [100, 100, 100],
+    [100, -100, 100],
+
+    [100, 100, 100],
+    [100, 100, -100],
+    [-100, 100, -100],
+
+    [100, 100, 100],
+    [-100, 100, -100],
+    [-100, 100, 100],
+
+    [100, 100, 100],
+    [-100, 100, 100],
+    [100, -100, 100],
+];
+
+const colors = [3, 1, 2, 1, 3, 2, 6, 4, 4, 5, 5, 6];
+
+function generate_scene() {
+    let vertices2 = [];
+    let colors2 = [];
+    for (let i = 0; i < 50; i++) {
+        const x_offset = Math.random() * 2000 - 1000;
+        const y_offset = Math.random() * 2000 - 1000;
+        const z_offset = Math.random() * 2000;
+        for (const v in vertices) {
+            const vertex = structuredClone(vertices[v]);
+            vertex[0] += x_offset;
+            vertex[1] += y_offset;
+            vertex[2] += z_offset;
+            vertices2.push(vertex);
+            if (v % 3 === 0) {
+                colors2.push(colors[(v / 3) % colors.length]);
+            }
+        }
+    }
+
+    return [vertices2, colors2];
+}
+
+function generate_mandelbrot() {
+    const [vertices2, colors2] = generate_scene();
+
+    return `
+// color
+var d[3] := {floor("index" / ${HEIGHT}) - ${HEIGHT} / 2, "index" % ${HEIGHT} - ${HEIGHT} / 2, 50};
+var p[3] := {0, 0, -500};
+
+var vs[9 * ${vertices2.flat().length / 9}] := {${vertices2.flat().join(", ")}};
+var cs[${colors2.flat().length}] := {${colors2.flat().join(", ")}};
+var color := 0;
+var depth := 1000000;
+
+for (var i := 0; i < ${vertices2.flat().length / 9}; i += 1) {
+    var v0[3] := {vs[i * 9], vs[i * 9 + 1], vs[i * 9 + 2]};
+    var v1[3] := {vs[i * 9 + 3], vs[i * 9 + 4], vs[i * 9 + 5]};
+    var v2[3] := {vs[i * 9 + 6], vs[i * 9 + 7], vs[i * 9 + 8]};
+
+    var e1[3];
+    diff3(v1, v0, e1);
+    var e2[3];
+    diff3(v2, v0, e2);
+
+    var h[3];
+    cross_product3(d, e2, h);
+    var a := dot_product3(e1, h);
+
+    if (a < -0.000001 or a > 0.000001) {
+        var f := 1 / a;
+        var s[3];
+        diff3(p, v0, s);
+        var u := f * dot_product3(s, h);
+
+        if (u > 0 and u < 1) {
+            var q[3];
+            cross_product3(s, e1, q);
+            var v := f * dot_product3(d, q);
+            if (v > 0 and u + v < 1) {
+                var t := f * dot_product3(e2, q);
+                if (t > -0.0000001) {
+                    var t2 := 1 - u - v;
+                    var d1[3] := {
+                        t2 * v0[0] + u * v1[0] + v * v2[0],
+                        t2 * v0[1] + u * v1[1] + v * v2[1],
+                        t2 * v0[2] + u * v1[2] + v * v2[2]
+                    };
+
+                    var d2[3];
+                    diff3(d1, p, d2);
+                    var dist := norm3(d2);
+                    if (dist < depth) {
+                        depth := dist;
+                        color := cs[i];
+                    }
+                }
+            }
+        }
+    }
+};
+
+color
+`;
+}
+
+function generate_layout() {
+    return {
+        plugin: "Heatmap",
+        settings: true,
+        group_by: [`floor("index" / ${HEIGHT}) - ${HEIGHT} / 2`],
+        split_by: [`"index" % ${HEIGHT} - ${HEIGHT} / 2`],
+        columns: ["color"],
+        expressions: [
+            generate_mandelbrot().trim(),
+            `floor("index" / ${HEIGHT}) - ${HEIGHT} / 2`,
+            `"index" % ${HEIGHT} - ${HEIGHT} / 2`,
+        ],
+    };
+}
+
+async function generate_data(table) {
+    let json = new Array(WIDTH * HEIGHT);
+    for (let x = 0; x < WIDTH; ++x) {
+        for (let y = 0; y < HEIGHT; ++y) {
+            const index = x * HEIGHT + y;
+            json[index] = {
+                index,
+            };
+        }
+    }
+
+    await table.replace(json);
+}
+
+window.addEventListener("DOMContentLoaded", async function () {
+    const heatmap_plugin = await window.viewer.getPlugin("Heatmap");
+    heatmap_plugin.max_cells = 100000;
+    const worker = perspective.worker();
+    const table = await worker.table({
+        index: "integer",
+    });
+    generate_data(table);
+    window.viewer.load(Promise.resolve(table));
+    await window.viewer.restore(generate_layout());
+});


### PR DESCRIPTION
* Adds 4 new vec3 functions to ExprTK/Perspective: `dot_product3`, `cross_product3`, `norm3` and `diff3`.
* Adds a new demo of a simple ray-casting engine written as a Perspective example similar to the existing Fractal example, as presented at OSSF NYC 2022.

<img width="998" alt="Screen Shot 2022-12-09 at 9 26 48 PM" src="https://user-images.githubusercontent.com/60666/206824314-69ca77ff-839e-4041-b35f-1d091a167754.png">

