### PR TITLE
Fix CSS compilation to not inline http resources

### DIFF
--- a/packages/perspective-esbuild-plugin/ignore_fonts.js
+++ b/packages/perspective-esbuild-plugin/ignore_fonts.js
@@ -1,6 +1,6 @@
 exports.IgnoreFontsPlugin = function IgnoreFontsPlugin() {
     function setup(build) {
-        build.onResolve({ filter: /\.ttf$/ }, async (args) => {
+        build.onResolve({ filter: /^https:\/\// }, async (args) => {
             return { path: args.path, external: true, namespace: "skip-ttf" };
         });
     }

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -46,7 +46,7 @@ export function pointSeriesCanvas(
             context.font = settings.textStyles.font;
             const { type } = settings.mainValues.find((x) => x.name === label);
             const value = toValue(type, d.row[label]);
-            let magnitude;
+            let magnitude = 0;
             if (size) {
                 // A = pi * r^2
                 // r = sqrt(A / pi)


### PR DESCRIPTION
During compilation, resources from Google Fonts were being downloaded and inlined, causing sporadic failures on CI.  These resources are now skipped.