### PR TITLE
Fix `update()` with `expressions` overcalc

### DIFF
--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -684,7 +684,6 @@ t_ctx_grouped_pkey::get_column_dtype(t_uindex idx) const {
 
 void
 t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> master,
-    std::shared_ptr<t_data_table> flattened,
     t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
@@ -692,10 +691,6 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> master,
 
     std::shared_ptr<t_data_table> master_expression_table
         = m_expression_tables->m_master;
-
-    t_uindex flattened_num_rows = flattened->size();
-    m_expression_tables->reserve_transitional_table_size(flattened_num_rows);
-    m_expression_tables->set_transitional_table_size(flattened_num_rows);
 
     // Set the master table to the right size.
     t_uindex num_rows = master->size();
@@ -707,9 +702,6 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> master,
         // Compute the expressions on the master table.
         expr->compute(
             master, master_expression_table, expression_vocab, regex_mapping);
-
-        expr->compute(flattened, m_expression_tables->m_flattened,
-            expression_vocab, regex_mapping);
     }
 }
 

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -612,7 +612,6 @@ t_ctx1::get_trav_depth(t_index idx) const {
 
 void
 t_ctx1::compute_expressions(std::shared_ptr<t_data_table> master,
-    std::shared_ptr<t_data_table> flattened,
     t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
@@ -620,10 +619,6 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> master,
 
     std::shared_ptr<t_data_table> master_expression_table
         = m_expression_tables->m_master;
-
-    t_uindex flattened_num_rows = flattened->size();
-    m_expression_tables->reserve_transitional_table_size(flattened_num_rows);
-    m_expression_tables->set_transitional_table_size(flattened_num_rows);
 
     // Set the master table to the right size.
     t_uindex num_rows = master->size();
@@ -635,9 +630,6 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> master,
         // Compute the expressions on the master table.
         expr->compute(
             master, master_expression_table, expression_vocab, regex_mapping);
-
-        expr->compute(flattened, m_expression_tables->m_flattened,
-            expression_vocab, regex_mapping);
     }
 }
 

--- a/cpp/perspective/src/cpp/context_two.cpp
+++ b/cpp/perspective/src/cpp/context_two.cpp
@@ -1054,7 +1054,6 @@ t_ctx2::get_column_dtype(t_uindex idx) const {
 
 void
 t_ctx2::compute_expressions(std::shared_ptr<t_data_table> master,
-    std::shared_ptr<t_data_table> flattened,
     t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
@@ -1062,10 +1061,6 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> master,
 
     std::shared_ptr<t_data_table> master_expression_table
         = m_expression_tables->m_master;
-
-    t_uindex flattened_num_rows = flattened->size();
-    m_expression_tables->reserve_transitional_table_size(flattened_num_rows);
-    m_expression_tables->set_transitional_table_size(flattened_num_rows);
 
     // Set the master table to the right size.
     t_uindex num_rows = master->size();
@@ -1077,9 +1072,6 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> master,
         // Compute the expressions on the master table.
         expr->compute(
             master, master_expression_table, expression_vocab, regex_mapping);
-
-        expr->compute(flattened, m_expression_tables->m_flattened,
-            expression_vocab, regex_mapping);
     }
 }
 

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -620,7 +620,6 @@ t_ctx0::get_step_delta(t_index bidx, t_index eidx) {
 
 void
 t_ctx0::compute_expressions(std::shared_ptr<t_data_table> master,
-    std::shared_ptr<t_data_table> flattened,
     t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
@@ -628,10 +627,6 @@ t_ctx0::compute_expressions(std::shared_ptr<t_data_table> master,
 
     std::shared_ptr<t_data_table> master_expression_table
         = m_expression_tables->m_master;
-
-    t_uindex flattened_num_rows = flattened->size();
-    m_expression_tables->reserve_transitional_table_size(flattened_num_rows);
-    m_expression_tables->set_transitional_table_size(flattened_num_rows);
 
     // Set the master table to the right size.
     t_uindex num_rows = master->size();
@@ -643,9 +638,6 @@ t_ctx0::compute_expressions(std::shared_ptr<t_data_table> master,
         // Compute the expressions on the master table.
         expr->compute(
             master, master_expression_table, expression_vocab, regex_mapping);
-
-        expr->compute(flattened, m_expression_tables->m_flattened,
-            expression_vocab, regex_mapping);
     }
 }
 

--- a/cpp/perspective/src/cpp/expression_tables.cpp
+++ b/cpp/perspective/src/cpp/expression_tables.cpp
@@ -52,6 +52,19 @@ t_expression_tables::get_table() const {
 }
 
 void
+t_expression_tables::set_flattened(std::shared_ptr<t_data_table> flattened) {
+    t_uindex flattened_num_rows = flattened->size();
+    reserve_transitional_table_size(flattened_num_rows);
+    set_transitional_table_size(flattened_num_rows);
+    const t_schema& schema = m_flattened->get_schema();
+    const std::vector<std::string>& column_names = schema.m_columns;
+    for (const auto& colname : column_names) {
+        m_flattened->set_column(
+            colname, flattened->get_column(colname)->clone());
+    }
+}
+
+void
 t_expression_tables::calculate_transitions(
     std::shared_ptr<t_data_table> existed) {
     const t_schema& schema = m_transitions->get_schema();

--- a/cpp/perspective/src/cpp/gnode.cpp
+++ b/cpp/perspective/src/cpp/gnode.cpp
@@ -871,8 +871,13 @@ t_gnode::_register_context(
             ctx->reset();
 
             if (should_update) {
-                ctx->compute_expressions(m_gstate->get_table(), pkeyed_table,
+                ctx->compute_expressions(m_gstate->get_table(),
                     expression_vocab, expression_regex_mapping);
+                ctx->get_expression_tables()->set_flattened(
+                    m_gstate->get_pkeyed_table(
+                        ctx->get_expression_tables()->m_master->get_schema(),
+                        ctx->get_expression_tables()->m_master));
+
                 update_context_from_state<t_ctx2>(ctx, name, pkeyed_table);
             }
         } break;
@@ -881,8 +886,12 @@ t_gnode::_register_context(
             t_ctx1* ctx = static_cast<t_ctx1*>(ptr_);
             ctx->reset();
             if (should_update) {
-                ctx->compute_expressions(m_gstate->get_table(), pkeyed_table,
+                ctx->compute_expressions(m_gstate->get_table(),
                     expression_vocab, expression_regex_mapping);
+                ctx->get_expression_tables()->set_flattened(
+                    m_gstate->get_pkeyed_table(
+                        ctx->get_expression_tables()->m_master->get_schema(),
+                        ctx->get_expression_tables()->m_master));
 
                 update_context_from_state<t_ctx1>(ctx, name, pkeyed_table);
             }
@@ -892,8 +901,13 @@ t_gnode::_register_context(
             t_ctx0* ctx = static_cast<t_ctx0*>(ptr_);
             ctx->reset();
             if (should_update) {
-                ctx->compute_expressions(m_gstate->get_table(), pkeyed_table,
+                ctx->compute_expressions(m_gstate->get_table(),
                     expression_vocab, expression_regex_mapping);
+                ctx->get_expression_tables()->set_flattened(
+                    m_gstate->get_pkeyed_table(
+                        ctx->get_expression_tables()->m_master->get_schema(),
+                        ctx->get_expression_tables()->m_master));
+
                 update_context_from_state<t_ctx0>(ctx, name, pkeyed_table);
             }
         } break;
@@ -913,8 +927,13 @@ t_gnode::_register_context(
             ctx->reset();
 
             if (should_update) {
-                ctx->compute_expressions(m_gstate->get_table(), pkeyed_table,
+                ctx->compute_expressions(m_gstate->get_table(),
                     expression_vocab, expression_regex_mapping);
+                ctx->get_expression_tables()->set_flattened(
+                    m_gstate->get_pkeyed_table(
+                        ctx->get_expression_tables()->m_master->get_schema(),
+                        ctx->get_expression_tables()->m_master));
+
                 update_context_from_state<t_ctx_grouped_pkey>(
                     ctx, name, pkeyed_table);
             }
@@ -999,27 +1018,39 @@ t_gnode::_compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
             case TWO_SIDED_CONTEXT: {
                 t_ctx2* ctx = static_cast<t_ctx2*>(ctxh.m_ctx);
                 ctx->compute_expressions(m_gstate->get_table(),
-                    flattened_masked, expression_vocab,
-                    expression_regex_mapping);
+                    expression_vocab, expression_regex_mapping);
+                ctx->get_expression_tables()->set_flattened(
+                    m_gstate->get_pkeyed_table(
+                        ctx->get_expression_tables()->m_master->get_schema(),
+                        ctx->get_expression_tables()->m_master));
             } break;
             case ONE_SIDED_CONTEXT: {
                 t_ctx1* ctx = static_cast<t_ctx1*>(ctxh.m_ctx);
                 ctx->compute_expressions(m_gstate->get_table(),
-                    flattened_masked, expression_vocab,
-                    expression_regex_mapping);
+                    expression_vocab, expression_regex_mapping);
+                ctx->get_expression_tables()->set_flattened(
+                    m_gstate->get_pkeyed_table(
+                        ctx->get_expression_tables()->m_master->get_schema(),
+                        ctx->get_expression_tables()->m_master));
             } break;
             case ZERO_SIDED_CONTEXT: {
                 t_ctx0* ctx = static_cast<t_ctx0*>(ctxh.m_ctx);
                 ctx->compute_expressions(m_gstate->get_table(),
-                    flattened_masked, expression_vocab,
-                    expression_regex_mapping);
+                    expression_vocab, expression_regex_mapping);
+                ctx->get_expression_tables()->set_flattened(
+                    m_gstate->get_pkeyed_table(
+                        ctx->get_expression_tables()->m_master->get_schema(),
+                        ctx->get_expression_tables()->m_master));
             } break;
             case GROUPED_PKEY_CONTEXT: {
                 t_ctx_grouped_pkey* ctx
                     = static_cast<t_ctx_grouped_pkey*>(ctxh.m_ctx);
                 ctx->compute_expressions(m_gstate->get_table(),
-                    flattened_masked, expression_vocab,
-                    expression_regex_mapping);
+                    expression_vocab, expression_regex_mapping);
+                ctx->get_expression_tables()->set_flattened(
+                    m_gstate->get_pkeyed_table(
+                        ctx->get_expression_tables()->m_master->get_schema(),
+                        ctx->get_expression_tables()->m_master));
             } break;
             case UNIT_CONTEXT:
                 break;

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -1580,10 +1580,10 @@ View<t_ctxunit>::to_columns(t_uindex start_row, t_uindex end_row,
     bool get_pkeys, bool get_ids, bool _leaves_only, t_uindex num_sides,
     bool _has_row_path, std::string nidx, t_uindex columns_length,
     t_uindex group_by_length) const {
-
+    PSP_GIL_UNLOCK();
+    PSP_READ_LOCK(get_lock());
     auto slice = get_data(start_row, end_row, start_col, end_col);
-    auto col_names = slice->get_column_names();
-    auto schema = m_ctx->get_schema();
+    auto& col_names = slice->get_column_names();
 
     rapidjson::StringBuffer s;
     rapidjson::Writer<rapidjson::StringBuffer> writer(s);
@@ -1628,9 +1628,12 @@ View<t_ctx0>::to_columns(t_uindex start_row, t_uindex end_row,
     bool get_pkeys, bool get_ids, bool _leaves_only, t_uindex num_sides,
     bool _has_row_path, std::string nidx, t_uindex columns_length,
     t_uindex group_by_length) const {
+    PSP_GIL_UNLOCK();
+    PSP_READ_LOCK(get_lock());
     auto slice = get_data(start_row, end_row, start_col, end_col);
-    auto col_names = slice->get_column_names();
-    auto schema = m_ctx->get_schema();
+    const std::vector<std::vector<t_tscalar>>& col_names
+        = slice->get_column_names();
+
     rapidjson::StringBuffer s;
     rapidjson::Writer<rapidjson::StringBuffer> writer(s);
     writer.StartObject();
@@ -1671,8 +1674,11 @@ View<t_ctx1>::to_columns(t_uindex start_row, t_uindex end_row,
     bool get_pkeys, bool get_ids, bool leaves_only, t_uindex num_sides,
     bool has_row_path, std::string nidx, t_uindex columns_length,
     t_uindex group_by_length) const {
+    PSP_GIL_UNLOCK();
+    PSP_READ_LOCK(get_lock());
+
     auto slice = get_data(start_row, end_row, start_col, end_col);
-    auto col_names = slice->get_column_names();
+    const auto& col_names = slice->get_column_names();
     rapidjson::StringBuffer s;
     rapidjson::Writer<rapidjson::StringBuffer> writer(s);
     writer.StartObject();
@@ -1721,8 +1727,10 @@ View<t_ctx2>::to_columns(t_uindex start_row, t_uindex end_row,
     bool get_pkeys, bool get_ids, bool leaves_only, t_uindex num_sides,
     bool has_row_path, std::string nidx, t_uindex columns_length,
     t_uindex group_by_length) const {
-    auto slice = get_data(start_row, end_row, start_col, end_col);
-    auto col_names = slice->get_column_names();
+    PSP_GIL_UNLOCK();
+    PSP_READ_LOCK(get_lock());
+    const auto slice = get_data(start_row, end_row, start_col, end_col);
+    const auto& col_names = slice->get_column_names();
     rapidjson::StringBuffer s;
     rapidjson::Writer<rapidjson::StringBuffer> writer(s);
     writer.StartObject();

--- a/cpp/perspective/src/include/perspective/context_common_decls.h
+++ b/cpp/perspective/src/include/perspective/context_common_decls.h
@@ -97,7 +97,6 @@ std::shared_ptr<t_expression_tables> get_expression_tables() const;
 // Given shared pointers to data tables from the gnode, use them to
 // compute the results of expression columns.
 void compute_expressions(std::shared_ptr<t_data_table> master,
-    std::shared_ptr<t_data_table> flattened_masked,
     t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping);
 
 void compute_expressions(std::shared_ptr<t_data_table> master,

--- a/cpp/perspective/src/include/perspective/expression_tables.h
+++ b/cpp/perspective/src/include/perspective/expression_tables.h
@@ -50,6 +50,8 @@ struct t_expression_tables {
     // Calculate the `t_transitions` value for each row.
     void calculate_transitions(std::shared_ptr<t_data_table> existed);
 
+    void set_flattened(std::shared_ptr<t_data_table> flattened);
+
     void reset();
 
     t_data_table* get_table() const;

--- a/cpp/perspective/src/include/perspective/gnode_state.h
+++ b/cpp/perspective/src/include/perspective/gnode_state.h
@@ -199,6 +199,8 @@ public:
     // Getters
     std::shared_ptr<t_data_table> get_table() const;
     std::shared_ptr<t_data_table> get_pkeyed_table() const;
+    std::shared_ptr<t_data_table> get_pkeyed_table(const t_schema& schema,
+        const std::shared_ptr<t_data_table> table) const;
 
     const t_schema& get_input_schema() const;
     const t_schema& get_output_schema() const;

--- a/tools/perspective-bench/src/js/worker.js
+++ b/tools/perspective-bench/src/js/worker.js
@@ -182,6 +182,31 @@ async function view_suite() {
     });
 
     await benchmark({
+        name: `.view({expressions: ["Sales" + "Profit"]})`,
+        before_all,
+        after_all,
+        after,
+        async test(perspective, { table, schema }) {
+            const [M, m, _] = perspective.version;
+            // const columns = Object.keys(schema);
+            columns = [`"Sales" + "Profit"`];
+            if ((M === 1 && m >= 2) || M === 2) {
+                return await table.view({
+                    columns,
+                    group_by: ["Product Name"],
+                    expressions: [`"Sales" + "Profit"`],
+                });
+            } else {
+                return await table.view({
+                    columns,
+                    row_pivots: ["Product Name"],
+                    expressions: [`"Sales" + "Profit"`],
+                });
+            }
+        },
+    });
+
+    await benchmark({
         name: `.view({group_by, aggregates: "median"})`,
         before_all,
         after_all,


### PR DESCRIPTION
Fixes an issue with expression calculation which caused expressions to be (approximately) calculated twice on `View` creation, due to mis-ordering the calculation of primary key indexing of input rows. Improves performance of the inital creation of any `View` with an `expressions` field.

Adds GIL-release to the `to_columns_string()` method.