### PR TITLE
Fix build.rs escaping OUT_DIR

### DIFF
--- a/rust/perspective-viewer/Cargo.lock
+++ b/rust/perspective-viewer/Cargo.lock
@@ -908,7 +908,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "perspective"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "perspective-bundle"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "flate2",
  "wasm-bindgen-cli-support",

--- a/rust/perspective-viewer/build.js
+++ b/rust/perspective-viewer/build.js
@@ -86,8 +86,8 @@ async function build_all() {
 
     // legacy compat
     const { default: cpy } = await cpy_mod;
-    cpy("target/themes/*", "dist/css");
-    cpy("dist/pkg/*", "dist/esm");
+    await cpy("target/themes/*", "dist/css");
+    await cpy("dist/pkg/*", "dist/esm");
 }
 
 build_all();

--- a/rust/perspective-viewer/build.rs
+++ b/rust/perspective-viewer/build.rs
@@ -44,25 +44,29 @@ fn glob_with_wd(indir: &str, input: &str) -> Vec<String> {
 }
 
 fn main() -> Result<(), anyhow::Error> {
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let out_path = std::path::Path::new(&out_dir);
+
     let mut build = BuildCss::new("./src/less");
     let files = glob_with_wd("./src/less", "**/*.less");
     for src in files.iter() {
         build.add_file(src);
     }
 
-    build.compile()?.write("./target/css")?;
-
+    build.compile()?.write(out_path.join("css"))?;
     let mut build = BuildCss::new("./src/themes");
-    build.add_file("variables.less");
-    build.add_file("fonts.less");
-    build.add_file("pro.less");
-    build.add_file("pro-dark.less");
-    build.add_file("monokai.less");
-    build.add_file("solarized.less");
-    build.add_file("solarized-dark.less");
-    build.add_file("vaporwave.less");
-    build.add_file("themes.less");
-    build.compile()?.write("./target/themes")?;
+    if !cfg!(feature = "define_custom_elements_async") {
+        build.add_file("variables.less");
+        build.add_file("fonts.less");
+        build.add_file("pro.less");
+        build.add_file("pro-dark.less");
+        build.add_file("monokai.less");
+        build.add_file("solarized.less");
+        build.add_file("solarized-dark.less");
+        build.add_file("vaporwave.less");
+        build.add_file("themes.less");
+        build.compile()?.write("./target/themes")?;
+    }
 
     println!(
         "cargo:rustc-env=PKG_VERSION={}",

--- a/rust/perspective-viewer/src/rust/components/column_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/column_dropdown.rs
@@ -18,7 +18,7 @@ use super::modal::*;
 use crate::utils::WeakScope;
 use crate::*;
 
-static CSS: &str = include_str!("../../../target/css/column-dropdown.css");
+static CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/css/column-dropdown.css"));
 
 pub enum ColumnDropDownMsg {
     SetValues(Vec<InPlaceColumn>, f64),

--- a/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
@@ -17,7 +17,7 @@ use super::modal::*;
 use crate::utils::WeakScope;
 use crate::*;
 
-static CSS: &str = include_str!("../../../target/css/filter-dropdown.css");
+static CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/css/filter-dropdown.css"));
 
 pub enum FilterDropDownMsg {
     SetValues(Vec<String>),

--- a/rust/perspective-viewer/src/rust/components/function_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/function_dropdown.rs
@@ -18,7 +18,7 @@ use crate::exprtk::CompletionItemSuggestion;
 use crate::utils::WeakScope;
 use crate::*;
 
-static CSS: &str = include_str!("../../../target/css/function-dropdown.css");
+static CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/css/function-dropdown.css"));
 
 pub enum FunctionDropDownMsg {
     SetValues(Vec<CompletionItemSuggestion>),

--- a/rust/perspective-viewer/src/rust/components/style/mod.rs
+++ b/rust/perspective-viewer/src/rust/components/style/mod.rs
@@ -38,25 +38,13 @@ macro_rules! css {
     ($name:expr) => {{
         (
             $name,
-            include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/target/css/",
-                $name,
-                ".css"
-            )),
+            include_str!(concat!(env!("OUT_DIR"), "/css/", $name, ".css")),
         )
     }};
     ($path:expr, $name:expr) => {{
         (
             $name,
-            include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/",
-                $path,
-                "/",
-                $name,
-                ".css"
-            )),
+            include_str!(concat!(env!("OUT_DIR"), "/", $path, "/", $name, ".css")),
         )
     }};
 }


### PR DESCRIPTION
Refactors `build.rs` to use `OUT_DIR` env var for directing generated CSS output, which is useful for Rust importers of `perspective`.