### PR TITLE
Fix binder installation to not manage dependencies seperately

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,1 +1,0 @@
-graphviz-dev

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,11 +1,2 @@
 #!/bin/bash
-python3 -m pip install -U perspective-python
-
-export NODE_OPTIONS=--max-old-space-size=32768
-
-VERSION=$(python3 -m pip show perspective-python | awk '/Version: (.+?)/ { print $2 }')
-EXTENSIONS="@jupyter-widgets/jupyterlab-manager @finos/perspective-jupyterlab@$VERSION"
-
-jupyter labextension install $EXTENSIONS --no-build
-jupyter lab build --dev-build=False --minimize=False
 jupyter serverextension enable --py jupyterlab

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,1 @@
-ipywidgets>=7.7
-jupyterlab>=3.4
-pandas>=1,<2
-pyarrow>=8.0.0
+perspective-python[jupyter]==2.5.0

--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9
+python-3.11


### PR DESCRIPTION
Do not merge until I can actually test on binder, im having issues getting it to respond
https://mybinder.org/v2/gh/finos/perspective/tkp/binder?urlpath=lab/tree/examples/jupyter-notebooks
