### PR TITLE
Remove Any Old Expressions from Codebase

### DIFF
--- a/packages/perspective-cli/test/js/superstore.spec.js
+++ b/packages/perspective-cli/test/js/superstore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const path = require("path");
 const { host } = require("../../src/js/index.js");
 

--- a/packages/perspective-jupyterlab/test/js/resize.spec.js
+++ b/packages/perspective-jupyterlab/test/js/resize.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test } = require("@playwright/test");
+const { test } = require("@finos/perspective-test");
 import { compareContentsToSnapshot } from "@finos/perspective-test";
 
 test.beforeEach(async ({ page }) => {

--- a/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
+++ b/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { expect } = require("@playwright/test");
+const { expect } = require("@finos/perspective-test");
 const path = require("path");
 const utils = require("@finos/perspective-test");
 const {

--- a/packages/perspective-viewer-d3fc/test/js/area.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/area.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/bar.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/bar.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     run_standard_tests,
     getSvgContentString,

--- a/packages/perspective-viewer-d3fc/test/js/barWidth.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/barWidth.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     API_VERSION,
     compareSVGContentsToSnapshot,

--- a/packages/perspective-viewer-d3fc/test/js/events.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/events.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { compareSVGContentsToSnapshot } from "@finos/perspective-test";
 
 test.describe("Events test", () => {

--- a/packages/perspective-viewer-d3fc/test/js/heatmap.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/heatmap.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/line.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/line.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/scatter.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/scatter.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareSVGContentsToSnapshot,
     getSvgContentString,

--- a/packages/perspective-viewer-d3fc/test/js/sunburst.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/sunburst.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/treemap.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/treemap.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/xy-line.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/xy-line.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-d3fc/test/js/yscatter.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/yscatter.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     getSvgContentString,
     run_standard_tests,

--- a/packages/perspective-viewer-datagrid/src/js/model/create.js
+++ b/packages/perspective-viewer-datagrid/src/js/model/create.js
@@ -58,7 +58,9 @@ export async function createModel(regular, table, view, extend = {}) {
     // Extract the entire expression string as typed by the user, so we can
     // feed it into `validate_expressions` and get back the data types for
     // each column without it being affected by a pivot.
-    const expressions = config.expressions.map((expr) => expr[1]);
+    const expressions = Object.fromEntries(
+        config.expressions.map((expr) => [expr[0], expr[1]])
+    );
     const [
         table_schema,
         validated_expressions,

--- a/packages/perspective-viewer-datagrid/test/js/column_style.spec.js
+++ b/packages/perspective-viewer-datagrid/test/js/column_style.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { compareContentsToSnapshot } from "@finos/perspective-test";
 
 async function test_column(page, selector, selector2) {

--- a/packages/perspective-viewer-datagrid/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-datagrid/test/js/superstore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     run_standard_tests,

--- a/packages/perspective-viewer-openlayers/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-openlayers/test/js/superstore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import { run_standard_tests } from "@finos/perspective-test";
 
 async function get_contents(page) {

--- a/packages/perspective-workspace/test/js/dom.spec.js
+++ b/packages/perspective-workspace/test/js/dom.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareLightDOMContents,
     compareShadowDOMContents,

--- a/packages/perspective-workspace/test/js/html.spec.js
+++ b/packages/perspective-workspace/test/js/html.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareLightDOMContents,
     compareShadowDOMContents,

--- a/packages/perspective-workspace/test/js/migrate_workspace.spec.js
+++ b/packages/perspective-workspace/test/js/migrate_workspace.spec.js
@@ -11,7 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 const { convert } = require("@finos/perspective-viewer/dist/cjs/migrate.js");
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     API_VERSION,
     compareLightDOMContents,

--- a/packages/perspective-workspace/test/js/restore.spec.js
+++ b/packages/perspective-workspace/test/js/restore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareLightDOMContents,
     compareShadowDOMContents,

--- a/packages/perspective-workspace/test/js/visibility.spec.js
+++ b/packages/perspective-workspace/test/js/visibility.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import {
     compareLightDOMContents,
     compareShadowDOMContents,

--- a/packages/perspective/test/js/clear.spec.js
+++ b/packages/perspective/test/js/clear.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 ((perspective) => {

--- a/packages/perspective/test/js/constructors.spec.js
+++ b/packages/perspective/test/js/constructors.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const moment = require("moment");

--- a/packages/perspective/test/js/delete.spec.js
+++ b/packages/perspective/test/js/delete.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 function it_old_behavior(name, capture) {

--- a/packages/perspective/test/js/delta.spec.js
+++ b/packages/perspective/test/js/delta.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const _ = require("underscore");

--- a/packages/perspective/test/js/expressions/conversions.spec.js
+++ b/packages/perspective/test/js/expressions/conversions.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 /**

--- a/packages/perspective/test/js/expressions/datetime.spec.js
+++ b/packages/perspective/test/js/expressions/datetime.spec.js
@@ -12,7 +12,7 @@
 
 const common = require("./common.js");
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 /**

--- a/packages/perspective/test/js/expressions/deltas.spec.js
+++ b/packages/perspective/test/js/expressions/deltas.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const match_delta = async function (perspective, delta, expected) {

--- a/packages/perspective/test/js/expressions/functionality.spec.js
+++ b/packages/perspective/test/js/expressions/functionality.spec.js
@@ -12,7 +12,7 @@
 
 const expressions_common = require("./common.js");
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 /**

--- a/packages/perspective/test/js/expressions/multiple_views.spec.js
+++ b/packages/perspective/test/js/expressions/multiple_views.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const expressions_common = require("./common.js");

--- a/packages/perspective/test/js/expressions/numeric.spec.js
+++ b/packages/perspective/test/js/expressions/numeric.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const common = require("./common.js");

--- a/packages/perspective/test/js/expressions/parsing.spec.js
+++ b/packages/perspective/test/js/expressions/parsing.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const common = require("./common.js");

--- a/packages/perspective/test/js/expressions/string.spec.js
+++ b/packages/perspective/test/js/expressions/string.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const CHARS = ` !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_\`abcdefghijklmnopqrstuvwxyz{|}~`;

--- a/packages/perspective/test/js/expressions/updates.spec.js
+++ b/packages/perspective/test/js/expressions/updates.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const common = require("./common.js");

--- a/packages/perspective/test/js/expressions/vectors.spec.js
+++ b/packages/perspective/test/js/expressions/vectors.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const common = require("./common.js");

--- a/packages/perspective/test/js/filters.spec.js
+++ b/packages/perspective/test/js/filters.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 var yesterday = new Date();

--- a/packages/perspective/test/js/get_min_max.spec.js
+++ b/packages/perspective/test/js/get_min_max.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const data = {

--- a/packages/perspective/test/js/hosted_tables.spec.js
+++ b/packages/perspective/test/js/hosted_tables.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 const { test_arrow } = require("./test_arrows");
 

--- a/packages/perspective/test/js/internal.spec.js
+++ b/packages/perspective/test/js/internal.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const test_null_arrow = require("./test_arrows.js").test_null_arrow;

--- a/packages/perspective/test/js/leaks.spec.js
+++ b/packages/perspective/test/js/leaks.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const fs = require("fs");

--- a/packages/perspective/test/js/lz4.spec.js
+++ b/packages/perspective/test/js/lz4.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const fs = require("fs");

--- a/packages/perspective/test/js/multiple.spec.js
+++ b/packages/perspective/test/js/multiple.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 var arrow_result = [

--- a/packages/perspective/test/js/pivot_nulls.spec.js
+++ b/packages/perspective/test/js/pivot_nulls.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 ((perspective) => {

--- a/packages/perspective/test/js/pivots.spec.js
+++ b/packages/perspective/test/js/pivots.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 var data = [

--- a/packages/perspective/test/js/ports.spec.js
+++ b/packages/perspective/test/js/ports.spec.js
@@ -12,7 +12,7 @@
 
 const _ = require("underscore");
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const data = {

--- a/packages/perspective/test/js/remote.spec.js
+++ b/packages/perspective/test/js/remote.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 let server;

--- a/packages/perspective/test/js/removes.spec.js
+++ b/packages/perspective/test/js/removes.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const _query = async (should_cache, table, config = {}, callback) => {

--- a/packages/perspective/test/js/sort.spec.js
+++ b/packages/perspective/test/js/sort.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const data = {

--- a/packages/perspective/test/js/sync_load.spec.js
+++ b/packages/perspective/test/js/sync_load.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 
 test.describe("perspective.js module", function () {
     test("does not access the WASM module until it is ready", async () => {

--- a/packages/perspective/test/js/to_column_string.spec.js
+++ b/packages/perspective/test/js/to_column_string.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 test.describe("to_columns_string", () => {

--- a/packages/perspective/test/js/to_format.spec.js
+++ b/packages/perspective/test/js/to_format.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const int_float_string_data = [

--- a/packages/perspective/test/js/to_format_viewport.spec.js
+++ b/packages/perspective/test/js/to_format_viewport.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const data = {

--- a/packages/perspective/test/js/updates.spec.js
+++ b/packages/perspective/test/js/updates.spec.js
@@ -13,7 +13,7 @@
 const _ = require("lodash");
 const arrows = require("./test_arrows.js");
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 function it_old_behavior(name, capture) {

--- a/packages/perspective/test/tz/timezone.spec.js
+++ b/packages/perspective/test/tz/timezone.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require("@finos/perspective-test");
 const perspective = require("@finos/perspective");
 
 const date_data = [

--- a/rust/perspective-viewer/test/js/column_settings.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { PageView } from "@finos/perspective-test";
 import { ColumnSettingsSidebar } from "@finos/perspective-test/src/js/models/column_settings";
 

--- a/rust/perspective-viewer/test/js/column_settings/datagrid.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings/datagrid.spec.ts
@@ -16,7 +16,7 @@ import {
     getEventListener,
 } from "@finos/perspective-test";
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "@finos/perspective-test";
 
 let runTests = (title: string, beforeEachAndLocalTests: () => void) => {
     return test.describe(title, () => {

--- a/rust/perspective-viewer/test/js/column_settings/xy.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings/xy.spec.ts
@@ -17,7 +17,8 @@ import {
 } from "@finos/perspective-test";
 import { SymbolPair } from "@finos/perspective-test/src/js/models/column_settings";
 
-import { Page, expect, test } from "@playwright/test";
+import { expect, test } from "@finos/perspective-test";
+import { Page } from "@playwright/test";
 
 const symbols = [
     "circle",

--- a/rust/perspective-viewer/test/js/dragdrop.spec.ts
+++ b/rust/perspective-viewer/test/js/dragdrop.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 // import {
 //
 //     compareSVGContentsToSnapshot,

--- a/rust/perspective-viewer/test/js/events.spec.ts
+++ b/rust/perspective-viewer/test/js/events.spec.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     API_VERSION,

--- a/rust/perspective-viewer/test/js/expressions.spec.js
+++ b/rust/perspective-viewer/test/js/expressions.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     shadow_click,

--- a/rust/perspective-viewer/test/js/leaks.spec.js
+++ b/rust/perspective-viewer/test/js/leaks.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { compareContentsToSnapshot } from "@finos/perspective-test";
 
 test.beforeEach(async ({ page }) => {

--- a/rust/perspective-viewer/test/js/migrate_viewer.spec.js
+++ b/rust/perspective-viewer/test/js/migrate_viewer.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     API_VERSION,

--- a/rust/perspective-viewer/test/js/plugins.spec.js
+++ b/rust/perspective-viewer/test/js/plugins.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { API_VERSION } from "@finos/perspective-test";
 
 test.beforeEach(async ({ page }) => {

--- a/rust/perspective-viewer/test/js/regressions.spec.js
+++ b/rust/perspective-viewer/test/js/regressions.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     API_VERSION,
     compareContentsToSnapshot,

--- a/rust/perspective-viewer/test/js/save_restore.spec.js
+++ b/rust/perspective-viewer/test/js/save_restore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import {
     compareContentsToSnapshot,
     API_VERSION,

--- a/rust/perspective-viewer/test/js/settings.spec.js
+++ b/rust/perspective-viewer/test/js/settings.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@finos/perspective-test";
 import { compareContentsToSnapshot } from "@finos/perspective-test";
 
 const path = require("path");
@@ -75,15 +75,9 @@ test.describe("Settings", () => {
     test.describe("Regressions", () => {
         test("load and restore with settings called at the same time does not throw", async ({
             page,
+            consoleLogs,
         }) => {
-            const logs = [],
-                errors = [];
-            page.on("console", async (msg) => {
-                if (msg.type() === "error") {
-                    logs.push(msg.text());
-                }
-            });
-
+            const errors = [];
             page.on("pageerror", async (msg) => {
                 errors.push(`${msg.name}::${msg.message}`);
             });
@@ -118,12 +112,13 @@ test.describe("Settings", () => {
                 //   "RuntimeError::unreachable",
             ]);
 
-            expect(logs.length).toBe(2);
-            expect(logs[0]).toMatch(
+            consoleLogs.expectedLogs.push(
+                "error",
                 /Invalid config, resetting to default \{[^}]+\} `restore\(\)` called before `load\(\)`/
             );
-            expect(logs[1]).toEqual(
-                "Caught error: `restore()` called before `load()`"
+            consoleLogs.expectedLogs.push(
+                "error",
+                /Caught error: `restore\(\)` called before `load\(\)`/
             );
         });
     });

--- a/rust/perspective-viewer/test/js/superstore.spec.js
+++ b/rust/perspective-viewer/test/js/superstore.spec.js
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { test } from "@playwright/test";
+import { test } from "@finos/perspective-test";
 import { run_standard_tests } from "@finos/perspective-test";
 
 async function get_contents(page) {

--- a/tools/perspective-test/src/js/fixture.ts
+++ b/tools/perspective-test/src/js/fixture.ts
@@ -1,0 +1,98 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test as base } from "@playwright/test";
+
+export { expect } from "@playwright/test";
+
+type Logs = { [x: string]: string[] };
+type LogFilter = RegExp | [RegExp, { expected: boolean }];
+type ExpectedLogs = {
+    [x: string]: LogFilter[];
+} & {
+    push: (type: string, filter: LogFilter) => void;
+};
+export const test = base.extend<{
+    consoleLogs: { logs: Logs; expectedLogs: ExpectedLogs };
+}>({
+    consoleLogs: [
+        async ({ page }, use) => {
+            const logs: Logs = {};
+            page.on("console", (msg) => {
+                let type = msg.type();
+                let text = msg.text();
+                logs[type] ? logs[type].push(text) : (logs[type] = [text]);
+            });
+            let expectedLogsConstructor: any = {
+                warning: [[/Legacy `expressions` format/, { expected: false }]],
+            };
+
+            // this is crazy
+            expectedLogsConstructor.push = (
+                type: string,
+                filter: LogFilter
+            ) => {
+                ((
+                    expectedLogs: ExpectedLogs,
+                    type: string,
+                    filter: LogFilter
+                ) => {
+                    expectedLogs[type]
+                        ? expectedLogs[type].push(filter)
+                        : (expectedLogs[type] = [filter]);
+                })(expectedLogsConstructor, type, filter);
+            };
+
+            let expectedLogs = expectedLogsConstructor as ExpectedLogs;
+
+            await use({ logs, expectedLogs });
+
+            Object.entries(expectedLogs).forEach(([type, filters]) => {
+                if (typeof filters == "function") {
+                    return;
+                }
+                for (let filter of filters) {
+                    let filterText: string | RegExp,
+                        expected = true;
+                    if (Array.isArray(filter)) {
+                        filterText = filter[0];
+                        expected = filter[1].expected;
+                    } else {
+                        filterText = filter;
+                    }
+                    let matched_expr = logs[type]?.find((msg) =>
+                        msg.match(filterText)
+                    );
+                    let msgLogs = Array.from(Object.entries(logs)).map(
+                        ([k, v]) =>
+                            `"${k}": [\n\t` +
+                            v.map((v) => `"${v}"`).join(",\n\t") +
+                            "\n],\n"
+                    );
+                    let message = `Filter was "${filterText}"\nLogs were: ${msgLogs}`;
+                    expected
+                        ? test
+                              .expect(matched_expr, {
+                                  message,
+                              })
+                              .toBeDefined()
+                        : test
+                              .expect(matched_expr, {
+                                  message,
+                              })
+                              .toBeUndefined();
+                }
+            });
+        },
+        { auto: true },
+    ],
+});

--- a/tools/perspective-test/src/js/fixture.ts
+++ b/tools/perspective-test/src/js/fixture.ts
@@ -27,6 +27,9 @@ export const test = base.extend<{
     consoleLogs: [
         async ({ page }, use) => {
             const logs: Logs = {};
+
+            page.setDefaultTimeout(5000);
+
             page.on("console", (msg) => {
                 let type = msg.type();
                 let text = msg.text();

--- a/tools/perspective-test/src/js/index.ts
+++ b/tools/perspective-test/src/js/index.ts
@@ -13,3 +13,4 @@
 export * from "./utils";
 export * from "./simple_viewer_tests";
 export * from "./models/page";
+export * from "./fixture";


### PR DESCRIPTION
This PR looks huge but it's actually quite small!

It does two things:
1. Datagrid was using an old-style expression when populating the view. This has been fixed.
2. I added a fixture to the playwright tests to ensure that no old-style expressions are still around.
 
Main changes occur in:
- `tools/perspective-test/src/js/fixture.ts` (adds fixture)
- `rust/perspective-viewer/test/js/settings.spec.js` (uses the new log tracking functionality)
- `packages/perspective-viewer-datagrid/src/js/model/create.js` (fixes datagrid bug)

The rest are dependency updates to use the fixture.