### PR TITLE
Write custom parser for us locale time string format

### DIFF
--- a/packages/perspective/test/js/constructors.spec.js
+++ b/packages/perspective/test/js/constructors.spec.js
@@ -1148,15 +1148,17 @@ function validate_typed_array(typed_array, column_data) {
             table.delete();
         });
 
-        test.skip("Handles datetime strings in US locale string old", async function () {
+        test("Handles datetime strings in US locale string old", async function () {
             // FIXME: 1/1/2020, 12:30:45 PM = 1/1/2020, 7:30:45 AM UTC, but
             // because C++ strptime in Emscripten parses the time as 12:30:45AM,
             // the output is 12/31/2019 19:30:45 PM UTC. This is clearly wrong.
             const data = {
                 x: [
                     "1/1/2020, 12:30:45 PM",
+                    "1/1/2020, 12:30:45 AM",
                     "03/15/2020, 11:30:45 AM",
                     "06/30/2020, 01:30:45 AM",
+                    "06/30/2020, 01:30:45 PM",
                     "12/31/2020, 11:59:59 PM",
                 ],
             };
@@ -1173,8 +1175,10 @@ function validate_typed_array(typed_array, column_data) {
             const expected = {
                 x: [
                     "1/1/2020, 12:30:45 PM",
+                    "1/1/2020, 12:30:45 AM",
                     "03/15/2020, 11:30:45 AM",
                     "06/30/2020, 01:30:45 AM",
+                    "06/30/2020, 01:30:45 PM",
                     "12/31/2020, 11:59:59 PM",
                 ].map((v) => new Date(v).getTime()),
             };


### PR DESCRIPTION
Fix for isssue( #1312 ) where US locale string format ("%m/%d/%Y, %I:%M:%S %p") is parsed wrongly by emscripten compiler. eg.  "03/15/2020, 11:30:45 AM" is incorrectly parsed as "03/15/2020, 11:30:45 PM"

Before Implementation - Test Fails
![after_time_implementation_1](https://github.com/finos/perspective/assets/131965000/6216ff8f-1a4f-4340-8ae4-15bcb6278868)


After Implementations - Test Passes
![After_time_implementation](https://github.com/finos/perspective/assets/131965000/80ebb820-8fc5-42eb-82fb-830edf7ba38f)
