### PR TITLE
Disable follow_symlinks

### DIFF
--- a/examples/python-aiohttp/server.py
+++ b/examples/python-aiohttp/server.py
@@ -52,9 +52,7 @@ def make_app():
 
     app = web.Application()
     app.router.add_get("/websocket", websocket_handler)
-    app.router.add_static(
-        "/node_modules/@finos", "../../node_modules/@finos", follow_symlinks=True
-    )
+    app.router.add_static("/node_modules/@finos", "../../node_modules/@finos")
     app.router.add_static(
         "/node_modules", "../../node_modules/@finos", follow_symlinks=True
     )


### PR DESCRIPTION
I'm checking that this parameter wasn't set by mistake.
The parameter allows a symlink to point to somewhere _outside_ of the static directory. Symlinks that point within the directory will work without enabling this parameter (it's badly named). Therefore enabling this option could make it easy to misconfigure an environment and introduce security issues.