### PR TITLE
Make homepage LayoutButton's keyboard-accessible

### DIFF
--- a/docs/src/components/Demo/index.js
+++ b/docs/src/components/Demo/index.js
@@ -54,6 +54,13 @@ function LayoutButton(props) {
             onMouseOver={props.onHover}
             className={clsx(styles.visButton, active)}
             id={props.name}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+                if(e.key === " " || e.key === "Enter"){
+                    props.onHover(e);
+                }
+            }}
         >
             {props.name}
         </div>


### PR DESCRIPTION
## Documentation

* Added accessibility attributes to the buttons on the front page. The attributes were: 
    * `role=button`, which provides semantic details for screen readers
    * `tabIndex="0"`, which allows keyboard-only users to tab to the buttons
    * keydown event handler, which allows keyboard-only users to press ENTER or SPACEBAR to activate the buttons

## Validation

I am presently unable to build Perspective in order to validate that this documentation works corrently. I have a discussion open to try to get myself to a point where I can build things. However, I wanted to submit this PR ahead of time, in case anyone wants to review the approach.

## Checklist

- [x] I have read the [`CONTRIBUTING.md`](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md) and followed its [Guidelines](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md#guidelines)