### PR TITLE
Fix TypeScript 5 `moduleResolution: "bundler"` support

### DIFF
--- a/examples/react-example/tsconfig.json
+++ b/examples/react-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es5",
         "lib": ["es6", "dom"],
         "module": "esnext",
@@ -26,8 +26,6 @@
         "experimentalDecorators": true,
         "downlevelIteration": true,
         "pretty": true
-      },
-    "exclude": [
-        "node_modules",
-    ]
+    },
+    "exclude": ["node_modules"]
 }

--- a/examples/react-example/webpack.config.js
+++ b/examples/react-example/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = {
         ],
     },
     devServer: {
-        contentBase: [
+        static: [
             path.join(__dirname, "dist"),
             path.join(__dirname, "../../node_modules/superstore-arrow"),
         ],

--- a/package.json
+++ b/package.json
@@ -74,10 +74,10 @@
         "tiny-glob": "^0.2.9",
         "ts-loader": "^6.2.0",
         "ts-node": "^10.9.1",
-        "typedoc": "^0.23.0",
+        "typedoc": "^0.24.8",
         "typedoc-plugin-markdown": "^3.14.0",
         "typedoc-plugin-no-inherit": "^1.4.0",
-        "typescript": "4.9.4",
+        "typescript": "5.1.6",
         "webpack": "^5.60.0",
         "webpack-cli": "^4.7.0",
         "webpack-dev-server": "^4.11.1"

--- a/packages/perspective-cli/package.json
+++ b/packages/perspective-cli/package.json
@@ -10,7 +10,7 @@
         "src/**/*",
         "perspective"
     ],
-    "typings": "index.d.ts",
+    "types": "index.d.ts",
     "scripts": {
         "clean": "rimraf build"
     },

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -12,6 +12,7 @@
     "jsdelivr": "dist/cdn/perspective.js",
     "exports": {
         ".": {
+            "types": "./index.d.ts",
             "node": "./dist/cjs/perspective.node.js",
             "default": "./dist/esm/perspective.inline.js"
         },

--- a/rust/perspective-viewer/package.json
+++ b/rust/perspective-viewer/package.json
@@ -10,7 +10,10 @@
     "unpkg": "dist/cdn/perspective-viewer.js",
     "jsdelivr": "dist/cdn/perspective-viewer.js",
     "exports": {
-        ".": "./dist/esm/perspective-viewer.inline.js",
+        ".": {
+            "types": "./dist/esm/perspective-viewer.d.ts",
+            "default": "./dist/esm/perspective-viewer.inline.js"
+        },
         "./dist/*": "./dist/*",
         "./src/*": "./src/*",
         "./test/*": "./test/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5073,6 +5073,11 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
+  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -11096,7 +11101,7 @@ markdown-it@^12.3.2:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-marked@^4.0.10, marked@^4.2.3, marked@^4.2.5:
+marked@^4.0.10, marked@^4.2.3:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.5.tgz#979813dfc1252cc123a79b71b095759a32f42a5d"
   integrity sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==
@@ -11105,6 +11110,11 @@ marked@^4.0.17:
   version "4.2.12"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.12.tgz#d69a64e21d71b06250da995dcd065c11083bebb5"
   integrity sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==
+
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 math-expression-evaluator@^1.2.14:
   version "1.3.7"
@@ -11370,6 +11380,13 @@ minimatch@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.2.tgz#0939d7d6f0898acbd1508abe534d1929368a8fff"
   integrity sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.0:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -14526,11 +14543,12 @@ shelljs@^0.8.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shiki@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.12.1.tgz#26fce51da12d055f479a091a5307470786f300cd"
-  integrity sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==
+shiki@^0.14.1:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.3.tgz#d1a93c463942bdafb9866d74d619a4347d0bbf64"
+  integrity sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==
   dependencies:
+    ansi-sequence-parser "^1.1.0"
     jsonc-parser "^3.2.0"
     vscode-oniguruma "^1.7.0"
     vscode-textmate "^8.0.0"
@@ -15580,20 +15598,20 @@ typedoc-plugin-no-inherit@^1.4.0:
   resolved "https://registry.yarnpkg.com/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.4.0.tgz#8eafc790588f63f0a24621b646219cd6e8d6e4d6"
   integrity sha512-cAvqQ8X9xh1xztVoDKtF4nYRSBx9XwttN3OBbNNpA0YaJSRM8XvpVVhugq8FoO1HdWjF3aizS0JzdUOMDt0y9g==
 
-typedoc@^0.23.0:
-  version "0.23.24"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.24.tgz#01cf32c09f2c19362e72a9ce1552d6e5b48c4fef"
-  integrity sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==
+typedoc@^0.24.8:
+  version "0.24.8"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.24.8.tgz#cce9f47ba6a8d52389f5e583716a2b3b4335b63e"
+  integrity sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==
   dependencies:
     lunr "^2.3.9"
-    marked "^4.2.5"
-    minimatch "^5.1.2"
-    shiki "^0.12.1"
+    marked "^4.3.0"
+    minimatch "^9.0.0"
+    shiki "^0.14.1"
 
-typescript@4.9.4:
-  version "4.9.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
-  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+typescript@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 typescript@~4.1.3:
   version "4.1.6"


### PR DESCRIPTION
Fixes support for the `moduleResolution: "bundler"` flag included in Typescript >5, which reads Perspective's `exports` metadata but requires the type definitions file `index.d.ts` to be included.