### PR TITLE
Add macOS arm wheels to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -954,7 +954,9 @@ jobs:
             ########
             # Macos
             - name: Python Build Steps (Macos)
-              run: yarn _wheel_python --ci --macos
+              run: |
+                  yarn _wheel_python --ci --macos
+                  yarn _wheel_python --ci --macos --arm
               env:
                   PYTHON_VERSION: ${{ matrix.python-version }}
               if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   # for pull_request so we can do HEAD^2
                   fetch-depth: 2
@@ -201,7 +201,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             ##########
             # Caches #
@@ -270,7 +270,7 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
@@ -425,7 +425,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             ##########
             # Caches #
@@ -462,7 +462,7 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
@@ -539,7 +539,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             ##########
             # Caches #
@@ -590,7 +590,7 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
@@ -776,7 +776,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             #####################################################
             # Conditionals                                      #
@@ -867,7 +867,7 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
@@ -1044,7 +1044,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - uses: actions/download-artifact@v3
               with:
@@ -1123,7 +1123,7 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
@@ -1250,7 +1250,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             ##########
             # Caches #
@@ -1287,7 +1287,7 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
@@ -1333,8 +1333,10 @@ jobs:
               run: python -m pip install -U *manylinux2014*.whl --target python/perspective
               if: ${{ runner.os == 'Linux' }}
 
+            # Note, on mac we must install the x86 wheel, the arm64 wheel
+            # would need an arm machine to test
             - name: Install wheel
-              run: python -m pip install -U *.whl --target python/perspective
+              run: python -m pip install -U *x86*.whl --target python/perspective
               if: ${{ runner.os == 'macOS' }}
 
             - name: Install wheel (windows)
@@ -1381,7 +1383,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             ##########
             # Caches #
@@ -1418,7 +1420,7 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"

--- a/scripts/_wheel_python.js
+++ b/scripts/_wheel_python.js
@@ -84,7 +84,9 @@ try {
         // cache and numpy paths from the pep-517/518 build in build_python.js
         cmd += `${PYTHON} setup.py build_ext bdist_wheel `;
         if (IS_ARM) {
-          cmd += `--plat-name=macos_11_0_arm64 `;
+            cmd = `CMAKE_OSX_ARCHITECTURES=arm64 ${cmd} --plat-name=macosx_11_0_arm64 `;
+        } else {
+            cmd = `CMAKE_OSX_ARCHITECTURES=x86_64 ${cmd} `;
         }
         cmd += " && mkdir -p ./wheelhouse && cp -v ./dist/*.whl ./wheelhouse ";
     } else {

--- a/scripts/_wheel_python.js
+++ b/scripts/_wheel_python.js
@@ -21,6 +21,7 @@ const {
 } = require("./script_utils.js");
 const IS_DOCKER = process.env.PSP_DOCKER;
 const IS_MACOS = getarg("--macos");
+const IS_ARM = getarg("--arm");
 let IMAGE = "manylinux2014";
 let MANYLINUX_VERSION;
 let PYTHON;
@@ -82,6 +83,9 @@ try {
         // Don't need to do any cleaning here since we will reuse the cmake
         // cache and numpy paths from the pep-517/518 build in build_python.js
         cmd += `${PYTHON} setup.py build_ext bdist_wheel `;
+        if (IS_ARM) {
+          cmd += `--plat-name=macos_11_0_arm64 `;
+        }
         cmd += " && mkdir -p ./wheelhouse && cp -v ./dist/*.whl ./wheelhouse ";
     } else {
         // Windows


### PR DESCRIPTION
Testing here:
https://github.com/finos/perspective/actions/runs/3804830237


`gh workflow run "Build Status" --ref tkp/armmac -f ci-include-windows=false -f ci-skip-python=false -f ci-full=true`