### PR TITLE
Fix output scrolling in Jupyter when `perspective-python` is installed

### DIFF
--- a/packages/perspective-jupyterlab/src/less/index.less
+++ b/packages/perspective-jupyterlab/src/less/index.less
@@ -30,12 +30,6 @@ div.PSPContainer {
     height: 520px;
 }
 
-// override for small style
-.jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea {
-    max-height: unset;
-    margin: auto;
-}
-
 // Widget height for Jupyter Notebook
 .jupyter-widgets-view div.PSPContainer {
     height: 520px;


### PR DESCRIPTION
Fixes #2494