### PR TITLE
Add native JSON load with `arrow::json` / `RapidJSON`

### DIFF
--- a/cmake/arrow/CMakeLists.txt
+++ b/cmake/arrow/CMakeLists.txt
@@ -138,9 +138,20 @@ set(ARROW_SRCS
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/csv/reader.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/csv/writer.cc
 
+    # JSON
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/json/converter.cc
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/json/chunker.cc
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/json/chunked_builder.cc
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/json/object_parser.cc
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/json/object_writer.cc
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/json/options.cc
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/json/parser.cc
+    # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/json/reader.cc
+
     # IPC
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/dictionary.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/feather.cc
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/json_simple.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/message.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/metadata_internal.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/ipc/options.cc
@@ -154,11 +165,11 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/expression.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/function.cc
-    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/function_internal.cc    
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/function_internal.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernel.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/ordering.cc
 
-    
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/registry.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/aggregate_basic.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -239,7 +250,8 @@ else()
         ${ARROW_SRCS}
         # Use our vendored reader that does not use threads.
         ${PSP_CPP_SRC}/src/cpp/vendor/single_threaded_reader.cpp
-        ${PSP_CPP_SRC}/src/cpp/vendor/arrow_single_threaded_reader.cpp)
+        ${PSP_CPP_SRC}/src/cpp/vendor/arrow_single_threaded_csv_reader.cpp
+        ${PSP_CPP_SRC}/src/cpp/vendor/arrow_single_threaded_json_reader.cpp)
 endif()
 
 set_property(SOURCE util/io_util.cc

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -418,6 +418,7 @@ set(SOURCE_FILES
     ${PSP_CPP_SRC}/src/cpp/aggregate.cpp
     ${PSP_CPP_SRC}/src/cpp/aggspec.cpp
     ${PSP_CPP_SRC}/src/cpp/arg_sort.cpp
+    ${PSP_CPP_SRC}/src/cpp/arrow_format.cpp
     ${PSP_CPP_SRC}/src/cpp/arrow_loader.cpp
     ${PSP_CPP_SRC}/src/cpp/arrow_writer.cpp
     ${PSP_CPP_SRC}/src/cpp/base.cpp
@@ -501,7 +502,6 @@ set(SOURCE_FILES
     ${PSP_CPP_SRC}/src/cpp/view.cpp
     ${PSP_CPP_SRC}/src/cpp/view_config.cpp
     ${PSP_CPP_SRC}/src/cpp/vocab.cpp
-    ${PSP_CPP_SRC}/src/cpp/arrow_csv.cpp
 )
 
 set(PYTHON_SOURCE_FILES ${SOURCE_FILES}
@@ -509,7 +509,8 @@ set(PYTHON_SOURCE_FILES ${SOURCE_FILES}
 )
 
 set(WASM_SOURCE_FILES ${SOURCE_FILES}
-    # ${PSP_CPP_SRC}/src/cpp/vendor/arrow_single_threaded_reader.cpp
+    # ${PSP_CPP_SRC}/src/cpp/vendor/arrow_single_threaded_csv_reader.cpp
+    # ${PSP_CPP_SRC}/src/cpp/vendor/arrow_single_threaded_json_reader.cpp
 )
 
 set(PYTHON_BINDING_SOURCE_FILES

--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -157,6 +157,21 @@ namespace apachearrow {
     }
 
     void
+    ArrowLoader::init_json(std::string& json, bool is_update,
+        std::unordered_map<std::string, std::shared_ptr<arrow::DataType>>&
+            psp_schema) {
+        m_table = jsonToTable(json, is_update, psp_schema);
+
+        std::shared_ptr<arrow::Schema> schema = m_table->schema();
+        std::vector<std::shared_ptr<arrow::Field>> fields = schema->fields();
+
+        for (auto field : fields) {
+            m_names.push_back(field->name());
+            m_types.push_back(convert_type(field->type()->name()));
+        }
+    }
+
+    void
     ArrowLoader::fill_table(t_data_table& tbl, const t_schema& input_schema,
         const std::string& index, std::uint32_t offset, std::uint32_t limit,
         bool is_update) {

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -14,6 +14,7 @@
 #include <perspective/arrow_loader.h>
 #include <perspective/arrow_writer.h>
 #include <arrow/csv/api.h>
+#include <arrow/json/api.h>
 #include <boost/optional.hpp>
 
 using namespace emscripten;
@@ -1135,7 +1136,7 @@ namespace binding {
     std::shared_ptr<Table>
     make_table(t_val table, t_data_accessor accessor, std::uint32_t limit,
         const std::string& index, t_op op, bool is_update, bool is_arrow,
-        bool is_csv, t_uindex port_id) {
+        bool is_csv_or_json, t_uindex port_id) {
         bool table_initialized = has_value(table);
         std::shared_ptr<t_pool> pool;
         std::shared_ptr<Table> tbl;
@@ -1160,7 +1161,7 @@ namespace binding {
         bool is_delete = op == OP_DELETE;
 
         if (is_arrow && !is_delete) {
-            if (is_csv) {
+            if (is_csv_or_json) {
                 std::string s = accessor.as<std::string>();
                 auto map = std::unordered_map<std::string,
                     std::shared_ptr<arrow::DataType>>();
@@ -1355,7 +1356,7 @@ namespace binding {
                 is_update);
         }
 
-        if (is_arrow && !is_csv) {
+        if (is_arrow && !is_csv_or_json) {
             free((void*)ptr);
         }
 

--- a/cpp/perspective/src/cpp/vendor/arrow_single_threaded_csv_reader.cpp
+++ b/cpp/perspective/src/cpp/vendor/arrow_single_threaded_csv_reader.cpp
@@ -5,8 +5,10 @@
  * This file is part of the Perspective library, distributed under the terms of
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
- * Originally forked from 
+ * Originally forked from
  * https://github.com/apache/arrow/blob/apache-arrow-1.0.1/cpp/src/arrow/csv/reader.cc
+ * Currently using
+ * https://github.com/apache/arrow/blob/apache-arrow-12.0.0/cpp/src/arrow/csv/reader.cc
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -27,17 +29,17 @@
  */
 
 /* * * * WARNING * * *
- * 
- * This file and respective header is a fork of 
- * https://github.com/apache/arrow/blob/apache-arrow-1.0.1/cpp/src/arrow/csv/reader.cc
+ *
+ * This file and respective header is a fork of
+ * https://github.com/apache/arrow/blob/apache-arrow-12.0.0/cpp/src/arrow/csv/reader.cc
  * which removes references to `std::thread` such that compilation under
  * Emscripten is possible.  It should not be modified directly.
- * 
+ *
  * TODO Pending a better solution or upstream fix ..
- * 
+ *
 */
 
-#include <perspective/vendor/arrow_single_threaded_reader.h>
+#include <perspective/vendor/arrow_single_threaded_csv_reader.h>
 
 #include <cstdint>
 #include <cstring>

--- a/cpp/perspective/src/cpp/vendor/arrow_single_threaded_json_reader.cpp
+++ b/cpp/perspective/src/cpp/vendor/arrow_single_threaded_json_reader.cpp
@@ -1,0 +1,383 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ * Originally forked from
+ * https://github.com/apache/arrow/blob/apache-arrow-12.0.0/cpp/src/arrow/json/reader.cc
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* * * * WARNING * * *
+ *
+ * This file and respective header is a fork of
+ * https://github.com/apache/arrow/blob/apache-arrow-12.0.0/cpp/src/arrow/json/reader.cc
+ * which removes references to `std::thread` such that compilation under
+ * Emscripten is possible.  It should not be modified directly.
+ *
+ * TODO Pending a better solution or upstream fix ..
+ *
+*/
+
+#include <perspective/vendor/arrow_single_threaded_json_reader.h>
+
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/buffer.h"
+#include "arrow/io/interfaces.h"
+#include "arrow/json/chunked_builder.h"
+#include "arrow/json/chunker.h"
+#include "arrow/json/converter.h"
+#include "arrow/json/parser.h"
+#include "arrow/record_batch.h"
+#include "arrow/table.h"
+// #include "arrow/util/async_generator.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/iterator.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/task_group.h"
+// #include "arrow/util/thread_pool.h"
+
+namespace arrow {
+
+using std::string_view;
+
+using internal::checked_cast;
+using internal::Executor;
+// using internal::GetCpuThreadPool;
+using internal::TaskGroup;
+// using internal::ThreadPool;
+
+namespace json {
+namespace {
+
+struct ChunkedBlock {
+  std::shared_ptr<Buffer> partial;
+  std::shared_ptr<Buffer> completion;
+  std::shared_ptr<Buffer> whole;
+  int64_t index = -1;
+};
+
+struct DecodedBlock {
+  std::shared_ptr<RecordBatch> record_batch;
+  int64_t num_bytes = 0;
+};
+
+}  // namespace
+}  // namespace json
+
+template <>
+struct IterationTraits<json::ChunkedBlock> {
+  static json::ChunkedBlock End() { return json::ChunkedBlock{}; }
+  static bool IsEnd(const json::ChunkedBlock& val) { return val.index < 0; }
+};
+
+template <>
+struct IterationTraits<json::DecodedBlock> {
+  static json::DecodedBlock End() { return json::DecodedBlock{}; }
+  static bool IsEnd(const json::DecodedBlock& val) { return !val.record_batch; }
+};
+
+namespace json {
+namespace {
+
+// Holds related parameters for parsing and type conversion
+class DecodeContext {
+ public:
+  explicit DecodeContext(MemoryPool* pool)
+      : DecodeContext(ParseOptions::Defaults(), pool) {}
+  explicit DecodeContext(ParseOptions options = ParseOptions::Defaults(),
+                         MemoryPool* pool = default_memory_pool())
+      : pool_(pool) {
+    SetParseOptions(std::move(options));
+  }
+
+  void SetParseOptions(ParseOptions options) {
+    parse_options_ = std::move(options);
+    if (parse_options_.explicit_schema) {
+      conversion_type_ = struct_(parse_options_.explicit_schema->fields());
+    } else {
+      parse_options_.unexpected_field_behavior = UnexpectedFieldBehavior::InferType;
+      conversion_type_ = struct_({});
+    }
+    promotion_graph_ =
+        parse_options_.unexpected_field_behavior == UnexpectedFieldBehavior::InferType
+            ? GetPromotionGraph()
+            : nullptr;
+  }
+
+  void SetSchema(std::shared_ptr<Schema> explicit_schema,
+                 UnexpectedFieldBehavior unexpected_field_behavior) {
+    parse_options_.explicit_schema = std::move(explicit_schema);
+    parse_options_.unexpected_field_behavior = unexpected_field_behavior;
+    SetParseOptions(std::move(parse_options_));
+  }
+  void SetSchema(std::shared_ptr<Schema> explicit_schema) {
+    SetSchema(std::move(explicit_schema), parse_options_.unexpected_field_behavior);
+  }
+  // Set the schema but ensure unexpected fields won't be accepted
+  void SetStrictSchema(std::shared_ptr<Schema> explicit_schema) {
+    auto unexpected_field_behavior = parse_options_.unexpected_field_behavior;
+    if (unexpected_field_behavior == UnexpectedFieldBehavior::InferType) {
+      unexpected_field_behavior = UnexpectedFieldBehavior::Error;
+    }
+    SetSchema(std::move(explicit_schema), unexpected_field_behavior);
+  }
+
+  [[nodiscard]] MemoryPool* pool() const { return pool_; }
+  [[nodiscard]] const ParseOptions& parse_options() const { return parse_options_; }
+  [[nodiscard]] const PromotionGraph* promotion_graph() const { return promotion_graph_; }
+  [[nodiscard]] const std::shared_ptr<DataType>& conversion_type() const {
+    return conversion_type_;
+  }
+
+ private:
+  ParseOptions parse_options_;
+  std::shared_ptr<DataType> conversion_type_;
+  const PromotionGraph* promotion_graph_;
+  MemoryPool* pool_;
+};
+
+Result<std::shared_ptr<Array>> ParseBlock(const ChunkedBlock& block,
+                                          const ParseOptions& parse_options,
+                                          MemoryPool* pool, int64_t* out_size = nullptr) {
+  std::unique_ptr<BlockParser> parser;
+  RETURN_NOT_OK(BlockParser::Make(pool, parse_options, &parser));
+
+  int64_t size = block.partial->size() + block.completion->size() + block.whole->size();
+  RETURN_NOT_OK(parser->ReserveScalarStorage(size));
+
+  if (block.partial->size() || block.completion->size()) {
+    std::shared_ptr<Buffer> straddling;
+    if (!block.completion->size()) {
+      straddling = block.partial;
+    } else if (!block.partial->size()) {
+      straddling = block.completion;
+    } else {
+      ARROW_ASSIGN_OR_RAISE(straddling,
+                            ConcatenateBuffers({block.partial, block.completion}, pool));
+    }
+    RETURN_NOT_OK(parser->Parse(straddling));
+  }
+  if (block.whole->size()) {
+    RETURN_NOT_OK(parser->Parse(block.whole));
+  }
+
+  std::shared_ptr<Array> parsed;
+  RETURN_NOT_OK(parser->Finish(&parsed));
+
+  if (out_size) *out_size = size;
+
+  return parsed;
+}
+
+class ChunkingTransformer {
+ public:
+  explicit ChunkingTransformer(std::unique_ptr<Chunker> chunker)
+      : chunker_(std::move(chunker)) {}
+
+  template <typename... Args>
+  static Transformer<std::shared_ptr<Buffer>, ChunkedBlock> Make(Args&&... args) {
+    return [self = std::make_shared<ChunkingTransformer>(std::forward<Args>(args)...)](
+               std::shared_ptr<Buffer> buffer) { return (*self)(std::move(buffer)); };
+  }
+
+ private:
+  Result<TransformFlow<ChunkedBlock>> operator()(std::shared_ptr<Buffer> next_buffer) {
+    if (!buffer_) {
+      if (ARROW_PREDICT_TRUE(!next_buffer)) {
+        DCHECK_EQ(partial_, nullptr) << "Logic error: non-null partial with null buffer";
+        return TransformFinish();
+      }
+      partial_ = std::make_shared<Buffer>("");
+      buffer_ = std::move(next_buffer);
+      return TransformSkip();
+    }
+    DCHECK_NE(partial_, nullptr);
+
+    std::shared_ptr<Buffer> whole, completion, next_partial;
+    if (!next_buffer) {
+      // End of file reached => compute completion from penultimate block
+      RETURN_NOT_OK(chunker_->ProcessFinal(partial_, buffer_, &completion, &whole));
+    } else {
+      std::shared_ptr<Buffer> starts_with_whole;
+      // Get completion of partial from previous block.
+      RETURN_NOT_OK(chunker_->ProcessWithPartial(partial_, buffer_, &completion,
+                                                 &starts_with_whole));
+      // Get all whole objects entirely inside the current buffer
+      RETURN_NOT_OK(chunker_->Process(starts_with_whole, &whole, &next_partial));
+    }
+
+    buffer_ = std::move(next_buffer);
+    return TransformYield(ChunkedBlock{std::exchange(partial_, next_partial),
+                                       std::move(completion), std::move(whole),
+                                       index_++});
+  }
+
+  std::unique_ptr<Chunker> chunker_;
+  std::shared_ptr<Buffer> partial_;
+  std::shared_ptr<Buffer> buffer_;
+  int64_t index_ = 0;
+};
+
+template <typename... Args>
+Iterator<ChunkedBlock> MakeChunkingIterator(Iterator<std::shared_ptr<Buffer>> source,
+                                            Args&&... args) {
+  return MakeTransformedIterator(std::move(source),
+                                 ChunkingTransformer::Make(std::forward<Args>(args)...));
+}
+
+class TableReaderImpl : public TableReader,
+                        public std::enable_shared_from_this<TableReaderImpl> {
+ public:
+  TableReaderImpl(MemoryPool* pool, const ReadOptions& read_options,
+                  const ParseOptions& parse_options,
+                  std::shared_ptr<TaskGroup> task_group)
+      : decode_context_(parse_options, pool),
+        read_options_(read_options),
+        task_group_(std::move(task_group)) {}
+
+  Status Init(std::shared_ptr<io::InputStream> input) {
+    ARROW_ASSIGN_OR_RAISE(auto it,
+                          io::MakeInputStreamIterator(input, read_options_.block_size));
+    return MakeReadaheadIterator(std::move(it), task_group_->parallelism())
+        .Value(&buffer_iterator_);
+  }
+
+  Result<std::shared_ptr<Table>> Read() override {
+    auto block_it = MakeChunkingIterator(std::move(buffer_iterator_),
+                                         MakeChunker(decode_context_.parse_options()));
+
+    bool did_read = false;
+    while (true) {
+      ARROW_ASSIGN_OR_RAISE(auto block, block_it.Next());
+      if (IsIterationEnd(block)) break;
+      if (!did_read) {
+        did_read = true;
+        RETURN_NOT_OK(MakeBuilder());
+      }
+      task_group_->Append(
+          [self = shared_from_this(), block] { return self->ParseAndInsert(block); });
+    }
+    if (!did_read) {
+      return Status::Invalid("Empty JSON file");
+    }
+
+    std::shared_ptr<ChunkedArray> array;
+    RETURN_NOT_OK(builder_->Finish(&array));
+    return Table::FromChunkedStructArray(array);
+  }
+
+ private:
+  Status MakeBuilder() {
+    return MakeChunkedArrayBuilder(task_group_, decode_context_.pool(),
+                                   decode_context_.promotion_graph(),
+                                   decode_context_.conversion_type(), &builder_);
+  }
+
+  Status ParseAndInsert(const ChunkedBlock& block) {
+    ARROW_ASSIGN_OR_RAISE(auto parsed, ParseBlock(block, decode_context_.parse_options(),
+                                                  decode_context_.pool()));
+    builder_->Insert(block.index, field("", parsed->type()), parsed);
+    return Status::OK();
+  }
+
+  DecodeContext decode_context_;
+  ReadOptions read_options_;
+  std::shared_ptr<TaskGroup> task_group_;
+  Iterator<std::shared_ptr<Buffer>> buffer_iterator_;
+  std::shared_ptr<ChunkedArrayBuilder> builder_;
+};
+
+// Callable object for parsing/converting individual JSON blocks. The class itself can be
+// called concurrently but reads from the `DecodeContext` aren't synchronized
+class DecodingOperator {
+ public:
+  explicit DecodingOperator(std::shared_ptr<const DecodeContext> context)
+      : context_(std::move(context)) {}
+
+  Result<DecodedBlock> operator()(const ChunkedBlock& block) const {
+    int64_t num_bytes;
+    ARROW_ASSIGN_OR_RAISE(auto unconverted, ParseBlock(block, context_->parse_options(),
+                                                       context_->pool(), &num_bytes));
+
+    std::shared_ptr<ChunkedArrayBuilder> builder;
+    RETURN_NOT_OK(MakeChunkedArrayBuilder(TaskGroup::MakeSerial(), context_->pool(),
+                                          context_->promotion_graph(),
+                                          context_->conversion_type(), &builder));
+    builder->Insert(0, field("", unconverted->type()), unconverted);
+
+    std::shared_ptr<ChunkedArray> chunked;
+    RETURN_NOT_OK(builder->Finish(&chunked));
+    ARROW_ASSIGN_OR_RAISE(
+        auto batch, RecordBatch::FromStructArray(chunked->chunk(0), context_->pool()));
+
+    return DecodedBlock{std::move(batch), num_bytes};
+  }
+
+ private:
+  std::shared_ptr<const DecodeContext> context_;
+};
+
+}  // namespace
+
+Result<std::shared_ptr<TableReader>> TableReader::Make(
+    MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+    const ReadOptions& read_options, const ParseOptions& parse_options) {
+  std::shared_ptr<TableReaderImpl> ptr;
+  // if (read_options.use_threads) {
+  //   ptr = std::make_shared<TableReaderImpl>(pool, read_options, parse_options,
+  //                                           TaskGroup::MakeThreaded(GetCpuThreadPool()));
+  // } else {
+    ptr = std::make_shared<TableReaderImpl>(pool, read_options, parse_options,
+                                            TaskGroup::MakeSerial());
+  // }
+  RETURN_NOT_OK(ptr->Init(input));
+  return ptr;
+}
+
+Result<std::shared_ptr<RecordBatch>> ParseOne(ParseOptions options,
+                                              std::shared_ptr<Buffer> json) {
+  DecodeContext context(std::move(options));
+
+  std::unique_ptr<BlockParser> parser;
+  RETURN_NOT_OK(BlockParser::Make(context.parse_options(), &parser));
+  RETURN_NOT_OK(parser->Parse(json));
+  std::shared_ptr<Array> parsed;
+  RETURN_NOT_OK(parser->Finish(&parsed));
+
+  std::shared_ptr<ChunkedArrayBuilder> builder;
+  RETURN_NOT_OK(MakeChunkedArrayBuilder(TaskGroup::MakeSerial(), context.pool(),
+                                        context.promotion_graph(),
+                                        context.conversion_type(), &builder));
+
+  builder->Insert(0, field("", context.conversion_type()), parsed);
+  std::shared_ptr<ChunkedArray> converted_chunked;
+  RETURN_NOT_OK(builder->Finish(&converted_chunked));
+
+  return RecordBatch::FromStructArray(converted_chunked->chunk(0), context.pool());
+}
+
+}  // namespace json
+}  // namespace arrow

--- a/cpp/perspective/src/include/perspective/arrow_format.h
+++ b/cpp/perspective/src/include/perspective/arrow_format.h
@@ -29,5 +29,14 @@ namespace apachearrow {
         std::unordered_map<std::string, std::shared_ptr<arrow::DataType>>&
             schema);
 
+    /**
+     * @brief Initialize the arrow loader with a JSON.
+     *
+     * @param ptr
+     */
+    std::shared_ptr<::arrow::Table> jsonToTable(std::string& csv, bool is_update,
+        std::unordered_map<std::string, std::shared_ptr<arrow::DataType>>&
+            schema);
+
 } // namespace apachearrow
 } // namespace perspective

--- a/cpp/perspective/src/include/perspective/arrow_loader.h
+++ b/cpp/perspective/src/include/perspective/arrow_loader.h
@@ -23,7 +23,7 @@
 #include <arrow/util/decimal.h>
 #include <arrow/io/memory.h>
 #include <arrow/ipc/reader.h>
-#include <perspective/arrow_csv.h>
+#include <perspective/arrow_format.h>
 
 namespace perspective {
 namespace apachearrow {
@@ -46,6 +46,15 @@ namespace apachearrow {
          * @param ptr
          */
         void init_csv(std::string& csv, bool is_update,
+            std::unordered_map<std::string, std::shared_ptr<arrow::DataType>>&
+                schema);
+
+        /**
+         * @brief Initialize the arrow loader with a JSON.
+         *
+         * @param ptr
+         */
+        void init_json(std::string& json, bool is_update,
             std::unordered_map<std::string, std::shared_ptr<arrow::DataType>>&
                 schema);
 

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -224,7 +224,7 @@ namespace binding {
     template <typename T>
     std::shared_ptr<Table> make_table(T table, T accessor, std::uint32_t limit,
         const std::string& index, t_op op, bool is_update, bool is_arrow,
-        bool is_csv, t_uindex port_id);
+        bool is_csv_or_json, t_uindex port_id);
 
     /******************************************************************************
      *

--- a/cpp/perspective/src/include/perspective/vendor/arrow_single_threaded_csv_reader.h
+++ b/cpp/perspective/src/include/perspective/vendor/arrow_single_threaded_csv_reader.h
@@ -5,8 +5,10 @@
  * This file is part of the Perspective library, distributed under the terms of
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
- * Originally forked from 
+ * Originally forked from
  * https://github.com/apache/arrow/blob/apache-arrow-1.0.1/cpp/src/arrow/csv/reader.h
+ * Currently using
+ * https://github.com/apache/arrow/blob/apache-arrow-12.0.0/cpp/src/arrow/csv/reader.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -63,11 +65,12 @@ class ARROW_EXPORT TableReader {
                                                    const ReadOptions&,
                                                    const ParseOptions&,
                                                    const ConvertOptions&);
-
-  ARROW_DEPRECATED("Use MemoryPool-less variant (the IOContext holds a pool already)")
-  static Result<std::shared_ptr<TableReader>> Make(
-      MemoryPool* pool, io::IOContext io_context, std::shared_ptr<io::InputStream> input,
-      const ReadOptions&, const ParseOptions&, const ConvertOptions&);
+  // ARROW_DEPRECATED(
+  //     "Deprecated in 4.0.0. "
+  //     "Use MemoryPool-less variant (the IOContext holds a pool already)")
+  // static Result<std::shared_ptr<TableReader>> Make(
+  //     MemoryPool* pool, io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+  //     const ReadOptions&, const ParseOptions&, const ConvertOptions&);
 };
 
 }  // namespace csv

--- a/cpp/perspective/src/include/perspective/vendor/arrow_single_threaded_json_reader.h
+++ b/cpp/perspective/src/include/perspective/vendor/arrow_single_threaded_json_reader.h
@@ -1,0 +1,64 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ * Originally forked from
+ * https://github.com/apache/arrow/blob/apache-arrow-12.0.0/cpp/src/arrow/json/reader.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <memory>
+
+#include "arrow/json/options.h"
+#include "arrow/io/type_fwd.h"
+#include "arrow/record_batch.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/util/macros.h"
+#include "arrow/util/type_fwd.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+namespace json {
+
+/// A class that reads an entire JSON file into a Arrow Table
+///
+/// The file is expected to consist of individual line-separated JSON objects
+class ARROW_EXPORT TableReader {
+ public:
+  virtual ~TableReader() = default;
+
+  /// Read the entire JSON file and convert it to a Arrow Table
+  virtual Result<std::shared_ptr<Table>> Read() = 0;
+
+  /// Create a TableReader instance
+  static Result<std::shared_ptr<TableReader>> Make(MemoryPool* pool,
+                                                   std::shared_ptr<io::InputStream> input,
+                                                   const ReadOptions&,
+                                                   const ParseOptions&);
+};
+
+ARROW_EXPORT Result<std::shared_ptr<RecordBatch>> ParseOne(ParseOptions options,
+                                                           std::shared_ptr<Buffer> json);
+}  // namespace json
+}  // namespace arrow

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -109,7 +109,7 @@ export default function (Module) {
         op,
         is_update,
         is_arrow,
-        is_csv,
+        is_csv_or_json,
         port_id
     ) {
         // C++ constructor cannot take null values - use default values if
@@ -130,7 +130,7 @@ export default function (Module) {
             op,
             is_update,
             is_arrow,
-            is_csv,
+            is_csv_or_json,
             port_id
         );
 
@@ -1854,7 +1854,7 @@ export default function (Module) {
         let schema = this._Table.get_schema();
         let types = schema.types();
         let is_arrow = false;
-        let is_csv = false;
+        let is_csv_or_json = false;
 
         pdata = accessor;
 
@@ -1865,7 +1865,7 @@ export default function (Module) {
             if (data[0] === ",") {
                 data = "_" + data;
             }
-            is_csv = true;
+            is_csv_or_json = true;
             is_arrow = true;
             pdata = data;
         } else {
@@ -1914,7 +1914,7 @@ export default function (Module) {
                 op,
                 true,
                 is_arrow,
-                is_csv,
+                is_csv_or_json,
                 options.port_id
             ).delete();
             this.initialized = true;
@@ -2074,7 +2074,7 @@ export default function (Module) {
             let data_accessor;
             let is_arrow = false;
             let overridden_types = {};
-            let is_csv = false;
+            let is_csv_or_json = false;
 
             if (
                 data instanceof ArrayBuffer ||
@@ -2086,7 +2086,7 @@ export default function (Module) {
                 if (data[0] === ",") {
                     data = "_" + data;
                 }
-                is_csv = true;
+                is_csv_or_json = true;
                 is_arrow = true;
                 data_accessor = data;
             } else {
@@ -2116,7 +2116,7 @@ export default function (Module) {
                     op,
                     false,
                     is_arrow,
-                    is_csv,
+                    is_csv_or_json,
                     0
                 );
 

--- a/python/perspective/bench/runtime/perspective_benchmark.py
+++ b/python/perspective/bench/runtime/perspective_benchmark.py
@@ -76,6 +76,7 @@ class PerspectiveBenchmark(Suite):
         `Runner` can find the tests at runtime."""
         self.benchmark_table_arrow()
         self.benchmark_table_csv()
+        self.benchmark_table_json()
         self.benchmark_view_zero()
         self.benchmark_view_one()
         self.benchmark_view_two()
@@ -100,6 +101,14 @@ class PerspectiveBenchmark(Suite):
         test_meta = make_meta("table", "csv")
         func = Benchmark(lambda: Table(csv), meta=test_meta)
         setattr(self, "table_csv", func)
+
+    def benchmark_table_json(self):
+        """Benchmark table from json separately as it requires opening the
+        Arrow file from the filesystem."""
+        json = self._view.to_json()
+        test_meta = make_meta("table", "json")
+        func = Benchmark(lambda: Table(json), meta=test_meta)
+        setattr(self, "table_json", func)
 
     def benchmark_view_zero(self):
         """Benchmark view creation with zero pivots."""
@@ -184,6 +193,7 @@ class PerspectiveBenchmark(Suite):
         for name in (
             "arrow",
             "csv",
+            "json",
             "columns",
             "records",
         ):
@@ -197,6 +207,7 @@ class PerspectiveBenchmark(Suite):
         for name in (
             "arrow",
             "csv",
+            "json",
             "columns",
             "records",
         ):
@@ -214,6 +225,7 @@ class PerspectiveBenchmark(Suite):
         for name in (
             "arrow",
             "csv",
+            "json",
             "columns",
             "records",
         ):

--- a/python/perspective/perspective/include/perspective/python/table.h
+++ b/python/perspective/perspective/include/perspective/python/table.h
@@ -28,11 +28,11 @@ namespace binding {
 
     std::shared_ptr<Table> make_table_py(t_data_accessor accessor,
         std::uint32_t limit, std::string index, t_op op, bool is_arrow,
-        bool is_csv, t_uindex port_id);
+        bool is_csv_or_json, t_uindex port_id);
 
     std::shared_ptr<Table> update_table_py(t_val table,
         t_data_accessor accessor, std::uint32_t limit, std::string index,
-        t_op op, bool is_arrow, bool is_csv, t_uindex port_id);
+        t_op op, bool is_arrow, bool is_csv_or_json, t_uindex port_id);
 
 } // namespace binding
 } // namespace perspective

--- a/python/perspective/perspective/table/table.py
+++ b/python/perspective/perspective/table/table.py
@@ -58,13 +58,14 @@ class Table(object):
                 writing at row 0.
         """
         self._is_arrow = isinstance(data, (bytes, bytearray))
-        self._is_csv = isinstance(data, str)
+        # String buffer, either CSV or JSON
+        self._is_csv_or_json = isinstance(data, str)
 
-        if self._is_csv:
-            # CSVs are loaded using the Arrow interface, so is_arrow is
-            # always true if we are loading a CSV
+        if self._is_csv_or_json:
+            # CSV/JSON are loaded using the Arrow interface, so is_arrow is always true
             self._is_arrow = True
 
+            # Fix CSV with empty first column
             if len(data) > 0 and data[0] == ",":
                 data = "_" + data
 
@@ -87,7 +88,7 @@ class Table(object):
             self._index or "",
             t_op.OP_INSERT,
             self._is_arrow,
-            self._is_csv,
+            self._is_csv_or_json,
             0,
         )
 
@@ -298,14 +299,16 @@ class Table(object):
         if not port_id:
             port_id = 0
 
+        # Binary arrow buffer
         _is_arrow = isinstance(data, (bytes, bytearray))
-        _is_csv = isinstance(data, str)
+        # String buffer, either CSV or JSON
+        _is_csv_or_json = isinstance(data, str)
 
-        if _is_csv:
-            # CSVs are loaded using the Arrow interface, so is_arrow is
-            # always true if we are loading a CSV
+        if _is_csv_or_json:
+            # CSV/JSON are loaded using the Arrow interface, so is_arrow is always true
             _is_arrow = True
 
+            # Fix CSV with empty first column
             if len(data) > 0 and data[0] == ",":
                 data = "_" + data
 
@@ -318,7 +321,7 @@ class Table(object):
                 self._index or "",
                 t_op.OP_INSERT,
                 _is_arrow,
-                _is_csv,
+                _is_csv_or_json,
                 port_id,
             )
             self._state_manager.set_process(self._table.get_pool(), self._table.get_id())


### PR DESCRIPTION
This PR adds support for loading/updating JSON strings directly. It uses the arrow JSON loader (similar to the current CSV loading). The native arrow JSON loading only supports JSONL/NDJSON format, so this also adds a small code block to convert a JSON array (`[{ ...}, {...}]`) into a JSONL (`{...}\n{...}\n`). 