### PR TITLE
Add support for StringDtype (fixes #1237)

### DIFF
--- a/python/perspective/perspective/core/data/pd.py
+++ b/python/perspective/perspective/core/data/pd.py
@@ -78,6 +78,12 @@ def deconstruct_pandas(data, kwargs=None):
                 if isinstance(v, pd.CategoricalDtype):
                     data[k] = data[k].astype(str)
 
+    # convert StringDtype to str
+    if isinstance(data, pd.DataFrame) and hasattr(pd, "CategoricalDtype"):
+        for k, v in data.dtypes.items():
+            if isinstance(v, pd.StringDtype):
+                data[k] = data[k].astype(str)
+
     if isinstance(data, pd.DataFrame) and isinstance(data.columns, pd.MultiIndex) and isinstance(data.index, pd.MultiIndex):
         # Row and col pivots
         kwargs["group_by"].extend([str(c) for c in data.index.names])

--- a/python/perspective/perspective/core/data/pd.py
+++ b/python/perspective/perspective/core/data/pd.py
@@ -79,7 +79,7 @@ def deconstruct_pandas(data, kwargs=None):
                     data[k] = data[k].astype(str)
 
     # convert StringDtype to str
-    if isinstance(data, pd.DataFrame) and hasattr(pd, "CategoricalDtype"):
+    if isinstance(data, pd.DataFrame) and hasattr(pd, "StringDtype"):
         for k, v in data.dtypes.items():
             if isinstance(v, pd.StringDtype):
                 data[k] = data[k].astype(str)

--- a/python/perspective/perspective/tests/table/test_table_pandas.py
+++ b/python/perspective/perspective/tests/table/test_table_pandas.py
@@ -597,3 +597,15 @@ class TestTablePandas(object):
         df_both = pd.DataFrame(np.random.randn(3, 16), index=["A", "B", "C"], columns=index)
         table = Table(df_both)
         assert table.size() == 48
+
+    def test_table_dataframe_for_dtype_equals_string(self):
+        df = pd.DataFrame({"a": ["aa", "bbb"], "b": ["dddd", "dd"]}, dtype="string")
+        table = Table(df)
+        view = table.view()
+
+        assert table.size() == 2
+
+        assert table.schema() == {"index": int, "a": str, "b": str}
+
+        view_df = view.to_df()
+        assert view_df.to_dict() == {"index": {0: 0, 1: 1}, "a": {0: "aa", 1: "bbb"}, "b": {0: "dddd", 1: "dd"}}


### PR DESCRIPTION
Add support for StringDtype (available in Pandas >=1.0)
Fixes #1237 

AFTER
![image](https://github.com/finos/perspective/assets/128140702/56368551-1249-4f67-9841-0748b519c824)
