### PR TITLE
gracefully handle websocket errors on python side, fixes #2132

### DIFF
--- a/examples/python-tornado-streaming/index.html
+++ b/examples/python-tornado-streaming/index.html
@@ -23,7 +23,7 @@
         <link
             rel="stylesheet"
             crossorigin="anonymous"
-            href="/node_modules/@finos/perspective-viewer/dist/css/themes.css"
+            href="/node_modules/perspective-viewer/dist/css/themes.css"
         />
 
         <style>

--- a/examples/python-tornado/client_server_editing.html
+++ b/examples/python-tornado/client_server_editing.html
@@ -19,7 +19,7 @@
     <script src="http://localhost:8080/node_modules/perspective-viewer-d3fc/dist/umd/perspective-viewer-d3fc.js"></script>
     <script src="http://localhost:8080/node_modules/perspective/dist/umd/perspective.js"></script>
 
-    <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
+    <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/perspective-viewer/dist/css/themes.css" />
 
     <style>
         perspective-viewer{position:absolute;top:0;left:0;right:0;bottom:0;}

--- a/examples/python-tornado/index.html
+++ b/examples/python-tornado/index.html
@@ -19,7 +19,7 @@
     <script src="http://localhost:8080/node_modules/perspective-viewer-d3fc/dist/umd/perspective-viewer-d3fc.js"></script>
     <script src="http://localhost:8080/node_modules/perspective/dist/umd/perspective.js"></script>
 
-    <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
+    <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/perspective-viewer/dist/css/themes.css" />
 
     <style>
         perspective-viewer{position:absolute;top:0;left:0;right:0;bottom:0;}

--- a/examples/python-tornado/server_mode.html
+++ b/examples/python-tornado/server_mode.html
@@ -19,7 +19,7 @@
     <script src="http://localhost:8080/node_modules/perspective-viewer-d3fc/dist/umd/perspective-viewer-d3fc.js"></script>
     <script src="http://localhost:8080/node_modules/perspective/dist/umd/perspective.js"></script>
 
-    <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
+    <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/perspective-viewer/dist/css/themes.css" />
 
     <style>
         perspective-viewer{position:absolute;top:0;left:0;right:0;bottom:0;}

--- a/python/perspective/perspective/handlers/aiohttp.py
+++ b/python/perspective/perspective/handlers/aiohttp.py
@@ -6,7 +6,7 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
-from aiohttp import web, WSMsgType
+from aiohttp import web, WSMsgType, WebSocketError
 
 from .common import PerspectiveHandlerBase
 
@@ -48,10 +48,14 @@ class PerspectiveAIOHTTPHandler(PerspectiveHandlerBase):
             self.on_close()
 
     async def write_message(self, message: str, binary: bool = False) -> None:
-        if binary:
-            await self._ws.send_bytes(message)
-        else:
-            await self._ws.send_str(message)
+        try:
+            if binary:
+                await self._ws.send_bytes(message)
+            else:
+                await self._ws.send_str(message)
+        except WebSocketError:
+            # Ignore error
+            ...
 
     # Use common docstring
     __init__.__doc__ = PerspectiveHandlerBase.__init__.__doc__

--- a/python/perspective/perspective/handlers/starlette.py
+++ b/python/perspective/perspective/handlers/starlette.py
@@ -6,6 +6,7 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 
+from starlette.websockets import WebSocketDisconnect
 from .common import PerspectiveHandlerBase
 
 
@@ -44,10 +45,14 @@ class PerspectiveStarletteHandler(PerspectiveHandlerBase):
             self.on_close()
 
     async def write_message(self, message: str, binary: bool = False) -> None:
-        if binary:
-            await self._websocket.send_bytes(message)
-        else:
-            await self._websocket.send_text(message)
+        try:
+            if binary:
+                await self._websocket.send_bytes(message)
+            else:
+                await self._websocket.send_text(message)
+        except WebSocketDisconnect:
+            # ignore error
+            ...
 
     # Use common docstring
     __init__.__doc__ = PerspectiveHandlerBase.__init__.__doc__


### PR DESCRIPTION
Disconnect-related errors were handled for `aiohttp` and `starlette` when waiting for the client to send a message, this PR adds that same support to tornado but also handles disconnect when trying to send outbound messages. 



**Note** While testing, I noticed the route to the themes is incorrect, this is particularly noticeable after the recent theme changes