### PR TITLE
Add `setAutoPause()` method

### DIFF
--- a/rust/perspective-viewer/src/rust/js/intersection_observer.rs
+++ b/rust/perspective-viewer/src/rust/js/intersection_observer.rs
@@ -1,0 +1,32 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(inline_js = "export const IntersectionObserver = window.IntersectionObserver")]
+extern "C" {
+    pub type IntersectionObserver;
+
+    #[wasm_bindgen(constructor, js_class = "IntersectionObserver")]
+    pub fn new(callback: &js_sys::Function) -> IntersectionObserver;
+
+    #[wasm_bindgen(method)]
+    pub fn observe(this: &IntersectionObserver, elem: &web_sys::HtmlElement);
+
+    #[wasm_bindgen(method)]
+    pub fn unobserve(this: &IntersectionObserver, elem: &web_sys::HtmlElement);
+
+    pub type IntersectionObserverEntry;
+
+    #[wasm_bindgen(method, getter, js_name = "isIntersecting")]
+    pub fn is_intersecting(this: &IntersectionObserverEntry) -> bool;
+}

--- a/rust/perspective-viewer/src/rust/js/mod.rs
+++ b/rust/perspective-viewer/src/rust/js/mod.rs
@@ -16,6 +16,7 @@
 
 mod clipboard;
 pub mod clipboard_item;
+mod intersection_observer;
 mod mimetype;
 pub mod perspective;
 pub mod plugin;
@@ -26,6 +27,7 @@ mod testing;
 mod tests;
 
 pub use self::clipboard::*;
+pub use self::intersection_observer::*;
 pub use self::mimetype::*;
 pub use self::perspective::*;
 pub use self::plugin::*;

--- a/rust/perspective-viewer/src/rust/model/intersection_observer.rs
+++ b/rust/perspective-viewer/src/rust/model/intersection_observer.rs
@@ -1,0 +1,83 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::*;
+
+use crate::config::*;
+use crate::js::*;
+use crate::model::*;
+use crate::renderer::*;
+use crate::session::Session;
+use crate::utils::*;
+use crate::*;
+
+pub struct IntersectionObserverHandle {
+    elem: HtmlElement,
+    observer: IntersectionObserver,
+    _callback: Closure<dyn FnMut(js_sys::Array)>,
+}
+
+impl IntersectionObserverHandle {
+    pub fn new(elem: &HtmlElement, session: &Session, renderer: &Renderer) -> Self {
+        clone!(session, renderer);
+        let _callback = (move |xs: js_sys::Array| {
+            let intersect = xs
+                .get(0)
+                .unchecked_into::<IntersectionObserverEntry>()
+                .is_intersecting();
+
+            clone!(session, renderer);
+            let state = IntersectionObserverState { session, renderer };
+            ApiFuture::spawn(state.set_pause(intersect));
+        })
+        .into_closure_mut();
+
+        let func = _callback.as_ref().unchecked_ref::<js_sys::Function>();
+        let observer = IntersectionObserver::new(func);
+        observer.observe(elem);
+        Self {
+            elem: elem.clone(),
+            _callback,
+            observer,
+        }
+    }
+}
+
+impl Drop for IntersectionObserverHandle {
+    fn drop(&mut self) {
+        self.observer.unobserve(&self.elem);
+    }
+}
+
+struct IntersectionObserverState {
+    session: Session,
+    renderer: Renderer,
+}
+
+impl IntersectionObserverState {
+    async fn set_pause(self, intersect: bool) -> ApiResult<()> {
+        if intersect {
+            if self.session.set_pause(false) {
+                tracing::error!("Shellac-ed");
+                self.update_and_render(ViewConfigUpdate::default()).await?;
+            }
+        } else {
+            self.session.set_pause(true);
+        };
+
+        Ok(())
+    }
+}
+
+derive_model!(Renderer, Session for IntersectionObserverState);

--- a/rust/perspective-viewer/src/rust/model/mod.rs
+++ b/rust/perspective-viewer/src/rust/model/mod.rs
@@ -70,7 +70,9 @@ mod copy_export;
 mod export_app;
 mod export_method;
 mod get_viewer_config;
+mod intersection_observer;
 mod plugin_config;
+mod resize_observer;
 mod structural;
 mod update_and_render;
 
@@ -78,6 +80,8 @@ pub use self::columns_iter_set::*;
 pub use self::copy_export::*;
 pub use self::export_method::*;
 pub use self::get_viewer_config::*;
+pub use self::intersection_observer::*;
 pub use self::plugin_config::*;
+pub use self::resize_observer::*;
 pub use self::structural::*;
 pub use self::update_and_render::*;

--- a/rust/perspective-viewer/src/rust/model/resize_observer.rs
+++ b/rust/perspective-viewer/src/rust/model/resize_observer.rs
@@ -1,0 +1,98 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::*;
+use yew::prelude::*;
+
+use crate::components::viewer::{PerspectiveViewer, PerspectiveViewerMsg};
+use crate::js::*;
+use crate::renderer::*;
+use crate::utils::*;
+use crate::*;
+
+pub struct ResizeObserverHandle {
+    elem: HtmlElement,
+    observer: ResizeObserver,
+    _callback: Closure<dyn FnMut(js_sys::Array)>,
+}
+
+impl ResizeObserverHandle {
+    pub fn new(
+        elem: &HtmlElement,
+        renderer: &Renderer,
+        root: &AppHandle<PerspectiveViewer>,
+    ) -> Self {
+        let on_resize = root.callback(|()| PerspectiveViewerMsg::Resize);
+        let mut state = ResizeObserverState {
+            elem: elem.clone(),
+            renderer: renderer.clone(),
+            width: elem.offset_width(),
+            height: elem.offset_height(),
+            on_resize,
+        };
+
+        let _callback = (move |xs| state.on_resize(&xs)).into_closure_mut();
+        let func = _callback.as_ref().unchecked_ref::<js_sys::Function>();
+        let observer = ResizeObserver::new(func);
+        observer.observe(elem);
+        Self {
+            elem: elem.clone(),
+            _callback,
+            observer,
+        }
+    }
+}
+
+impl Drop for ResizeObserverHandle {
+    fn drop(&mut self) {
+        self.observer.unobserve(&self.elem);
+    }
+}
+
+struct ResizeObserverState {
+    elem: HtmlElement,
+    renderer: Renderer,
+    width: i32,
+    height: i32,
+    on_resize: Callback<()>,
+}
+
+impl ResizeObserverState {
+    fn on_resize(&mut self, entries: &js_sys::Array) {
+        let is_visible = self
+            .elem
+            .offset_parent()
+            .map(|x| !x.is_null())
+            .unwrap_or(false);
+
+        for y in entries.iter() {
+            let entry: ResizeObserverEntry = y.unchecked_into();
+            let content = entry.content_rect();
+            let content_width = content.width().floor() as i32;
+            let content_height = content.height().floor() as i32;
+            let resized = self.width != content_width || self.height != content_height;
+            if resized && is_visible {
+                clone!(self.on_resize, self.renderer);
+                ApiFuture::spawn(async move {
+                    renderer.resize().await?;
+                    on_resize.emit(());
+                    Ok(())
+                });
+            }
+
+            self.width = content_width;
+            self.height = content_height;
+        }
+    }
+}

--- a/rust/perspective-viewer/src/ts/viewer.ts
+++ b/rust/perspective-viewer/src/ts/viewer.ts
@@ -110,6 +110,23 @@ export interface IPerspectiveViewerElement {
     setAutoSize(autosize): void;
 
     /**
+     * Determines the auto-pause behavior.  When `true` (default `false`), this
+     * element will enter paused state (deleting it's `View` and ignoring
+     * render calls) whenever it is not visible in the browser's viewport,
+     * utilizing an `IntersectionObserver`.
+     *
+     * @category Util
+     * @param autopause Whether to re-render when this element's dimensions
+     * change.
+     * @example <caption>Disable auto-size</caption>
+     *
+     * ```javascript
+     * await viewer.setAutoPause(true);
+     * ```
+     */
+    setAutoPause(autopause): void;
+
+    /**
      * Returns the `perspective.Table()` which was supplied to `load()`
      *
      * @category Data


### PR DESCRIPTION
This PR adds a new API method to the `<perspective-viewer>` custom element, `setAutoPause()`. When enabled with `viewer.setAutoPause(true)`, the `<perspective-viewer>` will register an `IntersectionObserver` to test its own visibility, enabling a new internal "pause" state when offscreen. The new "pause" state deletes its internal `View`, freeing any resources associated with it, and doesn't recreate it until the `IntersectionObserver` changes state, so while efficient for many small-data viewers, this may not yet be the right feature for a handful of large-data viewers. A future iteration which does _not_ delete the `View` (but just supresses rendering) may be a future iteration of this feature.