### PR TITLE
Fix autocomplete behavior for `in` and `not in` filter ops

### DIFF
--- a/rust/perspective-viewer/src/less/filter-item.less
+++ b/rust/perspective-viewer/src/less/filter-item.less
@@ -21,6 +21,7 @@
                 margin-top: 1px;
                 font-size: 12px;
                 min-width: 45px;
+                overflow: hidden;
 
                 &:after,
                 input,

--- a/rust/perspective-viewer/src/rust/components/config_selector/filter_item.rs
+++ b/rust/perspective-viewer/src/rust/components/config_selector/filter_item.rs
@@ -168,7 +168,7 @@ impl FilterItemProps {
         let mut filter = self.session.get_view_config().filter.clone();
         let filter_item = &mut filter.get_mut(self.idx).expect("Filter on no column");
         let filter_input = match filter_item.1 {
-            FilterOp::In => Some(FilterTerm::Array(
+            FilterOp::NotIn | FilterOp::In => Some(FilterTerm::Array(
                 val.split(',')
                     .map(|x| Scalar::String(x.trim().to_owned()))
                     .collect(),

--- a/rust/perspective-viewer/src/rust/custom_elements/filter_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/filter_dropdown.rs
@@ -73,10 +73,14 @@ impl FilterDropDownElement {
         match current_column {
             Some(filter_col) if filter_col == column => {
                 let values = filter_values(&input, &self.values);
-                self.modal.send_message_batch(vec![
-                    FilterDropDownMsg::SetCallback(callback),
-                    FilterDropDownMsg::SetValues(values),
-                ]);
+                if values.len() == 1 && values[0] == input {
+                    self.hide().unwrap();
+                } else {
+                    self.modal.send_message_batch(vec![
+                        FilterDropDownMsg::SetCallback(callback),
+                        FilterDropDownMsg::SetValues(values),
+                    ]);
+                }
             }
             _ => {
                 // TODO is this a race condition? `column` and `values` are out-of-sync
@@ -89,12 +93,16 @@ impl FilterDropDownElement {
                         let all_values = session.get_column_values(column.1).await?;
                         *values.borrow_mut() = Some(all_values);
                         let filter_values = filter_values(&input, &values);
-                        modal.send_message_batch(vec![
-                            FilterDropDownMsg::SetCallback(callback),
-                            FilterDropDownMsg::SetValues(filter_values),
-                        ]);
+                        if filter_values.len() == 1 && filter_values[0] == input {
+                            modal.hide()
+                        } else {
+                            modal.send_message_batch(vec![
+                                FilterDropDownMsg::SetCallback(callback),
+                                FilterDropDownMsg::SetValues(filter_values),
+                            ]);
 
-                        modal.open(target, None).await
+                            modal.open(target, None).await
+                        }
                     }
                 });
             }

--- a/rust/perspective-viewer/test/js/regressions.spec.js
+++ b/rust/perspective-viewer/test/js/regressions.spec.js
@@ -1,0 +1,49 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const utils = require("@finos/perspective-test");
+
+const path = require("path");
+
+async function get_contents(page) {
+    return await page.evaluate(async () => {
+        const viewer = document
+            .querySelector("perspective-viewer")
+            .shadowRoot.querySelector("#app_panel");
+        return viewer ? viewer.innerHTML : "MISSING";
+    });
+}
+
+utils.with_server({}, () => {
+    describe.page(
+        "superstore.html",
+        () => {
+            test.capture("not_in filter works correctly", async (page) => {
+                await page.evaluate(async () => {
+                    const viewer = document.querySelector("perspective-viewer");
+                    await viewer.restore({
+                        group_by: ["State"],
+                        columns: ["Sales"],
+                        settings: true,
+                        filter: [
+                            [
+                                "State",
+                                "not in",
+                                ["California", "Texas", "New York"],
+                            ],
+                        ],
+                    });
+                });
+
+                return await get_contents(page);
+            });
+        },
+        { root: path.join(__dirname, "..", "..") }
+    );
+});

--- a/rust/perspective-viewer/test/results/results.json
+++ b/rust/perspective-viewer/test/results/results.json
@@ -3,7 +3,7 @@
     "superstore.html/doesn't leak elements.": "d0fd18b3d4d7c183c5ed155b4bf37972",
     "superstore.html/doesn't leak views when setting group by.": "54daaa4bbbe59f6ed4acc301ba871bab",
     "superstore.html/doesn't leak views when setting filters.": "6dfc1e505f1428424c3265f0236f22fc",
-    "__GIT_COMMIT__": "43dd81da00f8f42eb33d71f3e4aa6a436fdf8f8a",
+    "__GIT_COMMIT__": "d41522fdf9e46f6794e750945bfb050a54d0e298",
     "blank.html/Handles reloading with a schema.": "e58c62f6e0ff16dc4d753f99e0fc39c3",
     "superstore_shows_a_grid_without_any_settings_applied_": "ae1c4690d978598ca14c8669244ce604",
     "superstore_Responsive_Layout_shows_horizontal_columns_on_small_vertical_viewports_": "57ba3ad341cf8a0e4df6ab96715ff2a0",
@@ -87,5 +87,6 @@
     "superstore-all_migrate_restore__New_Datagrid_style_API_": "993e68451858d6e9cb85b6282445bae0",
     "superstore-all_migrate_restore__New_Datagrid_style_API_with_a_bar_and_gradient_": "52ba63f266aaaf22f896ed4784ac4210",
     "superstore-all_migrate_restore__New_API,_reflexive_(new_API_is_unmodified)_": "8a158a3a29fd3a5f7884873aba12ed14",
-    "plugin-priority-order_Elements_are_loaded_in_priority_Order": "313ffe98bbf4d005b54489937ed7f7ba"
+    "plugin-priority-order_Elements_are_loaded_in_priority_Order": "313ffe98bbf4d005b54489937ed7f7ba",
+    "superstore_not_in_filter_works_correctly": "a27b38f0a11ec680ef993d8122ad8412"
 }


### PR DESCRIPTION
Fixes auto-complete dropdowns for `in` and `not in` filters.  Previously, while this filter could still be manually filled with a comma-separated set, doing so by selecting items in the dropdown with the mouse or arrow keys did not respect the separator.

Fixes #1962 