### PR TITLE
fix "Data" to "Heatmap" axes transposing-1127

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
@@ -100,4 +100,5 @@ heatmapChart.plugin = {
     },
 };
 
+
 export default heatmapChart;

--- a/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
@@ -28,16 +28,20 @@ function heatmapChart(container, settings) {
 
     const xAxis = axisFactory(settings)
         .excludeType(AXIS_TYPES.linear)
-        .settingName("crossValues")
-        .valueName("crossValue")(data);
-
-    const yAxis = axisFactory(settings)
-        .excludeType(AXIS_TYPES.linear)
         .settingName("splitValues")
-        .valueName("mainValue")
+        .valueName("crossValue")
         .modifyDomain((d) => {
             let is_number = !isNaN(d[0]);
             return is_number ? d.reverse() : d;
+        })(data);
+
+    const yAxis = axisFactory(settings)
+        .excludeType(AXIS_TYPES.linear)
+        .settingName("crossValues")
+        .valueName("mainValue")
+        .modifyDomain((d) => {
+            let is_number = typeof d[0];
+            return is_number === 'number' || is_number === 'string' ? d : d.reverse();
         })
         .orient("vertical")(data);
 

--- a/packages/perspective-viewer-d3fc/src/js/data/heatmapData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/heatmapData.js
@@ -12,24 +12,24 @@ import { labelFunction } from "../axis/axisLabel";
 
 export function heatmapData(settings, data) {
     const labelfn = labelFunction(settings);
-    const mainType = axisType(settings)
+    const crossType = axisType(settings)
         .excludeType(AXIS_TYPES.linear)
         .settingName("splitValues")();
 
     const heatmapData = [];
 
     data.forEach((col, i) => {
-        const crossValue = labelfn(col, i);
+        const mainValue = labelfn(col, i);
         Object.keys(col)
             .filter((key) => key !== "__ROW_PATH__")
             .forEach((key) => {
-                const mainValue = getMainValues(key);
+                const crossValue = getCrossValues(key);
                 heatmapData.push({
-                    crossValue: crossValue,
-                    mainValue:
-                        mainType === AXIS_TYPES.time
-                            ? new Date(mainValue)
-                            : mainValue,
+                    mainValue: mainValue,
+                    crossValue:
+                        crossType === AXIS_TYPES.time
+                            ? new Date(crossValue)
+                            : crossValue,
                     colorValue: col[key],
                     row: col,
                 });
@@ -39,7 +39,7 @@ export function heatmapData(settings, data) {
     return heatmapData;
 }
 
-function getMainValues(key) {
+function getCrossValues(key) {
     // Key format is based on "Split By" values plus the value label at the end
     // val1|val2|....|label
     const labels = key.split("|");


### PR DESCRIPTION
#1127 Datagrid gets transposed (axis are swapped) when plugin is changed from "Grid" to "Heatmap" #1127

BEFORE:

https://user-images.githubusercontent.com/38087267/231417874-52b84434-f842-437c-852c-43390608e9c8.mp4



AFTER:

https://user-images.githubusercontent.com/38087267/231418166-61ae528e-529d-4cc3-a7d9-033cd35eb094.mp4

