### PR TITLE
Fix color legend click hides series

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/legend/filter.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/filter.js
@@ -14,30 +14,36 @@ import { groupFromKey } from "../series/seriesKey";
 
 export function filterData(settings, data) {
     const useData = data || settings.data;
-    if (settings.hideKeys && settings.hideKeys.length > 0) {
-        return useData.map((col) => {
-            const clone = { ...col };
-            settings.hideKeys.forEach((k) => {
-                delete clone[k];
-            });
-            return clone;
-        });
-    }
-    return useData;
+    const len = settings.hideKeys?.length ?? 0;
+    return len > 0
+        ? useData.map((col) => {
+              const clone = { ...col };
+              settings.hideKeys.forEach((k) => {
+                  delete clone[k];
+              });
+              return clone;
+          })
+        : useData;
 }
 
 export function filterDataByGroup(settings, data) {
-    const useData = data || settings.data;
-    if (settings.hideKeys && settings.hideKeys.length > 0) {
-        return useData.map((col) => {
-            const clone = {};
-            Object.keys(col).map((key) => {
-                if (!settings.hideKeys.includes(groupFromKey(key))) {
-                    clone[key] = col[key];
-                }
-            });
-            return clone;
-        });
-    }
-    return useData;
+    const newData = data || settings.data;
+    const hideKeysLen = settings.hideKeys?.length ?? 0;
+    const splitValsLen = settings.splitValues.length;
+    return hideKeysLen > 0
+        ? splitValsLen === 0
+            ? newData.filter((row) => {
+                  return Object.values(row).reduce(
+                      (res, val) => res && !settings.hideKeys.includes(val),
+                      true
+                  );
+              })
+            : newData.map((row) => {
+                  const entries = Object.entries(row).filter(
+                      ([key, _val]) =>
+                          !settings.hideKeys.includes(groupFromKey(key))
+                  );
+                  return Object.fromEntries(entries);
+              })
+        : newData;
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -41,8 +41,7 @@ export function pointSeriesCanvas(
 
     series.decorate((context, d) => {
         const colorValue = color(d.colorValue);
-
-        const opacity = settings.colorStyles && settings.colorStyles.opacity;
+        const opacity = settings.colorStyles?.opacity;
         if (label) {
             const { type } = settings.mainValues.find((x) => x.name === label);
             const value = toValue(type, d.row[label]);

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
@@ -20,38 +20,23 @@ export function seriesColors(settings) {
     return colorScale().settings(settings).domain(domain)();
 }
 
-// TODO: We're iterating over all the data here to get the unique values for each colorBy field.
-// This is the only way to do it since we don't know the range of these values ahead of time.
-// This should be WASM-side code.
-export function seriesColorsFromField(settings, field) {
-    const data = settings.data;
-    const key = settings.realValues[field];
-    // alt:
-    // const domain = [...new Set(data.map((obj) => obj[key]))].sort();
-    const domain = data
-        .reduce((accum, obj) => {
-            const val = obj[key];
-            return accum.includes(val) ? accum : [...accum, val];
-        }, [])
-        .sort();
+export function seriesColorsFromColumn(settings, column) {
+    const data = settings.data.map((row) => row[column]);
+    const domain = [...new Set(data)].sort();
     return colorScale().settings(settings).domain(domain)();
 }
 
 export function seriesColorsFromDistinct(settings, data) {
-    let domain = Array.from(new Set(data));
+    let domain = [...new Set(data)];
     return colorScale().settings(settings).domain(domain)();
 }
 
 export function seriesColorsFromGroups(settings) {
     const col = settings.data[0] ?? {};
-    // alt:
-    // const domain = [...new Set(Object.keys(col).filter(k => k !== "__ROW_PATH__").map(k => groupFromKey(k)))];
-    const domain = Object.keys(col).reduce((accum, key) => {
-        if (key === "__ROW_PATH__") return accum;
-        const group = groupFromKey(key);
-        return accum.includes(group) ? accum : [...accum, group];
-    }, []);
-
+    const inner = Object.keys(col)
+        .filter((k) => k !== "__ROW_PATH__")
+        .map((k) => groupFromKey(k));
+    const domain = [...new Set(inner)];
     return colorScale().settings(settings).domain(domain)();
 }
 


### PR DESCRIPTION
# Bugfix

<!--- Describe your changes in detail. How does it fix the issue? Do you
have any questions about your approach/places for future improvement? -->

This PR updates the legend's filterDataByGroup to account for the case where `settings.hideKeys` has values but `settings.splitValues` is empty. X/Y Scatter plots always use split-by values, so when we color by a string without a split-by we need to account for difference in the column names. If a split-by is set, columns have names of the following form: `splitval1|splitval2|columnName`. Previously, the filterDataByGroup function was relying on `groupFromKey`, which gets the column name's split-by values. This was returning an empty string, causing the legend's click handler to effectively do nothing. The changes in this PR cause the filter to actually filter the data, i.e. remove values. I'm not sure why this isn't being done already, but changing it to a filter seems to break things.

## Testing

<!--- Describe in detail how your changes have been tested - were tests added
or changed? -->

No tests were added or changed.

## Screenshots (if appropriate)

<!--- If the bug report had a screenshot/could be reproduced visually,
please include a screenshot showing the fix. -->

https://github.com/finos/perspective/assets/41482263/94145a86-cffe-4e24-b93f-092b3e45ef29

## Checklist

<!--- If you have any questions, please reach out! We are here to help. -->

- [x] I have read the [`CONTRIBUTING.md`](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md) and followed its [Guidelines](https://github.com/finos/perspective/blob/master/CONTRIBUTING.md#guidelines)
- [x] I have linted my code locally, following the project's code style
- [x] I have tested my changes locally
