### PR TITLE
Fix windows python builds

### DIFF
--- a/cpp/perspective/src/include/perspective/step_delta.h
+++ b/cpp/perspective/src/include/perspective/step_delta.h
@@ -19,7 +19,6 @@
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/composite_key.hpp>
-#include <boost/variant/apply_visitor.hpp>
 
 namespace perspective {
 

--- a/scripts/_wheel_python.js
+++ b/scripts/_wheel_python.js
@@ -53,9 +53,9 @@ try {
         // install deps
         const boost = [
             `yum -y install wget libffi-devel`,
-            `wget https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz >/dev/null`,
-            `tar xfz boost_1_71_0.tar.gz`,
-            "cd boost_1_71_0",
+            `wget https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.gz >/dev/null`,
+            `tar xfz boost_1_81_0.tar.gz`,
+            "cd boost_1_81_0",
             `./bootstrap.sh`,
             `./b2 -j8 --with-program_options --with-filesystem --with-system install`,
             `cd ..`,


### PR DESCRIPTION
Fix regression in Python Windows builds which prevented publishing of 2.1.0