### PR TITLE
Fix expression editor bug with escaped characters in strings

### DIFF
--- a/rust/perspective-viewer/src/rust/exprtk/tokenize.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/tokenize.rs
@@ -165,4 +165,10 @@ mod tests {
             Literal("2"),
         ]);
     }
+
+    #[wasm_bindgen_test]
+    fn test_escape_strings() {
+        let s = "'test\\/'";
+        assert_eq!(tokenize(s), vec![Literal("'test\\/'"),]);
+    }
 }

--- a/rust/perspective-viewer/src/rust/exprtk/tokenize/string.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/tokenize/string.rs
@@ -55,7 +55,7 @@ impl StringFragment {
     const fn len(&self) -> usize {
         match self {
             Self::Literal(s) => *s,
-            Self::EscapedChar => 1,
+            Self::EscapedChar => 2,
             Self::EscapedWS => 0,
         }
     }


### PR DESCRIPTION
Fixes expression syntax highlighting to properly display escaped characters in strings.