### PR TITLE
Fix Jupyterlab Widget Save/Restore Symmetry

### DIFF
--- a/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
+++ b/packages/perspective-jupyterlab/test/jupyter/widget.spec.js
@@ -410,6 +410,20 @@ assert w.theme == "Pro Dark"
             }
         );
 
+        test_jupyter("Restores from saved config", [], async ({ page }) => {
+            await execute_all_cells(page);
+            let errored = await assert_no_error_in_cell(
+                page,
+                `
+                table = perspective.Table(arrow_data)
+                w = perspective.PerspectiveWidget(table)
+                config = w.save()
+                perpsective.PerspectiveWidget(df, **config)
+                `
+            );
+            expect(errored).toBe(false);
+        });
+
         // *************************
         // UTILS
         // *************************

--- a/python/perspective/perspective/viewer/viewer.py
+++ b/python/perspective/perspective/viewer/viewer.py
@@ -76,6 +76,8 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         settings=True,
         theme=None,
         title=None,
+        # ignored, here for restore compatibility
+        version=None,
     ):
         """Initialize an instance of `PerspectiveViewer` with the given viewer
         configuration.  Do not pass a `Table` or data into the constructor -
@@ -107,6 +109,9 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
             settings(:obj:`bool`): Whether the perspective query settings
                 panel should be open.
             theme (:obj:`str`): The color theme to use.
+            version (:obj:`str`): The version this configuration is restored from.
+                This should only be used when restoring a configuration,
+                and should not be set manually.
 
         Examples:
             >>> viewer = PerspectiveViewer(


### PR DESCRIPTION
Fixes https://github.com/finos/perspective/issues/2464

The version keyword should be ignored when restoring the widget, as it does not affect the widget itself. The version keyword is currently only used for migrations. Eventually, I would like to see automatic migrations based on version number, which will require a more sophisticated solution. This works for now :)