### PR TITLE
Improve `group_by` performance by inlining `boost::hash_range`

### DIFF
--- a/cpp/perspective/src/cpp/vocab.cpp
+++ b/cpp/perspective/src/cpp/vocab.cpp
@@ -73,9 +73,9 @@ t_vocab::get_interned(const char* s) {
     t_sidxmap::iterator iter = m_map.find(s);
 
     t_uindex idx, bidx, eidx;
-    t_uindex len = strlen(s) + 1;
 
     if (iter == m_map.end()) {
+        t_uindex len = strlen(s) + 1;
         idx = genidx();
 
         bidx = m_vlendata->size();

--- a/cpp/perspective/src/include/perspective/base.h
+++ b/cpp/perspective/src/include/perspective/base.h
@@ -442,7 +442,11 @@ struct t_cchar_umap_cmp
 struct t_cchar_umap_hash {
     inline t_uindex
     operator()(const char* s) const {
-        return boost::hash_range(s, s + std::strlen(s));
+        size_t h = 5381;
+        int c;
+        while ((c = *s++))
+            h = ((h << 5) + h) + c;
+        return h;
     }
 };
 

--- a/packages/perspective/src/js/perspective.node.js
+++ b/packages/perspective/src/js/perspective.node.js
@@ -94,9 +94,9 @@ module.exports.sync_module = async () => {
 };
 
 const DEFAULT_ASSETS = [
+    "../../../../tools/perspective-bench/dist",
     "@finos/perspective-test",
     "@finos/perspective/dist/cdn",
-    "@finos/perspective-bench/dist",
     "@finos/perspective-workspace/dist/cdn",
     "@finos/perspective-workspace/dist/css",
     "@finos/perspective-viewer/dist/cdn",

--- a/tools/perspective-bench/package.json
+++ b/tools/perspective-bench/package.json
@@ -22,6 +22,11 @@
         "microtime": "^3.0.0"
     },
     "dependencies": {
+        "perspective-1-9-0": "npm:@finos/perspective@1.9.0",
+        "perspective-1-8-0": "npm:@finos/perspective@1.8.0",
+        "perspective-1-7-0": "npm:@finos/perspective@1.7.0",
+        "perspective-1-6-0": "npm:@finos/perspective@1.6.0",
+        "perspective-1-5-0": "npm:@finos/perspective@1.5.0",
         "perspective-1-4-0": "npm:@finos/perspective@1.4.0",
         "perspective-1-3-0": "npm:@finos/perspective@1.3.0",
         "perspective-1-2-0": "npm:@finos/perspective@1.2.0",

--- a/tools/perspective-bench/src/js/bench.js
+++ b/tools/perspective-bench/src/js/bench.js
@@ -14,7 +14,7 @@ const VERSIONS = ["@finos/perspective", ...PKG_DEPS];
 
 function load_version(path, i) {
     const module = require(path);
-    let {version} = JSON.parse(
+    let { version } = JSON.parse(
         fs.readFileSync(require.resolve(`${path}/package.json`))
     );
 
@@ -22,7 +22,7 @@ function load_version(path, i) {
         version = `${version} (master)`;
     }
 
-    return {version, perspective: module.default || module};
+    return { version, perspective: module.default || module };
 }
 
 const MODULES = VERSIONS.map(load_version);
@@ -48,11 +48,12 @@ Object.defineProperty(Array.prototype, "sum", {
     },
 });
 
-async function benchmark({name, before, before_all, test, after, after_all}) {
+async function benchmark({ name, before, before_all, test, after, after_all }) {
     let obs_records = [];
     console.log(`${name}`);
     for (let j = 0; j < MODULES.length; j++) {
-        const {version, perspective} = MODULES[j];
+        const { version, perspective } = MODULES[j];
+        perspective.version = version.split(".").map((x) => parseInt(x));
         const args = [];
         args.push_if(await before_all?.(perspective));
         const observations = [];
@@ -106,10 +107,10 @@ async function to_data_suite() {
     async function before_all(perspective) {
         const table = await perspective.table(SUPERSTORE_ARROW.slice());
         const view = await table.view();
-        return {table, view};
+        return { table, view };
     }
 
-    async function after_all(perspective, {table, view}) {
+    async function after_all(perspective, { table, view }) {
         await view.delete();
         await table.delete();
     }
@@ -118,7 +119,7 @@ async function to_data_suite() {
         name: `.to_arrow()`,
         before_all,
         after_all,
-        async test(_perspective, {view}) {
+        async test(_perspective, { view }) {
             const _arrow = await view.to_arrow();
         },
     });
@@ -127,7 +128,7 @@ async function to_data_suite() {
         name: `.to_csv()`,
         before_all,
         after_all,
-        async test(_perspective, {view}) {
+        async test(_perspective, { view }) {
             const _csv = await view.to_csv();
         },
     });
@@ -136,7 +137,7 @@ async function to_data_suite() {
         name: `.to_columns()`,
         before_all,
         after_all,
-        async test(_perspective, {view}) {
+        async test(_perspective, { view }) {
             const _columns = await view.to_columns();
         },
     });
@@ -145,7 +146,7 @@ async function to_data_suite() {
         name: `.to_json()`,
         before_all,
         after_all,
-        async test(_perspective, {view}) {
+        async test(_perspective, { view }) {
             const _json = await view.to_json();
         },
     });
@@ -176,6 +177,21 @@ async function view_suite() {
         after,
         async test(_perspective, table) {
             return await table.view();
+        },
+    });
+
+    await benchmark({
+        name: `.view({group_by})`,
+        before_all,
+        after_all,
+        after,
+        async test(perspective, table) {
+            const [M, m, _] = perspective.version;
+            if (M === 1 && m >= 2) {
+                return await table.view({ group_by: ["Product Name"] });
+            } else {
+                return await table.view({ row_pivots: ["Product Name"] });
+            }
         },
     });
 }


### PR DESCRIPTION
Under profile, calls to `strlen` and `strcmp` feature prominently, as Perspective does not currently share `t_vocab` between table and view instances, these are currently re-interned as `char*`.  This should _definitely_ be fixed and should represent a significant performance improvement (AFAIK only the `join` aggregate can yield a not-yet-interned string result).

In the meantime, this single `boost::hash_range` call dominates view creation, as the index maps are built in this step.  First, it iterates the characters to calculate the range length, then _again_ to calculate the hash.  Replacing this with a single-pass hash calculate dedicated to C strings halves this computation time, as well as removes an unnecessary call to boost.

![untitled (4)](https://user-images.githubusercontent.com/60666/227730381-69dcc7a1-727f-417e-8456-2dd2a97d4e98.png)

![untitled (3)](https://user-images.githubusercontent.com/60666/227730378-ef0b8bf9-7426-402b-b9a8-1885d5bb5214.png)

