### PR TITLE
Add default .vscode project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ package-lock.json
 *.code-workspace
 .history
 /jsconfig.json
-.vscode
 
 # Org-mode
 .org-id-locations
@@ -116,7 +115,6 @@ website/yarn.lock
 website/node_modules
 website/i18n/*
 !website/i18n/en.json
-.vscode
 
 .idea
 cmake-build-debug
@@ -195,3 +193,4 @@ tools/perspective-build/lib
 docs/.docusaurus
 packages/perspective-esbuild-plugin/lib
 docs/static/blocks
+.vscode/c_cpp_properties.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["rust-lang.rust", "ms-vscode.cpptools-extension-pack"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "cmake.configureOnOpen": true,
+    "cmake.sourceDirectory": "${workspaceFolder}/cpp/perspective/",
+    "cmake.buildEnvironment": {
+        "PSP_ENABLE_WASM": "1"
+    },
+    "python.formatting.provider": "black",
+    "rust-analyzer.linkedProjects": [
+        "${workspaceFolder}/rust/perspective-viewer/Cargo.toml"
+    ],
+    "rust-analyzer.checkOnSave.command": "clippy"
+}

--- a/examples/blocks/server.js
+++ b/examples/blocks/server.js
@@ -42,11 +42,23 @@ const dev_template = (name) => `
 </li>
 `;
 
-const gists = JSON.parse(fs.readFileSync("gists.json"));
+const gists = [
+    "fractal",
+    "raycasting",
+    "evictions",
+    "streaming",
+    "covid",
+    "movies",
+    "superstore",
+    "citibike",
+    "olympics",
+    "editable",
+    "csv",
+];
 
 const lis = [];
 for (const key of fs.readdirSync("src")) {
-    if (!!gists[key]) {
+    if (gists.indexOf(key) >= 0) {
         lis.push(prod_template(key));
     } else {
         lis.push(dev_template(key));


### PR DESCRIPTION
Adds a default `.vscode` folder configured for Rust and C++ extensions, which don't really work with the default settings due to Perspective's multi-language monorepo.