### PR TITLE
A11y front page labels

### DIFF
--- a/docs/src/components/Demo/index.js
+++ b/docs/src/components/Demo/index.js
@@ -115,6 +115,7 @@ export function PerspectiveViewerDemo() {
                 </span>
                 <input
                     id="velocity"
+                    aria-label="Demo update rate in messages per second"
                     type="range"
                     className={clsx(styles.freqSlider)}
                     defaultValue={Math.round((freq - 190) * (5 / -9))}

--- a/docs/src/components/ExampleGallery/features.js
+++ b/docs/src/components/ExampleGallery/features.js
@@ -1,10 +1,12 @@
 exports.default = [
     {
         name: "Default",
+        description: "Data grid",
         config: {},
     },
     {
         name: "Group By 1",
+        description: "Data grid with 1 level of groups for rows",
         config: {
             group_by: ["Sub-Category"],
         },
@@ -12,12 +14,14 @@ exports.default = [
     },
     {
         name: "Group By 2",
+        description: "Data grid with 2 levels of groups for rows",
         config: {
             group_by: ["Category", "Sub-Category"],
         },
     },
     {
         name: "Split By",
+        description: "Data grid with 1 level of categories for columns",
         config: {
             split_by: ["Category"],
             columns: ["Sales", "Quantity", "Discount", "Profit"],
@@ -25,6 +29,7 @@ exports.default = [
     },
     {
         name: "Split By 2",
+        description: "Data grid with 2 levels of categories and columns",
         config: {
             split_by: ["Category", "Sub-Category"],
             columns: ["Sales", "Quantity", "Discount", "Profit"],
@@ -32,6 +37,7 @@ exports.default = [
     },
     {
         name: "Both",
+        description: "Data grid with grouped rows and categorized columns",
         config: {
             group_by: ["Region"],
             split_by: ["Category"],
@@ -40,6 +46,7 @@ exports.default = [
     },
     {
         name: "Both 2",
+        description: "Data grid with 2 levels of groups and 2 levels of categories",
         config: {
             group_by: ["Region", "State"],
             split_by: ["Category", "Sub-Category"],
@@ -48,6 +55,7 @@ exports.default = [
     },
     {
         name: "Background Row And Split By",
+        description: "Data grid with groups, categories, and solid color conditional highlighting",
         config: {
             group_by: ["State"],
             split_by: ["Sub-Category"],
@@ -65,6 +73,7 @@ exports.default = [
     },
     {
         name: "Gradient Row And Split By",
+        description: "Data grid with groups, categories, and gradient conditional highlighting",
         config: {
             group_by: ["State"],
             split_by: ["Sub-Category"],
@@ -82,6 +91,7 @@ exports.default = [
     },
     {
         name: "Background Row And Split By",
+        description: "Data grid with groups, categories, and a bar chart",
         config: {
             group_by: ["State"],
             split_by: ["Sub-Category"],
@@ -99,6 +109,7 @@ exports.default = [
     },
     {
         name: "Foreground Colors",
+        description: "Data grid with 6 categories. 3 categories have conditional formatting using foreground colors.",
         config: {
             columns: [
                 "Category",
@@ -129,6 +140,7 @@ exports.default = [
     },
     {
         name: "Background Colors",
+        description: "Data grid with 6 categories. 3 categories have custom, solid color conditional formatting.",
         config: {
             plugin: "Datagrid",
             plugin_config: {
@@ -169,6 +181,7 @@ exports.default = [
 
     {
         name: "Gradient Colors",
+        description: "Data grid with 6 categories. 3 categories have custom, gradient color conditional formatting.",
         config: {
             columns: [
                 "Category",
@@ -205,6 +218,7 @@ exports.default = [
     },
     {
         name: "Bar Colors",
+        description: "Data grid with 6 categories. 3 categories have custom colored bars.",
         config: {
             columns: [
                 "Category",
@@ -241,6 +255,7 @@ exports.default = [
     },
     {
         name: "Thermometer",
+       description: "Data grid with 1 group and 3 columns. 2 columns use bars and 1 column uses gradient conditional highlighting.",
         config: {
             group_by: ["State"],
             columns: ["Profit (-)", "Profit", "Profit (+)"],
@@ -271,6 +286,7 @@ exports.default = [
 
     {
         name: "Y Bar",
+        description: "Bar chart with 17 bars. X is 'Sub-Category', and Y is 'Sales'.",
         config: {
             plugin: "Y Bar",
             group_by: ["Sub-Category"],
@@ -279,6 +295,7 @@ exports.default = [
     },
     {
         name: "Y Bar, Sorted Desc By Y-Axis",
+        description: "Bar chart with 17 bars sorted descending. X is 'Sub-Category', and Y is 'Sales'.",
         config: {
             plugin: "Y Bar",
             group_by: ["Sub-Category"],
@@ -288,6 +305,7 @@ exports.default = [
     },
     {
         name: "Y Bar - Row And Split By",
+        description: "Stacked bar chart with 17 bars. X is 'Sub-Category', Y is 'Sales', and subgroup is 'Ship Mode'",
         config: {
             plugin: "Y Bar",
             group_by: ["Sub-Category"],
@@ -298,6 +316,7 @@ exports.default = [
 
     {
         name: "Y Bar - Group By 2 Sorted",
+        description: "Bar chart with 3 categories and 17 total subcategories, sorted descending within each category.",
         config: {
             plugin: "Y Bar",
             group_by: ["Category", "Sub-Category"],
@@ -307,6 +326,7 @@ exports.default = [
     },
     {
         name: "Y Bar - Group By 2 And Split By Sorted",
+        description: "Bar chart with 3 colored categories and 17 total subcategories, sorted descending within each category.",
         config: {
             plugin: "Y Bar",
             group_by: ["Category", "Sub-Category"],
@@ -317,6 +337,7 @@ exports.default = [
     },
     {
         name: "Y Bar - Group By 2 And 2 Split By Sorted",
+        description: "Stacked bar chart with 3 categories and 17 total subcategories, sorted descending within each category. X is 'Category, Sub-Category', y is 'Sales', subgroup is 'Region'",
         config: {
             plugin: "Y Bar",
             group_by: ["Category", "Sub-Category"],
@@ -327,6 +348,7 @@ exports.default = [
     },
     {
         name: "Y Bar - Group By 2 And 2 Split By Sorted 2",
+        description: "Bar chart. X is 'State', Y is 'Profit'. Each state has, when applicable, 2 bars: Profit and Loss. States are sorted by Net.",
         config: {
             plugin: "Y Bar",
             group_by: ["State"],
@@ -342,6 +364,7 @@ exports.default = [
 
     {
         name: "Y Bar Multi Axis",
+        description: "Groupd bar chart. X is 'Sub-Category', Y is 'Quantity' and 'Sales'. Each X value has 2 bars.",
         config: {
             plugin: "Y Bar",
             group_by: ["Sub-Category"],
@@ -352,6 +375,7 @@ exports.default = [
     },
     {
         name: "Y Bar Multi Axis - SPlit",
+        description: "Groupd bar chart. X is 'Sub-Category', Y is 'Quantity', and the second Y is 'Sales'. Each X value has 2 bars.",
         config: {
             plugin: "Y Bar",
             group_by: ["Sub-Category"],
@@ -366,6 +390,7 @@ exports.default = [
 
     {
         name: "X Bar",
+        description: "Horizontal bar chart with 17 bars. X is 'Sub-Category' and Y is 'Sales'.",
         config: {
             plugin: "X Bar",
             group_by: ["Sub-Category"],
@@ -374,6 +399,7 @@ exports.default = [
     },
     {
         name: "X Bar",
+        description: "Grouped horizontal bar chart. X is 'Sub-Category' and Y is 'Quantity, Profit'.",
         config: {
             plugin: "X Bar",
             group_by: ["Sub-Category"],
@@ -382,6 +408,7 @@ exports.default = [
     },
     {
         name: "X Bar, Sorted Desc By X-Axis",
+        description: "Sorted horizontal bar chart. X is 'Sub-Category' and Y is 'Sales'.",
         config: {
             plugin: "X Bar",
             group_by: ["Sub-Category"],
@@ -391,6 +418,7 @@ exports.default = [
     },
     {
         name: "X Bar - Row And Split By",
+        description: "Stacked horizontal bar chart. X is 'Sub-Category', Y is 'Sales', and subgroup is 'Region'",
         config: {
             plugin: "X Bar",
             group_by: ["Sub-Category"],
@@ -400,6 +428,7 @@ exports.default = [
     },
     {
         name: "X Bar - Row And Split By",
+        description: "Sorted stacked horizontal bar chart. X is 'Sub-Category', Y is 'Sales', and subgroup is 'Region'",
         config: {
             plugin: "X Bar",
             group_by: ["Sub-Category"],
@@ -413,6 +442,7 @@ exports.default = [
 
     {
         name: "Y Line - Datetime Axis",
+        description: "Line chart. X is Order Date from January 2014 to December 2017. Y is 'Sales'.",
         config: {
             plugin: "Y Line",
             group_by: ["Order Date"],
@@ -421,6 +451,7 @@ exports.default = [
     },
     {
         name: "Y Line - Datetime Axis",
+        description: "Line chart with 3 lines. X is Order Date, Y is Sales, and the lines are 'Consumer', 'Corporate', and 'Home Office'.",
         config: {
             plugin: "Y Line",
             group_by: ["Order Date"],
@@ -430,6 +461,7 @@ exports.default = [
     },
     {
         name: "Y Line - Datetime Axis Computed",
+        description: "Line Chart. X is 'Order Date', summarized by month. Y is 'Sales'",
         config: {
             plugin: "Y Line",
             group_by: ["bucket(\"Order Date\", 'M')"],
@@ -439,6 +471,7 @@ exports.default = [
     },
     {
         name: "Y Line - Datetime Axis",
+        description: "Line Chart with 4 lines. X is 'Order Date' from January 2014 to December 2017. Y is 'Sales'. Each line is for each year.",
         config: {
             plugin: "Y Line",
             group_by: ["bucket(\"Order Date\", 'M')"],
@@ -452,6 +485,7 @@ exports.default = [
     },
     {
         name: "Y Line - Datetime Axis And Split By",
+        description: "Line Chart with 4 lines. X is Order Date, Y is Sales, and the lines track different regions.",
         config: {
             plugin: "Y Line",
             group_by: ["bucket(\"Order Date\", 'M')"],
@@ -462,6 +496,7 @@ exports.default = [
     },
     {
         name: "Y Line - Category Axis",
+        description: "Line Chart. X is State and Y is Sales.",
         config: {
             plugin: "Y Line",
             group_by: ["State"],
@@ -471,6 +506,7 @@ exports.default = [
     },
     {
         name: "Y Line - Category Axis",
+        description: "Line Chart. X is State and Y is Sales. Sorted descending.",
         config: {
             plugin: "Y Line",
             group_by: ["State"],
@@ -481,6 +517,7 @@ exports.default = [
     },
     {
         name: "Y Line - Row and Split By",
+        description: "Line chart with 3 lines. X is State, Y is Sales, and each line tracks a customer segment. States are sorted descending by total sales.",
         config: {
             plugin: "Y Line",
             group_by: ["State"],
@@ -492,6 +529,7 @@ exports.default = [
     },
     {
         name: "Y Line - Multi Axis Split",
+        description: "Line chart with 2 lines. X is State, Y is Profit, and second Y is Sales. States are sorted descending by Sales.",
         config: {
             plugin: "Y Line",
             group_by: ["State"],
@@ -503,6 +541,7 @@ exports.default = [
     },
     {
         name: "Y Line - Multi Axis Split",
+        description: "Line chart with 2 lines. X is State, Y is Profit, second Y is Sales, and each line is profit/sales for each customer segment. States are sorted descending by total Sales.",
         config: {
             plugin: "Y Line",
             group_by: ["State"],
@@ -518,6 +557,7 @@ exports.default = [
 
     {
         name: "Y Area - Datetime Axis Computed",
+        description: "Area chart. X is 'Order Date', bucketed by month. Y is Sales.",
         config: {
             plugin: "Y Area",
             group_by: ["bucket(\"Order Date\", 'M')"],
@@ -527,6 +567,7 @@ exports.default = [
     },
     {
         name: "Y Area - Datetime Axis",
+        description: "Area chart. X is 'Order Date', bucketed by month. Y is sales. Each year is its own color and area.",
         config: {
             plugin: "Y Area",
             group_by: ["bucket(\"Order Date\", 'M')"],
@@ -540,6 +581,7 @@ exports.default = [
     },
     {
         name: "Y Area - Datetime Axis And Split By",
+        description: "Stacked area chart. X is 'Order Date', bucketed by month. Y is sales. Subgroup is Region.",
         config: {
             plugin: "Y Area",
             group_by: ["bucket(\"Order Date\", 'M')"],
@@ -550,6 +592,7 @@ exports.default = [
     },
     {
         name: "Y Area - Category Axis",
+        description: "Area chart. X is 'State'. Y is Sales.",
         config: {
             plugin: "Y Area",
             group_by: ["State"],
@@ -559,6 +602,7 @@ exports.default = [
     },
     {
         name: "Y Area - Row and Split By",
+        description: "Stacked area chart. X is 'State'. Y is 'Sales'. Subgroup is customer segment.",
         config: {
             plugin: "Y Area",
             group_by: ["State"],
@@ -569,6 +613,7 @@ exports.default = [
     },
     {
         name: "Y Area - 2 Group By",
+        description: "Grouped area chart. X is State, grouped by Region. Y is sales. Sorted descending by Sales for each region.",
         config: {
             plugin: "Y Area",
             group_by: ["Region", "State"],
@@ -579,6 +624,7 @@ exports.default = [
     },
     {
         name: "Y Area - Row and Split By",
+        description: "Grouped area chart. X is State, grouped by Region. Y is sales. Sorted descending by Sales for each region. Each group is a different color.",
         config: {
             plugin: "Y Area",
             group_by: ["Region", "State"],
@@ -590,6 +636,7 @@ exports.default = [
     },
     {
         name: "Y Area - Row and Split By 2",
+        description: "Stacked grouped area chart. X is State, grouped by Region. Y is sales. Subgroup is customer segment. Sorted descending by total sales.",
         config: {
             plugin: "Y Area",
             group_by: ["Region", "State"],
@@ -604,6 +651,7 @@ exports.default = [
 
     {
         name: "X/Y Scatter",
+        description: "Scatter plot. X is Sales. Y is Quantity.",
         config: {
             plugin: "X/Y Scatter",
             group_by: ["City"],
@@ -613,6 +661,7 @@ exports.default = [
     },
     {
         name: "X/Y Scatter - Split By",
+        description: "Grouped Scatter plot. X is Sales. Y is Quantity. Group is Region.",
         config: {
             plugin: "X/Y Scatter",
             group_by: ["City"],
@@ -623,6 +672,7 @@ exports.default = [
     },
     {
         name: "X/Y Scatter - Color By Float",
+        description: "Scatter plot. X is Sales. Y is Quantity. Each dot is colored by Profit.",
         config: {
             plugin: "X/Y Scatter",
             group_by: ["State"],
@@ -633,6 +683,7 @@ exports.default = [
     },
     {
         name: "X/Y Scatter - Bubble",
+        description: "Bubble plot. X is Sales. Y is Quantity. Size is Profit.",
         config: {
             plugin: "X/Y Scatter",
             group_by: ["Sub-Category"],
@@ -643,6 +694,7 @@ exports.default = [
     },
     {
         name: "X/Y Scatter - Bubble",
+        description: "Grouped bubble plot. X is Sales. Y is Quantity. Size is Profit. Group is Product Sub-Category.",
         config: {
             plugin: "X/Y Scatter",
             group_by: ["Sub-Category"],
@@ -654,6 +706,7 @@ exports.default = [
     },
     {
         name: "X/Y Scatter - Bubble",
+        description: "Colored bubble plot. X is Sales. Y is Quantity. Size is Row ID. Color is Profit.",
         config: {
             plugin: "X/Y Scatter",
             group_by: ["Sub-Category"],
@@ -671,6 +724,7 @@ exports.default = [
 
     {
         name: "X/Y Scatter - Category Y Axis",
+        description: "Horizontal Bubble plot. X is State. Y is Profit. Size is Quantity.",
         config: {
             plugin: "X/Y Scatter",
             columns: ["Profit", "State", null, "Quantity"],
@@ -684,6 +738,7 @@ exports.default = [
 
     {
         name: "X/Y Scatter - Category Y Axis And Size And Color",
+        description: "Colored Bubble plot. X is State. Y is product sub-category. Size is Sales. Color is Quantity.",
         config: {
             plugin: "X/Y Scatter",
             columns: ["State", "Sub-Category", "Quantity", "Sales", null],
@@ -701,6 +756,7 @@ exports.default = [
 
     {
         name: "X/Y Line",
+        description: "Line chart with 4 lines. X is Sales. Y is Profit. Each line represents a region.",
         config: {
             columns: ["Sales", "Profit"],
             plugin: "X/Y Line",
@@ -722,6 +778,7 @@ exports.default = [
 
     {
         name: "Treemap",
+        description: "Treemap with 1-level hierarchy and 17 tiles. Each tile is a product sub-category, and the tile's size represents sales",
         config: {
             plugin: "Treemap",
             group_by: ["Sub-Category"],
@@ -730,6 +787,7 @@ exports.default = [
     },
     {
         name: "Treemap - 2 Group By",
+        description: "Treemap with 2-level hierarchies for Category and Sub-Category. Size is Sales.",
         config: {
             plugin: "Treemap",
             group_by: ["Category", "Sub-Category", "Segment"],
@@ -738,6 +796,7 @@ exports.default = [
     },
     {
         name: "Treemap - Float Color",
+        description: "Colored treemap with 2-level hierarchies for Category and Sub-Category. Size is Sales. Color is Quantity.",
         config: {
             plugin: "Treemap",
             group_by: ["Category", "Sub-Category"],
@@ -747,6 +806,7 @@ exports.default = [
     },
     {
         name: "Treemap - Category Color",
+        description: "Treemap with 2-level hierarchies for Category and Sub-Category, with each Category colored differently. Size is Sales.",
         config: {
             plugin: "Treemap",
             group_by: ["Category", "Sub-Category"],
@@ -756,6 +816,7 @@ exports.default = [
     },
     {
         name: "Treemap - Row And Split By Float Color",
+        description: "Colored treemap with 3-level hierarchies for Region, Category, and Sub-Category. Size is Sales. Color is Quantity.",
         config: {
             plugin: "Treemap",
             group_by: ["Category", "Sub-Category"],
@@ -767,6 +828,7 @@ exports.default = [
     },
     {
         name: "Treemap - Row And Split By Category Color",
+        description: "Treemap with 3-level hierarchies for Region, Category, and Sub-Category, with each Region colored differently. Size is Sales.",
         config: {
             plugin: "Treemap",
             group_by: ["Category", "Sub-Category"],
@@ -778,6 +840,7 @@ exports.default = [
     },
     {
         name: "Treemap - Row And Split By Category Color 2",
+        description: "Treemap with 3-level hierarchies for Region, Category, and Sub-Category, with each Category colored differently. Size is Sales.",
         config: {
             plugin: "Treemap",
             group_by: ["Category", "Sub-Category"],
@@ -791,6 +854,7 @@ exports.default = [
 
     {
         name: "Sunburst",
+        description: "Sunburst with 1-level hierarchy. Hierarchy is Category. Size is Sales.",
         config: {
             plugin: "Sunburst",
             group_by: ["Sub-Category"],
@@ -799,6 +863,7 @@ exports.default = [
     },
     {
         name: "Sunburst - 2 Group By",
+        description: "Sunburst with 3-level hierarchy. Hierarchies are Category, Sub-category, and Customer Segment.",
         config: {
             plugin: "Sunburst",
             group_by: ["Category", "Sub-Category", "Segment"],
@@ -807,6 +872,7 @@ exports.default = [
     },
     {
         name: "Sunburst - Float Color",
+        description: "Colored sunburst with 2-level hierarchy. Hierarchies are Category and Sub-category. Size is Quantity. Color is Sales.",
         config: {
             plugin: "Sunburst",
             group_by: ["Category", "Sub-Category"],
@@ -816,6 +882,7 @@ exports.default = [
     },
     {
         name: "Sunburst - Category Color",
+        description: "Colored sunburst with 2-level hierarchy. Hierarchies are Category and Sub-category. Size is Sales. Color is also Category.",
         config: {
             plugin: "Sunburst",
             group_by: ["Category", "Sub-Category"],
@@ -825,6 +892,7 @@ exports.default = [
     },
     {
         name: "Sunburst - Row And Split By",
+        description: "Grouped sunbursts with 2-level hierarchy. Hierarchies are Category and Sub-category. Size is Sales. Each sunburst is a different region.",
         config: {
             plugin: "Sunburst",
             group_by: ["Category", "Sub-Category"],
@@ -835,6 +903,7 @@ exports.default = [
     },
     {
         name: "Sunburst - Row And Split By Float Color",
+        description: "Grouped colored sunbursts with 2-level hierarchy. Hierarchies are Category and Sub-category. Size is Sales. Color is Quantity. Each sunburst is a different region.",
         config: {
             plugin: "Sunburst",
             group_by: ["Category", "Sub-Category"],
@@ -845,6 +914,7 @@ exports.default = [
     },
     {
         name: "Sunburst - Row And Split By Category Color",
+        description: "Grouped sunbursts with 2-level hierarchy. Hierarchies are Category and Sub-category. Size is Sales. Each sunburst is a different region and color.",
         config: {
             plugin: "Sunburst",
             group_by: ["Category", "Sub-Category"],
@@ -856,6 +926,7 @@ exports.default = [
     },
     {
         name: "Sunburst - Row And Split By Category Color 2",
+        description: "Grouped sunbursts with 2-level hierarchy. Hierarchies are Category and Sub-category. Size is Sales. Each sunburst is a different region, and each category is colored.",
         config: {
             plugin: "Sunburst",
             group_by: ["Category", "Sub-Category"],
@@ -870,6 +941,7 @@ exports.default = [
 
     {
         name: "Heatmap",
+        description: "Heatmap. Columns are Sub-Category. Rows are Region. Color is Profit.",
         config: {
             plugin: "Heatmap",
             group_by: ["Sub-Category"],
@@ -885,6 +957,7 @@ exports.default = [
     },
     {
         name: "Heatmap 2",
+        description: "Heatmap. Columns are State. Rows are Sub-Category. Color is Profit.",
         config: {
             plugin: "Heatmap",
             group_by: ["State"],
@@ -900,6 +973,7 @@ exports.default = [
     },
     {
         name: "Heatmap 3",
+        description: "Heatmaps. Columns are order date, bucketed by month. Rows are Sub-Category. Color is Discount.",
         config: {
             columns: ["Discount"],
             plugin: "Heatmap",
@@ -916,6 +990,7 @@ exports.default = [
     },
     {
         name: "Heatmap 4",
+        description: "Heatmap. Columns are order date, bucketed by month. Rows are Profit, bucketed by 100. Color is Profit.",
         config: {
             plugin: "Heatmap",
             columns: ["Profit"],

--- a/docs/src/components/ExampleGallery/index.js
+++ b/docs/src/components/ExampleGallery/index.js
@@ -28,6 +28,7 @@ export default function ExampleGallery(props) {
                         className={clsx(
                             overlayVisible >= 0 ? styles.dimmed : undefined
                         )}
+                        alt={config.description}
                         src={useBaseUrl(`/features/feature_${i}${color}.png`)}
                         key={i}
                         onClick={clickCallback}


### PR DESCRIPTION
# Documentation

(Both on the front page)
- Added an aria-label to the Velocity range slider
- Added descriptions for every example's thumbnail, and surfaced them as `alt` text.

## Validation

I am presently unable to build Perspective in order to validate that this documentation works correctly. I have [a discussion](https://github.com/finos/perspective/discussions/2155) open to try to get myself to a point where I can build things.

However, I wanted to submit this PR ahead of time, in case anyone wants to review or change the image descriptions that I wrote.

- [ ] I have linted, spell-checked, and grammar-checked my documentation additions.
- [ ] I have run `yarn docs` to regenerate the API documentation from source.
- [ ] Within `/docs`, I have run `yarn start` to regenerate the Docusaurus site, and I have validated the changes
- [ ] My additions are styled and structured correctly on the Docusaurus site

## Checklist

<!--- If you have any questions, please reach out! We are here to help. -->

- [x] I have read the [`CONTRIBUTING.md`](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md) and followed its [Guidelines](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md#guidelines)