### PR TITLE
Fix a bug when calling `load()` with a rejected promise

### DIFF
--- a/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
@@ -358,15 +358,19 @@ impl PerspectiveViewerElement {
                     .ok_or("Already deleted")?
                     .send_message_async(move |x| Msg::ToggleSettingsComplete(settings, x));
 
-                let plugin = renderer.get_active_plugin()?;
-                if let Some(plugin_config) = &plugin_config {
-                    let js_config = JsValue::from_serde_ext(plugin_config)?;
-                    plugin.restore(&js_config);
-                }
+                let internal_task = async {
+                    let plugin = renderer.get_active_plugin()?;
+                    if let Some(plugin_config) = &plugin_config {
+                        let js_config = JsValue::from_serde_ext(plugin_config)?;
+                        plugin.restore(&js_config);
+                    }
 
-                let result = session.validate().await?.create_view().await;
+                    session.validate().await?.create_view().await
+                }
+                .await;
+
                 task.await?;
-                result
+                internal_task
             });
 
             draw_task.await?;

--- a/rust/perspective-viewer/test/js/settings.spec.js
+++ b/rust/perspective-viewer/test/js/settings.spec.js
@@ -7,12 +7,8 @@
  *
  */
 
-import { test } from "@playwright/test";
-import {
-    compareContentsToSnapshot,
-    shadow_click,
-    shadow_type,
-} from "@finos/perspective-test";
+import { test, expect } from "@playwright/test";
+import { compareContentsToSnapshot } from "@finos/perspective-test";
 
 const path = require("path");
 
@@ -25,44 +21,99 @@ async function get_contents(page) {
     });
 }
 
-test.beforeEach(async ({ page }) => {
-    await page.goto("/rust/perspective-viewer/test/html/superstore.html", {
-        waitUntil: "networkidle",
-    });
-
-    await page.evaluate(async () => {
-        await document.querySelector("perspective-viewer").restore({
-            plugin: "Debug",
-        });
-    });
-});
-
 test.describe("Settings", () => {
-    test("opens settings when field is set to true", async ({ page }) => {
-        await page.evaluate(async () => {
-            const viewer = document.querySelector("perspective-viewer");
-            await viewer.getTable();
-            await viewer.restore({ settings: true });
+    test.describe("Toggle", () => {
+        test.beforeEach(async ({ page }) => {
+            await page.goto(
+                "/rust/perspective-viewer/test/html/superstore.html",
+                {
+                    waitUntil: "networkidle",
+                }
+            );
+
+            await page.evaluate(async () => {
+                await document.querySelector("perspective-viewer").restore({
+                    plugin: "Debug",
+                });
+            });
         });
 
-        const contents = await get_contents(page);
+        test("opens settings when field is set to true", async ({ page }) => {
+            await page.evaluate(async () => {
+                const viewer = document.querySelector("perspective-viewer");
+                await viewer.getTable();
+                await viewer.restore({ settings: true });
+            });
 
-        await compareContentsToSnapshot(contents, [
-            "opens-settings-when-field-is-set-to-true.txt",
-        ]);
+            const contents = await get_contents(page);
+
+            await compareContentsToSnapshot(contents, [
+                "opens-settings-when-field-is-set-to-true.txt",
+            ]);
+        });
+
+        test("opens settings when field is set to false", async ({ page }) => {
+            await page.evaluate(async () => {
+                const viewer = document.querySelector("perspective-viewer");
+                await viewer.getTable();
+                await viewer.restore({ settings: false });
+            });
+
+            const contents = await get_contents(page);
+
+            await compareContentsToSnapshot(contents, [
+                "opens-settings-when-field-is-set-to-false.txt",
+            ]);
+        });
     });
 
-    test("opens settings when field is set to false", async ({ page }) => {
-        await page.evaluate(async () => {
-            const viewer = document.querySelector("perspective-viewer");
-            await viewer.getTable();
-            await viewer.restore({ settings: false });
+    test.describe("Regressions", () => {
+        test("load and restore with settings called at the same time does not throw", async ({
+            page,
+        }) => {
+            const logs = [],
+                errors = [];
+            page.on("console", async (msg) => {
+                if (msg.type() === "error") {
+                    logs.push(msg.text());
+                }
+            });
+
+            page.on("pageerror", async (msg) => {
+                errors.push(`${msg.name}::${msg.message}`);
+            });
+
+            await page.goto("/rust/perspective-viewer/test/html/blank.html", {
+                waitUntil: "networkidle",
+            });
+
+            await page.evaluate(async () => {
+                const viewer = document.querySelector("perspective-viewer");
+                viewer.load(
+                    new Promise((_, reject) => reject("Intentional Load Error"))
+                );
+                try {
+                    await viewer.restore({ settings: true, plugin: "Debug" });
+                } catch (e) {
+                    // We need to catch this error else the `evaluate()` fails.
+                    // We need to await the call because we want it to fail
+                    // before continuing the test.
+                    console.error("Caught error:", e);
+                }
+
+                await new Promise((x) => setTimeout(x, 1000));
+            });
+
+            const contents = await get_contents(page);
+            expect(errors).toEqual([
+                "::Intentional Load Error",
+                //   "RuntimeError::unreachable",
+            ]);
+
+            expect(logs).toEqual([
+                "Invalid config, resetting to default {group_by: Array(0), split_by: Array(0), columns: Array(0), filter: Array(0), sort: Array(0)} `restore()` called before `load()`",
+                "Caught error: `restore()` called before `load()`",
+            ]);
         });
-
-        const contents = await get_contents(page);
-
-        await compareContentsToSnapshot(contents, [
-            "opens-settings-when-field-is-set-to-false.txt",
-        ]);
     });
 });


### PR DESCRIPTION
Passing a rejected promise to `load()` on a `HTMLPerspectiveViewerElement` causes internal errors which can interfere with state update notifications.

This PR fixes the issue and adds a test which repros the behavior on 2.1.3.