### PR TITLE
Add API to give number of views into table

### DIFF
--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -166,6 +166,7 @@ declare module "@finos/perspective" {
         make_port(): number;
         get_index(): Promise<string | null>;
         get_limit(): Promise<number | null>;
+        get_num_views(): Promise<number>;
     };
 
     /**** perspective ****/

--- a/packages/perspective/src/js/api/table_api.js
+++ b/packages/perspective/src/js/api/table_api.js
@@ -106,6 +106,8 @@ table.prototype.get_index = async_queue("get_index", "table_method");
 
 table.prototype.get_limit = async_queue("get_limit", "table_method");
 
+table.prototype.get_num_views = async_queue("get_num_views", "table_method");
+
 table.prototype.make_port = async_queue("make_port", "table_method");
 
 table.prototype.remove_port = async_queue("remove_port", "table_method");

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1380,6 +1380,16 @@ export default function (Module) {
     };
 
     /**
+     * @returns The number of views associated to this table.
+     *          Note that this may be more than what is visible on a screen.
+     *          As views are created to manage various internal
+     *          state of the application.
+     */
+    table.prototype.get_num_views = function () {
+        return this.views.length;
+    };
+
+    /**
      * Replace all rows in this {@link module:perspective~table} the input data.
      */
     table.prototype.replace = function (data) {

--- a/packages/perspective/test/js/updates.spec.js
+++ b/packages/perspective/test/js/updates.spec.js
@@ -1136,6 +1136,26 @@ async function match_delta(perspective, delta, expected) {
             table.delete();
         });
 
+        test.only("Table.get_num_views", async function () {
+            const table = await perspective.table({
+                a: "integer",
+            });
+            const view1 = await table.view();
+            expect(await table.get_num_views()).toBe(1);
+            const view2 = await table.view();
+            const view3 = await table.view();
+            const view4 = await table.view();
+            const view5 = await table.view();
+            expect(await table.get_num_views()).toBe(5);
+            view1.delete();
+            view2.delete();
+            view3.delete();
+            view4.delete();
+            view5.delete();
+            expect(await table.get_num_views()).toBe(0);
+            table.delete();
+        });
+
         test("schema constructor indexed, then arrow update() with more columns than in the Table", async function () {
             const table = await perspective.table(
                 {

--- a/python/perspective/perspective/client/table_api.py
+++ b/python/perspective/perspective/client/table_api.py
@@ -66,6 +66,9 @@ class PerspectiveTableProxy(object):
     def get_limit(self):
         return self._async_queue("get_limit", "table_method")
 
+    def get_num_views(self):
+        return self._async_queue("get_num_views", "table_method")
+
     def clear(self):
         return self._async_queue("clear", "table_method")
 

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -121,6 +121,10 @@ class Table(object):
         specified by the user."""
         return self._limit
 
+    def get_num_views(self):
+        """Returns the number of views associated to this table."""
+        return len(self._views)
+
     def clear(self):
         """Removes all the rows in the :class:`~perspective.Table`, but
         preserves everything else including the schema and any callbacks or

--- a/python/perspective/perspective/tests/table/test_table.py
+++ b/python/perspective/perspective/tests/table/test_table.py
@@ -574,6 +574,31 @@ class TestTable(object):
         tbl = Table(data)
         assert tbl.get_limit() is None
 
+    # num_views
+
+    def test_table_get_num_views(self):
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        tbl = Table(data)
+        assert tbl.get_num_views() == 0
+        v1 = tbl.view()
+        v2 = tbl.view()
+        v3 = tbl.view()
+        assert tbl.get_num_views() == 3
+
+        v1.delete()
+        v2.delete()
+        assert tbl.get_num_views() == 1
+        failed = False
+        try:
+            tbl.delete()
+        except PerspectiveError:
+            failed = True
+        assert failed
+        v3.delete()
+        assert tbl.get_num_views() == 0
+        tbl.delete()
+
+
     # clear
 
     def test_table_clear(self):

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -12,7 +12,6 @@
 #![feature(lazy_cell)]
 #![feature(macro_metavar_expr)]
 #![feature(let_chains)]
-#![feature(anonymous_lifetime_in_impl_trait)]
 #![feature(stmt_expr_attributes)]
 #![warn(
     clippy::all,


### PR DESCRIPTION
The test describes the usage.

Would it possibly be better so simply give a `get_views` method, that returns each View object? Then we could just call `table.get_views().length`. 

Either way, happy to do it.