### PR TITLE
Fix "Split By" labels are not formatted correctly when splitting by date

### DIFF
--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -141,8 +141,9 @@ namespace binding {
                 }
             }
             case DTYPE_DATE: {
-                return t_date_to_jsdate(scalar.get<t_date>())
-                    .call<t_val>("getTime");
+                return cast_string ? t_val(scalar.to_string())
+                                   : t_date_to_jsdate(scalar.get<t_date>())
+                                         .call<t_val>("getTime");
             }
             case DTYPE_UINT8:
             case DTYPE_UINT16:

--- a/packages/perspective/test/js/pivots.spec.js
+++ b/packages/perspective/test/js/pivots.spec.js
@@ -2374,6 +2374,28 @@ const std = (nums) => {
             table.delete();
         });
 
+        test("['y'] only, date column", async function () {
+            const table = await perspective.table([
+                { x: "a", y: new Date("1997/2/5") },
+                { x: "b", y: new Date("1998/2/5") },
+                { x: "c", y: new Date("1999/2/5") },
+            ]);
+            const view = await table.view({
+                split_by: ["y"],
+            });
+            const paths = await view.column_paths();
+            expect(paths).toEqual([
+                "1997-02-05|x",
+                "1997-02-05|y",
+                "1998-02-05|x",
+                "1998-02-05|y",
+                "1999-02-05|x",
+                "1999-02-05|y",
+            ]);
+            view.delete();
+            table.delete();
+        });
+
         test("['x'] only, column-oriented input", async function () {
             var table = await perspective.table(data_7);
             var view = await table.view({


### PR DESCRIPTION
Within `perspective-viewer-datagrid`, `this._view.to_columns_string` is called to get the column data which ends up calling `write_scalar` for serialization. The header data is extracted separately with a call to `column_paths`. Both handle date formatting differently so this change fixes that by using `scalar.to_string` to format the date for column paths.

[packages/perspective-viewer-datagrid/src/js/data_listener/index.js#L48](https://github.com/finos/perspective/blob/master/packages/perspective-viewer-datagrid/src/js/data_listener/index.js#L48)

[cpp/perspective/src/cpp/view.cpp#L1455](https://github.com/finos/perspective/blob/master/cpp/perspective/src/cpp/view.cpp#L1455)

[packages/perspective-viewer-datagrid/src/js/data_listener/index.js#L80](https://github.com/finos/perspective/blob/master/packages/perspective-viewer-datagrid/src/js/data_listener/index.js#L80)


![finos-perspective-fix-datagrid-splitby-date](https://github.com/finos/perspective/assets/137890260/bb9e9dca-9685-4c1f-8c6b-a0f2056b2881)


Fixes #2306 