### PR TITLE
add parquet viewer support to jupyterlab mime renderer 

### DIFF
--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -44,7 +44,8 @@
         "@jupyter-widgets/base": "^2 || ^3 || ^4 || ^5 || ^6",
         "@jupyterlab/application": "^3.6.1",
         "@lumino/application": "^1.27.0",
-        "@lumino/widgets": "^1.37.0"
+        "@lumino/widgets": "^1.37.0",
+        "parquet-wasm": "^0.3.1"
     },
     "devDependencies": {
         "@finos/perspective-esbuild-plugin": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12060,6 +12060,11 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parquet-wasm@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/parquet-wasm/-/parquet-wasm-0.3.1.tgz#4c7306cac00e1bfacb00ee9e395a9ef8a4c8623f"
+  integrity sha512-8OMYwh7N+IcQBeKTuDgpvJR7xh/YKPgnQcs29CQW0Q4ziwroRu7N6tQmmsjiCaQ/W7enBNppquj6VAe2fA1yYQ==
+
 parse-entities@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"


### PR DESCRIPTION
Adds JupyterLab mimerender viewer for `.parquet` file using @kylebarron's https://github.com/kylebarron/parquet-wasm library. Note that since we're already compiling arrow to wasm anyway, we could consider also compiling the parquet bits and letting perspective natively read parquet files as it does arrow ipc data.

I've also renamed the context menu labels from e.g. `CSVPerspective` to `Perspective-CSV`, because I think it looks better. 

![tmp](https://user-images.githubusercontent.com/3105306/235193485-6b23a839-c59d-4769-8c12-d2e0b7ba6281.gif)

