### PR TITLE
Fix cargo features

### DIFF
--- a/rust/perspective-viewer/Cargo.toml
+++ b/rust/perspective-viewer/Cargo.toml
@@ -36,6 +36,10 @@ members = ["tasks/bundle", "tasks/bootstrap-runtime", "tasks/bootstrap"]
 crate-type = ["cdylib", "rlib"]
 path = "src/rust/lib.rs"
 
+[features]
+define_custom_elements_async = []
+default = []
+
 [profile.dev]
 panic = "abort"
 opt-level = "s"

--- a/rust/perspective-viewer/Cargo.toml
+++ b/rust/perspective-viewer/Cargo.toml
@@ -113,7 +113,7 @@ serde_json = { version = "1.0.107", features = ["raw_value"] }
 serde-wasm-bindgen = "0.6.0"
 
 # Async-aware logging that can be disabled at compile-time.
-tracing = { version = ">=0.1.36", features = ["release_max_level_error"] }
+tracing = { version = ">=0.1.36" }
 tracing-subscriber = "0.3.15"
 
 # Browser API bindings

--- a/rust/perspective-viewer/src/rust/components/containers/scroll_panel_item.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/scroll_panel_item.rs
@@ -75,7 +75,7 @@ impl Component for ScrollPanelItem {
     #[cfg(debug_assertions)]
     fn view(&self, ctx: &Context<Self>) -> Html {
         html! {
-            <div class="debug-size-wrapper" style="display:grid" ref={ self.node.clone() }>
+            <div class="debug-size-wrapper" style="display:flow-root" ref={ self.node.clone() }>
                 { for ctx.props().children.iter() }
             </div>
         }

--- a/rust/perspective-viewer/tasks/bundle/main.rs
+++ b/rust/perspective-viewer/tasks/bundle/main.rs
@@ -36,6 +36,7 @@ fn build(pkg: Option<&str>) {
 
     cmd.env("RUSTFLAGS", "--cfg=web_sys_unstable_apis")
         .args(["build"])
+        .args(["--features", "tracing/release_max_level_error"])
         .args(["--target", "wasm32-unknown-unknown"])
         .args(["-Z", "build-std=std,panic_abort"])
         .args(["-Z", "build-std-features=panic_immediate_abort"])


### PR DESCRIPTION
This PR fixes some outstanding issues with consuming the `perspective` Rust library, which is not well tested in this repo.

* Adds back the `define_custom_elements_async` feature which is necessary when the `perspective-viewer` TypeScript loader is not present.
* Removes `release_max_level_error` feature from `tracing` which pollutes consumers who may wish to see their own `tracing` logs.