### PR TITLE
Allow `pandas~=2.0.0` to be installed

### DIFF
--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -776,6 +776,8 @@ class TestTablePandas(object):
 
     def test_table_read_nat_datetime_col(self):
         data = pd.DataFrame({"str": ["abc", "def"], "datetime": ["NaT", datetime(2019, 7, 11, 11, 0)]})
+        # datetime col is `datetime` in pandas<2, `object` in pandas>=2, so convert
+        data.datetime = pd.to_datetime(data.datetime)
         tbl = Table(data)
         assert tbl.schema() == {
             "index": int,

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -54,7 +54,7 @@ requires = [
     "ipywidgets>=7.5.1,<9",
     "future>=0.16.0,<1",
     "numpy>=1.21.6,<2",
-    "pandas>=0.22.0,<2",
+    "pandas>=0.22.0,<2.1",
     "python-dateutil>=2.8.0,<3",
     "traitlets>=4.3.2,<6",
 ]

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -54,7 +54,7 @@ requires = [
     "ipywidgets>=7.5.1,<9",
     "future>=0.16.0,<1",
     "numpy>=1.21.6,<2",
-    "pandas>=0.22.0,<2.1",
+    "pandas>=0.22.0,<3",
     "python-dateutil>=2.8.0,<3",
     "traitlets>=4.3.2,<6",
 ]


### PR DESCRIPTION
I'm keen to be able to use `pandas~=2.0.0` alongside `perspective`. I couldn't see an issue for this so thought I'd initially see if it broke CI.

fixes https://github.com/finos/perspective/issues/2250