### PR TITLE
Make `@finos/perspective` importable in TypeScript ESM

### DIFF
--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -12,6 +12,7 @@
     "jsdelivr": "dist/cdn/perspective.js",
     "exports": {
         ".": {
+            "types": "./index.d.ts",
             "node": "./dist/cjs/perspective.node.js",
             "default": "./dist/esm/perspective.inline.js"
         },


### PR DESCRIPTION
This should make the package importable when setting [`moduleResolution: 'bundler'`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#moduleresolution-bundler).