### PR TITLE
Handle all exceptions in the Python Perspective manager __process method

### DIFF
--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -163,7 +163,7 @@ class _PerspectiveManagerInternal(object):
                 self._process_method_call(msg, post_callback, client_id)
             else:
                 logging.error("Unknown client message " + str(msg))
-        except (PerspectiveError, PerspectiveCppError) as error:
+        except Exception as error:
             # Log errors and return them to the client
             error_string = str(error)
             error_message = self._make_error_message(msg["id"], error_string)


### PR DESCRIPTION
I noticed an issue when using the `in` filter with a Perspective UI backed by Python: when the dropdown list of choices appears, clicking on one item or pressing ENTER was killing the perspective connection:
on the Python backend a RuntimeError was popping in the __process method of the manager_internal
```
Exception in perspective.__process: Unable to cast Python instance to C++ type (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)
```
the `post_callback` wasn't called on the backend - and the client was frozen waiting.

Handling the exception - broadening the handled exceptions so to call `post_callback` in this and other cases, fixed the issue and the `in` filter is now usable.