### PR TITLE
Bugfix: Settings panel width changes on split-by

### DIFF
--- a/rust/perspective-viewer/src/less/aggregate-selector.less
+++ b/rust/perspective-viewer/src/less/aggregate-selector.less
@@ -16,7 +16,7 @@
     .aggregate-selector-wrapper {
         height: 19px;
         display: flex;
-        padding-left: 5px;
+        padding-left: 23px;
         width: 85px;
         min-width: 85px;
         max-width: 85px;

--- a/rust/perspective-viewer/src/less/column-selector.less
+++ b/rust/perspective-viewer/src/less/column-selector.less
@@ -33,9 +33,10 @@
         overflow: hidden;
         text-overflow: ellipsis;
         flex: 0 1 auto;
-        padding-left: 5px;
+        padding-left: 23px;
         display: inline-block;
         align-items: center;
+        line-height: normal;
 
         &:only-child {
             padding-right: 12px;

--- a/rust/perspective-viewer/src/less/type-icon.less
+++ b/rust/perspective-viewer/src/less/type-icon.less
@@ -11,19 +11,19 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 :host .type-icon {
+    &.absolute {
+        position: absolute;
+        left: 15px;
+    }
+
     height: 13px;
     width: 13px;
-    // position: absolute;
-    // left: 15px;
-    // top: 4.5px;
-    // @include icon;
     background-repeat: no-repeat;
     background-color: var(--icon--color);
     content: "";
     display: inline-block;
     -webkit-mask-size: cover;
     mask-size: cover;
-    margin-left: 5px;
     flex-shrink: 0;
 
     &.none {

--- a/rust/perspective-viewer/src/rust/components/column_selector/active_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/active_column.rs
@@ -404,7 +404,7 @@ impl Component for ActiveColumn {
 
                             <div class="column-selector-column-border">
 
-                                <TypeIcon ty={col_type} />
+                                <TypeIcon absolute=true ty={col_type} />
 
                                 if ctx.props().is_aggregated {
                                     <AggregateSelector

--- a/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
@@ -480,7 +480,7 @@ impl Component for FilterColumn {
 
                 <LocalStyle href={ css!("filter-item") } />
                 <div class="pivot-column-border">
-                    <TypeIcon ty={Type::String} />
+                    <TypeIcon absolute=true ty={Type::String} />
                     <span class="column_name">
                         { filter.0.to_owned() }
                     </span>

--- a/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
@@ -205,7 +205,7 @@ impl Component for InactiveColumn {
                     { ondragend }>
 
                     <div class="column-selector-column-border">
-                        <TypeIcon ty={col_type} />
+                        <TypeIcon absolute=true ty={col_type} />
                         <span class={"column_name"}>
                             { ctx.props().name.clone() }
                         </span>

--- a/rust/perspective-viewer/src/rust/components/column_selector/pivot_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/pivot_column.rs
@@ -68,7 +68,7 @@ impl Component for PivotColumn {
                 ondragstart={ dragstart }
                 ondragend={ dragend }>
                 <div class="pivot-column-border">
-                    <TypeIcon ty={Type::String} />
+                    <TypeIcon absolute=true ty={Type::String} />
                     <span class="column_name">
                         { ctx.props().column.clone() }
                     </span>

--- a/rust/perspective-viewer/src/rust/components/column_selector/sort_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/sort_column.rs
@@ -108,7 +108,7 @@ impl Component for SortColumn {
                 ondragstart={ dragstart }
                 ondragend={ dragend }>
                 <div class="pivot-column-border">
-                    <TypeIcon ty={Type::String} />
+                    <TypeIcon absolute=true ty={Type::String} />
                     <span
                         class="column_name">
                         { ctx.props().sort.0.to_owned() }

--- a/rust/perspective-viewer/src/rust/components/type_icon.rs
+++ b/rust/perspective-viewer/src/rust/components/type_icon.rs
@@ -44,6 +44,8 @@ impl std::fmt::Display for TypeIconType {
 #[derive(PartialEq, Properties, Debug)]
 pub struct TypeIconProps {
     pub ty: TypeIconType,
+    #[prop_or_default]
+    pub absolute: bool,
 }
 
 #[function_component(TypeIcon)]
@@ -51,7 +53,7 @@ pub fn type_icon(p: &TypeIconProps) -> yew::Html {
     html_template! {
         <LocalStyle href={css!("type-icon")} />
         <span
-            class={classes!(p.ty.to_string(), "type-icon")}
+            class={classes!(p.ty.to_string(), "type-icon", p.absolute.then_some("absolute"))}
         ></span>
     }
 }


### PR DESCRIPTION
https://github.com/finos/perspective/assets/41482263/fe2e91e0-8212-472c-8777-f5355c559551

Before

https://github.com/finos/perspective/assets/41482263/9577e361-e6c7-47ed-83f5-e04e52fe7cff

After

This also fixes an alignment bug with the active column names. A better fix would probably be to remove the `:host *` rule which sets `line-height: 1.5`.