### PR TITLE
Fix parsing of bug related to d3fc splitting selection data (redux of #2039)

### DIFF
--- a/packages/perspective-viewer-d3fc/package.json
+++ b/packages/perspective-viewer-d3fc/package.json
@@ -39,6 +39,7 @@
         "test:build": "cpy --cwd test \"html/*\" ../dist/umd",
         "watch": ":",
         "test:run": "jest --rootDir=. --config=../../tools/perspective-test/jest.config.js --color",
+        "test:unit": "jest --rootDir=. --roots=test/js/unit --config=../../tools/perspective-test/jest.config.js --color --runInBand",
         "test": "npm-run-all test:build test:run",
         "clean": "rimraf dist",
         "clean:screenshots": "rimraf \"test/screenshots/**/*.@(failed|diff).png\""

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/generateHTML.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/generateHTML.js
@@ -32,7 +32,7 @@ function addDataValues(tooltipDiv, values) {
 }
 
 const formatNumber = (value) =>
-    value === null
+    value === null || value === undefined
         ? "-"
         : value.toLocaleString(undefined, {
               style: "decimal",

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
@@ -40,11 +40,14 @@ export function getGroupValues(data, settings) {
 
 export function getSplitValues(data, settings) {
     if (settings.splitValues.length === 0) return [];
-    const splitValues = data.key
-        ? data.key.split("|")
-        : data.mainValue.split
-        ? data.mainValue.split("|")
-        : [data.mainValue];
+    let splitValues = [data.mainValue];
+
+    if (data.key) {
+        splitValues = data.key.split("|");
+    } else if (data.mainValue?.split) {
+        splitValues = data.mainValue.split("|");
+    }
+
     return settings.splitValues.map((split, i) => ({
         name: split.name,
         value: toValue(split.type, splitValues[i]),

--- a/packages/perspective-viewer-d3fc/test/js/unit/tooltip/generateHTML.spec.js
+++ b/packages/perspective-viewer-d3fc/test/js/unit/tooltip/generateHTML.spec.js
@@ -143,4 +143,24 @@ describe("tooltip generateHTML should", () => {
             "main-1: 101",
         ]);
     });
+
+    test("Provide default number formatting for null and undefined types", () => {
+        settings.splitValues.push({ name: "split-1", type: "string" });
+        settings.splitValues.push({ name: "split-2", type: null });
+        settings.splitValues.push({ name: "split-3", type: undefined });
+
+        const data = {
+            key: "ts-1",
+            mainValue: 101,
+        };
+
+        generateHtml(tooltip, data, settings);
+
+        expect(getContent()).toEqual([
+            "split-1: ts-1",
+            "split-2: -",
+            "split-3: -",
+            "main-1: 101",
+        ]);
+    });
 });

--- a/packages/perspective-viewer-d3fc/test/js/unit/tooltip/selectionData.spec.js
+++ b/packages/perspective-viewer-d3fc/test/js/unit/tooltip/selectionData.spec.js
@@ -1,0 +1,75 @@
+const { getSplitValues } = require("../../../../src/js/tooltip/selectionData");
+
+describe("tooltip selectionData should", () => {
+    let settings = null;
+
+    beforeEach(() => {
+        settings = {
+            crossValues: [],
+            splitValues: [],
+            mainValues: [{ name: "main-1", type: "integer" }],
+            realValues: ["main-1"],
+        };
+    });
+
+    describe("getSplitValues", () => {
+        test("handle empty splitValues array", () => {
+            expect(getSplitValues(null, settings)).toEqual([]);
+        });
+
+        test("handle data that contains `|` in key property", () => {
+            settings.splitValues.push({ name: "split-1", type: "integer" });
+            const data = {
+                key: "1|2",
+            };
+
+            expect(getSplitValues(data, settings)).toEqual([
+                { name: "split-1", value: 1 },
+            ]);
+        });
+
+        test("handle data that does not contain `|` in key property", () => {
+            settings.splitValues.push({ name: "split-1", type: "integer" });
+            const data = {
+                key: "1",
+            };
+
+            expect(getSplitValues(data, settings)).toEqual([
+                { name: "split-1", value: 1 },
+            ]);
+        });
+
+        test("handle data that contains a `|` in mainValue property", () => {
+            settings.splitValues.push({ name: "split-1", type: "integer" });
+            const data = {
+                mainValue: "1|2",
+            };
+
+            expect(getSplitValues(data, settings)).toEqual([
+                { name: "split-1", value: 1 },
+            ]);
+        });
+
+        test("handle data that does not contain a `|` in mainValue property", () => {
+            settings.splitValues.push({ name: "split-1", type: "integer" });
+            const data = {
+                mainValue: "1",
+            };
+
+            expect(getSplitValues(data, settings)).toEqual([
+                { name: "split-1", value: 1 },
+            ]);
+        });
+
+        test("handle data with no key or mainValue property", () => {
+            settings.splitValues.push({ name: "split-1", type: "integer" });
+            const data = {
+                mainValue: "1",
+            };
+
+            expect(getSplitValues(data, settings)).toEqual([
+                { name: "split-1", value: 1 },
+            ]);
+        });
+    });
+});

--- a/rust/perspective-viewer/Cargo.lock
+++ b/rust/perspective-viewer/Cargo.lock
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "procss"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f5c7ec1d68af9d3f7ac4e59f9349494036cd57810605be2b6989b1bdf7debd"
+checksum = "2c4ccb04e6a508710d3d75f7377e47e79e582a04c013f3c1b83d03cf0b23fb8c"
 dependencies = [
  "anyhow",
  "base64",


### PR DESCRIPTION
Currently there is a bug where selection data text splitting logic will throw an error if certain values of the data (key and mainValue properties) are not "splittable". This PR aims to correct the logic surrounding this splitting of values.

redo of a [previous PR](https://github.com/finos/perspective/pull/2039)