### PR TITLE
Tweak rounding display logic for float filters

### DIFF
--- a/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
@@ -193,7 +193,13 @@ impl FilterColumnProps {
                     if val.is_empty() {
                         None
                     } else if let Ok(num) = val.parse::<f64>() {
-                        Some(FilterTerm::Scalar(Scalar::Float(num)))
+                        let scalar: Scalar = 
+                        if num.to_string().len() < val.len() {
+                            Scalar::String(val)
+                        } else {
+                            Scalar::Float(num)
+                        };
+                        Some(FilterTerm::Scalar(scalar))
                     } else {
                         None
                     }
@@ -401,6 +407,7 @@ impl Component for FilterColumn {
                 <input
                     type="number"
                     placeholder="Value"
+                    step="0.001"
                     class="num-filter"
                     ref={ noderef.clone() }
                     onkeydown={ keydown }


### PR DESCRIPTION
This is a somewhat silly implementation, but when you try to input floating point numbers for a filter, they will automatically be rounded and reformatted. This is a problem when you want to filter for decimals with leading `0`s, e.g. you won't be able to type in `1.0001`:

![tmp-2](https://github.com/finos/perspective/assets/3105306/e217db56-07a1-4d74-a12b-332507e00457)

This PR "fixes" that by cheating, and treating the user-inputted `float` as a `string`. This works because the `input` element won't let you input characters, and the actual use of the field occurs in C++ which will do its own conversion logic (or might just naively assume it to already be a `float`):

![tmp](https://github.com/finos/perspective/assets/3105306/bcac7187-0d90-4e98-b9c7-8b9c43030e07)

This is a pretty bad implementation, but I didn't see an obvious better implementation since the float formatting code in rust is enough layers removed from the `input` component that it doesn't make a ton of sense to bridge the gap in a more *elegant* way. 
