### PR TITLE
Fix workspace `save()` w/settings

### DIFF
--- a/packages/perspective-workspace/src/less/dockpanel.less
+++ b/packages/perspective-workspace/src/less/dockpanel.less
@@ -8,7 +8,7 @@
  */
 
 .p-DockPanel {
-    overflow: visible !important;
+    overflow: var(--dock-panel--overflow, hidden);
     position: absolute;
     background-color: var(--detail--background-color, transparent);
     padding: 3px;

--- a/rust/perspective-viewer/Cargo.lock
+++ b/rust/perspective-viewer/Cargo.lock
@@ -908,7 +908,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "perspective"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "perspective-bundle"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "flate2",
  "wasm-bindgen-cli-support",

--- a/tools/perspective-test/src/js/global_startup.ts
+++ b/tools/perspective-test/src/js/global_startup.ts
@@ -13,13 +13,8 @@ import path from "path";
 
 export default async function run() {
     const RESULTS_PATH = path.join(__dirname, "../../results.tar.gz");
-    try {
-        if (fs.existsSync(RESULTS_PATH)) {
-            console.log("Using results.tar.gz");
-            await tar.extract({ file: RESULTS_PATH, gzip: true });
-        }
-    } catch (e) {
-        console.error("Failed to untar results archives");
-        fs.unlinkSync(RESULTS_PATH);
+    if (fs.existsSync(RESULTS_PATH)) {
+        console.log("Using results.tar.gz");
+        await tar.extract({ file: RESULTS_PATH, gzip: true });
     }
 }

--- a/tools/perspective-test/src/js/global_teardown.ts
+++ b/tools/perspective-test/src/js/global_teardown.ts
@@ -36,7 +36,7 @@ export default async function run() {
                     return !path.endsWith(".DS_Store");
                 },
             },
-            [path.join(__dirname, "../../dist/snapshots")],
+            [path.join("tools/perspective-test/dist/snapshots")],
             x
         )
     );


### PR DESCRIPTION
Fixes `@finos/perspective-workspace`'s `save()` method when called with the settings panel open, which previously yielded JSON which does not recreate the GUI when provided to `restore()`.