### PR TITLE
replace type equality check with isinstance check

### DIFF
--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -355,7 +355,7 @@ class _PerspectiveManagerInternal(object):
         else:
             msg = self._make_message(id, None)
 
-        if len(args) > 1 and type(args[1]) == bytes:
+        if len(args) > 1 and isinstance(args[1], bytes):
             self._process_bytes(args[1], msg, post_callback)
         else:
             post_callback(self._message_to_json(msg["id"], msg))


### PR DESCRIPTION
Small fix to something now flagged by flake8, dont do a `type(…) == <type>`, do a `isinstance(…, <type>)`