### PR TITLE
Fix CSS positioning of expression panel in workspace

### DIFF
--- a/packages/perspective-workspace/src/themes/pro-dark.less
+++ b/packages/perspective-workspace/src/themes/pro-dark.less
@@ -28,6 +28,8 @@ perspective-workspace perspective-viewer {
 }
 
 perspective-workspace perspective-viewer[settings] {
+    --modal-panel--margin: -4px 0 -4px 0;
+    --status-bar--border-radius: 6px 0 0 0;
     --main-column--margin: 3px 0 3px 3px;
     --main-column--border: 1px solid var(--inactive--color);
     --main-column--border-width: 1px 0px 1px 1px;

--- a/packages/perspective-workspace/src/themes/pro.less
+++ b/packages/perspective-workspace/src/themes/pro.less
@@ -31,6 +31,8 @@ perspective-workspace {
 }
 
 perspective-workspace perspective-viewer[settings] {
+    --modal-panel--margin: -4px 0 -4px 0;
+    --status-bar--border-radius: 6px 0 0 0;
     --main-column--margin: 3px 0 3px 3px;
     --main-column--border: 1px solid var(--inactive--color);
     --main-column--border-width: 1px 0px 1px 1px;

--- a/rust/perspective-viewer/src/less/status-bar.less
+++ b/rust/perspective-viewer/src/less/status-bar.less
@@ -40,6 +40,7 @@
         left: 0;
         right: 0;
         height: var(--status-bar--height, 48px);
+        border-radius: var(--status-bar--border-radius);
 
         .input-sizer {
             display: inline-block;

--- a/rust/perspective-viewer/src/less/viewer.less
+++ b/rust/perspective-viewer/src/less/viewer.less
@@ -72,6 +72,11 @@
         }
     }
 
+    #modal_panel {
+        flex: 1 1 auto;
+        margin: var(--modal-panel--margin);
+    }
+
     #modal_panel > .split-panel-divider {
         border-left: 1px solid var(--inactive--color, #6E6E6E);
         margin-right: -5px;
@@ -93,7 +98,6 @@
         border: var(--main-column--border);
         border-width: var(--main-column--border-width);
         border-radius: var(--main-column--border-radius);
-        overflow: hidden;
     }
 
     #main_panel_container {


### PR DESCRIPTION
Fixes ugly 4px vertical offset of expression panel when in a workspace.

<img width="326" alt="Screenshot 2023-06-04 at 1 21 23 PM" src="https://github.com/finos/perspective/assets/60666/72f36529-c7cd-41c8-b93e-2c7071ede7c9">
