### PR TITLE
Fix empty column name validation in ExprTk editor

### DIFF
--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1529,13 +1529,6 @@ export default function (Module) {
         const expression_idx_map = {};
 
         for (let expression_string of expressions) {
-            if (expression_string.includes('""')) {
-                console.error(
-                    `Skipping expression '${expression_string}', as it cannot reference an empty column!`
-                );
-                continue;
-            }
-
             // Map of column names to column IDs, so that we generate
             // column IDs correctly without collision.
             let column_name_map = {};


### PR DESCRIPTION
Removes empty column skip from `parse_expression_strings` in `@finos/perspective`. This allows `validate_expressions` to validate any empty columns

Fixes #2268

![finos-perspective](https://github.com/finos/perspective/assets/137890260/e9eeec45-1d73-466c-8c2b-43c293c0c654)