### PR TITLE
Add `index()`, `col()`, and `vlookup()` to ExprTk

### DIFF
--- a/cpp/perspective/src/cpp/computed_expression.cpp
+++ b/cpp/perspective/src/cpp/computed_expression.cpp
@@ -476,7 +476,6 @@ t_computed_function_store::t_computed_function_store(t_expression_vocab& vocab,
           computed_function::replace(vocab, regex_mapping, is_type_validator))
     , m_replace_all_fn(computed_function::replace_all(
           vocab, regex_mapping, is_type_validator))
-    , m_add_one_fn(computed_function::add_one())
     , m_index_fn(computed_function::index(pkey_map, source_table, row_idx))
     , m_col_fn(computed_function::col(
           vocab, is_type_validator, source_table, row_idx))
@@ -516,7 +515,6 @@ t_computed_function_store::register_computed_functions(
     sym_table.add_function("month_of_year", m_month_of_year_fn);
     sym_table.add_function("today", computed_function::today);
     sym_table.add_function("now", computed_function::now);
-    sym_table.add_function("add_one", m_add_one_fn);
 
     // String functions
     sym_table.add_function("intern", m_intern_fn);

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -11,6 +11,8 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 #include <perspective/computed_function.h>
+#include <perspective/gnode_state.h>
+#include <perspective/column.h>
 #include <math.h>
 
 namespace perspective {
@@ -45,12 +47,6 @@ namespace computed_function {
         t_string_view temp_string(gt);
         std::string temp_str
             = std::string(temp_string.begin(), temp_string.end());
-
-        if (m_is_type_validator) {
-            // Return the sentinel value which indicates a valid output from
-            // type checking, as the output value is not STATUS_CLEAR
-            return m_sentinel;
-        }
 
         // Intern the string into the vocabulary.
         rval.set(m_expression_vocab.intern(temp_str));
@@ -2183,6 +2179,183 @@ namespace computed_function {
 
         std::int64_t timestamp = temp_scalar.to_double();
         rval.set(t_time(timestamp));
+        return rval;
+    }
+
+    add_one::add_one()
+        : exprtk::igeneric_function<t_tscalar>("T") {}
+    add_one::~add_one() {}
+
+    t_tscalar
+    add_one::operator()(t_parameter_list params) {
+        t_tscalar rval;
+        rval.clear();
+
+        t_generic_type& gt = params[0];
+        t_scalar_view temp(gt);
+        t_tscalar temp_scalar;
+
+        temp_scalar.set(temp());
+        t_dtype dtype = temp_scalar.get_dtype();
+
+        switch (dtype) {
+            case DTYPE_INT8:
+            case DTYPE_INT16:
+            case DTYPE_INT32:
+                rval.set(temp_scalar.to_int32() + 1);
+                break;
+            case DTYPE_INT64:
+                rval.set(temp_scalar.to_int64() + 1);
+                break;
+            case DTYPE_UINT8:
+            case DTYPE_UINT16:
+            case DTYPE_UINT32:
+            case DTYPE_UINT64:
+                rval.set(temp_scalar.to_uint64() + 1);
+                break;
+            case DTYPE_FLOAT32:
+            case DTYPE_FLOAT64:
+                rval.set(temp_scalar.to_double() + 1);
+                break;
+            case DTYPE_NONE:
+                rval.set(0.0);
+            default:
+                rval.m_status = STATUS_CLEAR;
+                return rval;
+        }
+
+        if (!temp_scalar.is_valid()) {
+            return rval;
+        }
+
+        return rval;
+    }
+
+    index::index(const t_gstate::t_mapping& pkey_map,
+        std::shared_ptr<t_data_table> source_table, t_uindex& row_idx)
+        : exprtk::igeneric_function<t_tscalar>("Z")
+        , m_pkey_map(pkey_map)
+        , m_source_table(source_table)
+        , m_row_idx(row_idx) {}
+
+    index::~index() {}
+
+    t_tscalar
+    index::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+
+        auto col = m_source_table->get_const_column("psp_pkey");
+        auto res = col->get_scalar(m_row_idx);
+        rval.set(res);
+
+        return rval;
+    }
+
+    col::col(t_expression_vocab& expression_vocab, bool is_type_validator,
+        std::shared_ptr<t_data_table> source_table, t_uindex& row_idx)
+        : exprtk::igeneric_function<t_tscalar>("T")
+        , m_expression_vocab(expression_vocab)
+        , m_is_type_validator(is_type_validator)
+        , m_source_table(source_table)
+        , m_row_idx(row_idx) {}
+    col::~col() {}
+
+    t_tscalar
+    col::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+
+        t_generic_type& gt = parameters[0];
+        t_scalar_view temp(gt);
+        t_tscalar temp_scalar;
+
+        temp_scalar.set(temp());
+        t_dtype dtype = temp_scalar.get_dtype();
+
+        if (dtype != DTYPE_STR) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        if (!temp_scalar.is_valid()) {
+            return rval;
+        }
+
+        std::string temp_str = temp_scalar.to_string();
+
+        // rval.set(m_expression_vocab.intern(temp_str));
+        // return rval;
+
+        if (!m_source_table->get_schema().has_column(temp_str)) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+        auto col = m_source_table->get_const_column(temp_str);
+        auto res = col->get_scalar(m_row_idx);
+        rval.set(res);
+        rval.m_type = col->get_dtype();
+
+        return rval;
+    }
+
+    vlookup::vlookup(t_expression_vocab& expression_vocab,
+        bool is_type_validator, std::shared_ptr<t_data_table> source_table,
+        t_uindex& row_idx)
+        : exprtk::igeneric_function<t_tscalar>("TT")
+        , m_expression_vocab(expression_vocab)
+        , m_is_type_validator(is_type_validator)
+        , m_source_table(source_table)
+        , m_row_idx(row_idx) {}
+    vlookup::~vlookup() {}
+
+    t_tscalar
+    vlookup::operator()(t_parameter_list parameters) {
+        t_tscalar rval;
+        rval.clear();
+
+        t_generic_type& column_gt = parameters[0];
+        t_scalar_view column_gt_view(column_gt);
+        t_tscalar column_name;
+
+        column_name.set(column_gt_view());
+        t_dtype column_name_dtype = column_name.get_dtype();
+
+        t_generic_type& index_gt = parameters[1];
+        t_scalar_view index_gt_view(index_gt);
+        t_tscalar index;
+
+        index.set(index_gt_view());
+
+        if (column_name_dtype != DTYPE_STR || !index.is_numeric()) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+
+        if (!column_name.is_valid() || !index.is_valid()) {
+            return rval;
+        }
+
+        std::string col_name_str = column_name.to_string();
+        if (!m_source_table->get_schema().has_column(col_name_str)) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
+        auto col = m_source_table->get_const_column(col_name_str);
+
+        if (m_is_type_validator) {
+            rval.m_status = STATUS_VALID;
+            rval.m_type = col->get_dtype();
+            return rval;
+        }
+
+        auto idx = index.to_uint64();
+        if (idx < col->size()) {
+            auto res = col->get_scalar(idx);
+            rval.set(res);
+        }
+        rval.m_type = col->get_dtype();
+
         return rval;
     }
 

--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -48,12 +48,6 @@ namespace computed_function {
         std::string temp_str
             = std::string(temp_string.begin(), temp_string.end());
 
-        if (m_is_type_validator) {
-            // Return the sentinel value which indicates a valid output from
-            // type checking, as the output value is not STATUS_CLEAR
-            return m_sentinel;
-        }
-
         // Intern the string into the vocabulary.
         rval.set(m_expression_vocab.intern(temp_str));
         return rval;
@@ -2211,7 +2205,7 @@ namespace computed_function {
 
     col::col(t_expression_vocab& expression_vocab, bool is_type_validator,
         std::shared_ptr<t_data_table> source_table, t_uindex& row_idx)
-        : exprtk::igeneric_function<t_tscalar>("S")
+        : exprtk::igeneric_function<t_tscalar>("T")
         , m_expression_vocab(expression_vocab)
         , m_is_type_validator(is_type_validator)
         , m_source_table(source_table)
@@ -2223,8 +2217,14 @@ namespace computed_function {
         t_tscalar rval;
         rval.clear();
 
-        t_string_view _colname(parameters[0]);
-        std::string temp_str = std::string(_colname.begin(), _colname.end());
+        t_scalar_view _colname_view(parameters[0]);
+        t_tscalar _colname = _colname_view();
+        std::string temp_str = _colname.to_string();
+
+        if (_colname.get_dtype() != DTYPE_STR) {
+            rval.m_status = STATUS_CLEAR;
+            return rval;
+        }
 
         if (!m_source_table->get_schema().has_column(temp_str)) {
             rval.m_status = STATUS_CLEAR;
@@ -2241,7 +2241,7 @@ namespace computed_function {
     vlookup::vlookup(t_expression_vocab& expression_vocab,
         bool is_type_validator, std::shared_ptr<t_data_table> source_table,
         t_uindex& row_idx)
-        : exprtk::igeneric_function<t_tscalar>("ST")
+        : exprtk::igeneric_function<t_tscalar>("TT")
         , m_expression_vocab(expression_vocab)
         , m_is_type_validator(is_type_validator)
         , m_source_table(source_table)
@@ -2253,8 +2253,12 @@ namespace computed_function {
         t_tscalar rval;
         rval.clear();
 
-        t_string_view _colname(parameters[0]);
-        auto column_name = std::string(_colname.begin(), _colname.end());
+        t_generic_type& column_gt = parameters[0];
+        t_scalar_view column_gt_view(column_gt);
+        t_tscalar column_name;
+
+        column_name.set(column_gt_view());
+        t_dtype column_name_dtype = column_name.get_dtype();
 
         t_generic_type& index_gt = parameters[1];
         t_scalar_view index_gt_view(index_gt);
@@ -2262,20 +2266,24 @@ namespace computed_function {
 
         index.set(index_gt_view());
 
-        if (!index.is_numeric()) {
+        auto pkey_col = m_source_table->get_const_column("psp_pkey");
+
+        if (column_name_dtype != DTYPE_STR
+            || index.get_dtype() != pkey_col->get_dtype()) {
             rval.m_status = STATUS_CLEAR;
             return rval;
         }
 
-        if (!index.is_valid()) {
+        if (!column_name.is_valid()) {
             return rval;
         }
 
-        if (!m_source_table->get_schema().has_column(column_name)) {
+        std::string col_name_str = column_name.to_string();
+        if (!m_source_table->get_schema().has_column(col_name_str)) {
             rval.m_status = STATUS_CLEAR;
             return rval;
         }
-        auto col = m_source_table->get_const_column(column_name);
+        auto col = m_source_table->get_const_column(col_name_str);
 
         if (m_is_type_validator) {
             rval.m_status = STATUS_VALID;

--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -11,9 +11,9 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 
+#include <perspective/context_grouped_pkey.h>
 #include <perspective/first.h>
 #include <perspective/get_data_extents.h>
-#include <perspective/context_grouped_pkey.h>
 #include <perspective/extract_aggregate.h>
 #include <perspective/filter.h>
 #include <perspective/sparse_tree.h>
@@ -684,7 +684,8 @@ t_ctx_grouped_pkey::get_column_dtype(t_uindex idx) const {
 
 void
 t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> master,
-    t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
+    const t_gstate::t_mapping& pkey_map, t_expression_vocab& expression_vocab,
+    t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
@@ -700,13 +701,14 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr->compute(
-            master, master_expression_table, expression_vocab, regex_mapping);
+        expr->compute(master, pkey_map, master_expression_table,
+            expression_vocab, regex_mapping);
     }
 }
 
 void
 t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> master,
+    const t_gstate::t_mapping& pkey_map,
     std::shared_ptr<t_data_table> flattened,
     std::shared_ptr<t_data_table> delta, std::shared_ptr<t_data_table> prev,
     std::shared_ptr<t_data_table> current,
@@ -729,25 +731,25 @@ t_ctx_grouped_pkey::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr->compute(master, m_expression_tables->m_master, expression_vocab,
-            regex_mapping);
+        expr->compute(master, pkey_map, m_expression_tables->m_master,
+            expression_vocab, regex_mapping);
 
         // flattened: compute based on the latest update dataset
-        expr->compute(flattened, m_expression_tables->m_flattened,
+        expr->compute(flattened, pkey_map, m_expression_tables->m_flattened,
             expression_vocab, regex_mapping);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr->compute(delta, m_expression_tables->m_delta, expression_vocab,
-            regex_mapping);
+        expr->compute(delta, pkey_map, m_expression_tables->m_delta,
+            expression_vocab, regex_mapping);
 
         // prev: the values of the updated rows before this update was applied
-        expr->compute(
-            prev, m_expression_tables->m_prev, expression_vocab, regex_mapping);
+        expr->compute(prev, pkey_map, m_expression_tables->m_prev,
+            expression_vocab, regex_mapping);
 
         // current: the current values of the updated rows
-        expr->compute(current, m_expression_tables->m_current, expression_vocab,
-            regex_mapping);
+        expr->compute(current, pkey_map, m_expression_tables->m_current,
+            expression_vocab, regex_mapping);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -612,7 +612,8 @@ t_ctx1::get_trav_depth(t_index idx) const {
 
 void
 t_ctx1::compute_expressions(std::shared_ptr<t_data_table> master,
-    t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
+    const t_gstate::t_mapping& pkey_map, t_expression_vocab& expression_vocab,
+    t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
@@ -628,13 +629,14 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr->compute(
-            master, master_expression_table, expression_vocab, regex_mapping);
+        expr->compute(master, pkey_map, master_expression_table,
+            expression_vocab, regex_mapping);
     }
 }
 
 void
 t_ctx1::compute_expressions(std::shared_ptr<t_data_table> master,
+    const t_gstate::t_mapping& pkey_map,
     std::shared_ptr<t_data_table> flattened,
     std::shared_ptr<t_data_table> delta, std::shared_ptr<t_data_table> prev,
     std::shared_ptr<t_data_table> current,
@@ -657,25 +659,25 @@ t_ctx1::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr->compute(master, m_expression_tables->m_master, expression_vocab,
-            regex_mapping);
+        expr->compute(master, pkey_map, m_expression_tables->m_master,
+            expression_vocab, regex_mapping);
 
         // flattened: compute based on the latest update dataset
-        expr->compute(flattened, m_expression_tables->m_flattened,
+        expr->compute(flattened, pkey_map, m_expression_tables->m_flattened,
             expression_vocab, regex_mapping);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr->compute(delta, m_expression_tables->m_delta, expression_vocab,
-            regex_mapping);
+        expr->compute(delta, pkey_map, m_expression_tables->m_delta,
+            expression_vocab, regex_mapping);
 
         // prev: the values of the updated rows before this update was applied
-        expr->compute(
-            prev, m_expression_tables->m_prev, expression_vocab, regex_mapping);
+        expr->compute(prev, pkey_map, m_expression_tables->m_prev,
+            expression_vocab, regex_mapping);
 
         // current: the current values of the updated rows
-        expr->compute(current, m_expression_tables->m_current, expression_vocab,
-            regex_mapping);
+        expr->compute(current, pkey_map, m_expression_tables->m_current,
+            expression_vocab, regex_mapping);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/context_two.cpp
+++ b/cpp/perspective/src/cpp/context_two.cpp
@@ -1054,7 +1054,8 @@ t_ctx2::get_column_dtype(t_uindex idx) const {
 
 void
 t_ctx2::compute_expressions(std::shared_ptr<t_data_table> master,
-    t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
+    const t_gstate::t_mapping& pkey_map, t_expression_vocab& expression_vocab,
+    t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
@@ -1070,13 +1071,14 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr->compute(
-            master, master_expression_table, expression_vocab, regex_mapping);
+        expr->compute(master, pkey_map, master_expression_table,
+            expression_vocab, regex_mapping);
     }
 }
 
 void
 t_ctx2::compute_expressions(std::shared_ptr<t_data_table> master,
+    const t_gstate::t_mapping& pkey_map,
     std::shared_ptr<t_data_table> flattened,
     std::shared_ptr<t_data_table> delta, std::shared_ptr<t_data_table> prev,
     std::shared_ptr<t_data_table> current,
@@ -1099,25 +1101,25 @@ t_ctx2::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr->compute(master, m_expression_tables->m_master, expression_vocab,
-            regex_mapping);
+        expr->compute(master, pkey_map, m_expression_tables->m_master,
+            expression_vocab, regex_mapping);
 
         // flattened: compute based on the latest update dataset
-        expr->compute(flattened, m_expression_tables->m_flattened,
+        expr->compute(flattened, pkey_map, m_expression_tables->m_flattened,
             expression_vocab, regex_mapping);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr->compute(delta, m_expression_tables->m_delta, expression_vocab,
-            regex_mapping);
+        expr->compute(delta, pkey_map, m_expression_tables->m_delta,
+            expression_vocab, regex_mapping);
 
         // prev: the values of the updated rows before this update was applied
-        expr->compute(
-            prev, m_expression_tables->m_prev, expression_vocab, regex_mapping);
+        expr->compute(prev, pkey_map, m_expression_tables->m_prev,
+            expression_vocab, regex_mapping);
 
         // current: the current values of the updated rows
-        expr->compute(current, m_expression_tables->m_current, expression_vocab,
-            regex_mapping);
+        expr->compute(current, pkey_map, m_expression_tables->m_current,
+            expression_vocab, regex_mapping);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -620,7 +620,8 @@ t_ctx0::get_step_delta(t_index bidx, t_index eidx) {
 
 void
 t_ctx0::compute_expressions(std::shared_ptr<t_data_table> master,
-    t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping) {
+    const t_gstate::t_mapping& pkey_map, t_expression_vocab& expression_vocab,
+    t_regex_mapping& regex_mapping) {
     // Clear the transitional expression tables on the context so they are
     // ready for the next update.
     m_expression_tables->clear_transitional_tables();
@@ -636,14 +637,15 @@ t_ctx0::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // Compute the expressions on the master table.
-        expr->compute(
-            master, master_expression_table, expression_vocab, regex_mapping);
+        expr->compute(master, pkey_map, master_expression_table,
+            expression_vocab, regex_mapping);
     }
 }
 
 // TODO rewrite const&
 void
 t_ctx0::compute_expressions(std::shared_ptr<t_data_table> master,
+    const t_gstate::t_mapping& pkey_map,
     std::shared_ptr<t_data_table> flattened,
     std::shared_ptr<t_data_table> delta, std::shared_ptr<t_data_table> prev,
     std::shared_ptr<t_data_table> current,
@@ -666,25 +668,25 @@ t_ctx0::compute_expressions(std::shared_ptr<t_data_table> master,
     const auto& expressions = m_config.get_expressions();
     for (const auto& expr : expressions) {
         // master: compute based on latest state of the gnode state table
-        expr->compute(master, m_expression_tables->m_master, expression_vocab,
-            regex_mapping);
+        expr->compute(master, pkey_map, m_expression_tables->m_master,
+            expression_vocab, regex_mapping);
 
         // flattened: compute based on the latest update dataset
-        expr->compute(flattened, m_expression_tables->m_flattened,
+        expr->compute(flattened, pkey_map, m_expression_tables->m_flattened,
             expression_vocab, regex_mapping);
 
         // delta: for each numerical column, the numerical delta between the
         // previous value and the current value in the row.
-        expr->compute(delta, m_expression_tables->m_delta, expression_vocab,
-            regex_mapping);
+        expr->compute(delta, pkey_map, m_expression_tables->m_delta,
+            expression_vocab, regex_mapping);
 
         // prev: the values of the updated rows before this update was applied
-        expr->compute(
-            prev, m_expression_tables->m_prev, expression_vocab, regex_mapping);
+        expr->compute(prev, pkey_map, m_expression_tables->m_prev,
+            expression_vocab, regex_mapping);
 
         // current: the current values of the updated rows
-        expr->compute(current, m_expression_tables->m_current, expression_vocab,
-            regex_mapping);
+        expr->compute(current, pkey_map, m_expression_tables->m_current,
+            expression_vocab, regex_mapping);
     }
 
     // Calculate the transitions now that the intermediate tables are computed

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1539,7 +1539,8 @@ namespace binding {
             std::shared_ptr<t_computed_expression> expression
                 = t_computed_expression_parser::precompute(expression_alias,
                     expression_string, parsed_expression_string, column_ids,
-                    schema, expression_vocab, regex_mapping);
+                    gnode.get_table_sptr(), gnode.get_pkey_map(), schema,
+                    expression_vocab, regex_mapping);
 
             schema->add_column(expression_alias, expression->get_dtype());
             expressions.push_back(expression);

--- a/cpp/perspective/src/cpp/gnode.cpp
+++ b/cpp/perspective/src/cpp/gnode.cpp
@@ -638,7 +638,7 @@ t_gnode::get_table() const {
 }
 
 std::shared_ptr<t_data_table>
-t_gnode::get_table_sptr() {
+t_gnode::get_table_sptr() const {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "Cannot `get_table_sptr` on an uninited gnode.");
     return m_gstate->get_table();
@@ -872,7 +872,8 @@ t_gnode::_register_context(
 
             if (should_update) {
                 ctx->compute_expressions(m_gstate->get_table(),
-                    expression_vocab, expression_regex_mapping);
+                    m_gstate->get_pkey_map(), expression_vocab,
+                    expression_regex_mapping);
                 ctx->get_expression_tables()->set_flattened(
                     m_gstate->get_pkeyed_table(
                         ctx->get_expression_tables()->m_master->get_schema(),
@@ -887,7 +888,8 @@ t_gnode::_register_context(
             ctx->reset();
             if (should_update) {
                 ctx->compute_expressions(m_gstate->get_table(),
-                    expression_vocab, expression_regex_mapping);
+                    m_gstate->get_pkey_map(), expression_vocab,
+                    expression_regex_mapping);
                 ctx->get_expression_tables()->set_flattened(
                     m_gstate->get_pkeyed_table(
                         ctx->get_expression_tables()->m_master->get_schema(),
@@ -902,7 +904,8 @@ t_gnode::_register_context(
             ctx->reset();
             if (should_update) {
                 ctx->compute_expressions(m_gstate->get_table(),
-                    expression_vocab, expression_regex_mapping);
+                    m_gstate->get_pkey_map(), expression_vocab,
+                    expression_regex_mapping);
                 ctx->get_expression_tables()->set_flattened(
                     m_gstate->get_pkeyed_table(
                         ctx->get_expression_tables()->m_master->get_schema(),
@@ -928,7 +931,8 @@ t_gnode::_register_context(
 
             if (should_update) {
                 ctx->compute_expressions(m_gstate->get_table(),
-                    expression_vocab, expression_regex_mapping);
+                    m_gstate->get_pkey_map(), expression_vocab,
+                    expression_regex_mapping);
                 ctx->get_expression_tables()->set_flattened(
                     m_gstate->get_pkeyed_table(
                         ctx->get_expression_tables()->m_master->get_schema(),
@@ -1018,7 +1022,8 @@ t_gnode::_compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
             case TWO_SIDED_CONTEXT: {
                 t_ctx2* ctx = static_cast<t_ctx2*>(ctxh.m_ctx);
                 ctx->compute_expressions(m_gstate->get_table(),
-                    expression_vocab, expression_regex_mapping);
+                    m_gstate->get_pkey_map(), expression_vocab,
+                    expression_regex_mapping);
                 ctx->get_expression_tables()->set_flattened(
                     m_gstate->get_pkeyed_table(
                         ctx->get_expression_tables()->m_master->get_schema(),
@@ -1027,7 +1032,8 @@ t_gnode::_compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
             case ONE_SIDED_CONTEXT: {
                 t_ctx1* ctx = static_cast<t_ctx1*>(ctxh.m_ctx);
                 ctx->compute_expressions(m_gstate->get_table(),
-                    expression_vocab, expression_regex_mapping);
+                    m_gstate->get_pkey_map(), expression_vocab,
+                    expression_regex_mapping);
                 ctx->get_expression_tables()->set_flattened(
                     m_gstate->get_pkeyed_table(
                         ctx->get_expression_tables()->m_master->get_schema(),
@@ -1036,7 +1042,8 @@ t_gnode::_compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
             case ZERO_SIDED_CONTEXT: {
                 t_ctx0* ctx = static_cast<t_ctx0*>(ctxh.m_ctx);
                 ctx->compute_expressions(m_gstate->get_table(),
-                    expression_vocab, expression_regex_mapping);
+                    m_gstate->get_pkey_map(), expression_vocab,
+                    expression_regex_mapping);
                 ctx->get_expression_tables()->set_flattened(
                     m_gstate->get_pkeyed_table(
                         ctx->get_expression_tables()->m_master->get_schema(),
@@ -1046,7 +1053,8 @@ t_gnode::_compute_expressions(std::shared_ptr<t_data_table> flattened_masked) {
                 t_ctx_grouped_pkey* ctx
                     = static_cast<t_ctx_grouped_pkey*>(ctxh.m_ctx);
                 ctx->compute_expressions(m_gstate->get_table(),
-                    expression_vocab, expression_regex_mapping);
+                    m_gstate->get_pkey_map(), expression_vocab,
+                    expression_regex_mapping);
                 ctx->get_expression_tables()->set_flattened(
                     m_gstate->get_pkeyed_table(
                         ctx->get_expression_tables()->m_master->get_schema(),
@@ -1082,28 +1090,28 @@ t_gnode::_compute_expressions(std::shared_ptr<t_data_table> master,
         switch (ctxh.get_type()) {
             case TWO_SIDED_CONTEXT: {
                 t_ctx2* ctx = static_cast<t_ctx2*>(ctxh.m_ctx);
-                ctx->compute_expressions(master, flattened, delta, prev,
-                    current, transitions, existed, expression_vocab,
-                    expression_regex_mapping);
+                ctx->compute_expressions(master, m_gstate->get_pkey_map(),
+                    flattened, delta, prev, current, transitions, existed,
+                    expression_vocab, expression_regex_mapping);
             } break;
             case ONE_SIDED_CONTEXT: {
                 t_ctx1* ctx = static_cast<t_ctx1*>(ctxh.m_ctx);
-                ctx->compute_expressions(master, flattened, delta, prev,
-                    current, transitions, existed, expression_vocab,
-                    expression_regex_mapping);
+                ctx->compute_expressions(master, m_gstate->get_pkey_map(),
+                    flattened, delta, prev, current, transitions, existed,
+                    expression_vocab, expression_regex_mapping);
             } break;
             case ZERO_SIDED_CONTEXT: {
                 t_ctx0* ctx = static_cast<t_ctx0*>(ctxh.m_ctx);
-                ctx->compute_expressions(master, flattened, delta, prev,
-                    current, transitions, existed, expression_vocab,
-                    expression_regex_mapping);
+                ctx->compute_expressions(master, m_gstate->get_pkey_map(),
+                    flattened, delta, prev, current, transitions, existed,
+                    expression_vocab, expression_regex_mapping);
             } break;
             case GROUPED_PKEY_CONTEXT: {
                 t_ctx_grouped_pkey* ctx
                     = static_cast<t_ctx_grouped_pkey*>(ctxh.m_ctx);
-                ctx->compute_expressions(master, flattened, delta, prev,
-                    current, transitions, existed, expression_vocab,
-                    expression_regex_mapping);
+                ctx->compute_expressions(master, m_gstate->get_pkey_map(),
+                    flattened, delta, prev, current, transitions, existed,
+                    expression_vocab, expression_regex_mapping);
             } break;
             case UNIT_CONTEXT:
                 break;
@@ -1118,6 +1126,13 @@ t_gnode::_compute_expressions(std::shared_ptr<t_data_table> master,
  *
  * Getters
  */
+
+const t_gstate::t_mapping&
+t_gnode::get_pkey_map() const {
+    PSP_TRACE_SENTINEL();
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    return m_gstate->get_pkey_map();
+}
 
 std::shared_ptr<t_expression_vocab>
 t_gnode::get_expression_vocab() const {

--- a/cpp/perspective/src/cpp/gnode_state.cpp
+++ b/cpp/perspective/src/cpp/gnode_state.cpp
@@ -537,6 +537,11 @@ t_gstate::get_output_schema() const {
     return m_output_schema;
 }
 
+const t_gstate::t_mapping&
+t_gstate::get_pkey_map() const {
+    return m_mapping;
+}
+
 t_dtype
 t_gstate::get_pkey_dtype() const {
     if (m_mapping.empty())

--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -116,7 +116,8 @@ Table::validate_expressions(
 
         t_dtype expression_dtype = t_computed_expression_parser::get_dtype(
             expression_alias, expression_string, parsed_expression_string,
-            column_ids, gnode_schema, error, expression_vocab, regex_mapping);
+            column_ids, m_gnode->get_table_sptr(), m_gnode->get_pkey_map(),
+            gnode_schema, error, expression_vocab, regex_mapping);
 
         // FIXME: none == bad type? what about clear
         if (expression_dtype == DTYPE_NONE) {

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -20,6 +20,7 @@
 #include <perspective/data_table.h>
 #include <perspective/rlookup.h>
 #include <perspective/computed_function.h>
+#include <perspective/gnode_state.h>
 #include <date/date.h>
 #include <tsl/hopscotch_set.h>
 
@@ -54,6 +55,7 @@ public:
         t_dtype dtype);
 
     void compute(std::shared_ptr<t_data_table> source_table,
+        const t_gstate::t_mapping& pkey_map,
         std::shared_ptr<t_data_table> destination_table,
         t_expression_vocab& vocab, t_regex_mapping& regex_mapping) const;
 
@@ -98,8 +100,9 @@ public:
         const std::string& expression_string,
         const std::string& parsed_expression_string,
         const std::vector<std::pair<std::string, std::string>>& column_ids,
-        std::shared_ptr<t_schema> schema, t_expression_vocab& vocab,
-        t_regex_mapping& regex_mapping);
+        std::shared_ptr<t_data_table> source_table,
+        const t_gstate::t_mapping& pkey_map, std::shared_ptr<t_schema> schema,
+        t_expression_vocab& vocab, t_regex_mapping& regex_mapping);
 
     /**
      * @brief Returns the dtype of the given expression, or `DTYPE_NONE`
@@ -125,8 +128,10 @@ public:
         const std::string& expression_string,
         const std::string& parsed_expression_string,
         const std::vector<std::pair<std::string, std::string>>& column_ids,
-        const t_schema& schema, t_expression_error& error,
-        t_expression_vocab& vocab, t_regex_mapping& regex_mapping);
+        std::shared_ptr<t_data_table> source_table,
+        const t_gstate::t_mapping& pkey_map, const t_schema& schema,
+        t_expression_error& error, t_expression_vocab& vocab,
+        t_regex_mapping& regex_mapping);
 
     static std::shared_ptr<exprtk::parser<t_tscalar>> PARSER;
 
@@ -188,7 +193,9 @@ struct PERSPECTIVE_EXPORT t_computed_function_store {
     PSP_NON_COPYABLE(t_computed_function_store);
 
     t_computed_function_store(t_expression_vocab& vocab,
-        t_regex_mapping& regex_mapping, bool is_type_validator);
+        t_regex_mapping& regex_mapping, bool is_type_validator,
+        std::shared_ptr<t_data_table> source_table,
+        const t_gstate::t_mapping& pkey_map, t_uindex& row_count);
 
     void register_computed_functions(
         exprtk::symbol_table<t_tscalar>& sym_table);
@@ -216,6 +223,10 @@ struct PERSPECTIVE_EXPORT t_computed_function_store {
     computed_function::substring m_substring_fn;
     computed_function::replace m_replace_fn;
     computed_function::replace_all m_replace_all_fn;
+    computed_function::add_one m_add_one_fn;
+    computed_function::index m_index_fn;
+    computed_function::col m_col_fn;
+    computed_function::vlookup m_vlookup_fn;
 };
 
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/computed_expression.h
+++ b/cpp/perspective/src/include/perspective/computed_expression.h
@@ -223,7 +223,6 @@ struct PERSPECTIVE_EXPORT t_computed_function_store {
     computed_function::substring m_substring_fn;
     computed_function::replace m_replace_fn;
     computed_function::replace_all m_replace_all_fn;
-    computed_function::add_one m_add_one_fn;
     computed_function::index m_index_fn;
     computed_function::col m_col_fn;
     computed_function::vlookup m_vlookup_fn;

--- a/cpp/perspective/src/include/perspective/computed_function.h
+++ b/cpp/perspective/src/include/perspective/computed_function.h
@@ -26,6 +26,7 @@
 #include <type_traits>
 #include <date/date.h>
 #include <tsl/hopscotch_set.h>
+#include <perspective/raw_types.h>
 
 namespace perspective {
 
@@ -183,6 +184,47 @@ namespace computed_function {
 
     // Length of the string
     FUNCTION_HEADER(length)
+
+    // Add one to a column
+    FUNCTION_HEADER(add_one)
+
+    struct index : public exprtk::igeneric_function<t_tscalar> {
+        index(const t_pkey_mapping& pkey_map,
+            std::shared_ptr<t_data_table> source_table, t_uindex& row_idx);
+        ~index();
+        t_tscalar operator()(t_parameter_list parameters);
+
+    private:
+        const t_pkey_mapping& m_pkey_map;
+        std::shared_ptr<t_data_table> m_source_table;
+        t_uindex& m_row_idx;
+    };
+
+    struct col : public exprtk::igeneric_function<t_tscalar> {
+        col(t_expression_vocab& expression_vocab, bool is_type_validator,
+            std::shared_ptr<t_data_table> source_table, t_uindex& row_idx);
+        ~col();
+        t_tscalar operator()(t_parameter_list parameters);
+
+    private:
+        t_expression_vocab& m_expression_vocab;
+        bool m_is_type_validator;
+        std::shared_ptr<t_data_table> m_source_table;
+        t_uindex& m_row_idx;
+    };
+
+    struct vlookup : public exprtk::igeneric_function<t_tscalar> {
+        vlookup(t_expression_vocab& expression_vocab, bool is_type_validator,
+            std::shared_ptr<t_data_table> source_table, t_uindex& row_idx);
+        ~vlookup();
+        t_tscalar operator()(t_parameter_list parameters);
+
+    private:
+        t_expression_vocab& m_expression_vocab;
+        bool m_is_type_validator;
+        std::shared_ptr<t_data_table> m_source_table;
+        t_uindex& m_row_idx;
+    };
 
     /**
      * @brief Return the hour of the day the date/datetime belongs to.

--- a/cpp/perspective/src/include/perspective/computed_function.h
+++ b/cpp/perspective/src/include/perspective/computed_function.h
@@ -185,9 +185,6 @@ namespace computed_function {
     // Length of the string
     FUNCTION_HEADER(length)
 
-    // Add one to a column
-    FUNCTION_HEADER(add_one)
-
     struct index : public exprtk::igeneric_function<t_tscalar> {
         index(const t_pkey_mapping& pkey_map,
             std::shared_ptr<t_data_table> source_table, t_uindex& row_idx);

--- a/cpp/perspective/src/include/perspective/context_common_decls.h
+++ b/cpp/perspective/src/include/perspective/context_common_decls.h
@@ -97,9 +97,11 @@ std::shared_ptr<t_expression_tables> get_expression_tables() const;
 // Given shared pointers to data tables from the gnode, use them to
 // compute the results of expression columns.
 void compute_expressions(std::shared_ptr<t_data_table> master,
-    t_expression_vocab& expression_vocab, t_regex_mapping& regex_mapping);
+    const t_gstate::t_mapping& pkey_map, t_expression_vocab& expression_vocab,
+    t_regex_mapping& regex_mapping);
 
 void compute_expressions(std::shared_ptr<t_data_table> master,
+    const t_gstate::t_mapping& pkey_map,
     std::shared_ptr<t_data_table> flattened,
     std::shared_ptr<t_data_table> delta, std::shared_ptr<t_data_table> prev,
     std::shared_ptr<t_data_table> current,

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -156,7 +156,7 @@ public:
     const t_data_table* get_table() const;
     t_data_table* get_table();
 
-    std::shared_ptr<t_data_table> get_table_sptr();
+    std::shared_ptr<t_data_table> get_table_sptr() const;
 
     t_data_table* _get_otable(t_uindex port_id);
     t_data_table* _get_itable(t_uindex port_id);
@@ -212,6 +212,8 @@ public:
 
     std::shared_ptr<t_expression_vocab> get_expression_vocab() const;
     std::shared_ptr<t_regex_mapping> get_expression_regex_mapping() const;
+
+    const t_gstate::t_mapping& get_pkey_map() const;
 
 #ifdef PSP_PARALLEL_FOR
     void set_lock(boost::shared_mutex* lock);

--- a/cpp/perspective/src/include/perspective/gnode_state.h
+++ b/cpp/perspective/src/include/perspective/gnode_state.h
@@ -27,6 +27,7 @@ std::pair<t_tscalar, t_tscalar> get_vec_min_max(
     const std::vector<t_tscalar>& vec);
 
 class PERSPECTIVE_EXPORT t_gstate {
+public:
     /**
      * @brief A mapping of `t_tscalar` primary keys to `t_uindex` row indices.
      */
@@ -34,7 +35,6 @@ class PERSPECTIVE_EXPORT t_gstate {
 
     typedef tsl::hopscotch_set<t_uindex> t_free_items;
 
-public:
     /**
      * @brief Construct a new `t_gstate`, which manages the canonical state of
      * the `t_gnode` and associated `Table`.
@@ -204,6 +204,7 @@ public:
 
     const t_schema& get_input_schema() const;
     const t_schema& get_output_schema() const;
+    const t_mapping& get_pkey_map() const;
 
     std::vector<t_tscalar> get_row_data_pkeys(
         const std::vector<t_tscalar>& pkeys) const;

--- a/cpp/perspective/src/include/perspective/raw_types.h
+++ b/cpp/perspective/src/include/perspective/raw_types.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <set>
 #include <limits>
+#include <tsl/hopscotch_map.h>
 
 namespace perspective {
 
@@ -150,5 +151,9 @@ template <>
 struct t_accumulation_type<bool> {
     using type = std::int64_t;
 };
+
+struct t_tscalar;
+
+typedef tsl::hopscotch_map<t_tscalar, t_uindex> t_pkey_mapping;
 
 } // end namespace perspective

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1495,17 +1495,6 @@ export default function (Module) {
                 )}'${value}'${match.substring(intern_idx + intern_fn.length)}`;
             };
 
-            parsed_expression_string = parsed_expression_string.replace(
-                /(col|vlookup)\((.*)\)/g,
-                (match, _, args, __) => {
-                    const start = match.indexOf(args);
-                    return `${match.substring(0, start)}${args.replace(
-                        /intern\('([^']*)'\)/g,
-                        "'$1'"
-                    )})`;
-                }
-            );
-
             // Replace intern() for bucket and regex functions that take
             // a string literal parameter and does not work if that param is
             // interned. TODO: this is clumsy and we should have a better

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1495,6 +1495,17 @@ export default function (Module) {
                 )}'${value}'${match.substring(intern_idx + intern_fn.length)}`;
             };
 
+            parsed_expression_string = parsed_expression_string.replace(
+                /(col|vlookup)\((.*)\)/g,
+                (match, _, args, __) => {
+                    const start = match.indexOf(args);
+                    return `${match.substring(0, start)}${args.replace(
+                        /intern\('([^']*)'\)/g,
+                        "'$1'"
+                    )})`;
+                }
+            );
+
             // Replace intern() for bucket and regex functions that take
             // a string literal parameter and does not work if that param is
             // interned. TODO: this is clumsy and we should have a better

--- a/packages/perspective/test/js/expressions/functionality.spec.js
+++ b/packages/perspective/test/js/expressions/functionality.spec.js
@@ -418,21 +418,22 @@ const perspective = require("@finos/perspective");
             });
 
             test("Switch on multiple columns with resulting expression", async function () {
-                const table = await perspective.table(
-                    expressions_common.int_float_data
-                );
+                const table = await perspective.table({
+                    w: "float",
+                    x: "float",
+                    y: "string",
+                    z: "boolean",
+                });
+                table.update(expressions_common.int_float_data);
+                const expr = `switch { case "w" > 2: (sqrt(144) * "w"); case "y" == 'a': (sqrt(121) * "w"); default: "x"; }`;
                 const view = await table.view({
-                    expressions: [
-                        `switch { case "w" > 2: (sqrt(144) * "w"); case "y" == 'a': (sqrt(121) * "w"); default: "x"; }`,
-                    ],
+                    expressions: [expr],
                 });
 
                 const results = await view.to_columns();
-                expect(
-                    results[
-                        `switch { case "w" > 2: (sqrt(144) * "w"); case "y" == 'a': (sqrt(121) * "w"); default: "x"; }`
-                    ]
-                ).toEqual([16.5, 30, 42, 54]);
+                const schema = await view.schema();
+                expect(schema[expr]).toEqual("float");
+                expect(results[expr]).toEqual([16.5, 30, 42, 54]);
 
                 await view.delete();
                 await table.delete();
@@ -3186,14 +3187,15 @@ const perspective = require("@finos/perspective");
                     a: [1, 2, 3, 4],
                     b: ["a", "b", "c", "d"],
                 });
+                const expr = "vlookup('b', integer(0))";
                 const view = await table.view({
-                    expressions: ["vlookup('b', 0)"],
+                    expressions: [expr],
                 });
                 const result = await view.to_columns();
                 expect(result).toEqual({
                     a: [1, 2, 3, 4],
                     b: ["a", "b", "c", "d"],
-                    "vlookup('b', 0)": ["a", "a", "a", "a"],
+                    [expr]: ["a", "a", "a", "a"],
                 });
                 view.delete();
                 table.delete();

--- a/packages/perspective/test/js/expressions/functionality.spec.js
+++ b/packages/perspective/test/js/expressions/functionality.spec.js
@@ -3180,6 +3180,77 @@ const perspective = require("@finos/perspective");
                 view.delete();
                 table.delete();
             });
+
+            test("Vlookup should access the correct row", async function () {
+                const table = await perspective.table({
+                    a: [1, 2, 3, 4],
+                    b: ["a", "b", "c", "d"],
+                });
+                const view = await table.view({
+                    expressions: ["vlookup('b', 0)"],
+                });
+                const result = await view.to_columns();
+                expect(result).toEqual({
+                    a: [1, 2, 3, 4],
+                    b: ["a", "b", "c", "d"],
+                    "vlookup('b', 0)": ["a", "a", "a", "a"],
+                });
+                view.delete();
+                table.delete();
+            });
+
+            test("Col should behave the same as direct column access", async function () {
+                const table = await perspective.table({
+                    a: [1, 2, 3, 4],
+                    b: ["a", "b", "c", "d"],
+                });
+                const view = await table.view({
+                    expressions: ["col('b')"],
+                });
+                const result = await view.to_columns();
+                expect(result).toEqual({
+                    a: [1, 2, 3, 4],
+                    b: ["a", "b", "c", "d"],
+                    "col('b')": ["a", "b", "c", "d"],
+                });
+                view.delete();
+                table.delete();
+            });
+
+            test("index() should return the correct row number", async function () {
+                const table = await perspective.table({
+                    a: [1, 2, 3, 4],
+                });
+                const view = await table.view({
+                    expressions: ["index()"],
+                });
+                const result = await view.to_columns();
+                expect(result).toEqual({
+                    a: [1, 2, 3, 4],
+                    "index()": [0, 1, 2, 3],
+                });
+                view.delete();
+                table.delete();
+            });
+
+            test("index() should work with custom a index", async function () {
+                const table = await perspective.table(
+                    {
+                        a: [1, 2, 3, 4],
+                    },
+                    { index: "a" }
+                );
+                const view = await table.view({
+                    expressions: ["index()"],
+                });
+                const result = await view.to_columns();
+                expect(result).toEqual({
+                    a: [1, 2, 3, 4],
+                    "index()": [1, 2, 3, 4],
+                });
+                view.delete();
+                table.delete();
+            });
         });
     });
 })(perspective);

--- a/python/perspective/perspective/src/view.cpp
+++ b/python/perspective/perspective/src/view.cpp
@@ -211,7 +211,8 @@ namespace binding {
             std::shared_ptr<t_computed_expression> expression
                 = t_computed_expression_parser::precompute(expression_alias,
                     expression_string, parsed_expression_string, column_ids,
-                    schema, expression_vocab, regex_mapping);
+                    gnode.get_table_sptr(), gnode.get_pkey_map(), schema,
+                    expression_vocab, regex_mapping);
 
             expressions.push_back(expression);
             schema->add_column(expression_alias, expression->get_dtype());

--- a/python/perspective/perspective/table/_utils.py
+++ b/python/perspective/perspective/table/_utils.py
@@ -19,6 +19,8 @@ ALIAS_REGEX = re.compile(r"//(.+)\n")
 EXPRESSION_COLUMN_NAME_REGEX = re.compile(r"\"(.*?[^\\])\"")
 STRING_LITERAL_REGEX = re.compile(r"'(.*?[^\\])'")
 FUNCTION_LITERAL_REGEX = re.compile(r"(bucket|match|match_all|search|indexof)\(.*?,\s*(intern\(\'(.+)\'\)).*\)")
+MATCH_INTERNED_ARGS_REGEX = re.compile(r"intern\('([^']*)'\)")
+UNINTERNED_FNS_REGEX = re.compile(r"(col|vlookup)\((.*)\)")
 REPLACE_FN_REGEX = re.compile(r"(replace_all|replace)\(.*?,\s*(intern\(\'(.*)\'\)),.*\)")
 BOOLEAN_LITERAL_REGEX = re.compile(r"([a-zA-Z_]+[a-zA-Z0-9_]*)")
 
@@ -196,6 +198,9 @@ def _parse_expression_strings(expressions):
             lambda match: "intern({0})".format(match.group(0)),
             parsed,
         )
+
+        # remove _all_ `intern()` calls in these functions.
+        parsed = re.sub(UNINTERNED_FNS_REGEX, lambda match: re.sub(MATCH_INTERNED_ARGS_REGEX, r"'\1'", match.group(0)), parsed)
 
         # remove the `intern()` in bucket and regex functions that take
         # string literal parameters. TODO this logic should be centralized

--- a/python/perspective/perspective/table/_utils.py
+++ b/python/perspective/perspective/table/_utils.py
@@ -20,7 +20,6 @@ EXPRESSION_COLUMN_NAME_REGEX = re.compile(r"\"(.*?[^\\])\"")
 STRING_LITERAL_REGEX = re.compile(r"'(.*?[^\\])'")
 FUNCTION_LITERAL_REGEX = re.compile(r"(bucket|match|match_all|search|indexof)\(.*?,\s*(intern\(\'(.+)\'\)).*\)")
 MATCH_INTERNED_ARGS_REGEX = re.compile(r"intern\('([^']*)'\)")
-UNINTERNED_FNS_REGEX = re.compile(r"(col|vlookup)\((.*)\)")
 REPLACE_FN_REGEX = re.compile(r"(replace_all|replace)\(.*?,\s*(intern\(\'(.*)\'\)),.*\)")
 BOOLEAN_LITERAL_REGEX = re.compile(r"([a-zA-Z_]+[a-zA-Z0-9_]*)")
 
@@ -198,9 +197,6 @@ def _parse_expression_strings(expressions):
             lambda match: "intern({0})".format(match.group(0)),
             parsed,
         )
-
-        # remove _all_ `intern()` calls in these functions.
-        parsed = re.sub(UNINTERNED_FNS_REGEX, lambda match: re.sub(MATCH_INTERNED_ARGS_REGEX, r"'\1'", match.group(0)), parsed)
 
         # remove the `intern()` in bucket and regex functions that take
         # string literal parameters. TODO this logic should be centralized

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -395,6 +395,26 @@ thread_local! {
                 insert_text: "replace(${1:string}, ${2:pattern}, ${3:replacer})",
                 documentation: "Replaces all non-overlapping matches of pattern in string with replacer, or return the original string if no replaces were made.",
             },
+            CompletionItemSuggestion {
+                label: "add_one",
+                insert_text: "add_one(${1:uint64})",
+                documentation: "Adds one to a number",
+            },
+            CompletionItemSuggestion {
+                label: "index",
+                insert_text: "index()",
+                documentation: "Looks up the index value of the current row",
+            },
+            CompletionItemSuggestion {
+                label: "col",
+                insert_text: "col(${1:string})",
+                documentation: "Looks up a column value by name",
+            },
+            CompletionItemSuggestion {
+                label: "vlookup",
+                insert_text: "vlookup(${1:string}, ${2:uint64})",
+                documentation: "Looks up a value in another column by index",
+            },
         ]
     ;
 }

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -396,11 +396,6 @@ thread_local! {
                 documentation: "Replaces all non-overlapping matches of pattern in string with replacer, or return the original string if no replaces were made.",
             },
             CompletionItemSuggestion {
-                label: "add_one",
-                insert_text: "add_one(${1:uint64})",
-                documentation: "Adds one to a number",
-            },
-            CompletionItemSuggestion {
                 label: "index",
                 insert_text: "index()",
                 documentation: "Looks up the index value of the current row",


### PR DESCRIPTION
This adds `index()` which returns the primary key of the current row, `col('column_name')` which is essentially the same as `"column_name"` except that it takes a string literal, and `vlookup('column_name', index)` which will lookup a value in a column by primary key such that `col('a') == vlookup('a', index())`.