### PR TITLE
Integrate protobuf

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: "-*,modernize-*,performance-*,readability-*,clang-analyzer-*,bugprone-*,portability-*,-modernize-use-trailing-return-type,-readability-identifier-length"
+# WarningsAsErrors: "*"

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,1 @@
+cpp/perspective/dist/release/.clangd

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -11,5 +11,6 @@
     "rust-analyzer.check.command": "clippy",
     "playwright.env": {
         "TZ": "UTC"
-    }
+    },
+    "clangd.arguments": ["--enable-config"]
 }

--- a/cmake/modules/FindInstallDependency.cmake
+++ b/cmake/modules/FindInstallDependency.cmake
@@ -12,6 +12,8 @@ function(psp_build_dep name cmake_file)
     else()
         configure_file(${cmake_file} ${CMAKE_BINARY_DIR}/${name}-download/CMakeLists.txt)
         set(_cwd ${CMAKE_BINARY_DIR}/${name}-download)
+        
+        message(STATUS "Configuring ${name} in ${_cwd}")
 
         execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
             RESULT_VARIABLE result

--- a/cmake/modules/FindInstallDependency.cmake
+++ b/cmake/modules/FindInstallDependency.cmake
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.7.2)
 
+# Workaround for: https://gitlab.kitware.com/cmake/cmake/-/issues/22740
+set(D "$")
+
 # ##################################################
 # Helper to grab dependencies from remote sources #
 # ##################################################
@@ -7,15 +10,20 @@ function(psp_build_dep name cmake_file)
     if(EXISTS ${CMAKE_BINARY_DIR}/${name}-build AND NOT name STREQUAL "lz4")
         psp_build_message("${Cyan}Dependency found - not rebuilding - ${CMAKE_BINARY_DIR}/${name}-build${ColorReset}")
     else()
-        configure_file(${cmake_file} ${name}-download/CMakeLists.txt)
+        configure_file(${cmake_file} ${CMAKE_BINARY_DIR}/${name}-download/CMakeLists.txt)
+        set(_cwd ${CMAKE_BINARY_DIR}/${name}-download)
 
         execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
             RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${name}-download)
+            OUTPUT_VARIABLE cmd_output
+            ERROR_VARIABLE cmd_error
+            WORKING_DIRECTORY ${_cwd})
 
         if(result)
-            message(FATAL_ERROR "CMake step for ${name} failed: ${result}")
+            message(FATAL_ERROR "CMake step for ${name} failed:\nSTDOUT:${cmd_output}\nSTDERR: ${cmd_error}")
         endif()
+        
+        message("${cmd_output}")
 
         execute_process(COMMAND ${CMAKE_COMMAND} --build .
             RESULT_VARIABLE result
@@ -52,6 +60,12 @@ function(psp_build_dep name cmake_file)
             ${CMAKE_BINARY_DIR}/${name}-build
             EXCLUDE_FROM_ALL)
         include_directories(SYSTEM ${CMAKE_BINARY_DIR}/${name}-src/lib)
+    elseif(${name} STREQUAL protobuf)
+        add_subdirectory(${CMAKE_BINARY_DIR}/${name}-src
+            ${CMAKE_BINARY_DIR}/${name}-build
+            EXCLUDE_FROM_ALL)
+        list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR}/${name}-build/cmake/protobuf)
+        include_directories(SYSTEM ${CMAKE_BINARY_DIR}/${name}-src)
     else()
         add_subdirectory(${CMAKE_BINARY_DIR}/${name}-src
             ${CMAKE_BINARY_DIR}/${name}-build

--- a/cmake/modules/FindProtoc.cmake
+++ b/cmake/modules/FindProtoc.cmake
@@ -1,0 +1,83 @@
+find_program(PROTOC_EXECUTABLE NAMES protoc)
+
+if(NOT PROTOC_EXECUTABLE)
+    message(FATAL_ERROR "protoc not found")
+    set(Protoc_FOUND FALSE)
+else()
+    set(Protoc_FOUND TRUE)
+    message(STATUS "Found protoc: ${PROTOC_EXECUTABLE}")
+
+    function(CHECK_PROTOC_VERSION)
+        execute_process(
+            COMMAND ${PROTOC_EXECUTABLE} --version
+            OUTPUT_VARIABLE PROTOC_VERSION_OUTPUT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(NOT PROTOC_VERSION_OUTPUT MATCHES "^libprotoc ([0-9]+)\\.([0-9]+)(:?\\.([0-9]+))?")
+            message(WARNING "Unable to determine protoc version")
+            return()
+        endif()
+
+        set(PROTOC_VERSION_MAJOR ${CMAKE_MATCH_1})
+        set(PROTOC_VERSION_MINOR ${CMAKE_MATCH_2})
+        set(PROTOC_VERSION_PATCH ${CMAKE_MATCH_3})
+
+        if (NOT PROTOC_VERSION_PATCH)
+            set(FOUND_VERSION "${PROTOC_VERSION_MAJOR}.${PROTOC_VERSION_MINOR}")
+        else()
+            set(FOUND_VERSION "${PROTOC_VERSION_MAJOR}.${PROTOC_VERSION_MINOR}.${PROTOC_VERSION_PATCH}")
+        endif()
+        
+        # Force the external project to use the same version as our installed protoc CLI
+        set(LIBPROTOBUF_VERSION "v${FOUND_VERSION}" PARENT_SCOPE)
+
+        set(MIN_PROTOC_VERSION_MAJOR 24)
+
+        if(PROTOC_VERSION_MAJOR LESS MIN_PROTOC_VERSION_MAJOR)
+            message(FATAL_ERROR "protoc version ${FOUND_VERSION} is too old, at least ${MIN_PROTOC_VERSION_MAJOR}.x.x is required")
+        else()
+            message(STATUS "Found protoc version ${FOUND_VERSION}")
+        endif()
+    endfunction()
+
+    # Check the version of protoc
+    CHECK_PROTOC_VERSION()
+endif()
+
+# Function to compile .proto files to C++ with protoc
+function(protobuf_generate_cpp SRCS HDRS)
+    if(NOT ARGN)
+        message(SEND_ERROR "Error: protobuf_generate_cpp() called without any proto files")
+        return()
+    endif()
+
+    set(_PROTOBUF_GENERATE_CPP_SRCS)
+    set(_PROTOBUF_GENERATE_CPP_HDRS)
+
+    foreach(PROTO_FILE ${ARGN})
+        get_filename_component(PROTO_NAME ${PROTO_FILE} NAME_WE)
+        get_filename_component(PROTO_PATH ${PROTO_FILE} PATH)
+
+        set(GENERATED_SRC "${CMAKE_CURRENT_BINARY_DIR}/${PROTO_NAME}.pb.cc")
+        set(GENERATED_HDR "${CMAKE_CURRENT_BINARY_DIR}/${PROTO_NAME}.pb.h")
+
+        execute_process(
+            # COMMAND ${PROTOC_EXECUTABLE} --cpp_out ${CMAKE_CURRENT_BINARY_DIR} --proto_path ${PROTO_PATH} ${PROTO_FILE}
+            COMMAND ${PROTOC_EXECUTABLE} --cpp_out ${CMAKE_CURRENT_BINARY_DIR} ${PROTO_FILE}
+            RESULT_VARIABLE PROTOC_RESULT
+            OUTPUT_VARIABLE PROTOC_OUTPUT
+            ERROR_VARIABLE PROTOC_ERROR
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+
+        if(NOT ${PROTOC_RESULT} EQUAL 0)
+            message(FATAL_ERROR "protoc failed: ${PROTOC_ERROR}")
+        endif()
+
+        list(APPEND _PROTOBUF_GENERATE_CPP_SRCS "${GENERATED_SRC}")
+        list(APPEND _PROTOBUF_GENERATE_CPP_HDRS "${GENERATED_HDR}")
+    endforeach()
+    set(${SRCS} ${_PROTOBUF_GENERATE_CPP_SRCS} PARENT_SCOPE)
+    set(${HDRS} ${_PROTOBUF_GENERATE_CPP_HDRS} PARENT_SCOPE)
+endfunction()

--- a/cmake/protobuf.txt.in
+++ b/cmake/protobuf.txt.in
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.7.2)
+
+project(protobuf-download NONE)
+
+if("" STREQUAL "${LIBPROTOBUF_VERSION}")
+  set(LIBPROTOBUF_VERSION v25.1)
+  message(FATAL_ERROR "LIBPROTOBUF_VERSION not set, using default: ${D}{LIBPROTOBUF_VERSION}")
+else()
+  set(LIBPROTOBUF_VERSION ${LIBPROTOBUF_VERSION})
+  message(STATUS "LIBPROTOBUF_VERSION set to: ${D}{LIBPROTOBUF_VERSION}")
+endif()
+
+include(ExternalProject)
+ExternalProject_Add(protobuf
+  GIT_REPOSITORY    https://github.com/protocolbuffers/protobuf.git
+  GIT_TAG           "${D}{LIBPROTOBUF_VERSION}"
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/protobuf-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/protobuf-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+  #CMAKE_ARGS        " -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}"
+  CMAKE_ARGS        ""
+)

--- a/cpp/perspective/.clangd.in
+++ b/cpp/perspective/.clangd.in
@@ -1,0 +1,3 @@
+CompileFlags:
+    @CLANGD_ADD_FLAGS@
+    CompilationDatabase: @CMAKE_BINARY_DIR@

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -5,6 +5,7 @@ include(CheckCCompilerFlag)
 set(CMAKE_BUILD_TYPE "Release")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # CMAKE POLICIES
 # option() should use new cmake behavior wrt variable clobbering
@@ -300,7 +301,6 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         message(FATAL_ERROR "${Red}Boost could not be located${ColorReset}")
     else()
         psp_build_message("${Cyan}Found Boost: `Boost_INCLUDE_DIRS`: ${Boost_INCLUDE_DIRS}, `Boost_LIBRARY_DIRS` - ${Boost_LIBRARY_DIRS} ${ColorReset}")
-        include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
         if(WIN32)
             add_definitions(-DBOOST_UUID_FORCE_AUTO_LINK)
@@ -660,3 +660,32 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         target_compile_definitions(psp PRIVATE _WIN32=1)
     endif()
 endif()
+
+set(WORKSPACE_ROOT "${CMAKE_SOURCE_DIR}/../..")
+
+if(PSP_WASM_BUILD)
+    set(CLANGD_ADD_FLAGS "Add:
+        [
+            -target,
+            wasm32-unknown-emscripten,
+            --sysroot=${WORKSPACE_ROOT}/.emsdk/upstream/emscripten/cache/sysroot,
+        ]")
+else()
+    set(CLANGD_ADD_FLAGS "")
+endif()
+
+# Configure the .clangd file from the template
+configure_file(
+    ${CMAKE_SOURCE_DIR}/.clangd.in
+    ${CMAKE_BINARY_DIR}/.clangd
+    @ONLY
+)
+
+# On MacOS this includes the entire /opt/homebrew/include directory which
+# will mask local includes and cause mysterious compile errors in libre2 and
+# others which will occasionally resolve includes to homebrew and local headers
+# in the same file. Keeping this at the end of the file helps mitigate that issue.
+if((PSP_CPP_BUILD OR PSP_PYTHON_BUILD) AND Boost_FOUND)
+    include_directories(AFTER SYSTEM ${Boost_INCLUDE_DIRS})
+endif()
+# DO NOT WRITE BELOW THIS LINE, ADD NEW INCLUDES ABOVE

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -25,7 +25,7 @@ cmake_policy(SET CMP0074 NEW)
 cmake_policy(SET CMP0094 NEW)
 
 if(NOT DEFINED PSP_CMAKE_MODULE_PATH)
-    set(PSP_CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake/")
+    set(PSP_CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake")
 endif()
 
 set(CMAKE_MODULE_PATH "${PSP_CMAKE_MODULE_PATH}/modules" ${CMAKE_MODULE_PATH})
@@ -65,6 +65,9 @@ endfunction()
 # ######################
 find_package(Color)
 find_package(InstallDependency)
+
+# Protobuf setup
+add_subdirectory(../../protos "${CMAKE_BINARY_DIR}/protos-build")
 
 # OPTIONS
 option(CMAKE_BUILD_TYPE "Release/Debug build" RELEASE)

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -66,9 +66,6 @@ endfunction()
 find_package(Color)
 find_package(InstallDependency)
 
-# Protobuf setup
-add_subdirectory(../../protos "${CMAKE_BINARY_DIR}/protos-build")
-
 # OPTIONS
 option(CMAKE_BUILD_TYPE "Release/Debug build" RELEASE)
 option(PSP_WASM_BUILD "Build the WebAssembly Project" ON)
@@ -393,6 +390,9 @@ psp_build_dep("re2" "${PSP_CMAKE_MODULE_PATH}/re2.txt.in")
 
 # Build exprtk for expression parsing
 psp_build_dep("exprtk" "${PSP_CMAKE_MODULE_PATH}/exprtk.txt.in")
+
+# Protobuf setup
+add_subdirectory(${PSP_CMAKE_MODULE_PATH}/../protos "${CMAKE_BINARY_DIR}/protos-build")
 
 # ####################
 set(CMAKE_C_FLAGS_DEBUG "")

--- a/protos/CMakeLists.txt
+++ b/protos/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.18.2)
+project(perspective-protos)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(NOT DEFINED psp_build_message)
+    function(psp_build_message message)
+        set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${message}")
+    endfunction()
+endif()
+
+# Include the FindProtobuf.cmake module
+list(APPEND CMAKE_MODULE_PATH "../cmake/modules")
+
+find_package(Protoc REQUIRED)
+find_package(InstallDependency REQUIRED)
+
+if(NOT DEFINED PSP_CMAKE_MODULE_PATH)
+    set(PSP_CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+    message(STATUS "PSP_CMAKE_MODULE_PATH not defined, using ${PSP_CMAKE_MODULE_PATH}")
+endif()
+
+psp_build_dep("protobuf" "${PSP_CMAKE_MODULE_PATH}/protobuf.txt.in")
+
+set(PROTO_FILES perspective.proto)
+
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${PROTO_FILES})
+add_library(protos ${PROTO_SRCS} ${PROTO_HDRS})
+target_include_directories(protos PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/protobuf-src/src)
+target_link_libraries(protos protobuf::libprotobuf)

--- a/protos/perspective.proto
+++ b/protos/perspective.proto
@@ -1,0 +1,81 @@
+syntax = "proto3";
+
+import "google/protobuf/struct.proto";
+
+package perspective.proto;
+
+message MultiplexEnvelope {
+  uint32 id = 1;
+  bytes payload = 2;
+}
+
+message Request {
+  oneof client_req {
+    MakeTableReq make_table_req = 1;
+    TableSizeReq table_size_req = 2;
+    TableToArrow to_arrow_req = 3;
+    TableSchemaReq table_schema_req = 4;
+    TableMakePortReq table_make_port_req = 5;
+  }
+}
+
+message Response {
+  oneof client_resp {
+    MakeTableResp make_table_resp = 1;
+    TableSizeResp table_size_resp = 2;
+    ArrowStreamResp arrow_stream_resp = 3;
+    TableSchemaResp table_schema_resp = 4;
+    TableMakePortResp table_make_port_resp = 5;
+  }
+}
+
+message TableMakePortReq {
+}
+
+message TableMakePortResp {
+  uint64 port_id = 1;
+}
+
+message TableSchemaReq {
+}
+
+message TableSchemaResp {
+  map<string, uint32> schema = 1;
+}
+
+message TableToArrow { }
+
+message ArrowStreamResp {
+  bytes data = 1;
+}
+
+message MakeTableReq {
+}
+message MakeTableResp {
+  uint32 id = 1;
+}
+
+message TableSizeReq {
+}
+
+message TableSizeResp {
+  uint64 size = 2;
+}
+
+message Schema {
+  repeated Field fields = 1;
+}
+
+message Field {
+  string name = 1;
+  uint32 dtype = 2;
+}
+
+message TableCreateReq {
+  // Schema schema = 1;
+  optional uint32 reserve_rows = 2;
+}
+
+message TableCreateResp {
+  uint32 id = 1;
+}

--- a/python/perspective/.clangd
+++ b/python/perspective/.clangd
@@ -1,0 +1,1 @@
+build/last_build/.clangd

--- a/python/perspective/setup.py
+++ b/python/perspective/setup.py
@@ -225,6 +225,15 @@ class PSPBuild(build_ext):
             env=env,
             stderr=subprocess.STDOUT,
         )
+
+        # Symlink build_temp to a sibling directory called `last_build` so that we can
+        # use it for C++/Python IntelliSense in VSCode.
+        if os.name != "nt":
+            last_build = os.path.join(os.path.dirname(self.build_temp), "last_build")
+            if os.path.exists(last_build):
+                os.unlink(last_build)
+            os.symlink(os.path.join("..", self.build_temp), last_build)
+
         print()  # Add an empty line for cleaner output
 
 

--- a/tools/perspective-scripts/sh_perspective.mjs
+++ b/tools/perspective-scripts/sh_perspective.mjs
@@ -230,6 +230,8 @@ export const copy_files_to_python_folder = (link_files) => {
     const dlic = sh.path`${dist}/LICENSE`;
     const readme = sh.path`${__dirname}/../../README.md`;
     const dreadme = sh.path`${dist}/README.md`;
+    const clangd = sh.path`${__dirname}/../../cpp/perspective/.clangd.in`;
+    const dclangd = sh.path`${dist}/.clangd.in`;
 
     fse.mkdirpSync(dist);
     const copies = [
@@ -238,6 +240,7 @@ export const copy_files_to_python_folder = (link_files) => {
         [lic, dlic],
         [readme, dreadme],
         [cmake, dcmake],
+        [clangd, dclangd],
     ];
     for (let [src, dst] of copies) {
         if (link_files) {

--- a/tools/perspective-scripts/sh_perspective.mjs
+++ b/tools/perspective-scripts/sh_perspective.mjs
@@ -232,6 +232,8 @@ export const copy_files_to_python_folder = (link_files) => {
     const dreadme = sh.path`${dist}/README.md`;
     const clangd = sh.path`${__dirname}/../../cpp/perspective/.clangd.in`;
     const dclangd = sh.path`${dist}/.clangd.in`;
+    const protos = sh.path`${__dirname}/../../protos`;
+    const protosd = sh.path`${dist}/protos`;
 
     fse.mkdirpSync(dist);
     const copies = [
@@ -241,6 +243,7 @@ export const copy_files_to_python_folder = (link_files) => {
         [readme, dreadme],
         [cmake, dcmake],
         [clangd, dclangd],
+        [protos, protosd],
     ];
     for (let [src, dst] of copies) {
         if (link_files) {


### PR DESCRIPTION
This integrates protobuf into the cmake build using some modular tooling. We'll now need `protoc` installed locally to build, this will use that to parse the protobuf version used in the CLI and checkout/build the correct version based on what the user has locally.

Changes:
* Make psp_build_dep always output to the top-level target's binary dir.
* Improve error reporting in psp_build_dep so that errors aren't white text above the top level error message.
* Workaround templating issue with external dependencies.
* Adds Protoc integration module that uses the globally installed `protoc` and provides helpers for building C++ modules from them.

Depends on [this PR](https://github.com/finos/perspective/pull/2467) being merged.