### PR TITLE
remove unnecessary is_vlen_dtype call

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
+      boilerplate notice, with the fields enclosed by brackets "WolfEYc"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a

--- a/cpp/perspective/src/cpp/column.cpp
+++ b/cpp/perspective/src/cpp/column.cpp
@@ -115,7 +115,7 @@ t_column::t_column(t_dtype dtype, bool missing_enabled,
     LOG_CONSTRUCTOR("t_column");
     m_isvlen = is_vlen_dtype(m_dtype);
 
-    if (is_vlen_dtype(dtype)) {
+    if (m_isvlen) {
         t_lstore_recipe vlendata_args(a);
         t_lstore_recipe extents_args(a);
 
@@ -160,8 +160,10 @@ t_column::init() {
         m_status->init();
     }
 
-    if (is_deterministic_sized(m_dtype))
+    if (is_deterministic_sized(m_dtype)) {
         m_elemsize = get_dtype_size(m_dtype);
+    }
+    
     m_init = true;
     COLUMN_CHECK_VALUES();
 }


### PR DESCRIPTION
The duplicate call is unnecessary, so I removed it in favor of using the private member var.