### PR TITLE
Refactor How Column Style Components Are Selected

### DIFF
--- a/packages/perspective-cli/test/js/superstore.spec.js
+++ b/packages/perspective-cli/test/js/superstore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const path = require("path");
 const { host } = require("../../src/js/index.js");
 

--- a/packages/perspective-jupyterlab/test/js/resize.spec.js
+++ b/packages/perspective-jupyterlab/test/js/resize.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test } = require("@playwright/test");
+const { test } = require("@finos/perspective-test");
 import { compareContentsToSnapshot } from "@finos/perspective-test";
 
 test.beforeEach(async ({ page }) => {

--- a/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
+++ b/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { expect } = require("@playwright/test");
+const { expect } = require("@finos/perspective-test");
 const path = require("path");
 const utils = require("@finos/perspective-test");
 const {

--- a/packages/perspective-viewer-d3fc/test/js/area.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/area.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/bar.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/bar.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     run_standard_tests,
     getSvgContentString,

--- a/packages/perspective-viewer-d3fc/test/js/barWidth.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/barWidth.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     API_VERSION,
     compareSVGContentsToSnapshot,

--- a/packages/perspective-viewer-d3fc/test/js/events.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/events.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { compareSVGContentsToSnapshot } from "@finos/perspective-test";
 
 test.describe("Events test", () => {

--- a/packages/perspective-viewer-d3fc/test/js/heatmap.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/heatmap.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/line.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/line.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/scatter.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/scatter.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareSVGContentsToSnapshot,
     getSvgContentString,

--- a/packages/perspective-viewer-d3fc/test/js/sunburst.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/sunburst.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/treemap.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/treemap.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/xy-line.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/xy-line.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/yscatter.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/yscatter.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-datagrid/src/js/model/create.js
+++ b/packages/perspective-viewer-datagrid/src/js/model/create.js
@@ -58,7 +58,9 @@ export async function createModel(regular, table, view, extend = {}) {
     // Extract the entire expression string as typed by the user, so we can
     // feed it into `validate_expressions` and get back the data types for
     // each column without it being affected by a pivot.
-    const expressions = config.expressions.map((expr) => expr[1]);
+    const expressions = Object.fromEntries(
+        config.expressions.map((expr) => [expr[0], expr[1]])
+    );
     const [
         table_schema,
         validated_expressions,

--- a/packages/perspective-viewer-datagrid/test/js/column_style.spec.js
+++ b/packages/perspective-viewer-datagrid/test/js/column_style.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { compareContentsToSnapshot } from "@finos/perspective-test";
 
 async function test_column(page, selector, selector2) {

--- a/packages/perspective-viewer-datagrid/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-datagrid/test/js/superstore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     run_standard_tests,

--- a/packages/perspective-viewer-openlayers/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-openlayers/test/js/superstore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import { run_standard_tests } from "@finos/perspective-test";
 
 async function get_contents(page) {

--- a/packages/perspective-workspace/test/js/dom.spec.js
+++ b/packages/perspective-workspace/test/js/dom.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareLightDOMContents,
     compareShadowDOMContents,

--- a/packages/perspective-workspace/test/js/html.spec.js
+++ b/packages/perspective-workspace/test/js/html.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareLightDOMContents,
     compareShadowDOMContents,

--- a/packages/perspective-workspace/test/js/migrate_workspace.spec.js
+++ b/packages/perspective-workspace/test/js/migrate_workspace.spec.js
@@ -11,7 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 const { convert } = require("@finos/perspective-viewer/dist/cjs/migrate.js");
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     API_VERSION,
     compareLightDOMContents,

--- a/packages/perspective-workspace/test/js/restore.spec.js
+++ b/packages/perspective-workspace/test/js/restore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareLightDOMContents,
     compareShadowDOMContents,

--- a/packages/perspective-workspace/test/js/visibility.spec.js
+++ b/packages/perspective-workspace/test/js/visibility.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareLightDOMContents,
     compareShadowDOMContents,

--- a/packages/perspective/test/js/clear.spec.js
+++ b/packages/perspective/test/js/clear.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 ((perspective) => {

--- a/packages/perspective/test/js/constructors.spec.js
+++ b/packages/perspective/test/js/constructors.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const moment = require("moment");

--- a/packages/perspective/test/js/delete.spec.js
+++ b/packages/perspective/test/js/delete.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 function it_old_behavior(name, capture) {

--- a/packages/perspective/test/js/delta.spec.js
+++ b/packages/perspective/test/js/delta.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const _ = require("underscore");

--- a/packages/perspective/test/js/expressions/conversions.spec.js
+++ b/packages/perspective/test/js/expressions/conversions.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 /**

--- a/packages/perspective/test/js/expressions/datetime.spec.js
+++ b/packages/perspective/test/js/expressions/datetime.spec.js
@@ -12,7 +12,7 @@
 
 const common = require("./common.js");
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 /**

--- a/packages/perspective/test/js/expressions/deltas.spec.js
+++ b/packages/perspective/test/js/expressions/deltas.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const match_delta = async function (perspective, delta, expected) {

--- a/packages/perspective/test/js/expressions/functionality.spec.js
+++ b/packages/perspective/test/js/expressions/functionality.spec.js
@@ -12,7 +12,7 @@
 
 const expressions_common = require("./common.js");
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 /**

--- a/packages/perspective/test/js/expressions/multiple_views.spec.js
+++ b/packages/perspective/test/js/expressions/multiple_views.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const expressions_common = require("./common.js");

--- a/packages/perspective/test/js/expressions/numeric.spec.js
+++ b/packages/perspective/test/js/expressions/numeric.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const common = require("./common.js");

--- a/packages/perspective/test/js/expressions/parsing.spec.js
+++ b/packages/perspective/test/js/expressions/parsing.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const common = require("./common.js");

--- a/packages/perspective/test/js/expressions/string.spec.js
+++ b/packages/perspective/test/js/expressions/string.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const CHARS = ` !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_\`abcdefghijklmnopqrstuvwxyz{|}~`;

--- a/packages/perspective/test/js/expressions/updates.spec.js
+++ b/packages/perspective/test/js/expressions/updates.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const common = require("./common.js");

--- a/packages/perspective/test/js/expressions/vectors.spec.js
+++ b/packages/perspective/test/js/expressions/vectors.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const common = require("./common.js");

--- a/packages/perspective/test/js/filters.spec.js
+++ b/packages/perspective/test/js/filters.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 var yesterday = new Date();

--- a/packages/perspective/test/js/get_min_max.spec.js
+++ b/packages/perspective/test/js/get_min_max.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const data = {

--- a/packages/perspective/test/js/hosted_tables.spec.js
+++ b/packages/perspective/test/js/hosted_tables.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 const { test_arrow } = require("./test_arrows");
 

--- a/packages/perspective/test/js/internal.spec.js
+++ b/packages/perspective/test/js/internal.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const test_null_arrow = require("./test_arrows.js").test_null_arrow;

--- a/packages/perspective/test/js/leaks.spec.js
+++ b/packages/perspective/test/js/leaks.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const fs = require("fs");

--- a/packages/perspective/test/js/lz4.spec.js
+++ b/packages/perspective/test/js/lz4.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const fs = require("fs");

--- a/packages/perspective/test/js/multiple.spec.js
+++ b/packages/perspective/test/js/multiple.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 var arrow_result = [

--- a/packages/perspective/test/js/pivot_nulls.spec.js
+++ b/packages/perspective/test/js/pivot_nulls.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 ((perspective) => {

--- a/packages/perspective/test/js/pivots.spec.js
+++ b/packages/perspective/test/js/pivots.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 var data = [

--- a/packages/perspective/test/js/ports.spec.js
+++ b/packages/perspective/test/js/ports.spec.js
@@ -12,7 +12,7 @@
 
 const _ = require("underscore");
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const data = {

--- a/packages/perspective/test/js/remote.spec.js
+++ b/packages/perspective/test/js/remote.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 let server;

--- a/packages/perspective/test/js/removes.spec.js
+++ b/packages/perspective/test/js/removes.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const _query = async (should_cache, table, config = {}, callback) => {

--- a/packages/perspective/test/js/sort.spec.js
+++ b/packages/perspective/test/js/sort.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const data = {

--- a/packages/perspective/test/js/sync_load.spec.js
+++ b/packages/perspective/test/js/sync_load.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 
 test.describe("perspective.js module", function () {
     test("does not access the WASM module until it is ready", async () => {

--- a/packages/perspective/test/js/to_column_string.spec.js
+++ b/packages/perspective/test/js/to_column_string.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 test.describe("to_columns_string", () => {

--- a/packages/perspective/test/js/to_format.spec.js
+++ b/packages/perspective/test/js/to_format.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const int_float_string_data = [

--- a/packages/perspective/test/js/to_format_viewport.spec.js
+++ b/packages/perspective/test/js/to_format_viewport.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const data = {

--- a/packages/perspective/test/js/updates.spec.js
+++ b/packages/perspective/test/js/updates.spec.js
@@ -13,7 +13,7 @@
 const _ = require("lodash");
 const arrows = require("./test_arrows.js");
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 function it_old_behavior(name, capture) {

--- a/packages/perspective/test/tz/timezone.spec.js
+++ b/packages/perspective/test/tz/timezone.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const date_data = [

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/sidebar.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/sidebar.rs
@@ -12,7 +12,6 @@
 
 use std::fmt::Display;
 
-use wasm_bindgen::UnwrapThrowExt;
 use yew::{function_component, html, use_callback, use_state, Callback, Html, Properties};
 
 use crate::components::column_settings_sidebar::attributes_tab::AttributesTab;
@@ -83,9 +82,6 @@ pub fn ColumnSettingsSidebar(p: &ColumnSettingsProps) -> Html {
     // view_ty != table_ty when aggregate is applied, i.e. on group-by
     let maybe_view_ty = p.session.metadata().get_column_view_type(&column_name);
     let maybe_table_ty = p.session.metadata().get_column_table_type(&column_name);
-    let (view_ty, table_ty) = maybe_view_ty
-        .zip(maybe_table_ty)
-        .expect_throw("Unable to get view and table types!");
 
     let mut tabs = vec![];
 
@@ -94,8 +90,10 @@ pub fn ColumnSettingsSidebar(p: &ColumnSettingsProps) -> Html {
     // plugin API. Leaving it for now.
     let plugin = p.renderer.get_active_plugin().unwrap();
     let show_styles = match &*plugin.name() {
-        "Datagrid" => view_ty != Type::Bool,
-        "X/Y Scatter" => table_ty == Type::String,
+        "Datagrid" => maybe_view_ty.map(|ty| ty != Type::Bool).unwrap_or_default(),
+        "X/Y Scatter" => maybe_table_ty
+            .map(|ty| ty == Type::String)
+            .unwrap_or_default(),
         _ => false,
     };
 
@@ -148,8 +146,8 @@ pub fn ColumnSettingsSidebar(p: &ColumnSettingsProps) -> Html {
                         { renderer }
                         { custom_events }
                         { column_name }
-                        { view_ty }
-                        { table_ty }
+                        { maybe_view_ty }
+                        { maybe_table_ty }
                         />
                 },
             }

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
@@ -30,8 +30,8 @@ pub struct StyleTabProps {
     pub session: Session,
     pub renderer: Renderer,
 
-    pub table_ty: Type,
-    pub view_ty: Type,
+    pub maybe_table_ty: Option<Type>,
+    pub maybe_view_ty: Option<Type>,
     pub column_name: String,
 }
 
@@ -87,7 +87,7 @@ pub fn StyleTab(props: &StyleTabProps) -> Html {
                 custom_events={ props.custom_events.clone() }
                 session={ props.session.clone() }
                 renderer={ props.renderer.clone() }
-                view_ty={ props.view_ty }
+                view_ty={ props.maybe_view_ty.expect_throw("Could not unwrap view type!") }
                 column_name={ props.column_name.clone() }/>
         }),
         _ => None,

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/column_style.rs
@@ -13,6 +13,7 @@
 use serde::de::DeserializeOwned;
 use yew::{function_component, html, Callback, Html, Properties};
 
+use crate::components::column_settings_sidebar::style_tab::stub::Stub;
 use crate::components::datetime_column_style::DatetimeColumnStyle;
 use crate::components::number_column_style::NumberColumnStyle;
 use crate::components::string_column_style::StringColumnStyle;
@@ -161,17 +162,11 @@ pub fn ColumnStyle(p: &ColumnStyleProps) -> Html {
         _ => Err("Booleans aren't styled yet.".into()),
     };
     let contents = opt_html.unwrap_or_else(|e| {
-        tracing::error!(
-            "Unable to create a style for this component! This is a developer error. Please open \
-             an issue at github.com/finos/perspective.\nError: {e}"
-        );
-
         html! {
-            <div class="style_contents">
-                <div id="column-style-container" class="no-style">
-                    <div class="style-contents">{ "No styles available" }</div>
-                </div>
-            </div>
+            <Stub
+                message="No styles available"
+                error={e}
+            />
         }
     });
     html_template! {

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/column_style.rs
@@ -11,7 +11,6 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 use serde::de::DeserializeOwned;
-use wasm_bindgen::UnwrapThrowExt;
 use yew::{function_component, html, Callback, Html, Properties};
 
 use crate::components::datetime_column_style::DatetimeColumnStyle;
@@ -161,9 +160,22 @@ pub fn ColumnStyle(p: &ColumnStyleProps) -> Html {
         }),
         _ => Err("Booleans aren't styled yet.".into()),
     };
+    let contents = opt_html.unwrap_or_else(|e| {
+        tracing::error!(
+            "Unable to create a style for this component! This is a developer error. Please open \
+             an issue at github.com/finos/perspective.\nError: {e}"
+        );
 
+        html! {
+            <div class="style_contents">
+                <div id="column-style-container" class="no-style">
+                    <div class="style-contents">{ "No styles available" }</div>
+                </div>
+            </div>
+        }
+    });
     html_template! {
         <LocalStyle href={ css!("column-style") } />
-        {opt_html.expect_throw("Could not generate HTML to style this column!")}
+        {contents}
     }
 }

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/stub.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/stub.rs
@@ -1,0 +1,34 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+use yew::{function_component, html, Html, Properties};
+
+#[derive(Properties, PartialEq)]
+pub struct StubProps {
+    pub error: Option<String>,
+    pub message: String,
+}
+
+#[function_component(Stub)]
+pub fn stub(p: &StubProps) -> Html {
+    if let Some(error) = p.error.clone() {
+        tracing::error!("RENDERED STUB: {error}");
+    }
+
+    html! {
+        <div class="style_contents">
+            <div id="column-style-container" class="no-style">
+                <div class="style-contents">{p.message.clone()}</div>
+            </div>
+        </div>
+    }
+}

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/symbol.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/symbol.rs
@@ -24,7 +24,6 @@ use self::types::{SymbolConfig, SymbolKVPair};
 use crate::components::column_settings_sidebar::style_tab::symbol::symbol_pairs::PairsList;
 use crate::components::style::LocalStyle;
 use crate::config::plugin::{PluginConfig, Symbol};
-use crate::config::Type;
 use crate::custom_elements::FilterDropDownElement;
 use crate::custom_events::CustomEvents;
 use crate::model::{GetPluginConfig, UpdatePluginConfig};
@@ -40,7 +39,6 @@ pub fn next_default_symbol(values: &Vec<Symbol>, pairs_len: usize) -> String {
 }
 #[derive(Properties, PartialEq, Clone)]
 pub struct SymbolAttrProps {
-    pub attr_type: Type,
     pub column_name: String,
     pub session: Session,
     pub renderer: Renderer,
@@ -61,12 +59,12 @@ pub enum SymbolAttrMsg {
     UpdatePairs(Vec<SymbolKVPair>),
 }
 
-pub struct SymbolAttr {
+pub struct SymbolStyle {
     pairs: Vec<SymbolKVPair>,
     row_dropdown: Rc<FilterDropDownElement>,
 }
 
-impl yew::Component for SymbolAttr {
+impl yew::Component for SymbolStyle {
     type Message = SymbolAttrMsg;
     type Properties = SymbolAttrProps;
 

--- a/rust/perspective-viewer/src/rust/components/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/number_column_style.rs
@@ -171,8 +171,7 @@ impl Component for NumberColumnStyle {
                     self.config.pos_fg_color = Some(self.pos_fg_color.to_owned());
                     self.config.neg_fg_color = Some(self.neg_fg_color.to_owned());
                     if self.fg_mode.needs_gradient() {
-                        self.config.fg_gradient =
-                            Some(self.fg_gradient.expect_throw("no gradient!"));
+                        self.config.fg_gradient = Some(self.fg_gradient.unwrap());
                     } else {
                         self.config.fg_gradient = None;
                     }
@@ -197,8 +196,7 @@ impl Component for NumberColumnStyle {
                     self.config.pos_bg_color = Some(self.pos_bg_color.to_owned());
                     self.config.neg_bg_color = Some(self.neg_bg_color.to_owned());
                     if self.bg_mode.needs_gradient() {
-                        self.config.bg_gradient =
-                            Some(self.bg_gradient.expect_throw("No gradient!"));
+                        self.config.bg_gradient = Some(self.bg_gradient.unwrap());
                     } else {
                         self.config.bg_gradient = None;
                     }
@@ -240,7 +238,7 @@ impl Component for NumberColumnStyle {
                 self.fg_mode = val;
                 self.config.number_fg_mode = val;
                 if self.fg_mode.needs_gradient() {
-                    self.config.fg_gradient = Some(self.fg_gradient.expect_throw("no gradient!"));
+                    self.config.fg_gradient = Some(self.fg_gradient.unwrap());
                 } else {
                     self.config.fg_gradient = None;
                 }
@@ -252,7 +250,7 @@ impl Component for NumberColumnStyle {
                 self.bg_mode = val;
                 self.config.number_bg_mode = val;
                 if self.bg_mode.needs_gradient() {
-                    self.config.bg_gradient = Some(self.bg_gradient.expect_throw("no gradient!"));
+                    self.config.bg_gradient = Some(self.bg_gradient.unwrap());
                 } else {
                     self.config.bg_gradient = None;
                 }

--- a/rust/perspective-viewer/test/js/column_settings.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { PageView } from "@finos/perspective-test";
 import { ColumnSettingsSidebar } from "@finos/perspective-test/src/js/models/column_settings";
 

--- a/rust/perspective-viewer/test/js/column_settings/datagrid.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings/datagrid.spec.ts
@@ -16,7 +16,7 @@ import {
     getEventListener,
 } from "@finos/perspective-test";
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "@finos/perspective-test";
 
 let runTests = (title: string, beforeEachAndLocalTests: () => void) => {
     return test.describe(title, () => {

--- a/rust/perspective-viewer/test/js/column_settings/xy.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings/xy.spec.ts
@@ -17,7 +17,8 @@ import {
 } from "@finos/perspective-test";
 import { SymbolPair } from "@finos/perspective-test/src/js/models/column_settings";
 
-import { Page, expect, test } from "@playwright/test";
+import { expect, test } from "@finos/perspective-test";
+import { Page } from "@playwright/test";
 
 const symbols = [
     "circle",

--- a/rust/perspective-viewer/test/js/dragdrop.spec.ts
+++ b/rust/perspective-viewer/test/js/dragdrop.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 // import {
 //
 //     compareSVGContentsToSnapshot,

--- a/rust/perspective-viewer/test/js/events.spec.ts
+++ b/rust/perspective-viewer/test/js/events.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     API_VERSION,

--- a/rust/perspective-viewer/test/js/expressions.spec.js
+++ b/rust/perspective-viewer/test/js/expressions.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     shadow_click,

--- a/rust/perspective-viewer/test/js/leaks.spec.js
+++ b/rust/perspective-viewer/test/js/leaks.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { compareContentsToSnapshot } from "@finos/perspective-test";
 
 test.beforeEach(async ({ page }) => {

--- a/rust/perspective-viewer/test/js/migrate_viewer.spec.js
+++ b/rust/perspective-viewer/test/js/migrate_viewer.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     API_VERSION,

--- a/rust/perspective-viewer/test/js/plugins.spec.js
+++ b/rust/perspective-viewer/test/js/plugins.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { API_VERSION } from "@finos/perspective-test";
 
 test.beforeEach(async ({ page }) => {

--- a/rust/perspective-viewer/test/js/regressions.spec.js
+++ b/rust/perspective-viewer/test/js/regressions.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     API_VERSION,
     compareContentsToSnapshot,

--- a/rust/perspective-viewer/test/js/save_restore.spec.js
+++ b/rust/perspective-viewer/test/js/save_restore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     API_VERSION,

--- a/rust/perspective-viewer/test/js/settings.spec.js
+++ b/rust/perspective-viewer/test/js/settings.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { compareContentsToSnapshot } from "@finos/perspective-test";
 
 const path = require("path");
@@ -75,15 +75,9 @@ test.describe("Settings", () => {
     test.describe("Regressions", () => {
         test("load and restore with settings called at the same time does not throw", async ({
             page,
+            consoleLogs,
         }) => {
-            const logs = [],
-                errors = [];
-            page.on("console", async (msg) => {
-                if (msg.type() === "error") {
-                    logs.push(msg.text());
-                }
-            });
-
+            const errors = [];
             page.on("pageerror", async (msg) => {
                 errors.push(`${msg.name}::${msg.message}`);
             });
@@ -118,12 +112,13 @@ test.describe("Settings", () => {
                 //   "RuntimeError::unreachable",
             ]);
 
-            expect(logs.length).toBe(2);
-            expect(logs[0]).toMatch(
+            consoleLogs.expectedLogs.push(
+                "error",
                 /Invalid config, resetting to default \{[^}]+\} `restore\(\)` called before `load\(\)`/
             );
-            expect(logs[1]).toEqual(
-                "Caught error: `restore()` called before `load()`"
+            consoleLogs.expectedLogs.push(
+                "error",
+                /Caught error: `restore\(\)` called before `load\(\)`/
             );
         });
     });

--- a/rust/perspective-viewer/test/js/superstore.spec.js
+++ b/rust/perspective-viewer/test/js/superstore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import { run_standard_tests } from "@finos/perspective-test";
 
 async function get_contents(page) {

--- a/tools/perspective-test/src/js/fixture.ts
+++ b/tools/perspective-test/src/js/fixture.ts
@@ -1,0 +1,98 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test as base } from "@playwright/test";
+
+export { expect } from "@playwright/test";
+
+type Logs = { [x: string]: string[] };
+type LogFilter = RegExp | [RegExp, { expected: boolean }];
+type ExpectedLogs = {
+    [x: string]: LogFilter[];
+} & {
+    push: (type: string, filter: LogFilter) => void;
+};
+export const test = base.extend<{
+    consoleLogs: { logs: Logs; expectedLogs: ExpectedLogs };
+}>({
+    consoleLogs: [
+        async ({ page }, use) => {
+            const logs: Logs = {};
+            page.on("console", (msg) => {
+                let type = msg.type();
+                let text = msg.text();
+                logs[type] ? logs[type].push(text) : (logs[type] = [text]);
+            });
+            let expectedLogsConstructor: any = {
+                warning: [[/Legacy `expressions` format/, { expected: false }]],
+            };
+
+            // this is crazy
+            expectedLogsConstructor.push = (
+                type: string,
+                filter: LogFilter
+            ) => {
+                ((
+                    expectedLogs: ExpectedLogs,
+                    type: string,
+                    filter: LogFilter
+                ) => {
+                    expectedLogs[type]
+                        ? expectedLogs[type].push(filter)
+                        : (expectedLogs[type] = [filter]);
+                })(expectedLogsConstructor, type, filter);
+            };
+
+            let expectedLogs = expectedLogsConstructor as ExpectedLogs;
+
+            await use({ logs, expectedLogs });
+
+            Object.entries(expectedLogs).forEach(([type, filters]) => {
+                if (typeof filters == "function") {
+                    return;
+                }
+                for (let filter of filters) {
+                    let filterText: string | RegExp,
+                        expected = true;
+                    if (Array.isArray(filter)) {
+                        filterText = filter[0];
+                        expected = filter[1].expected;
+                    } else {
+                        filterText = filter;
+                    }
+                    let matched_expr = logs[type]?.find((msg) =>
+                        msg.match(filterText)
+                    );
+                    let msgLogs = Array.from(Object.entries(logs)).map(
+                        ([k, v]) =>
+                            `"${k}": [\n\t` +
+                            v.map((v) => `"${v}"`).join(",\n\t") +
+                            "\n],\n"
+                    );
+                    let message = `Filter was "${filterText}"\nLogs were: ${msgLogs}`;
+                    expected
+                        ? test
+                              .expect(matched_expr, {
+                                  message,
+                              })
+                              .toBeDefined()
+                        : test
+                              .expect(matched_expr, {
+                                  message,
+                              })
+                              .toBeUndefined();
+                }
+            });
+        },
+        { auto: true },
+    ],
+});

--- a/tools/perspective-test/src/js/fixture.ts
+++ b/tools/perspective-test/src/js/fixture.ts
@@ -37,6 +37,7 @@ export const test = base.extend<{
             });
             let expectedLogsConstructor: any = {
                 warning: [[/Legacy `expressions` format/, { expected: false }]],
+                error: [[/RENDERED STUB/, { expected: false }]],
             };
 
             // this is crazy

--- a/tools/perspective-test/src/js/fixture.ts
+++ b/tools/perspective-test/src/js/fixture.ts
@@ -27,6 +27,9 @@ export const test = base.extend<{
     consoleLogs: [
         async ({ page }, use) => {
             const logs: Logs = {};
+
+            page.setDefaultTimeout(5000);
+
             page.on("console", (msg) => {
                 let type = msg.type();
                 let text = msg.text();

--- a/tools/perspective-test/src/js/index.ts
+++ b/tools/perspective-test/src/js/index.ts
@@ -13,3 +13,4 @@
 export * from "./utils";
 export * from "./simple_viewer_tests";
 export * from "./models/page";
+export * from "./fixture";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4008,10 +4008,10 @@
   resolved "https://registry.npmjs.org/@prospective.co/procss/-/procss-0.1.13.tgz"
   integrity sha512-cgkhvnge5WM5Ih6f+a/TivPhvs3I2HZYnBlK9zZxrG+QasTSYTSFZ6T+xcBgwjeZeviRb1HV3sW1CCLjlXBOwA==
 
-"@prospective.co/procss@^0.1.14":
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/@prospective.co/procss/-/procss-0.1.14.tgz#93a82c7d0d65aa6a12e75c742142e443657736e8"
-  integrity sha512-Q+6eag8vk0prnAAQ/UD8YKxmydH3iO4O+Kc1YIw+BrhqHQSOm24bqj0iJOedp3KOpZ0zEj/7zzysCYPI45hZDA==
+"@prospective.co/procss@^0.1.15":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@prospective.co/procss/-/procss-0.1.15.tgz#d6c7eb7adf9c567713555c6d626be2a9f76f8a83"
+  integrity sha512-wTjE7IqzU+WmR0Qkyn9i/Mgr0EFHEzmOY8xifXrTIVdeEp8W9XikKE/y+ozWVPgEBM+A+WpF90/8G4u03yfsyQ==
 
 "@rjsf/core@^3.1.0":
   version "3.2.1"


### PR DESCRIPTION
This PR does what it says on the tin. The goal is to prevent unnecessary style component renders and to replace the default "no styles available" content with a hard error.

There are some remaining issues with the symbol column settings when aggregating. In particular, the column value selector does not get the aggregated values, but the raw table values, so the key-value selector doesn't match up with what is in the plugin. 