### PR TITLE
Remove references to 3.7, default to python 3.10 if not specified, migrate from flake8 to ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ flycheck_*.el
 *.out
 *.app
 
+# Build artifacts
 build
 CMakeCache.txt
 CMakeFiles
@@ -99,30 +100,46 @@ node_modules
 *.mem
 ftpsync.settings
 *.log
-screenshots/
 Gemfile
 Gemfile.lock
 Vagrantfile
 /packages/sigma
-/packages/fin-hypergrid
-coverage
+cmake-build-debug
+/src/include/boost
+obj
+packages/*/cjs
+cppbuild
+docsbuild
+tools/perspective-build/lib
+packages/perspective-esbuild-plugin/lib
 
+# editor, IDE, OS
 .DS_Store
+.idea
+rust/perspective-viewer/target.vscode
+target.vscode
+.vscode/c_cpp_properties.json
 
+# docs
 website/translated_docs
 website/build/
 website/yarn.lock
 website/node_modules
 website/i18n/*
 !website/i18n/en.json
+website/static/css/material-dark.css
+website/static/css/pro-dark.css
 
-.idea
-cmake-build-debug
+# test artifacts
 .ipynb_checkpoints
 .python-version
 .pytest_cache
-
-website/static/css/pro-dark.css
+.mypy_cache
+.coverage
+coverage
+screenshots/
+junit.xml
+results.debug.json
 
 # CPP Compile
 /src/include/boost
@@ -130,26 +147,36 @@ obj
 packages/*/cjs
 cppbuild
 docsbuild
-.coverage
 
 # docs generated
+docs/.docusaurus
 docs/_build
+docs/i18n/en.json
 docs/modules.rst
 docs/perspective.*.rst
 docs/python
-package.json.bak
-yarn.lock.bak
 docs/static/img/**/*
 !docs/static/img/logo/
 !docs/static/img/logo/**
-
-
+docs/static/css/material-dark.css
+docs/i18n/en.json
+docs/.docusaurus
+docs/static/blocks
+docs/static/features
 docs/static/arrow/
-.perspectiverc
+docs/static/js
+docs/static/js/logo.js
+docs/static/js/logo.js.map
+docs/static/css/pro-dark.css
+
+# other
+package.json.bak
+yarn.lock.bak
 
 # Python
 *.pyc
 __pycache__/
+py_modules
 
 # Copied outer source folders
 python/perspective/cmake
@@ -160,37 +187,21 @@ python/cpp
 python/perspective/perspective_python.egg-info
 python/perspective/perspective/tests/table/psp_test
 python/perspective/perspective/node/assets/*
-/__pycache__
-docs/static/js/logo.js
-docs/static/js/logo.js.map
 python/perspective/pip-wheel-metadata
-junit.xml
 python/perspective/README.md
 python/perspective/python_junit.xml
 python/perspective/coverage.xml
 python/perspective/bench/stresstest/results
 rust/perspective-viewer/target*
+rust/perspective-viewer/target.vscode
 rust/perspective-viewer/pkg
 
+# config and deps
+.perspectiverc
 .emsdk
 vcpkg
-
-docs/static/css/pro-dark.css
-docs/i18n/en.json
-docs/static/js
-
-rust/perspective-viewer/target.vscode
-target.vscode
+.vscode/c_cpp_properties.json
 
 # jupyterlab test artifacts
 packages/perspective-jupyterlab/test/config/jupyter/lab
 packages/perspective-jupyterlab/test/config/jupyter/migrated
-docs/static/features
-results.debug.json
-
-tools/perspective-build/lib
-docs/.docusaurus
-packages/perspective-esbuild-plugin/lib
-docs/static/blocks
-.vscode/c_cpp_properties.json
-py_modules

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -112,7 +112,7 @@ elseif(PSP_PYTHON_BUILD)
     set(PSP_CPP_BUILD ON)
 
     if(NOT DEFINED PSP_PYTHON_VERSION)
-        set(PSP_PYTHON_VERSION 3.7)
+        set(PSP_PYTHON_VERSION 3.10)
     endif()
 endif()
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
         "lint_js": "npm-run-all lint:*",
         "lint:js": "prettier --check \"examples/**/*.js\" \"examples/**/*.ts\" \"examples/**/*.tsx\" \"scripts/*.js\" \"rust/**/*.ts\" \"rust/**/*.js\" \"packages/**/*.js\" \"packages/**/*.ts\" \"cpp/**/*.js\"",
         "lint_python": "node scripts/lint_python.js",
+        "lint:python": "node scripts/lint_python.js",
         "fix:js": "prettier --write \"examples/**/*.js\" \"examples/**/*.ts\" \"examples/**/*.tsx\" \"scripts/*.js\" \"rust/**/*.ts\" \"rust/**/*.js\" \"packages/**/*.js\" \"packages/**/*.ts\" \"cpp/**/*.js\"",
         "fix:md": "prettier docs/docs/*.md --prose-wrap=always --write",
         "fix:yaml": "prettier **/*.yml --write",

--- a/python/perspective/perspective/widget/widget.py
+++ b/python/perspective/perspective/widget/widget.py
@@ -219,7 +219,7 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
         limit=None,
         server=False,
         client=not is_libpsp(),
-        **kwargs
+        **kwargs,
     ):
         """Initialize an instance of :class`~perspective.PerspectiveWidget`
         with the given table/data and viewer configuration.

--- a/python/perspective/pyproject.toml
+++ b/python/perspective/pyproject.toml
@@ -1,2 +1,27 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy>=1.13.1,<2"]
+build-backend="setuptools.build_meta"
+
+[tool.black]
+line-length = 88
+target-version = ['py37', 'py38']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  | perspective/tests
+)/
+'''
+
+[tool.ruff]
+line-length = 200
+exclude = [
+    "perspective/tests"
+]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401", "F403"]
+"libpsp.py" = ["F401", "F403"]
+
+[tool.pytest.ini_options]
+asyncio_mode = 'strict'
+testpaths = 'perspective/tests'

--- a/python/perspective/setup.cfg
+++ b/python/perspective/setup.cfg
@@ -4,19 +4,3 @@ long_description_content_type=text/markdown
 
 [build_ext]
 inplace=0
-
-[black]
-exclude=perspective/tests/
-
-[flake8]
-ignore=E203, W503
-max-line-length=200
-exclude=perspective/tests/
-per-file-ignores =
-    __init__.py: F401, F403
-    libpsp.py: F401, F403
-
-[tool:pytest]
-asyncio_mode=strict
-testpaths =
-    perspective/tests

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -27,7 +27,7 @@ try:
 
     CPU_COUNT = os.cpu_count()
 except ImportError:
-    raise Exception("Requires Python 3.7 or later")
+    raise Exception("Requires Python 3.8 or later")
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -35,7 +35,7 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read().replace("\r\n", "\n")
 
 if sys.version_info.major < 3:
-    raise Exception("Requires Python 3.7 or later")
+    raise Exception("Requires Python 3.8 or later")
 
 # Check for `cmake`
 if which("cmake") is None and which("cmake.exe") is None:
@@ -74,10 +74,8 @@ requires_tornado = ["tornado>=4.5.3,<7"]
 
 requires_dev = (
     [
-        "black==22.8",
+        "black==23.1.0",
         "Faker>=1.0.0",
-        "flake8>=5",
-        "flake8-black>=0.3.3",
         "httpx>=0.23,<1",
         "pip",
         "psutil>=5,<6",
@@ -90,6 +88,7 @@ requires_dev = (
         "pytest-check-links>=0.7",
         "pytest-tornado>=0.8",
         "pytz>=2022",
+        "ruff>=0.0.252",
         "Sphinx>=1.8.4",
         "sphinx-markdown-builder>=0.5.2",
         "wheel",
@@ -286,12 +285,13 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="analytics tools plotting",
     packages=find_packages(exclude=["bench", "bench.*"]),
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=requires,
     extras_require={
         "aiohttp": requires_aiohttp,

--- a/scripts/lint_python.js
+++ b/scripts/lint_python.js
@@ -38,8 +38,8 @@ try {
 
 try {
     let cmd;
-    let lint_cmd = `${PYTHON} -m flake8 perspective bench setup.py`;
-    let fix_cmd = `${PYTHON} -m black perspective bench setup.py --exclude tests`;
+    let lint_cmd = `${PYTHON} -m ruff perspective bench setup.py && ${PYTHON} -m black --check perspective setup.py`;
+    let fix_cmd = `${PYTHON} -m ruff perspective bench setup.py --exclude tests --fix && ${PYTHON} -m black perspective bench setup.py`;
 
     if (process.env.PSP_DOCKER) {
         cmd = `cd python/perspective && ${IS_FIX ? fix_cmd : lint_cmd}`;


### PR DESCRIPTION
- remove a few remaining references to python `3.7`
- default python version to 3.10 if not otherwise specified (should not happen), was `3.7`
- clean up `.gitignore`
- migrate more things from `setup.cfg` to `pyproject.toml` in anticipation of future changes
- remove usage of `flake8`, switch to the much faster [`ruff`](https://github.com/charliermarsh/ruff)
