### PR TITLE
Implement `title` field in `PerspectiveWidget`

### DIFF
--- a/packages/perspective-jupyterlab/src/js/view.js
+++ b/packages/perspective-jupyterlab/src/js/view.js
@@ -98,7 +98,8 @@ export class PerspectiveView extends DOMWidgetView {
                 new_value &&
                 typeof new_value === "string" &&
                 name !== "plugin" &&
-                name !== "theme"
+                name !== "theme" &&
+                name !== "title"
             ) {
                 new_value = JSON.parse(new_value);
             }
@@ -113,8 +114,8 @@ export class PerspectiveView extends DOMWidgetView {
     }
 
     /**
-     * Attach event handlers, and watch the DOM for state changes in order to
-     * reflect them back to Python.
+     * Attach event handlers to the model for state changes in order to
+     * reflect them back to the DOM.
      */
 
     render() {
@@ -131,6 +132,7 @@ export class PerspectiveView extends DOMWidgetView {
         this.model.on("change:plugin_config", this.plugin_config_changed, this);
         this.model.on("change:theme", this.theme_changed, this);
         this.model.on("change:settings", this.settings_changed, this);
+        this.model.on("change:title", this.title_changed, this);
 
         /**
          * Request a table from the manager. If a table has been loaded, proxy
@@ -260,6 +262,7 @@ export class PerspectiveView extends DOMWidgetView {
             plugin_config: this.model.get("plugin_config"),
             theme: this.model.get("theme"),
             settings: this.model.get("settings"),
+            title: this.model.get("title"),
         });
     }
 
@@ -488,6 +491,12 @@ export class PerspectiveView extends DOMWidgetView {
     settings_changed() {
         this.luminoWidget.restore({
             settings: this.model.get("settings"),
+        });
+    }
+
+    title_changed() {
+        this.luminoWidget.restore({
+            title: this.model.get("title"),
         });
     }
 }

--- a/python/perspective/perspective/viewer/validate.py
+++ b/python/perspective/perspective/viewer/validate.py
@@ -172,3 +172,7 @@ def validate_expressions(expressions):
 
 def validate_plugin_config(plugin_config):
     return plugin_config
+
+
+def validate_title(title):
+    return title

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -54,6 +54,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         "plugin_config",
         "theme",
         "settings",
+        "title",
     )
 
     def __init__(
@@ -69,6 +70,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         plugin_config=None,
         settings=True,
         theme=None,
+        title=None,
     ):
         """Initialize an instance of `PerspectiveViewer` with the given viewer
         configuration.  Do not pass a `Table` or data into the constructor -
@@ -132,6 +134,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         self.plugin_config = validate_plugin_config(plugin_config) or {}
         self.settings = settings
         self.theme = theme
+        self.title = title
 
     @property
     def table(self):

--- a/python/perspective/perspective/viewer/viewer_traitlets.py
+++ b/python/perspective/perspective/viewer/viewer_traitlets.py
@@ -17,6 +17,7 @@ from .validate import (
     validate_filter,
     validate_expressions,
     validate_plugin_config,
+    validate_title,
 )
 
 
@@ -48,6 +49,7 @@ class PerspectiveTraitlets(HasTraits):
     theme = Unicode("Pro Light", allow_none=True).tag(sync=True)
     server = Bool(False).tag(sync=True)
     client = Bool(False).tag(sync=True)
+    title = Unicode(None, allow_none=True).tag(sync=True)
 
     @validate("plugin")
     def _validate_plugin(self, proposal):
@@ -84,3 +86,7 @@ class PerspectiveTraitlets(HasTraits):
     @validate("plugin_config")
     def _validate_plugin_config(self, proposal):
         return validate_plugin_config(proposal.value)
+
+    @validate("title")
+    def _validate_title(self, proposal):
+        return validate_title(proposal.value)


### PR DESCRIPTION
### Works:
* can set title from a notebook `widget.title = "Hello world"`
### Doesn't work
* setting the view's title from the widget doesn't update python state, so doesn't persist across refreshes