### PR TITLE
Update webpack dev server configuration options, fixes for perspective 2.0+

### DIFF
--- a/examples/promo/webpack.config.js
+++ b/examples/promo/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = {
         ],
     },
     devServer: {
-        contentBase: [
+        static: [
             path.join(__dirname, "dist"),
             path.join(__dirname, "../../node_modules/superstore-arrow"),
         ],

--- a/examples/workspace-editing-python/src/index.js
+++ b/examples/workspace-editing-python/src/index.js
@@ -12,6 +12,7 @@
 
 import perspective from "@finos/perspective";
 import "@finos/perspective-workspace";
+import "@finos/perspective-viewer";
 import "@finos/perspective-viewer-datagrid";
 import "@finos/perspective-viewer-d3fc";
 

--- a/examples/workspace-editing-python/src/index.less
+++ b/examples/workspace-editing-python/src/index.less
@@ -11,6 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 @import "~@finos/perspective-workspace/dist/theme/pro.less";
+@import "~@finos/perspective-viewer/dist/css/themes.css";
  
 body {
   display: flex;

--- a/examples/workspace-editing-python/webpack.config.js
+++ b/examples/workspace-editing-python/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = {
         ],
     },
     devServer: {
-        contentBase: [
+        static: [
             path.join(__dirname, "dist"),
             path.join(__dirname, "../../node_modules/superstore-arrow"),
         ],

--- a/examples/workspace/src/index.js
+++ b/examples/workspace/src/index.js
@@ -38,18 +38,30 @@ const DEFAULT_LAYOUT = {
         },
     },
     viewers: {
-        One: { table: "superstore", editable: true },
+        One: {
+            table: "superstore",
+            title: "Test Widget I",
+            editable: true,
+            linked: true,
+        },
+        Two: {
+            table: "superstore",
+            title: "Test Widget II (modified)",
+            linked: true,
+        },
         Three: {
             table: "superstore",
-            name: "Test Widget III (modified)",
+            title: "Test Widget III (modified)",
             group_by: ["State"],
             columns: ["Sales", "Profit"],
+            linked: true,
         },
         Four: {
             table: "superstore",
-            name: "Test Widget IV (modified)",
+            title: "Test Widget IV (modified)",
             group_by: ["Category", "Sub-Category"],
             columns: ["Sales", "Profit"],
+            linked: true,
         },
     },
 };

--- a/examples/workspace/src/index.js
+++ b/examples/workspace/src/index.js
@@ -12,6 +12,7 @@
 
 import perspective from "@finos/perspective";
 import "@finos/perspective-workspace";
+import "@finos/perspective-viewer";
 import "@finos/perspective-viewer-datagrid";
 import "@finos/perspective-viewer-d3fc";
 

--- a/examples/workspace/src/index.less
+++ b/examples/workspace/src/index.less
@@ -11,6 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 @import "~@finos/perspective-workspace/dist/css/pro-dark.css";
+@import "~@finos/perspective-viewer/dist/css/themes.css";
 
 body {
     display: flex;

--- a/examples/workspace/webpack.config.js
+++ b/examples/workspace/webpack.config.js
@@ -49,7 +49,7 @@ module.exports = {
         ],
     },
     devServer: {
-        contentBase: [
+        static: [
             path.join(__dirname, "dist"),
             path.join(__dirname, "../../node_modules/superstore-arrow"),
         ],


### PR DESCRIPTION
This PR fixes a few issues:
- web pack `contentBase` was renamed to `static`
- import of `@finos/perspective-workspace` no longer include `@finos/perspective-viewer`, so that needs to be imported separately
- same but for CSS assets