### PR TITLE
Fix racing tests.

### DIFF
--- a/packages/perspective-cli/test/js/superstore.spec.js
+++ b/packages/perspective-cli/test/js/superstore.spec.js
@@ -15,14 +15,18 @@ const path = require("path");
 const { host } = require("../../src/js/index.js");
 
 test.describe("CLI", function () {
-    test("Tests something", async ({ page }) => {
+    let server, port;
+    test.beforeAll(async () => {
         const options = { port: 0 };
-        const server = await host(
-            path.join(__dirname, "../csv/test.csv"),
-            options
-        );
-        const port = server._server.address().port;
+        server = await host(path.join(__dirname, "../csv/test.csv"), options);
+        port = server._server.address().port;
+    });
 
+    test.afterAll(async (options) => {
+        await server.close();
+    });
+
+    test("Tests something", async ({ page }) => {
         await page.goto(`http://localhost:${port}/`);
         await page.waitForSelector(
             "perspective-viewer perspective-viewer-datagrid"
@@ -30,6 +34,7 @@ test.describe("CLI", function () {
 
         const json = await page.evaluate(async function () {
             const viewer = document.querySelector("perspective-viewer");
+            await viewer.flush();
             const view = await viewer.getView();
             return await view.to_json();
         });
@@ -39,7 +44,5 @@ test.describe("CLI", function () {
             { x: 3, y: 4 },
             { x: 5, y: 6 },
         ]);
-        await page.close();
-        server.close();
     });
 });

--- a/python/perspective/perspective/table/_state.py
+++ b/python/perspective/perspective/table/_state.py
@@ -69,10 +69,9 @@ class _PerspectiveStateManager(object):
         Args:
             table_id (:obj`int`): The unique ID of the Table
         """
-        pool = _PerspectiveStateManager.TO_PROCESS.get(table_id, None)
+        pool = _PerspectiveStateManager.TO_PROCESS.pop(table_id, None)
         if pool is not None:
             pool._process()
-            self.remove_process(table_id)
 
     def remove_process(self, table_id):
         """Remove a pool from the execution cache, indicating that it should no

--- a/python/perspective/perspective/tests/handlers/test_tornado_thread_pool_executor.py
+++ b/python/perspective/perspective/tests/handlers/test_tornado_thread_pool_executor.py
@@ -96,7 +96,7 @@ class TestPerspectiveTornadoHandlerAsyncMode(object):
         client = await websocket("ws://127.0.0.1:{}/websocket".format(port))
         return client
 
-    @pytest.mark.gen_test(run_sync=False)
+    @pytest.mark.gen_test(run_sync=False, timeout=30)
     async def test_tornado_handler_async_manager_thread(
         self, app, http_client, http_port, sentinel
     ):


### PR DESCRIPTION
Fixes two tests which flapped incessantly, causing endless CI headaches.

`@finos/perspective-cli`'s test suite must start and stop a Perspective server, which causes some log spam as the browser and server are consecutively shutdown. These errors are innocuous in this case as they occur after the server is in a shutdown-prepare state, but the logging itself is important as the condition `View method cancelled` can occur in other contexts unexpectedly. Moving this initialization out of the test prevents it from failing.
https://github.com/finos/perspective/actions/runs/5427137814/jobs/9870282667

`perspective-python`'s recent multi-threading support added tests to check for concurrency race conditions, and uncovered one in CI. Debugging these failing tests uncovered that `update()` calls were being conflated correctly, but the internal state which "marked" a `Table` as having pending updates that needed to be applied was subject to race condition, which left the engine in a state where some updates at the end of a long stream of subsequent updates may become "stuck" in this state, pending application to the table but without the flag set to trigger the engine to apply it. In practice, the next `update()` call will flush the pending ones, but it still means an update may not resolve in the correct order (or for a long time and/or appear stuck). As the tests don't ever interact with the engine again after the test setup is applied, this test failed infrequently, making it difficult to detect until a full build was run.
https://github.com/finos/perspective/actions/runs/5448608452/jobs/9912906432