### PR TITLE
Fixing broken example for esbuild 

### DIFF
--- a/examples/esbuild-example/src/index.html
+++ b/examples/esbuild-example/src/index.html
@@ -7,7 +7,7 @@
         <title>Perspective `esbuild` Example</title>
 
         <link rel="preload" href="perspective.cpp.wasm" as="fetch" type="application/wasm" crossorigin="anonymous">
-        <link rel="preload" href="perspective_viewer_bg.wasm" as="fetch" type="application/wasm" crossorigin="anonymous">
+        <link rel="preload" href="perspective_bg.wasm" as="fetch" type="application/wasm" crossorigin="anonymous">
         <link rel="preload" href="superstore.arrow" as="fetch" type="arraybuffer" crossorigin="anonymous">
         <link rel="preload" href="perspective.worker.js" as="fetch" type="application/javascript" crossorigin="anonymous">
         <link rel="preload" href="editor.worker.js" as="fetch" type="application/javascript" crossorigin="anonymous">


### PR DESCRIPTION
Please refer to this issue for detail https://github.com/finos/perspective/issues/2091

It appears the name of the .wasm file changed and the example never got updated.