### PR TITLE
Improve C++/LSP/VSCode Integration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,12 @@
 ---
-Language:        Cpp
+Language: Cpp
 # BasedOnStyle:  WebKit
+LineEnding: LF
 AccessModifierOffset: -4
 AlignAfterOpenBracket: false
 AlignConsecutiveAssignments: false
 AlignEscapedNewlinesLeft: false
-AlignOperands:   false
+AlignOperands: false
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
@@ -28,15 +29,15 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-DisableFormat:   false
+DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+ForEachMacros: [foreach, Q_FOREACH, BOOST_FOREACH]
 IndentCaseLabels: true
-IndentWidth:     4
+IndentWidth: 4
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
+MacroBlockBegin: ""
+MacroBlockEnd: ""
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: Inner
 ObjCBlockIndentWidth: 4
@@ -54,13 +55,12 @@ SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        4
-UseTab:          Never
-SortIncludes:	 false
-...
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never
+SortIncludes: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,17 @@
+Checks: >
+    -*,
+    modernize-*,
+    performance-*,
+    readability-*,
+    clang-analyzer-*,
+    bugprone-*,
+    portability-*,
+    -modernize-use-trailing-return-type,
+    -readability-identifier-length,
+    -readability-magic-numbers,
+    -bugprone-easily-swappable-parameters,
+    -readability-convert-member-functions-to-static,
+    -misc-const-correctness,
+    -readability-function-cognitive-complexity
+
+# WarningsAsErrors: "*"

--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,5 @@ benchmark_venv
 venv/
 testenv
 .cache
+.clangd
+.llvm/

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -22,5 +22,6 @@
     "rust-analyzer.check.command": "clippy",
     "playwright.env": {
         "TZ": "UTC"
-    }
+    },
+    "clangd.path": "${workspaceFolder}/.llvm/llvm-toolchain/bin/clangd"
 }

--- a/cmake/modules/LLVMToolchain.cmake
+++ b/cmake/modules/LLVMToolchain.cmake
@@ -1,0 +1,9 @@
+set(LLVM_ROOT $ENV{LLVM_ROOT})
+
+set(CMAKE_C_COMPILER "${LLVM_ROOT}/bin/clang")
+set(CMAKE_CXX_COMPILER "${LLVM_ROOT}/bin/clang++")
+set(CMAKE_AR "${LLVM_ROOT}/bin/llvm-ar")
+set(CMAKE_RANLIB "${LLVM_ROOT}/bin/llvm-ranlib")
+
+# include_directories(BEFORE SYSTEM "${LLVM_ROOT}/include")
+# link_directories(BEFORE "${LLVM_ROOT}/lib")

--- a/cpp/perspective/.clangd.in
+++ b/cpp/perspective/.clangd.in
@@ -1,0 +1,3 @@
+CompileFlags:
+    @CLANGD_ADD_FLAGS@
+    CompilationDatabase: @CMAKE_BINARY_DIR@

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -201,15 +201,6 @@ if(PSP_WASM_BUILD)
     # ###################
     # EMSCRIPTEN BUILD #
     # ###################
-    execute_process(COMMAND which emcc OUTPUT_VARIABLE EMCC)
-    execute_process(COMMAND which em++ OUTPUT_VARIABLE EMPP)
-    string(STRIP "${EMCC}" EMCC)
-    string(STRIP "${EMPP}" EMPP)
-    set(CMAKE_C_COMPILER ${EMCC})
-    set(CMAKE_CXX_COMPILER ${EMPP})
-    set(CMAKE_TOOLCHAIN_FILE "$ENV{EMSCRIPTEN_ROOT}/cmake/Modules/Platform/Emscripten.cmake")
-    set(CMAKE_AR emar)
-    set(CMAKE_RANLIB emranlib)
     set(CMAKE_EXECUTABLE_SUFFIX ".js")
     list(APPEND CMAKE_PREFIX_PATH /usr/local)
 
@@ -300,9 +291,9 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         message(FATAL_ERROR "${Red}Boost could not be located${ColorReset}")
     else()
         psp_build_message("${Cyan}Found Boost: `Boost_INCLUDE_DIRS`: ${Boost_INCLUDE_DIRS}, `Boost_LIBRARY_DIRS` - ${Boost_LIBRARY_DIRS} ${ColorReset}")
-        include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
         if(WIN32)
+            include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
             add_definitions(-DBOOST_UUID_FORCE_AUTO_LINK)
         endif()
     endif()
@@ -659,4 +650,41 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         target_compile_definitions(psp PRIVATE WIN32=1)
         target_compile_definitions(psp PRIVATE _WIN32=1)
     endif()
+endif()
+
+# C++ IDE Setup
+
+set(WORKSPACE_ROOT "${CMAKE_SOURCE_DIR}/../..")
+
+if(PSP_WASM_BUILD)
+    set(CLANGD_ADD_FLAGS "Add:
+        [
+            -target,
+            wasm32-unknown-emscripten,
+            --sysroot=${WORKSPACE_ROOT}/.emsdk/upstream/emscripten/cache/sysroot,
+        ]")
+else()
+    set(CLANGD_ADD_FLAGS "")
+endif()
+
+# Check for existence of .clangd file
+if(EXISTS ${CMAKE_SOURCE_DIR}/.clangd.in)
+    message(STATUS "${Cyan}Found ${CMAKE_SOURCE_DIR}/.clangd.in${ColorReset}")
+    # Configure the .clangd file from the template
+    configure_file(
+        ${CMAKE_SOURCE_DIR}/.clangd.in
+        ${CMAKE_BINARY_DIR}/.clangd
+        @ONLY
+    )
+    # Symlink .clangd to the project root
+    execute_process(
+        COMMAND ln -sf ${CMAKE_BINARY_DIR}/.clangd ${WORKSPACE_ROOT}/.clangd
+    )
+    message(STATUS "${Cyan}Created ${CMAKE_BINARY_DIR}/.clangd${ColorReset}")
+else()
+    message("${Yellow}No .clangd.in found, skipping IDE setup${ColorReset}")
+endif()
+
+if(NOT WIN32)
+    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 endif()

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         }
     },
     "emscripten": "3.1.48",
+    "llvm": "17.0.6",
     "engines": {
         "node": ">=14.18.2"
     },
@@ -86,6 +87,7 @@
         "postinstall:emsdk": "node tools/perspective-scripts/install_emsdk.mjs",
         "postinstall:playwright": "npx playwright install --with-deps",
         "postinstall:vscode": "cp -n ./.vscode/settings.default.json ./.vscode/settings.json || true",
+        "install_llvm": "node tools/perspective-scripts/install_llvm.mjs",
         "build,test": "npm run --silent build && npm run --silent test",
         "build_js": "node tools/perspective-scripts/build_js.mjs",
         "build": "node tools/perspective-scripts/build.mjs",

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -136,7 +136,7 @@ class PSPBuild(build_ext):
         cfg = "Debug" if self.debug else "Release"
 
         PYTHON_VERSION = "{}.{}".format(sys.version_info.major, sys.version_info.minor)
-
+        
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + os.path.abspath(os.path.join(extdir, "perspective", "table")).replace("\\", "/"),
             "-DCMAKE_BUILD_TYPE=" + cfg,
@@ -158,6 +158,12 @@ class PSPBuild(build_ext):
 
         build_args = ["--config", cfg]
         env = os.environ.copy()
+
+        # Breaks universal binaries on MacOS somehow :'(
+        # if "LLVM_ROOT" in os.environ:
+        #     llvm_module = os.path.join(ext.sourcedir, "cmake", "modules", "LLVMToolchain.cmake")
+        #     cmake_args.append("-DCMAKE_TOOLCHAIN_FILE={}".format(llvm_module))
+        #     env["LLVM_ROOT"] = os.environ["LLVM_ROOT"]
 
         if platform.system() == "Windows":
             import distutils.msvccompiler as dm

--- a/tools/perspective-scripts/fix.mjs
+++ b/tools/perspective-scripts/fix.mjs
@@ -13,6 +13,7 @@
 import * as url from "url";
 import * as dotenv from "dotenv";
 import { lint_js } from "./lint.mjs";
+import * as cppLint from "./lint_cpp.mjs";
 
 if (import.meta.url.startsWith("file:")) {
     if (process.argv[1] === url.fileURLToPath(import.meta.url)) {
@@ -25,5 +26,7 @@ if (import.meta.url.startsWith("file:")) {
         } else {
             lint_js(true);
         }
+
+        cppLint.fixFormatting();
     }
 }

--- a/tools/perspective-scripts/install_llvm.mjs
+++ b/tools/perspective-scripts/install_llvm.mjs
@@ -1,0 +1,73 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import pkg from "../../package.json" assert { type: "json" };
+import os from "os";
+import * as fs from "node:fs";
+import * as url from "url";
+import { mkdirSync } from "fs";
+import { execSync } from "child_process";
+import path from "path";
+
+const __dirname = url.fileURLToPath(new URL(".", import.meta.url)).slice(0, -1);
+
+const LLVM_VERSION = pkg.llvm;
+const DOWNLOAD_DIR = path.join(`${__dirname}/../../.llvm`, "llvm-toolchain");
+
+function getLLVMPackageName() {
+    const system = os.platform();
+    const arch = os.arch();
+
+    if (arch === "arm64" && system === "linux") {
+        return `clang+llvm-${LLVM_VERSION}-aarch64-linux-gnu.tar.xz`;
+    } else if (arch === "x64" && system === "linux") {
+        return `clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-22.04.tar.xz`;
+    } else if (arch === "x64" && system === "darwin") {
+        return `clang+llvm-${LLVM_VERSION}-x86_64-apple-darwin21.0.tar.xz`;
+    } else if (arch === "arm64" && system === "darwin") {
+        return `clang+llvm-${LLVM_VERSION}-arm64-apple-darwin22.0.tar.xz`;
+    } else {
+        throw new Error(`Unsupported system: ${arch} on ${system}`);
+    }
+}
+
+async function downloadLLVM(packageName) {
+    const llvmUrl = `https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${packageName}`;
+    const outputPath = path.join(DOWNLOAD_DIR, packageName);
+
+    console.log(`Downloading LLVM ${LLVM_VERSION} from ${llvmUrl}...`);
+
+    mkdirSync(DOWNLOAD_DIR, { recursive: true });
+    fs.writeFileSync(`${DOWNLOAD_DIR}/.llvm-version`, LLVM_VERSION);
+    execSync(`wget -O ${outputPath} ${llvmUrl}`, { stdio: "inherit" });
+    execSync(`tar -xvf ${outputPath} -C ${DOWNLOAD_DIR} --strip-components=1`, {
+        stdio: "inherit",
+    });
+    execSync(`rm ${outputPath}`, { stdio: "inherit" });
+}
+
+const llvmPackageName = getLLVMPackageName();
+
+if (fs.existsSync(DOWNLOAD_DIR)) {
+    console.log(`LLVM ${LLVM_VERSION} already downloaded`);
+    if (
+        !fs.existsSync(`${DOWNLOAD_DIR}/.llvm-version`) ||
+        fs.readFileSync(`${DOWNLOAD_DIR}/.llvm-version`).toString().trim() !==
+            LLVM_VERSION
+    ) {
+        console.log(`LLVM version mismatch, re-downloading...`);
+        fs.rmdirSync(DOWNLOAD_DIR, { recursive: true });
+        downloadLLVM(llvmPackageName);
+    }
+} else {
+    downloadLLVM(llvmPackageName);
+}

--- a/tools/perspective-scripts/lint.mjs
+++ b/tools/perspective-scripts/lint.mjs
@@ -13,6 +13,7 @@
 import sh from "./sh.mjs";
 import * as url from "url";
 import * as dotenv from "dotenv";
+import * as cppLint from "./lint_cpp.mjs";
 
 export function lint_js(is_fix = false) {
     const prettier_flags = is_fix ? "--write" : "--check";
@@ -44,6 +45,7 @@ if (import.meta.url.startsWith("file:")) {
         } else {
             lint_js();
         }
+        cppLint.checkFormatting();
         process.exit(exit_code);
     }
 }

--- a/tools/perspective-scripts/lint_cpp.mjs
+++ b/tools/perspective-scripts/lint_cpp.mjs
@@ -1,0 +1,108 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import sh from "./sh.mjs";
+import * as fs from "fs";
+import * as url from "url";
+import * as os from "os";
+import glob from "glob";
+import { execSync } from "child_process";
+
+const __dirname = url.fileURLToPath(new URL(".", import.meta.url)).slice(0, -1);
+
+export function lint() {
+    if (process.env.PSP_PROJECT === "js") {
+        const cppPath = sh.path`${__dirname}/../../cpp/perspective`;
+        const cppDistPath = sh.path`${cppPath}/dist/release`;
+        tidy(cppDistPath, sh.path`${cppPath}/src`);
+    } else if (process.env.PSP_PROJECT === "python") {
+        const cppPath = sh.path`${__dirname}/../../python/perspective`;
+        const cppDistPath = sh.path`${cppPath}/build/last_build`;
+        tidy(cppDistPath, sh.path`${cppPath}/perspective`);
+    } else {
+        console.error("Unknown project type, skipping lint");
+    }
+}
+
+/** @typedef {import('./sh.mjs').Command} Command */
+
+/**
+ * Runs clang tidy on the source directory using the compile_commands.json
+ * from the build directory.
+ *
+ * @param {string} buildDir
+ * @param {string} sourceDir
+ */
+function tidy(buildDir, sourceDir) {
+    const ctpath = clangTidyPath();
+    if (!fs.existsSync(ctpath)) {
+        console.warn("run-clang-tidy not found, skipping lint");
+        return;
+    }
+    if (fs.existsSync(buildDir)) {
+        const jobs = os.cpus().length;
+        const sources = glob.sync(`${sourceDir}/**/*.{cpp,h}`);
+        // @ts-ignore
+        sh`${ctpath} -use-color -p${buildDir} -j${jobs} ${sources}`.runSync();
+    } else {
+        console.warn("No C++ build directory found, skipping lint");
+    }
+}
+
+function clangTidyPath() {
+    if (process.env.PSP_CLANG_TIDY_PATH !== undefined) {
+        return process.env.PSP_CLANG_TIDY_PATH;
+    } else {
+        return `${__dirname}/../../.llvm/llvm-toolchain/bin/run-clang-tidy`;
+    }
+}
+
+// lint();
+
+// .llvm/llvm-toolchain/bin/clang-format
+const CLANG_FMT_PATH = `${__dirname}/../../.llvm/llvm-toolchain/bin/clang-format`;
+
+function formatLint(dir) {
+    execSync(`${CLANG_FMT_PATH} -style=file --dry-run -Werror ${dir}`, {
+        stdio: "inherit",
+    });
+}
+
+function clangFormatFix(dir) {
+    execSync(`${CLANG_FMT_PATH} -style=file -i ${dir}`, {
+        stdio: "inherit",
+    });
+}
+
+export function checkFormatting() {
+    formatLint(sh.path`./cpp/perspective/src/cpp/*.cpp`);
+    formatLint(sh.path`./cpp/perspective/src/include/perspective/*.h`);
+    formatLint(sh.path`./python/perspective/perspective/src/*.cpp`);
+    formatLint(
+        sh.path`./python/perspective/perspective/include/perspective/*.h`
+    );
+    formatLint(
+        sh.path`./python/perspective/perspective/include/perspective/python/*.h`
+    );
+}
+
+export function fixFormatting() {
+    clangFormatFix(sh.path`./cpp/perspective/src/cpp/*.cpp`);
+    clangFormatFix(sh.path`./cpp/perspective/src/include/perspective/*.h`);
+    clangFormatFix(sh.path`./python/perspective/perspective/src/*.cpp`);
+    clangFormatFix(
+        sh.path`./python/perspective/perspective/include/perspective/*.h`
+    );
+    clangFormatFix(
+        sh.path`./python/perspective/perspective/include/perspective/python/*.h`
+    );
+}


### PR DESCRIPTION
Improvements to C++ developer experience:
* Setup ClangD with Emscripten/Python.

Fixes:
* Fix boost include shadowing local headers.

Before this I was having a hard time getting Intellisense in VSCode to work properly particularly in `emscripten.cpp` with the calls to code in `./.emsdk` in the workspace root. After these changes it works great for me:
<img width="1117" alt="image" src="https://github.com/finos/perspective/assets/3655689/ccee906c-21fb-4d48-85f1-c9a01d99887c">

Also if you build the Python library and open `python/perspective` in VSCode, pybind and everything works as well:
<img width="1261" alt="image" src="https://github.com/finos/perspective/assets/3655689/dc3ac662-4f80-4592-9b2a-4f3b2aa33642">
