### PR TITLE
X/Y Scatter Symbol Serialization as Dictionary

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
@@ -10,28 +10,18 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
 import { select } from "d3";
-import { axisFactory } from "../axis/axisFactory";
-import { chartCanvasFactory } from "../axis/chartFactory";
-import {
-    pointSeriesCanvas,
-    symbolTypeFromColumn,
-} from "../series/pointSeriesCanvas";
+import { symbolTypeFromColumn } from "../series/pointSeriesCanvas";
 import { pointData } from "../data/pointData";
 import {
     seriesColorsFromColumn,
     seriesColorsFromDistinct,
     colorScale,
 } from "../series/seriesColors";
-import { seriesLinearRange, seriesColorRange } from "../series/seriesRange";
-import { symbolLegend, colorLegend, colorGroupLegend } from "../legend/legend";
+import { seriesColorRange } from "../series/seriesRange";
+import { symbolLegend, colorLegend } from "../legend/legend";
 import { colorRangeLegend } from "../legend/colorRangeLegend";
 import { filterDataByGroup } from "../legend/filter";
-import withGridLines from "../gridlines/gridlines";
-import { hardLimitZeroPadding } from "../d3fc/padding/hardLimitZero";
-import zoomableChart from "../zoom/zoomableChart";
-import nearbyTip from "../tooltip/nearbyTip";
 import { symbolsObj } from "../series/seriesSymbols";
 import { gridLayoutMultiChart } from "../layout/gridLayoutMultiChart";
 import xyScatterSeries from "../series/xy-scatter/xyScatterSeries";
@@ -55,7 +45,8 @@ function overrideSymbols(settings, symbols) {
     for (let i in domain) {
         range[i] = range[i % len];
     }
-    settings.columns?.[symbolCol]?.symbols?.forEach(({ key, value }) => {
+    let maybeSymbols = settings.columns?.[symbolCol]?.symbols;
+    Object.entries(maybeSymbols ?? {}).forEach(([key, value]) => {
         // TODO: Define custom symbol types based on the values passed in here.
         // https://d3js.org/d3-shape/symbol#custom-symbols
         let symbolType = symbolsObj[value] ?? d3.symbolCircle;

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -59,6 +59,13 @@
             padding: 0;
             font-size: 14px;
 
+            d3fc-group:first-child {
+                padding: 16px;
+                padding-top: 0px;
+                width: calc(100% - 32px);
+                height: calc(100% - 16px);
+            }
+
             & .multi-xlabel {
                 position: absolute;
                 bottom: 0;
@@ -87,7 +94,7 @@
             & .inner-container {
                 display: inline-grid;
                 overflow-y: auto;
-                width: 100%;
+                width: calc(100% - 16px);
                 height: 100%;
                 padding: 0;
                 margin: 0;

--- a/packages/perspective-viewer-datagrid/src/js/event_handlers/edit_click.js
+++ b/packages/perspective-viewer-datagrid/src/js/event_handlers/edit_click.js
@@ -56,7 +56,7 @@ export function write_cell(table, model, active_cell) {
                 return false;
             }
         } else if (type === "boolean") {
-            text = text === "check" ? false : text === "close" ? true : null;
+            text = text === "true" ? false : text === "false" ? true : null;
         }
 
         const msg = {

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/symbol.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/symbol.rs
@@ -79,7 +79,12 @@ impl yew::Component for SymbolAttr {
             .and_then(|json_val| {
                 serde_json::from_value::<SymbolConfig>(json_val.clone())
                     .ok()
-                    .map(|s| s.symbols.into_iter().map(|s| s.into()).collect_vec())
+                    .map(|s| {
+                        s.symbols
+                            .into_iter()
+                            .map(|s| SymbolKVPair::new(Some(s.0), s.1))
+                            .collect_vec()
+                    })
             })
             .unwrap_or_default();
 
@@ -101,7 +106,7 @@ impl yew::Component for SymbolAttr {
                 let serialized = new_pairs
                     .clone()
                     .into_iter()
-                    .filter_map(|pair| pair.try_into().ok())
+                    .filter_map(|pair| Some((pair.key?, pair.value)))
                     .collect();
 
                 p.send_plugin_config(

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/symbol/types.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/symbol/types.rs
@@ -10,36 +10,15 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::components::containers::kvpair::KVPair;
-use crate::utils::ApiError;
 
 #[derive(Serialize, Deserialize)]
 pub struct SymbolConfig {
-    pub symbols: Vec<SymbolSerde>,
+    pub symbols: HashMap<String, String>,
 }
-#[derive(Serialize, Deserialize)]
-pub struct SymbolSerde(pub KVPair<String, String>);
 
 pub type SymbolKVPair = KVPair<Option<String>, String>;
-impl TryFrom<SymbolKVPair> for SymbolSerde {
-    type Error = ApiError;
-
-    fn try_from(pair: SymbolKVPair) -> Result<Self, Self::Error> {
-        Ok(SymbolSerde(KVPair {
-            key: pair
-                .key
-                .ok_or::<Self::Error>("Could not unwrap {pair:?}".into())?,
-            value: pair.value,
-        }))
-    }
-}
-impl From<SymbolSerde> for SymbolKVPair {
-    fn from(pair: SymbolSerde) -> Self {
-        Self {
-            key: Some(pair.0.key),
-            value: pair.0.value,
-        }
-    }
-}

--- a/rust/perspective-viewer/src/rust/components/containers/kvpair.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/kvpair.rs
@@ -44,4 +44,8 @@ where
             value,
         }
     }
+
+    pub fn tuple(&self) -> (&K, &V) {
+        (&self.key, &self.value)
+    }
 }


### PR DESCRIPTION
This PR changes the X/Y Scatter plot's symbol serialization format to a dictionary. It also fixes a bug in the datagrid. (Editable bools were not toggling correctly.)