### PR TITLE
Add type-specific aggregates for median and middle

### DIFF
--- a/cpp/perspective/src/cpp/sparse_tree.cpp
+++ b/cpp/perspective/src/cpp/sparse_tree.cpp
@@ -1120,7 +1120,17 @@ t_stree::update_agg_table(t_uindex nidx, t_agg_update_info& info,
                             std::nth_element(
                                 values.begin(), middle, values.end());
 
-                            return *middle;
+                            if (values.size() % 2 == 0) {
+                                // If there are an even number of values,
+                                // return the average of the two middle elements
+                                t_tscalar median1 = *middle;
+                                t_tscalar median2 = *(middle - 1);
+                                return (median1 + median2) / 2.0;
+                            } else {
+                                // If there are an odd number of values,
+                                // return the middle element
+                                return *middle;
+                            }
                         }
                     }));
 


### PR DESCRIPTION
Refactor median aggregate to support two type-specific aggregates (median and middle) to ensure consistent behavior for numeric and category columns. Type dispatching is performed internally to handle even and odd numbers of values. This simplifies and improves the implementation. fixes #1928

Javascript code to reproduce:
```javascript
const perspective = require("@finos/perspective")
const worker = perspective.worker()
const main = async () => {
    const data = [
        {
            Fruit: 'Apple',
            Price: 1,
        },
        {
            Fruit: 'Apple',
            Price: 2,
        },
        {
            Fruit: 'Apple',
            Price: 4,
        },
        {
            Fruit: 'Orange',
            Price: 5,
        },
        {
            Fruit: 'Orange',
            Price: 6,
        },
    ];
    const options = {
        columns: ['Price'],
        aggregates: { Price: 'median' },
        group_by: ['Fruit'],
    };
    const schema = {
        Fruit: 'string',
        Price: 'float'
    };
    const table = await worker.table(schema);
    table.update(data)
    const view = await table.view(options)
    const aggregationResult = await view.to_json();
    console.log(aggregationResult);
}; 
main();
```
**Aggregation Result**
```
[
  { __ROW_PATH__: [], Price: 4 },
  { __ROW_PATH__: [ 'Apple' ], Price: 2 },
  { __ROW_PATH__: [ 'Orange' ], Price: 5.5 }
]
```