### PR TITLE
Fix python segfault in multi-threaded execution

### DIFF
--- a/cpp/perspective/src/cpp/pool.cpp
+++ b/cpp/perspective/src/cpp/pool.cpp
@@ -80,9 +80,6 @@ t_pool::init() {
     }
     m_run.test_and_set(std::memory_order_acquire);
     m_data_remaining.store(false);
-    std::thread t(&t_pool::_process, this);
-    set_thread_name(t, "psp_pool_thread");
-    t.detach();
 }
 
 t_uindex

--- a/cpp/perspective/src/include/perspective/pyutils.h
+++ b/cpp/perspective/src/include/perspective/pyutils.h
@@ -22,15 +22,22 @@
 namespace perspective {
 
 #ifdef PSP_PARALLEL_FOR
+// Use this when you want to acquire the reader lock without unlocking the GIL.
 #define PSP_GIL_READ_LOCK(X)                                                   \
     auto _thread_state = PyEval_SaveThread();                                  \
     boost::shared_lock<boost::shared_mutex> _lock(*X);                         \
+    PyEval_RestoreThread(_thread_state);
+
+#define PSP_GIL_WRITE_LOCK(X)                                                  \
+    auto _thread_state = PyEval_SaveThread();                                  \
+    boost::unique_lock<boost::shared_mutex> _lock(*X);                         \
     PyEval_RestoreThread(_thread_state);
 
 #define PSP_READ_LOCK(X) boost::shared_lock<boost::shared_mutex> _lock(*X);
 #define PSP_WRITE_LOCK(X) boost::unique_lock<boost::shared_mutex> _lock(*X);
 #else
 #define PSP_GIL_READ_LOCK(X)
+#define PSP_GIL_WRITE_LOCK(X)
 #define PSP_READ_LOCK(X)
 #define PSP_WRITE_LOCK(X)
 #endif

--- a/python/perspective/perspective/client/websocket.py
+++ b/python/perspective/perspective/client/websocket.py
@@ -13,7 +13,7 @@
 import asyncio
 import json
 from abc import ABC, abstractmethod
-
+from threading import Lock
 from .base import PerspectiveClient
 from ..manager.manager_internal import DateTimeEncoder
 
@@ -64,6 +64,8 @@ class PerspectiveWebsocketClient(PerspectiveClient):
         self._pending_binary_length = 0
         self._pending_port_id = None
         self._full_binary = b""
+        self._json_queue = []
+        self._lock = Lock()
 
     async def _send_ping(self):
         """Send a `ping` heartbeat message to the server's Websocket, which will
@@ -93,11 +95,16 @@ class PerspectiveWebsocketClient(PerspectiveClient):
     def on_message(self, msg):
         """When a message is received, send it to the `_handle` method, or
         await the incoming binary from the server."""
+
         if msg == "pong":
             # Do not respond to server pong heartbeats - only send them
             return
 
-        if self._pending_binary is not None:
+        self._lock.acquire()
+        if self._pending_binary is not None and isinstance(msg, str):
+            self._json_queue.append(msg)
+
+        elif self._pending_binary is not None:
             binary_msg = msg
 
             self._full_binary += binary_msg
@@ -108,6 +115,7 @@ class PerspectiveWebsocketClient(PerspectiveClient):
 
             else:
                 # Wait for the next chunk
+                self._lock.release()
                 return
 
             result = {"data": {"id": self._pending_binary, "data": binary_msg}}
@@ -118,13 +126,26 @@ class PerspectiveWebsocketClient(PerspectiveClient):
                     "delta": binary_msg,
                 }
 
-            self._handle(result)
-
             # Clear flags for special binary message flow
             self._pending_binary = None
             self._pending_binary_length = None
             self._pending_port_id = None
             self._full_binary = b""
+
+            # self._lock.release()
+            self._handle(result)
+            for msg in self._json_queue:
+                msg = json.loads(msg)
+                if msg.get("binary_length"):
+                    self._pending_binary = msg["id"]
+                    self._pending_binary_length = msg["binary_length"]
+
+                    if msg.get("data") and msg["data"].get("port_id", None) is not None:
+                        self._pending_port_id = msg["data"].get("port_id")
+                else:
+                    self._handle({"data": msg})
+
+            self._json_queue = []
 
         elif isinstance(msg, str):
             msg = json.loads(msg)
@@ -140,6 +161,7 @@ class PerspectiveWebsocketClient(PerspectiveClient):
         else:
             # websocket client sometimes calls None on disconnect ..
             pass
+        self._lock.release()
 
     async def send(self, msg):
         """Send a message to the Websocket endpoint."""

--- a/python/perspective/perspective/handlers/common.py
+++ b/python/perspective/perspective/handlers/common.py
@@ -98,7 +98,8 @@ class PerspectiveHandlerBase(ABC):
                     if end >= len(message):
                         end = len(message)
 
-                    asyncio.ensure_future(self.write_message(message[start:end], binary=True))
+                    await asyncio.ensure_future(self.write_message(message[start:end], binary=True))
+
                     start = end
 
                     # Allow the loop to process heartbeats so that client sockets don't

--- a/python/perspective/perspective/handlers/tornado.py
+++ b/python/perspective/perspective/handlers/tornado.py
@@ -54,7 +54,7 @@ class PerspectiveTornadoHandler(PerspectiveHandlerBase, WebSocketHandler):
 
     async def write_message(self, message: str, binary: bool = False) -> None:
         try:
-            return WebSocketHandler.write_message(self, message=message, binary=binary)
+            return await WebSocketHandler.write_message(self, message=message, binary=binary)
         except WebSocketClosedError:
             # ignore error
             self.on_close()

--- a/python/perspective/perspective/include/perspective/python.h
+++ b/python/perspective/perspective/include/perspective/python.h
@@ -427,6 +427,7 @@ PYBIND11_MODULE(libpsppy, m) {
      */
     m.def("str_to_filter_op", &str_to_filter_op);
     m.def("make_table", &make_table_py);
+    m.def("update_table", &update_table_py);
     m.def("make_view_unit", &make_view_unit);
     m.def("make_view_zero", &make_view_ctx0);
     m.def("make_view_one", &make_view_ctx1);

--- a/python/perspective/perspective/include/perspective/python/table.h
+++ b/python/perspective/perspective/include/perspective/python/table.h
@@ -25,9 +25,14 @@ namespace binding {
      *
      * Table API
      */
-    std::shared_ptr<Table> make_table_py(t_val table, t_data_accessor accessor,
-        std::uint32_t limit, std::string index, t_op op, bool is_update,
-        bool is_arrow, bool is_csv, t_uindex port_id);
+
+    std::shared_ptr<Table> make_table_py(t_data_accessor accessor,
+        std::uint32_t limit, std::string index, t_op op, bool is_arrow,
+        bool is_csv, t_uindex port_id);
+
+    std::shared_ptr<Table> update_table_py(t_val table,
+        t_data_accessor accessor, std::uint32_t limit, std::string index,
+        t_op op, bool is_arrow, bool is_csv, t_uindex port_id);
 
 } // namespace binding
 } // namespace perspective

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -25,6 +25,7 @@ from ._utils import (
 )
 from .libpsppy import (
     make_table,
+    update_table,
     str_to_filter_op,
     t_dtype,
     t_filter_op,
@@ -81,12 +82,10 @@ class Table(object):
         # for `index` and 4294967295 for `limit`, but always store `self._index`
         # and `self._limit` as user-provided kwargs or `None`.
         self._table = make_table(
-            None,
             _accessor,
             self._limit or 4294967295,
             self._index or "",
             t_op.OP_INSERT,
-            False,
             self._is_arrow,
             self._is_csv,
             0,
@@ -312,13 +311,12 @@ class Table(object):
 
         if _is_arrow:
             _accessor = data
-            self._table = make_table(
+            self._table = update_table(
                 self._table,
                 _accessor,
                 self._limit or 4294967295,
                 self._index or "",
                 t_op.OP_INSERT,
-                True,
                 _is_arrow,
                 _is_csv,
                 port_id,
@@ -346,13 +344,12 @@ class Table(object):
             else:
                 _accessor._types.append(t_dtype.DTYPE_INT32)
 
-        self._table = make_table(
+        self._table = update_table(
             self._table,
             _accessor,
             self._limit or 4294967295,
             self._index or "",
             t_op.OP_INSERT,
-            True,
             False,
             False,
             port_id,
@@ -384,13 +381,12 @@ class Table(object):
         _accessor._names = [self._index]
         _accessor._types = types
 
-        t = make_table(
+        t = update_table(
             self._table,
             _accessor,
             self._limit or 4294967295,
             self._index or "",
             t_op.OP_DELETE,
-            True,
             False,
             False,
             port_id,

--- a/python/perspective/perspective/table/view.py
+++ b/python/perspective/perspective/table/view.py
@@ -423,6 +423,7 @@ class View(object):
         self._delete_callbacks.remove_callbacks(lambda cb: cb == callback)
 
     def to_arrow(self, **kwargs):
+        self._table._state_manager.call_process(self._table._table.get_id())
         options = _parse_format_options(self, kwargs)
         if self._is_unit_context:
             return to_arrow_unit(

--- a/python/perspective/perspective/tests/handlers/test_tornado_thread_pool_executor.py
+++ b/python/perspective/perspective/tests/handlers/test_tornado_thread_pool_executor.py
@@ -1,0 +1,132 @@
+#  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+#  ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+#  ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+#  ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+#  ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+#  ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+#  ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+#  ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+#  ┃ This file is part of the Perspective library, distributed under the terms ┃
+#  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+#  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+# This test demonstrates the necessity of locks for server
+# responses to multiple clients
+
+# This test should be implemented for every new server handler, but
+# should otherwise never fail for existing locking implementations.
+
+# To demonstrate failing behavior, modify the tornado handler like so:
+# -        yield self._stream_lock.acquire()
+# +        # yield self._stream_lock.acquire()
+#          try:
+#              yield f(*args, **kwargs)
+#          except tornado.websocket.WebSocketClosedError:
+#              pass
+#          finally:
+# -            yield self._stream_lock.release()
+# +            ...
+# +            # yield self._stream_lock.release()
+
+
+import asyncio
+import pytest
+import random
+import threading
+import tornado
+import concurrent.futures
+from datetime import datetime
+
+from perspective import (
+    Table,
+    PerspectiveManager,
+    PerspectiveTornadoHandler,
+    tornado_websocket as websocket,
+)
+
+
+data = {
+    "a": [i for i in range(100)],
+    "b": [i * 1.5 for i in range(100)],
+    "c": [str(i) for i in range(100)],
+    "d": [datetime(2020, 3, (i % 28) + 1, i % 12, 30, 45) for i in range(1, 101)],
+}
+
+MANAGER = PerspectiveManager()
+
+
+def perspective_thread(manager):
+    psp_loop = asyncio.new_event_loop()
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        manager.set_loop_callback(psp_loop.run_in_executor, executor)
+        psp_loop.run_forever()
+
+
+thread = threading.Thread(target=perspective_thread, args=(MANAGER,))
+thread.daemon = True
+thread.start()
+
+
+APPLICATION = tornado.web.Application(
+    [
+        (
+            r"/websocket",
+            PerspectiveTornadoHandler,
+            {"manager": MANAGER, "check_origin": True, "chunk_size": 10},
+        )
+    ]
+)
+
+
+@pytest.fixture
+def app():
+    return APPLICATION
+
+
+class TestPerspectiveTornadoHandlerAsyncMode(object):
+    def setup_method(self):
+        """Flush manager state before each test method execution."""
+        MANAGER._tables = {}
+        MANAGER._views = {}
+
+    async def websocket_client(self, port):
+        """Connect and initialize a websocket client connection to the
+        Perspective tornado server.
+        """
+        client = await websocket("ws://127.0.0.1:{}/websocket".format(port))
+        return client
+
+    @pytest.mark.gen_test(run_sync=False)
+    async def test_tornado_handler_async_manager_thread(
+        self, app, http_client, http_port, sentinel
+    ):
+        global data
+        table_name = str(random.random())
+        _table = Table(data)
+        data = _table.view().to_arrow()
+        MANAGER.host_table(table_name, _table)
+        assert _table.size() == 100
+
+        client = await self.websocket_client(http_port)
+        table = client.open_table(table_name)
+        view = await table.view()
+        reqs = []
+        for x in range(10):
+            reqs.append(table.update(data))
+            reqs.append(view.to_arrow())
+
+        await asyncio.gather(*reqs)
+        # await asyncio.sleep(5)
+
+        # In single-threaded execution, "read" methods like `to_arrow` flush the
+        # pending updates queue, so that `to_arrow()` following an `update()`
+        # always reflects the update. In multi-threaded execution, this is much
+        # harder to guarantee. In practice for the Perspective, it's only useful
+        # for tests anyway, so in this case, it is enough to test that the
+        # result is eventually correct
+        record_size = await table.size()
+        while record_size != 1100:
+            record_size = await table.size()
+
+        records = await view.to_records()
+        assert len(records) == 1100


### PR DESCRIPTION
Fixes a potential Python segfault introduced in `2.3.0`, which can occur when:
* Perspective is running in async mode via a multi-threaded executor and ...
* A `Table()` is constructed via Arrow input and ...
* `Table.update()` is called with an `Arrow` by a separate thread before the previous call has resolved.

[See the included test for a repro](https://github.com/finos/perspective/blob/py-segfault-fix/python/perspective/perspective/tests/handlers/test_tornado_thread_pool_executor.py#L100), which implements a multi-threaded executor then queues 20 read/write Arrow operations at once.
