### PR TITLE
1237: Add support for StringDtype

### DIFF
--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -9,7 +9,7 @@
 #  ┃ This file is part of the Perspective library, distributed under the terms ┃
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-
+import pandas
 from datetime import date, datetime
 
 from ..core.exception import PerspectiveError
@@ -71,6 +71,9 @@ class Table(object):
         if self._is_arrow:
             _accessor = data
         else:
+            if isinstance(data, pandas.DataFrame):
+                if data[data.columns[0]].dtypes == "string":
+                    data = data.astype("object")
             _accessor = _PerspectiveAccessor(data)
 
         self._date_validator = _PerspectiveDateValidator()

--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -916,3 +916,15 @@ class TestTablePandas(object):
         df_both = pd.DataFrame(np.random.randn(3, 16), index=['A', 'B', 'C'], columns=index)
         table = Table(df_both)
         assert table.size() == 48
+
+    def test_table_dataframe_for_dtype_equals_string(self):
+        df = pd.DataFrame({"a": ["aa", "bbb"], "b": ["dddd", "dd"]}, dtype="string")
+        table = Table(df)
+        view = table.view()
+
+        assert table.size() == 2
+
+        assert table.schema() == {"index": int, "a": str, "b": str}
+
+        view_df = view.to_df()
+        assert view_df.to_dict() == {"index": {0: 0, 1: 1}, "a": {0: "aa", 1: "bbb"}, "b": {0: "dddd", 1: "dd"}}


### PR DESCRIPTION
#1237 Add support for StringDtype (available in Pandas >=1.0)

AFTER
![perspective](https://github.com/finos/perspective/assets/128140702/31162409-159b-470b-94a5-78abbc60c9f3)
