### PR TITLE
fix some viewer bugs

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/plugin/activate.js
+++ b/packages/perspective-viewer-datagrid/src/js/plugin/activate.js
@@ -160,17 +160,20 @@ export async function activate(view) {
         viewer.addEventListener(
             "perspective-toggle-column-settings",
             (event) => {
-                style_selected_column(
-                    this.regular_table,
-                    event.detail.column_name
-                );
-                if (!event.detail.open) {
-                    this.model._column_settings_selected_column = null;
-                    return;
-                }
+                // NOTE: This is a hack. We'll need to implement a `deactivate` function on the API to properly remove this eventlistener.
+                if (this.isConnected) {
+                    style_selected_column(
+                        this.regular_table,
+                        event.detail.column_name
+                    );
+                    if (!event.detail.open) {
+                        this.model._column_settings_selected_column = null;
+                        return;
+                    }
 
-                this.model._column_settings_selected_column =
-                    event.detail.column_name;
+                    this.model._column_settings_selected_column =
+                        event.detail.column_name;
+                }
             }
         );
 

--- a/rust/perspective-viewer/src/less/containers/split-panel.less
+++ b/rust/perspective-viewer/src/less/containers/split-panel.less
@@ -11,7 +11,8 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 :host {
-    .split-panel.orient-reverse > .split-panel-child:not(:last-child):not(.is-width-override) {
+    .split-panel.orient-reverse
+        > .split-panel-child:not(:last-child):not(.is-width-override) {
         max-width: 300px;
     }
 
@@ -52,7 +53,7 @@
         .split-panel-divider {
             flex: 0 0 6px;
             transition: background-color 0.2s ease-out;
-            z-index: 2;
+            z-index: var(--settings-panel-z-index);
 
             &:hover {
                 background-color: rgba(0, 0, 0, 0.05);

--- a/rust/perspective-viewer/src/less/viewer.less
+++ b/rust/perspective-viewer/src/less/viewer.less
@@ -10,6 +10,10 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
+:host {
+    --settings-panel-z-index: 10;
+}
+
 :host .sidebar_close_button {
     position: absolute;
     top: 0;
@@ -132,6 +136,7 @@
         padding-left: 8px;
         box-sizing: border-box;
         width: 100%;
+        z-index: var(--settings-panel-z-index);
 
         & > .split-panel-child {
             overflow: hidden;
@@ -301,6 +306,8 @@
         width: 100%;
         background-color: var(--inactive--color, #6e6e6e);
         margin-top: 1px;
+        flex-shrink: 0;
+        flex-grow: 0;
     }
 
     .expr_editor_column,


### PR DESCRIPTION
This PR fixes a few small bugs.
- The perspective-datagrid-plugin was throwing some annoying errors when you switched between plugins. This was because we are registering an event listener on the perspective-viewer element, and it is never being unregistered. The only way we can unregister the event listener is to add a `deactivate` method to the API where we can clean up the listeners. For now, I  added a quick hack.
- Fixed some visual bugs regarding borders on the side panels. The top border should no longer shrink and the column settings panel should now go beneath the settings panel when resizing.