### PR TITLE
Fix Typos and Broken Link in Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ When submitting Pull Request (PR), please respect the following coding
 guidelines:
 
 -   Complete your
-    [FINOS CLA](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530375/Contribution+Compliance+Requirements#ContributionComplianceRequirements-ContributorLicenseAgreement)
+    [FINOS CLA](https://community.finos.org/docs/governance/software-projects/easycla/)
     _before_ opening a PR.
 -   Please make sure PRs include:
 

--- a/docs/docs/python.md
+++ b/docs/docs/python.md
@@ -615,7 +615,7 @@ viewer.load(table);
 `perspective.websocket` expects a Websocket URL where it will send instructions.
 When `open_table` is called, the name to a hosted Table is passed through, and a
 request is sent through the socket to fetch the Table. No actual `Table`
-instance is passed inbetween the runtimes; all instructions are proxied through
+instance is passed between the runtimes; all instructions are proxied through
 websockets.
 
 This provides for great flexibility — while `Perspective.js` is full of

--- a/docs/docs/python.md
+++ b/docs/docs/python.md
@@ -472,7 +472,7 @@ Building on top of the API provided by `perspective.Table`, the
 of Perspective within the Jupyter environment. It supports the same API
 semantics of `<perspective-viewer>`, along with the additional data types
 supported by `perspective.Table`. `PerspectiveWidget` takes keyword arguments
-for the managed `View`; additioanl arguments `index` and `limit` will be passed
+for the managed `View`; additional arguments `index` and `limit` will be passed
 to the `Table`. For convenience are the
 [`Aggregate`](https://github.com/finos/perspective/blob/master/python/perspective/perspective/core/aggregate.py),
 [`Sort`](https://github.com/finos/perspective/blob/master/python/perspective/perspective/core/sort.py),


### PR DESCRIPTION
-Fixes two typos in the Python documentation
-Fixes broken link to CLA information in Contributing documentation