### PR TITLE
Fix build.rs escaping OUT_DIR

### DIFF
--- a/rust/perspective-viewer/build.rs
+++ b/rust/perspective-viewer/build.rs
@@ -44,13 +44,16 @@ fn glob_with_wd(indir: &str, input: &str) -> Vec<String> {
 }
 
 fn main() -> Result<(), anyhow::Error> {
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let out_path = std::path::Path::new(&out_dir);
+
     let mut build = BuildCss::new("./src/less");
     let files = glob_with_wd("./src/less", "**/*.less");
     for src in files.iter() {
         build.add_file(src);
     }
 
-    build.compile()?.write("./target/css")?;
+    build.compile()?.write(out_path.join("css"))?;
 
     let mut build = BuildCss::new("./src/themes");
     build.add_file("variables.less");
@@ -62,7 +65,7 @@ fn main() -> Result<(), anyhow::Error> {
     build.add_file("solarized-dark.less");
     build.add_file("vaporwave.less");
     build.add_file("themes.less");
-    build.compile()?.write("./target/themes")?;
+    build.compile()?.write(out_path.join("themes"))?;
 
     println!(
         "cargo:rustc-env=PKG_VERSION={}",

--- a/rust/perspective-viewer/src/rust/components/column_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/column_dropdown.rs
@@ -18,7 +18,7 @@ use super::modal::*;
 use crate::utils::WeakScope;
 use crate::*;
 
-static CSS: &str = include_str!("../../../target/css/column-dropdown.css");
+static CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/css/column-dropdown.css"));
 
 pub enum ColumnDropDownMsg {
     SetValues(Vec<InPlaceColumn>, f64),

--- a/rust/perspective-viewer/src/rust/components/column_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector.rs
@@ -350,7 +350,7 @@ impl Component for ColumnSelector {
 
         if !inactive_children.is_empty() {
             html_template! {
-                <LocalStyle href={ css!("column-selector") } />
+                <LocalStyle href={ css_internal!("column-selector") } />
                 <SplitPanel no_wrap={ true } orientation={ Orientation::Vertical }>
                     { selected_columns }
                     <ScrollPanel
@@ -362,7 +362,7 @@ impl Component for ColumnSelector {
             }
         } else {
             html_template! {
-                <LocalStyle href={ css!("column-selector") } />
+                <LocalStyle href={ css_internal!("column-selector") } />
                 <div class="split-panel-child">
                     { selected_columns }
                 </div>

--- a/rust/perspective-viewer/src/rust/components/column_selector/aggregate_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/aggregate_selector.rs
@@ -91,7 +91,7 @@ impl Component for AggregateSelector {
 
         let values = self.aggregates.clone();
         html_template! {
-            <LocalStyle href={ css!("aggregate-selector") } />
+            <LocalStyle href={ css_internal!("aggregate-selector") } />
             <div class="aggregate-selector-wrapper">
                 <Select<Aggregate>
                     class={ "aggregate-selector" }

--- a/rust/perspective-viewer/src/rust/components/column_selector/config_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/config_selector.rs
@@ -469,7 +469,7 @@ impl Component for ConfigSelector {
                 class={ class }
                 ondragend={ dragend }>
 
-                <LocalStyle href={ css!("config-selector") } />
+                <LocalStyle href={ css_internal!("config-selector") } />
 
                 if !config.group_by.is_empty() && config.split_by.is_empty() {
                     <span

--- a/rust/perspective-viewer/src/rust/components/column_selector/empty_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/empty_column.rs
@@ -16,7 +16,7 @@ use web_sys::*;
 use yew::prelude::*;
 
 use crate::components::style::LocalStyle;
-use crate::css;
+use crate::css_internal;
 use crate::custom_elements::ColumnDropDownElement;
 
 #[derive(Default)]
@@ -65,7 +65,7 @@ impl Component for EmptyColumn {
 
         html! {
             <div class="pivot-column column-empty">
-                <LocalStyle href={ css!("empty-column") } />
+                <LocalStyle href={ css_internal!("empty-column") } />
                 <input
                     spellcheck="false"
                     ref={ self.input_ref.clone() }

--- a/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
@@ -472,7 +472,7 @@ impl Component for FilterColumn {
                 ondragstart={ dragstart }
                 ondragend={ dragend }>
 
-                <LocalStyle href={ css!("filter-item") } />
+                <LocalStyle href={ css_internal!("filter-item") } />
                 <div class="pivot-column-border">
                     <span class="column_name string">
                         { filter.0.to_owned() }

--- a/rust/perspective-viewer/src/rust/components/containers/dropdown_menu.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/dropdown_menu.rs
@@ -104,7 +104,7 @@ where
         };
 
         html_template! {
-            <LocalStyle href={ css!("containers/dropdown-menu") } />
+            <LocalStyle href={ css_internal!("containers/dropdown-menu") } />
             { body }
         }
     }

--- a/rust/perspective-viewer/src/rust/components/containers/radio_list.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/radio_list.rs
@@ -160,7 +160,7 @@ where
         };
 
         html_template! {
-            <LocalStyle href={ css!("containers/radio-list") } />
+            <LocalStyle href={ css_internal!("containers/radio-list") } />
             {
                 ctx.props()
                 .children

--- a/rust/perspective-viewer/src/rust/components/containers/scroll_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/scroll_panel.rs
@@ -308,7 +308,7 @@ impl Component for ScrollPanel {
         };
 
         html_template! {
-            <LocalStyle href={ css!("containers/scroll-panel") } />
+            <LocalStyle href={ css_internal!("containers/scroll-panel") } />
             { items }
         }
     }

--- a/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
@@ -334,7 +334,7 @@ impl Component for SplitPanel {
         }
 
         let contents = html_template! {
-            <LocalStyle href={ css!("containers/split-panel") } />
+            <LocalStyle href={ css_internal!("containers/split-panel") } />
             <SplitPanelChild
                 style={ self.styles[0].clone() }
                 ref_={ self.refs[0].clone() }>

--- a/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
@@ -232,7 +232,7 @@ impl Component for DatetimeColumnStyle {
 
         html! {
             <StyleProvider>
-                <LocalStyle href={ css!("column-style") } />
+                <LocalStyle href={ css_internal!("column-style") } />
                 <div id="column-style-container">
                     <div class="column-style-label">
                         <label class="indent">{ "Color" }</label>

--- a/rust/perspective-viewer/src/rust/components/expression_editor.rs
+++ b/rust/perspective-viewer/src/rust/components/expression_editor.rs
@@ -168,7 +168,7 @@ impl Component for ExpressionEditor {
         .unwrap_or_default();
 
         html_template! {
-            <LocalStyle href={ css!("expression-editor") } />
+            <LocalStyle href={ css_internal!("expression-editor") } />
             <SplitPanel orientation={ Orientation::Vertical }>
                 <div id="editor-container">
                     <CodeEditor

--- a/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
@@ -17,7 +17,7 @@ use super::modal::*;
 use crate::utils::WeakScope;
 use crate::*;
 
-static CSS: &str = include_str!("../../../target/css/filter-dropdown.css");
+static CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/css/filter-dropdown.css"));
 
 pub enum FilterDropDownMsg {
     SetValues(Vec<String>),

--- a/rust/perspective-viewer/src/rust/components/form/code_editor.rs
+++ b/rust/perspective-viewer/src/rust/components/form/code_editor.rs
@@ -176,7 +176,7 @@ pub fn code_editor(props: &CodeEditorProps) -> Html {
         .collect::<Html>();
 
     html_template! {
-        <LocalStyle href={ css!("form/code-editor") } />
+        <LocalStyle href={ css_internal!("form/code-editor") } />
         <div id="editor">
             <textarea
                 id="textarea_editable"

--- a/rust/perspective-viewer/src/rust/components/function_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/function_dropdown.rs
@@ -18,7 +18,7 @@ use crate::exprtk::CompletionItemSuggestion;
 use crate::utils::WeakScope;
 use crate::*;
 
-static CSS: &str = include_str!("../../../target/css/function-dropdown.css");
+static CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/css/function-dropdown.css"));
 
 pub enum FunctionDropDownMsg {
     SetValues(Vec<CompletionItemSuggestion>),

--- a/rust/perspective-viewer/src/rust/components/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/number_column_style.rs
@@ -364,7 +364,7 @@ impl Component for NumberColumnStyle {
 
         html! {
             <StyleProvider>
-                <LocalStyle href={ css!("column-style") } />
+                <LocalStyle href={ css_internal!("column-style") } />
                 <div id="column-style-container">
                     <div class="column-style-label">
                         <label id="fixed-examples" class="indent">{

--- a/rust/perspective-viewer/src/rust/components/plugin_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/plugin_selector.rs
@@ -121,7 +121,7 @@ impl Component for PluginSelector {
         });
 
         html_template! {
-            <LocalStyle href={ css!("plugin-selector") } />
+            <LocalStyle href={ css_internal!("plugin-selector") } />
             <div id="plugin_selector_container" { class }>
                 <PluginSelect
                     name={ plugin_name }

--- a/rust/perspective-viewer/src/rust/components/render_warning.rs
+++ b/rust/perspective-viewer/src/rust/components/render_warning.rs
@@ -128,7 +128,7 @@ impl Component for RenderWarning {
 
             let onclick = ctx.link().callback(|_| RenderWarningMsg::DismissWarning);
             html_template! {
-                <LocalStyle href={ css!("render-warning") } />
+                <LocalStyle href={ css_internal!("render-warning") } />
                 <div
                     class="plugin_information plugin_information--warning"
                     id="plugin_information--size">

--- a/rust/perspective-viewer/src/rust/components/status_bar.rs
+++ b/rust/perspective-viewer/src/rust/components/status_bar.rs
@@ -237,7 +237,7 @@ impl Component for StatusBar {
         });
 
         html_template! {
-            <LocalStyle href={ css!("status-bar") } />
+            <LocalStyle href={ css_internal!("status-bar") } />
             <div id={ ctx.props().id.clone() } class={ is_updating_class_name }>
                 <div class="section">
                     <span id="status" class={ class_name }></span>

--- a/rust/perspective-viewer/src/rust/components/string_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/string_column_style.rs
@@ -189,7 +189,7 @@ impl Component for StringColumnStyle {
 
         html! {
             <StyleProvider>
-                <LocalStyle href={ css!("column-style") } />
+                <LocalStyle href={ css_internal!("column-style") } />
                 <div id="column-style-container">
                     <div class="column-style-label">
                         <label class="indent">{ "Format" }</label>

--- a/rust/perspective-viewer/src/rust/components/style/mod.rs
+++ b/rust/perspective-viewer/src/rust/components/style/mod.rs
@@ -34,6 +34,23 @@ pub use local_style::LocalStyle;
 pub use style_provider::StyleProvider;
 
 #[macro_export]
+macro_rules! css_internal {
+    ($name:expr) => {{
+        (
+            $name,
+            include_str!(concat!(env!("OUT_DIR"), "/css/", $name, ".css")),
+        )
+    }};
+    ($path:expr, $name:expr) => {{
+        (
+            $name,
+            include_str!(concat!(env!("OUT_DIR"), "/", $path, "/", $name, ".css")),
+        )
+    }};
+}
+
+
+#[macro_export]
 macro_rules! css {
     ($name:expr) => {{
         (

--- a/rust/perspective-viewer/src/rust/components/style/style_cache.rs
+++ b/rust/perspective-viewer/src/rust/components/style/style_cache.rs
@@ -25,7 +25,7 @@ type CSSResource = (&'static str, &'static str);
 /// A dictionary of CSS fragments for native HTML elements which should always
 /// be loaded (and perhaps lack yew components wrappers from which to have
 /// their styles registered).
-static DOM_STYLES: &[CSSResource] = &[css!("dom/checkbox"), css!("dom/select")];
+static DOM_STYLES: &[CSSResource] = &[css_internal!("dom/checkbox"), css_internal!("dom/select")];
 
 /// A state object for `<style>` snippets used by a yew `Component` with a
 /// `<StyleProvider>` at the root.

--- a/rust/perspective-viewer/src/rust/components/viewer.rs
+++ b/rust/perspective-viewer/src/rust/components/viewer.rs
@@ -278,7 +278,7 @@ impl Component for PerspectiveViewer {
 
         html_template! {
             <StyleProvider>
-                <LocalStyle href={ css!("viewer") } />
+                <LocalStyle href={ css_internal!("viewer") } />
                 if self.settings_open {
                     <SplitPanel
                         id="app_panel"


### PR DESCRIPTION
According to [The Cargo Book](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script) build scripts aren't supposed to modify files outside `OUT_DIR`. I modified the `build.rs` to follow that rule and made a separate `css` macro that doesn't point at the target directory.

The reason I made a new macro is that it's technically a breaking change to do this because any projects depending on this macro will break since it'll point to the `OUT_DIR` of _their_ crate which may note even have a `build.rs` at all. But also the previous version of this would've also pointed to the user's `CARGO_MANIFEST_DIR` which seems maybe not the most useful?

We could either break this and force users to use the `OUT_DIR` (which maybe they should already be doing if they have a build script generating CSS) or keep this PR as is.