### PR TITLE
Fix bug preventing blocks example server from starting.

### DIFF
--- a/examples/blocks/package.json
+++ b/examples/blocks/package.json
@@ -4,7 +4,7 @@
     "version": "2.3.0",
     "description": "A collection of simple client-side Perspective examples for `http://bl.ocks.org`.",
     "scripts": {
-        "start": "mkdirp dist && node server.js"
+        "start": "mkdirp dist && node server.mjs"
     },
     "main": "index.mjs",
     "keywords": [],

--- a/examples/blocks/server.mjs
+++ b/examples/blocks/server.mjs
@@ -10,9 +10,14 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const fs = require("fs");
-const { WebSocketServer } = require("@finos/perspective");
-const { dist_examples } = require("./index.js");
+import fs from "fs";
+import { WebSocketServer } from "@finos/perspective";
+import { dist_examples } from "./index.mjs";
+
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 dist_examples(`${__dirname}/dist`);
 


### PR DESCRIPTION
This PR fixes a bug where the blocks server could not be started with the command `yarn start blocks`.