### PR TITLE
Add Docs Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -706,7 +706,7 @@ jobs:
             # Fancy HTML reports #
             ######################
             - uses: actions/upload-artifact@v3
-              if: always()
+              if: failure()
               with:
                   name: playwright-report
                   path: tools/perspective-test/playwright-report/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -702,6 +702,16 @@ jobs:
             - name: WebAssembly Test
               run: yarn test_js --ci
 
+            ######################
+            # Fancy HTML reports #
+            ######################
+            - uses: actions/upload-artifact@v3
+              if: always()
+              with:
+                  name: playwright-report
+                  path: tools/perspective-test/playwright-report/
+                  retention-days: 30
+
     #############################         ##############################
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~#         #~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
     #~~~~~~~~~~/########\~~~~~~~#         #~~~~~~~~~|##########|~~~~~~~#

--- a/docs/src/components/HomepageFeatures/python.md
+++ b/docs/src/components/HomepageFeatures/python.md
@@ -7,8 +7,8 @@ Production, or as an embedded JupyterLab Widget for Research.
 
 For Application Developers, virtualized `<perspective-viewer>` will only
 consume the data necessary to render the current screen, enabling _ludicrous size_
-datasets with nearly instant load. Or - stream the entire dataset to the
-WebAssembly runtime via efficiently via Apache Arrow, and give your server a
+datasets with nearly instant load. Or - efficiently stream the entire dataset to the
+WebAssembly runtime via Apache Arrow, and give your server a
 break!
 
 For Researchers and Data Scientists, `PerspectiveWidget` is available as a

--- a/docs/template.html
+++ b/docs/template.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+    <script type="module" src="/node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"></script>
+    <script type="module"
+        src="/node_modules/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js"></script>
+    <script type="module"
+        src="/node_modules/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js"></script>
+    <link rel='stylesheet' href="/node_modules/@finos/perspective-viewer/dist/css/pro.css">
+    <style>
+        perspective-viewer {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+        }
+
+        perspective-viewer[theme="Pro Light"] {
+            --plugin--background: #f2f4f6
+        }
+    </style>
+</head>
+
+<body>
+    <perspective-viewer editable>
+    </perspective-viewer>
+    <script type="module">
+        import perspective from "/node_modules/@finos/perspective/dist/cdn/perspective.js";
+        const WORKER = perspective.worker();
+        async function on_load() {
+            console.log("ON LOAD");
+            var el = document.getElementsByTagName('perspective-viewer')[0];
+            console.log("VIEWR ELEMENT:", el);
+            const plugin = await el.getPlugin("Heatmap");
+            plugin.render_warning = false;
+            const table = WORKER.table(this.response);
+            await el.load(table);
+            await el.toggleConfig();
+            window.__TEST_PERSPECTIVE_READY__ = true;
+        }
+        window.addEventListener('DOMContentLoaded', function () {
+            console.log("DOM CONTENT LOADED");
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', '/node_modules/superstore-arrow/superstore.lz4.arrow', true);
+            xhr.responseType = "arraybuffer"
+            xhr.onload = on_load.bind(xhr);
+            xhr.send(null);
+        });
+    </script>
+</body>
+
+</html>

--- a/docs/test/js/examples.spec.ts
+++ b/docs/test/js/examples.spec.ts
@@ -1,0 +1,103 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import {
+    test,
+    getSvgContentString,
+    compareSVGContentsToSnapshot,
+    PageView,
+} from "@finos/perspective-test";
+import EXAMPLES from "../../src/components/ExampleGallery/features";
+const { convert } = require("@finos/perspective-viewer/dist/cjs/migrate.js");
+
+test.describe.configure({ mode: "parallel" });
+
+test.describe("Examples", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("docs/template.html");
+        await page.evaluate(async () => {
+            while (!window["__TEST_PERSPECTIVE_READY__"]) {
+                await new Promise((x) => setTimeout(x, 10));
+            }
+        });
+    });
+
+    for (const idx in EXAMPLES.default) {
+        const example = EXAMPLES.default[idx];
+        test(`${idx} - ${example.name}`, async ({ page }) => {
+            const { config } = example;
+            const new_config = await convert(
+                Object.assign(
+                    {
+                        plugin: "Datagrid",
+                        group_by: [],
+                        expressions: {},
+                        split_by: [],
+                        sort: [],
+                        aggregates: {},
+                    },
+                    config
+                )
+            );
+            await page.evaluate(async (config) => {
+                const viewer = document.querySelector("perspective-viewer");
+                viewer?.addEventListener("perspective-config-update", (e) => {
+                    window.__CONFIG_UPDATED__ = true;
+                    console.log(e);
+                });
+                await viewer.reset();
+                await viewer.restore(config);
+            }, new_config);
+
+            if (Object.keys(config).length !== 0) {
+                await page.evaluate(async () => {
+                    while (!window["__CONFIG_UPDATED__"]) {
+                        await new Promise((x) => setTimeout(x, 10));
+                    }
+                });
+            }
+
+            let selector = "";
+            if (new_config.plugin === "Datagrid") {
+                selector = "perspective-viewer-datagrid";
+            } else if (new_config.plugin === "Map Scatter") {
+                selector = "perspective-viewer-openlayers-scatter";
+            } else {
+                const plugin = new_config.plugin
+                    .replace(/[-\/\s]/gi, "")
+                    .toLowerCase();
+                selector = `perspective-viewer-d3fc-${plugin}`;
+            }
+
+            await compareSVGContentsToSnapshot(page, selector, [
+                `${idx}-${example.name}.txt`,
+            ]);
+        });
+    }
+});
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("docs/template.html");
+    await page.evaluate(async () => {
+        while (!window["__TEST_PERSPECTIVE_READY__"]) {
+            await new Promise((x) => setTimeout(x, 10));
+        }
+    });
+});
+test("test svgs", async ({ page }) => {
+    const viewer = new PageView(page);
+    await viewer.restore({ plugin: "X/Y Scatter" });
+    const contents = await getSvgContentString(
+        "perspective-viewer-d3fc-xyscatter"
+    )(page);
+    console.log(contents);
+});

--- a/packages/perspective-viewer-d3fc/test/js/area.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/area.spec.ts
@@ -35,6 +35,6 @@ test.describe("Area Tests", () => {
 
     run_standard_tests(
         "area",
-        getSvgContentString("perspective-viewer perspective-viewer-d3fc-xyline")
+        getSvgContentString("perspective-viewer perspective-viewer-d3fc-yarea")
     );
 });

--- a/packages/perspective-viewer-d3fc/test/js/line.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/line.spec.ts
@@ -35,6 +35,6 @@ test.describe("Line Tests", () => {
 
     run_standard_tests(
         "yline",
-        getSvgContentString("perspective-viewer perspective-viewer-d3fc-xyline")
+        getSvgContentString("perspective-viewer perspective-viewer-d3fc-yline")
     );
 });

--- a/rust/perspective-viewer/README.md
+++ b/rust/perspective-viewer/README.md
@@ -32,7 +32,6 @@ relevent DOM method e.g. `document.createElement("perspective-viewer")` or
 ### Type Aliases
 
 - [PerspectiveViewerConfig](#perspectiveviewerconfig)
-- [Semver](#semver)
 
 ### Variables
 
@@ -41,9 +40,7 @@ relevent DOM method e.g. `document.createElement("perspective-viewer")` or
 ### Functions
 
 - [chain](#chain)
-- [cmp\_semver](#cmp_semver)
 - [convert](#convert)
-- [parse\_semver](#parse_semver)
 
 ## Type Aliases
 
@@ -53,29 +50,7 @@ relevent DOM method e.g. `document.createElement("perspective-viewer")` or
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:15](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L15)
-
-___
-
-### Semver
-
-Ƭ **Semver**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `build?` | { `major`: `number` ; `minor`: `number` ; `patch`: `number`  } |
-| `build.major` | `number` |
-| `build.minor` | `number` |
-| `build.patch` | `number` |
-| `major` | `number` |
-| `minor` | `number` |
-| `patch` | `number` |
-
-#### Defined in
-
-[rust/perspective-viewer/src/ts/migrate.ts:77](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/migrate.ts#L77)
+[rust/perspective-viewer/src/ts/viewer.ts:15](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L15)
 
 ## Variables
 
@@ -85,7 +60,7 @@ ___
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/perspective-viewer.ts:44](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/perspective-viewer.ts#L44)
+[rust/perspective-viewer/src/ts/perspective-viewer.ts:44](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/perspective-viewer.ts#L44)
 
 ## Functions
 
@@ -109,30 +84,7 @@ Chains functions of `args` and apply to `old`
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/migrate.ts:194](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/migrate.ts#L194)
-
-___
-
-### cmp\_semver
-
-▸ **cmp_semver**(`left`, `right_str`): `boolean`
-
-Checks if left > right
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `left` | [`Semver`](#semver) |
-| `right_str` | `string` |
-
-#### Returns
-
-`boolean`
-
-#### Defined in
-
-[rust/perspective-viewer/src/ts/migrate.ts:115](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/migrate.ts#L115)
+[rust/perspective-viewer/src/ts/migrate.ts:174](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/migrate.ts#L174)
 
 ___
 
@@ -191,27 +143,7 @@ script's package.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/migrate.ts:58](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/migrate.ts#L58)
-
-___
-
-### parse\_semver
-
-▸ **parse_semver**(`ver`): [`Semver`](#semver)
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `ver` | `string` |
-
-#### Returns
-
-[`Semver`](#semver)
-
-#### Defined in
-
-[rust/perspective-viewer/src/ts/migrate.ts:88](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/migrate.ts#L88)
+[rust/perspective-viewer/src/ts/migrate.ts:62](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/migrate.ts#L62)
 
 
 # Interface: IPerspectiveViewerElement
@@ -326,7 +258,7 @@ await viewer2.load(table);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:176](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L176)
+[rust/perspective-viewer/src/ts/viewer.ts:176](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L176)
 
 ___
 
@@ -361,7 +293,7 @@ await view.set_depth(0);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:198](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L198)
+[rust/perspective-viewer/src/ts/viewer.ts:198](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L198)
 
 ___
 
@@ -409,7 +341,7 @@ my_viewer.load(tbl);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:98](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L98)
+[rust/perspective-viewer/src/ts/viewer.ts:98](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L98)
 
 ___
 
@@ -431,7 +363,7 @@ A pointer to this model
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:498](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L498)
+[rust/perspective-viewer/src/ts/viewer.ts:498](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L498)
 
 ___
 
@@ -490,7 +422,7 @@ await viewer.restore(token);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:238](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L238)
+[rust/perspective-viewer/src/ts/viewer.ts:238](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L238)
 
 ___
 
@@ -523,7 +455,7 @@ await viewer.reset();
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:306](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L306)
+[rust/perspective-viewer/src/ts/viewer.ts:306](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L306)
 
 ___
 
@@ -556,7 +488,7 @@ localStorage.setItem("viewer_state", token);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:263](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L263)
+[rust/perspective-viewer/src/ts/viewer.ts:263](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L263)
 
 ▸ **save**(`format`): `Promise`<[`PerspectiveViewerConfig`](#perspectiveviewerconfig)\>
 
@@ -572,7 +504,7 @@ localStorage.setItem("viewer_state", token);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:264](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L264)
+[rust/perspective-viewer/src/ts/viewer.ts:264](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L264)
 
 ▸ **save**(`format`): `Promise`<`ArrayBuffer`\>
 
@@ -588,7 +520,7 @@ localStorage.setItem("viewer_state", token);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:265](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L265)
+[rust/perspective-viewer/src/ts/viewer.ts:265](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L265)
 
 ▸ **save**(`format`): `Promise`<`string`\>
 
@@ -604,7 +536,7 @@ localStorage.setItem("viewer_state", token);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:266](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L266)
+[rust/perspective-viewer/src/ts/viewer.ts:266](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L266)
 
 ▸ **save**(`format?`): `Promise`<`string` \| [`PerspectiveViewerConfig`](#perspectiveviewerconfig) \| `ArrayBuffer`\>
 
@@ -620,7 +552,7 @@ localStorage.setItem("viewer_state", token);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:267](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L267)
+[rust/perspective-viewer/src/ts/viewer.ts:267](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L267)
 
 ___
 
@@ -645,7 +577,7 @@ An `Array` of the plugin instances for this
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:488](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L488)
+[rust/perspective-viewer/src/ts/viewer.ts:488](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L488)
 
 ___
 
@@ -676,7 +608,7 @@ The active or requested plugin instance.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:475](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L475)
+[rust/perspective-viewer/src/ts/viewer.ts:475](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L475)
 
 ___
 
@@ -713,7 +645,7 @@ button.addEventListener("click", async () => {
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:346](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L346)
+[rust/perspective-viewer/src/ts/viewer.ts:346](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L346)
 
 ___
 
@@ -735,7 +667,7 @@ Download this element's data as a CSV file.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:326](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L326)
+[rust/perspective-viewer/src/ts/viewer.ts:326](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L326)
 
 ___
 
@@ -771,7 +703,7 @@ await viewer.toggleConfig();
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:458](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L458)
+[rust/perspective-viewer/src/ts/viewer.ts:458](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L458)
 
 ___
 
@@ -793,7 +725,7 @@ bound to.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:317](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L317)
+[rust/perspective-viewer/src/ts/viewer.ts:317](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L317)
 
 ___
 
@@ -828,7 +760,7 @@ console.log("Viewer has been rendered with a pivot!");
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:291](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L291)
+[rust/perspective-viewer/src/ts/viewer.ts:291](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L291)
 
 ___
 
@@ -864,7 +796,7 @@ view.on_update(obj => {
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:405](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L405)
+[rust/perspective-viewer/src/ts/viewer.ts:405](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L405)
 
 ___
 
@@ -890,7 +822,7 @@ console.log(stats.virtual_fps);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:419](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L419)
+[rust/perspective-viewer/src/ts/viewer.ts:419](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L419)
 
 ___
 
@@ -932,7 +864,7 @@ window.addEventListener("resize", () => viewer.notifyResize());
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:124](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L124)
+[rust/perspective-viewer/src/ts/viewer.ts:124](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L124)
 
 ___
 
@@ -971,7 +903,7 @@ await viewer.resetThemes(["Pro Light", "Pro Dark"]);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:381](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L381)
+[rust/perspective-viewer/src/ts/viewer.ts:381](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L381)
 
 ___
 
@@ -991,7 +923,7 @@ as SVG and Canvas attributes.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:357](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L357)
+[rust/perspective-viewer/src/ts/viewer.ts:357](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L357)
 
 ___
 
@@ -1024,7 +956,7 @@ await viewer.setAutoPause(true);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:158](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L158)
+[rust/perspective-viewer/src/ts/viewer.ts:158](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L158)
 
 ___
 
@@ -1057,7 +989,7 @@ await viewer.setAutoSize(false);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:141](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L141)
+[rust/perspective-viewer/src/ts/viewer.ts:141](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L141)
 
 ___
 
@@ -1090,7 +1022,7 @@ await viewer.setThrottle(1000);
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/viewer.ts:437](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/viewer.ts#L437)
+[rust/perspective-viewer/src/ts/viewer.ts:437](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/viewer.ts#L437)
 
 
 # Interface: IPerspectiveViewerPlugin
@@ -1172,7 +1104,7 @@ logic.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:82](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L82)
+[rust/perspective-viewer/src/ts/plugin.ts:82](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L82)
 
 ___
 
@@ -1194,7 +1126,7 @@ identical behavior to 1.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:73](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L73)
+[rust/perspective-viewer/src/ts/plugin.ts:73](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L73)
 
 ___
 
@@ -1212,7 +1144,7 @@ display name for this plugin in the `<perspective-viewer>` UI.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:54](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L54)
+[rust/perspective-viewer/src/ts/plugin.ts:54](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L54)
 
 ___
 
@@ -1235,7 +1167,7 @@ a `HTMLPerspectiveViewerPluginElement.restore` call.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:94](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L94)
+[rust/perspective-viewer/src/ts/plugin.ts:94](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L94)
 
 ___
 
@@ -1254,7 +1186,7 @@ on column state), leaving existing columns alone.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:62](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L62)
+[rust/perspective-viewer/src/ts/plugin.ts:62](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L62)
 
 ## Methods
 
@@ -1281,7 +1213,7 @@ async clear(): Promise<void> {
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:138](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L138)
+[rust/perspective-viewer/src/ts/plugin.ts:138](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L138)
 
 ___
 
@@ -1297,7 +1229,7 @@ Free any resources acquired by this plugin and prepare to be deleted.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:173](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L173)
+[rust/perspective-viewer/src/ts/plugin.ts:173](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L173)
 
 ___
 
@@ -1330,7 +1262,7 @@ async draw(view: perspective.View): Promise<void> {
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:109](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L109)
+[rust/perspective-viewer/src/ts/plugin.ts:109](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L109)
 
 ___
 
@@ -1347,7 +1279,7 @@ and the underlying data has not.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:144](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L144)
+[rust/perspective-viewer/src/ts/plugin.ts:144](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L144)
 
 ___
 
@@ -1369,7 +1301,7 @@ Restore this plugin to a state previously returned by `save()`.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:168](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L168)
+[rust/perspective-viewer/src/ts/plugin.ts:168](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L168)
 
 ___
 
@@ -1386,7 +1318,7 @@ plugins which read CSS styles via `window.getComputedStyle()`.
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:150](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L150)
+[rust/perspective-viewer/src/ts/plugin.ts:150](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L150)
 
 ___
 
@@ -1410,7 +1342,7 @@ reload.  For example, `@finos/perspective-viewer-d3fc` uses
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:163](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L163)
+[rust/perspective-viewer/src/ts/plugin.ts:163](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L163)
 
 ___
 
@@ -1442,6 +1374,6 @@ async update(view: perspective.View): Promise<void> {
 
 #### Defined in
 
-[rust/perspective-viewer/src/ts/plugin.ts:123](https://github.com/finos/perspective/blob/7392c2a64/rust/perspective-viewer/src/ts/plugin.ts#L123)
+[rust/perspective-viewer/src/ts/plugin.ts:123](https://github.com/finos/perspective/blob/ccd772889/rust/perspective-viewer/src/ts/plugin.ts#L123)
 
 

--- a/rust/perspective-viewer/src/ts/migrate/2-6-1.ts
+++ b/rust/perspective-viewer/src/ts/migrate/2-6-1.ts
@@ -55,26 +55,28 @@ export default function migrate_2_6_1(old, options) {
     }
 
     // check for string expressions, replace with objects
-    let new_exprs = {};
-    for (let i in old.expressions) {
-        if (typeof old.expressions[i] === "string") {
-            if (options.warn) {
-                console.warn(
-                    "Replacing deprecated string expression with object"
-                );
-            }
-            let old_expr = old.expressions[i];
-            let [whole_expr, name, expr] = old_expr.match(
-                /\/\/\s*([^\n]+)\n(.*)/
-            ) ?? [old_expr, null, null];
-            if (name && expr) {
-                new_exprs[name] = expr;
-            } else {
-                new_exprs[whole_expr] = whole_expr;
+    if (Array.isArray(old.expressions)) {
+        let new_exprs = {};
+        for (let i in old.expressions) {
+            if (typeof old.expressions[i] === "string") {
+                if (options.warn) {
+                    console.warn(
+                        "Replacing deprecated string expression with object"
+                    );
+                }
+                let old_expr = old.expressions[i];
+                let [whole_expr, name, expr] = old_expr.match(
+                    /\/\/\s*([^\n]+)\n(.*)/
+                ) ?? [old_expr, null, null];
+                if (name && expr) {
+                    new_exprs[name] = expr;
+                } else {
+                    new_exprs[whole_expr] = whole_expr;
+                }
             }
         }
+        old.expressions = new_exprs;
     }
-    old.expressions = new_exprs;
 
     if (options.verbose) {
         console.log(old);

--- a/tools/perspective-test/playwright.config.ts
+++ b/tools/perspective-test/playwright.config.ts
@@ -72,6 +72,10 @@ const BROWSER_PACKAGES = [
         packageName: "perspective-cli",
         testDir: "packages/perspective-cli/test/js",
     },
+    {
+        packageName: "docs",
+        testDir: "docs/test/js",
+    },
 ];
 
 const NODE_PACKAGES = [

--- a/tools/perspective-test/playwright.config.ts
+++ b/tools/perspective-test/playwright.config.ts
@@ -157,7 +157,7 @@ export default defineConfig({
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
     quiet: true,
-    reporter: process.env.CI ? "github" : "dot",
+    reporter: process.env.CI ? [["github"], ["html"]] : [["dot"]],
     projects: PROJECTS,
     outputDir: "dist/results",
     use: {


### PR DESCRIPTION
Currently on https://perspective.finos.org, there are broken examples on the home page. This occurs on X/Y scatter plots due to a failing migration.
Building and testing on main does not replicate the bug, as the website is running on v2.7.1 and [a fix has been added](https://github.com/finos/perspective/commit/3b648543e60805c98c0e5bb4fece03caa4341f6d) since that release.
This PR simply adds tests for the examples (one for each example, totaling 75) to ensure this doesn't happen again.