### PR TITLE
Handling null updates in sum test cases

### DIFF
--- a/packages/perspective/test/js/pivots.spec.js
+++ b/packages/perspective/test/js/pivots.spec.js
@@ -3082,5 +3082,124 @@ const std = (nums) => {
             view.delete();
             table.delete();
         });
+
+        test("Sum value flips back and forth when a new view is created upon table update", async function () {
+
+            var answer = [
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 200 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 100 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 100 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 0 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 200 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 100 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 100 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 0 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 200 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 100 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 100 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 0 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ]
+            ];
+
+            const schema = { "ticker": "string", "pnl": "integer" };
+            const data = [
+                { "ticker": "IBM", "pnl": 100 },
+                { "ticker": "AAPL", "pnl": 100 }
+            ]
+            const table = await perspective.table(schema, { index: "ticker" });
+            table.update(data)
+
+            let flip = true;
+            for (let i = 0; i < 6; i++) {
+                const view = await table.view({
+                    group_by: ["ticker"],
+                    columns: [
+                        "ticker",
+                        "pnl",
+                    ],
+                })
+                let result = await view.to_json();
+                expect(result).toEqual(answer[i]);
+                table.update([{ "ticker": "AAPL", "pnl": flip ? null : 100 }]);
+                flip = !flip;
+            }
+        });
+
+        test("Sum value increments when no new view is created upon table update", async function () {
+
+            var answer = [
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 200 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 100 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 200 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 100 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 300 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 200 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 300 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 200 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 400 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 300 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ],
+                [
+                    { __ROW_PATH__: [], ticker: 2, pnl: 400 },
+                    { __ROW_PATH__: ['AAPL'], ticker: 1, pnl: 300 },
+                    { __ROW_PATH__: ['IBM'], ticker: 1, pnl: 100 }
+                ]
+            ];
+
+            const schema = { "ticker": "string", "pnl": "integer" };
+            const data = [
+                { "ticker": "IBM", "pnl": 100 },
+                { "ticker": "AAPL", "pnl": 100 }
+            ]
+            const table = await perspective.table(schema, { index: "ticker" });
+            table.update(data)
+
+            const view = await table.view({
+                group_by: ["ticker"],
+                columns: [
+                    "ticker",
+                    "pnl",
+                ],
+            })
+
+            let flip = true;
+            for (let i = 0; i < 6; i++) {
+                let result = await view.to_json();
+                expect(result).toEqual(answer[i]);
+                table.update([{ "ticker": "AAPL", "pnl": flip ? null : 100 }]);
+                flip = !flip;
+            }
+        });
     });
 })(perspective);


### PR DESCRIPTION
Upon investigation, this  issue (#1256)  is not really an issue, it is as a result of the way perspective view is interacted with, creating new instances of perspective view upon table update flips the aggregate value back and forth, however, not creating new instances of perspective view upon table update increments the sum aggregate (issue complained about by @nmichaud ). @texodus @timkpaine @sc1f could you please review if all is good?


### Sum value flips back and forth when a new view is created upon table update

https://github.com/finos/perspective/assets/131965000/b0ee5b5b-e94b-47e2-9025-41894700f3e6




### Sum value increments when no new view is created upon table update

https://github.com/finos/perspective/assets/131965000/19173b9c-37bd-4afb-8c2d-39d7e21bad0a

