### PR TITLE
Fix regression in `perspective-cli`

### DIFF
--- a/packages/perspective-cli/src/js/index.js
+++ b/packages/perspective-cli/src/js/index.js
@@ -161,6 +161,10 @@ program
     .option("-o, --open", "Open a browser automagically.")
     .action(host);
 
-if (require.main && !process.argv.slice(2).length) {
-    program.help();
+if (require.main) {
+    if (!process.argv.slice(2).length) {
+        program.help();
+    } else {
+        program.parse(process.argv);
+    }
 }


### PR DESCRIPTION
Fixes #2085 - this was a bone-headed regression that was introduced while trying to write a test to ensure this functionality worked.