### PR TITLE
fixed filter keyword

### DIFF
--- a/examples/jupyter-notebooks/widget_tutorial.ipynb
+++ b/examples/jupyter-notebooks/widget_tutorial.ipynb
@@ -142,7 +142,7 @@
    "outputs": [],
    "source": [
     "# Sorts and filters\n",
-    "PerspectiveWidget(df, columns=[\"Order Date\", \"State\", \"Sales\", \"Profit\"], sort=[[\"Order Date\", \"desc\"]], filters=[[\"State\", \"==\", \"Texas\"]])"
+    "PerspectiveWidget(df, columns=[\"Order Date\", \"State\", \"Sales\", \"Profit\"], sort=[[\"Order Date\", \"desc\"]], filter=[[\"State\", \"==\", \"Texas\"]])"
    ]
   },
   {


### PR DESCRIPTION
Worked through `examples/jupyter-notebooks`, noticed a kwarg for `PerspectiveWidget` should be `filter` not `filters`.