### PR TITLE
Feature/improved point label position (redux of #2045)

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -12,6 +12,9 @@ import { groupFromKey } from "./seriesKey";
 import { fromDomain } from "./seriesSymbols";
 import { toValue } from "../tooltip/selectionData";
 
+const LABEL_PADDING = 5;
+const LABEL_COSINE = 0.7071067811865476; // cos(45 * Math.PI / 180)
+
 export function pointSeriesCanvas(
     settings,
     seriesKey,
@@ -43,11 +46,25 @@ export function pointSeriesCanvas(
             context.font = settings.textStyles.font;
             const { type } = settings.mainValues.find((x) => x.name === label);
             const value = toValue(type, d.row[label]);
-            const offset = size
-                ? Math.round(scale_factor * size(d.size)) * (15 / 1000) + 10
-                : 10;
 
-            context.fillText(value, offset, 4);
+            let magnitude = 10;
+
+            if (size) {
+                // `size(d.size)` is area (A) of circle.
+                // A = pi * r^2
+                // r = sqrt(A / pi)
+                const radius = Math.sqrt(
+                    (scale_factor * size(d.size)) / Math.PI
+                );
+
+                // magnitude = r * cos(45 * Math.PI / 180)
+                magnitude = radius * LABEL_COSINE;
+            }
+
+            const mag_with_padding = magnitude + LABEL_PADDING;
+
+            // NOTE: Point origin is at the center of the circle, so we need to invert the y-axis.
+            context.fillText(value, mag_with_padding, -mag_with_padding);
         }
 
         context.strokeStyle = withoutOpacity(colorValue);

--- a/rust/perspective-viewer/Cargo.lock
+++ b/rust/perspective-viewer/Cargo.lock
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "procss"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f5c7ec1d68af9d3f7ac4e59f9349494036cd57810605be2b6989b1bdf7debd"
+checksum = "2c4ccb04e6a508710d3d75f7377e47e79e582a04c013f3c1b83d03cf0b23fb8c"
 dependencies = [
  "anyhow",
  "base64",


### PR DESCRIPTION
Currently tooltips (labels) of point data have the possibility of overlapping the actual point area. This PR is an attempt to provide a more calculated offset based on the area of the point.

redux of [this PR](https://github.com/finos/perspective/pull/2045)