### PR TITLE
fix "Data" to "Heatmap" axes transposing-1127

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
@@ -18,6 +18,52 @@ import { colorRangeLegend } from "../legend/colorRangeLegend";
 import zoomableChart from "../zoom/zoomableChart";
 import nearbyTip from "../tooltip/nearbyTip";
 
+export const invertAxesFlag = false;
+
+function invertAxes(flag, settings, data) {
+    let xAxis = axisFactory(settings)
+        .excludeType(AXIS_TYPES.linear)
+        .settingName("crossValues")
+        .valueName("crossValue")(data);
+
+    let yAxis = axisFactory(settings)
+        .excludeType(AXIS_TYPES.linear)
+        .settingName("splitValues")
+        .valueName("mainValue")
+        .modifyDomain((d) => {
+            let is_number = !isNaN(d[0]);
+            return is_number ? d.reverse() : d;
+        })
+        .orient("vertical")(data);
+
+    if (flag === true) {
+        xAxis = axisFactory(settings)
+            .excludeType(AXIS_TYPES.linear)
+            .settingName("splitValues")
+            .valueName("crossValue")
+            .modifyDomain((d) => {
+                let is_number = !isNaN(d[0]);
+                return is_number ? d.reverse() : d;
+            })(data);
+
+        yAxis = axisFactory(settings)
+            .excludeType(AXIS_TYPES.linear)
+            .settingName("crossValues")
+            .valueName("mainValue")
+            .modifyDomain((d) => {
+                let is_number = typeof d[0];
+                return is_number === "number" || is_number === "string"
+                    ? d
+                    : d.reverse();
+            })
+            .orient("vertical")(data);
+    }
+    return {
+        xAxis,
+        yAxis,
+    };
+}
+
 function heatmapChart(container, settings) {
     const data = heatmapData(settings, filterData(settings));
 
@@ -26,24 +72,7 @@ function heatmapChart(container, settings) {
 
     const legend = colorRangeLegend().scale(color);
 
-    const xAxis = axisFactory(settings)
-        .excludeType(AXIS_TYPES.linear)
-        .settingName("splitValues")
-        .valueName("crossValue")
-        .modifyDomain((d) => {
-            let is_number = !isNaN(d[0]);
-            return is_number ? d.reverse() : d;
-        })(data);
-
-    const yAxis = axisFactory(settings)
-        .excludeType(AXIS_TYPES.linear)
-        .settingName("crossValues")
-        .valueName("mainValue")
-        .modifyDomain((d) => {
-            let is_number = typeof d[0];
-            return is_number === 'number' || is_number === 'string' ? d : d.reverse();
-        })
-        .orient("vertical")(data);
+    const { xAxis, yAxis } = invertAxes(invertAxesFlag, settings, data);
 
     const chart = chartCanvasFactory(xAxis, yAxis).plotArea(
         withGridLines(series, settings).canvas(true)

--- a/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
@@ -28,16 +28,20 @@ function heatmapChart(container, settings) {
 
     const xAxis = axisFactory(settings)
         .excludeType(AXIS_TYPES.linear)
-        .settingName("crossValues")
-        .valueName("crossValue")(data);
-
-    const yAxis = axisFactory(settings)
-        .excludeType(AXIS_TYPES.linear)
         .settingName("splitValues")
-        .valueName("mainValue")
+        .valueName("crossValue")
         .modifyDomain((d) => {
             let is_number = !isNaN(d[0]);
             return is_number ? d.reverse() : d;
+        })(data);
+
+    const yAxis = axisFactory(settings)
+        .excludeType(AXIS_TYPES.linear)
+        .settingName("crossValues")
+        .valueName("mainValue")
+        .modifyDomain((d) => {
+            let is_number = typeof d[0];
+            return is_number === 'number' || is_number === 'string' ? d : d.reverse();
         })
         .orient("vertical")(data);
 

--- a/packages/perspective-viewer-d3fc/src/js/data/heatmapData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/heatmapData.js
@@ -9,37 +9,50 @@
 import { axisType } from "../axis/axisType";
 import { AXIS_TYPES } from "../axis/axisType";
 import { labelFunction } from "../axis/axisLabel";
+import { invertAxesFlag } from "../charts/heatmap";
 
 export function heatmapData(settings, data) {
     const labelfn = labelFunction(settings);
-    const crossType = axisType(settings)
+    const mainType = axisType(settings)
         .excludeType(AXIS_TYPES.linear)
         .settingName("splitValues")();
 
     const heatmapData = [];
 
     data.forEach((col, i) => {
-        const mainValue = labelfn(col, i);
+        const crossValue = labelfn(col, i);
         Object.keys(col)
             .filter((key) => key !== "__ROW_PATH__")
             .forEach((key) => {
-                const crossValue = getCrossValues(key);
-                heatmapData.push({
-                    mainValue: mainValue,
-                    crossValue:
-                        crossType === AXIS_TYPES.time
-                            ? new Date(crossValue)
-                            : crossValue,
-                    colorValue: col[key],
-                    row: col,
-                });
+                const mainValue = getMainValues(key);
+                if (invertAxesFlag === false) {
+                    heatmapData.push({
+                        crossValue: crossValue,
+                        mainValue:
+                            mainType === AXIS_TYPES.time
+                                ? new Date(mainValue)
+                                : mainValue,
+                        colorValue: col[key],
+                        row: col,
+                    });
+                } else {
+                    heatmapData.push({
+                        mainValue: crossValue,
+                        crossValue:
+                            mainType === AXIS_TYPES.time
+                                ? new Date(mainValue)
+                                : mainValue,
+                        colorValue: col[key],
+                        row: col,
+                    });
+                }
             });
     });
 
     return heatmapData;
 }
 
-function getCrossValues(key) {
+function getMainValues(key) {
     // Key format is based on "Split By" values plus the value label at the end
     // val1|val2|....|label
     const labels = key.split("|");

--- a/packages/perspective-viewer-d3fc/src/js/data/heatmapData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/heatmapData.js
@@ -12,24 +12,24 @@ import { labelFunction } from "../axis/axisLabel";
 
 export function heatmapData(settings, data) {
     const labelfn = labelFunction(settings);
-    const mainType = axisType(settings)
+    const crossType = axisType(settings)
         .excludeType(AXIS_TYPES.linear)
         .settingName("splitValues")();
 
     const heatmapData = [];
 
     data.forEach((col, i) => {
-        const crossValue = labelfn(col, i);
+        const mainValue = labelfn(col, i);
         Object.keys(col)
             .filter((key) => key !== "__ROW_PATH__")
             .forEach((key) => {
-                const mainValue = getMainValues(key);
+                const crossValue = getCrossValues(key);
                 heatmapData.push({
-                    crossValue: crossValue,
-                    mainValue:
-                        mainType === AXIS_TYPES.time
-                            ? new Date(mainValue)
-                            : mainValue,
+                    mainValue: mainValue,
+                    crossValue:
+                        crossType === AXIS_TYPES.time
+                            ? new Date(crossValue)
+                            : crossValue,
                     colorValue: col[key],
                     row: col,
                 });
@@ -39,7 +39,7 @@ export function heatmapData(settings, data) {
     return heatmapData;
 }
 
-function getMainValues(key) {
+function getCrossValues(key) {
     // Key format is based on "Split By" values plus the value label at the end
     // val1|val2|....|label
     const labels = key.split("|");


### PR DESCRIPTION
#1127 Datagrid gets transposed (axis are swapped) when plugin is changed from "Grid" to "Heatmap" #1127

[https://github.com/finos/perspective/issues/1127]

BEFORE:

https://user-images.githubusercontent.com/38087267/231719273-e1d65e1b-f7d3-4bae-b517-8d51200530aa.mp4



AFTER:

https://user-images.githubusercontent.com/38087267/231719332-166b59bb-da4c-4294-a1d3-fcdb5244e7d1.mp4

