### PR TITLE
Fix `title` synchronization in `PerspectiveWidget`

### DIFF
--- a/packages/perspective-jupyterlab/src/js/view.js
+++ b/packages/perspective-jupyterlab/src/js/view.js
@@ -139,7 +139,6 @@ export class PerspectiveView extends DOMWidgetView {
         this.model.on("change:plugin_config", this.plugin_config_changed, this);
         this.model.on("change:theme", this.theme_changed, this);
         this.model.on("change:settings", this.settings_changed, this);
-        this.model.on("change:title", this.title_changed, this);
 
         /**
          * Request a table from the manager. If a table has been loaded, proxy
@@ -498,12 +497,6 @@ export class PerspectiveView extends DOMWidgetView {
     settings_changed() {
         this.luminoWidget.restore({
             settings: this.model.get("settings"),
-        });
-    }
-
-    title_changed() {
-        this.luminoWidget.restore({
-            title: this.model.get("title"),
         });
     }
 }

--- a/rust/perspective-viewer/src/rust/custom_events.rs
+++ b/rust/perspective-viewer/src/rust/custom_events.rs
@@ -31,7 +31,7 @@ use crate::*;
 /// on `CustomElements`, but when it is `drop()` the Custom Element will no
 /// longer dispatch events such as `"perspective-config-change"`.
 #[derive(Clone)]
-pub struct CustomEvents(Rc<(CustomEventsDataRc, [Subscription; 4])>);
+pub struct CustomEvents(Rc<(CustomEventsDataRc, [Subscription; 5])>);
 
 #[derive(Clone)]
 struct CustomEventsDataRc(Rc<CustomEventsData>);
@@ -69,6 +69,11 @@ impl CustomEvents {
             last_dispatched: Default::default(),
         }));
 
+        let title_sub = presentation.title_changed.add_listener({
+            clone!(data);
+            move |_| data.clone().dispatch_config_update()
+        });
+
         let theme_sub = presentation.theme_config_updated.add_listener({
             clone!(data);
             move |_| data.clone().dispatch_config_update()
@@ -98,6 +103,7 @@ impl CustomEvents {
         });
 
         Self(Rc::new((data, [
+            title_sub,
             theme_sub,
             settings_sub,
             plugin_sub,


### PR DESCRIPTION
The `perspective-config-update` event is not triggered when the title is changed and that is the cause of the issue. The changes in this PR listens to title change events and dispatches config update event.

https://github.com/finos/perspective/blob/master/packages/perspective-jupyterlab/src/js/view.js#L59
```js
this.luminoWidget.viewer.addEventListener(
    "perspective-config-update",
    this._synchronize_state
);
```

Fixes #2131

https://github.com/finos/perspective/assets/137890260/fba4c1bf-4df2-427f-ad66-8c27f18783d8

