### PR TITLE
A few CSS fixes for regular-table in shadow DOM

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/custom_elements/datagrid.js
+++ b/packages/perspective-viewer-datagrid/src/js/custom_elements/datagrid.js
@@ -137,6 +137,10 @@ export class HTMLPerspectiveViewerDatagridPluginElement extends HTMLElement {
         this.regular_table.clear();
     }
 
-    static renderTarget = "shadow";
+    static renderTarget =
+        window.CSS?.supports &&
+        window.CSS?.supports("selector(:host-context(foo))")
+            ? "shadow"
+            : "light";
     static #sheet;
 }

--- a/packages/perspective-viewer-datagrid/src/less/mitered-headers.less
+++ b/packages/perspective-viewer-datagrid/src/less/mitered-headers.less
@@ -37,11 +37,18 @@
         0px 10px 0 -9px var(--inactive--border-color, #8b868045);
 }
 
-perspective-viewer[settings],
-:host-context(perspective-viewer[settings]) {
+@mixin disabled-menu-funky-box-shadow {
     tr.rt-autosize .psp-header-leaf.psp-header-border:not(.psp-menu-enabled) {
         box-shadow: 1px 0px var(--inactive--border-color, #8b868045);
     }
+}
+
+perspective-viewer[settings] {
+    @include disabled-menu-funky-box-shadow;
+}
+
+:host-context(perspective-viewer[settings]) {
+    @include disabled-menu-funky-box-shadow;
 }
 
 .psp-header-leaf.psp-header-border {

--- a/packages/perspective-viewer-datagrid/src/less/mitered-headers.less
+++ b/packages/perspective-viewer-datagrid/src/less/mitered-headers.less
@@ -37,10 +37,11 @@
         0px 10px 0 -9px var(--inactive--border-color, #8b868045);
 }
 
-perspective-viewer[settings]
-    tr.rt-autosize
-    .psp-header-leaf.psp-header-border:not(.psp-menu-enabled) {
-    box-shadow: 1px 0px var(--inactive--border-color, #8b868045);
+perspective-viewer[settings],
+:host-context(perspective-viewer[settings]) {
+    tr.rt-autosize .psp-header-leaf.psp-header-border:not(.psp-menu-enabled) {
+        box-shadow: 1px 0px var(--inactive--border-color, #8b868045);
+    }
 }
 
 .psp-header-leaf.psp-header-border {

--- a/packages/perspective-viewer-datagrid/src/less/regular_table.less
+++ b/packages/perspective-viewer-datagrid/src/less/regular_table.less
@@ -81,9 +81,12 @@ perspective-viewer[settings],
     }
 }
 
-perspective-viewer regular-table table thead tr:last-child th {
-    border-bottom-width: 1px;
-    border-bottom-color: var(--inactive--border-color, #8b868045);
+perspective-viewer,
+:host-context(perspective-viewer) {
+    regular-table table thead tr:last-child th {
+        border-bottom-width: 1px;
+        border-bottom-color: var(--inactive--border-color, #8b868045);
+    }
 }
 
 .psp-sort-enabled:hover {
@@ -120,8 +123,11 @@ td:focus {
     outline-width: 1px;
 }
 
-perspective-viewer.dragging regular-table {
-    pointer-events: none;
+perspective-viewer.dragging,
+:host-context(perspective-viewer.dragging) {
+    regular-table {
+        pointer-events: none;
+    }
 }
 
 .psp-header-border:last-child {

--- a/packages/perspective-viewer-datagrid/src/less/regular_table.less
+++ b/packages/perspective-viewer-datagrid/src/less/regular_table.less
@@ -289,7 +289,7 @@ regular-table table {
 // _first_ frame as if its in the wrong state, as it detects sidepanel state
 // via HTML attribute checking.
 perspective-viewer:not([settings]),
-:host-context(:not([settings])) {
+:host-context(perspective-viewer:not([settings])) {
     regular-table #psp-column-edit-buttons:after {
         content: none;
     }

--- a/packages/perspective-viewer-datagrid/src/less/regular_table.less
+++ b/packages/perspective-viewer-datagrid/src/less/regular_table.less
@@ -27,8 +27,15 @@
     mask-size: cover;
 }
 
-perspective-viewer:not([settings]),
+perspective-viewer:not([settings]) {
+    @include settings-not-open;
+}
+
 :host-context(perspective-viewer:not([settings])) {
+    @include settings-not-open;
+}
+
+@mixin settings-not-open {
     regular-table table tr.rt-autosize + tr th {
         height: 0px;
         span {
@@ -37,8 +44,7 @@ perspective-viewer:not([settings]),
     }
 }
 
-perspective-viewer[settings],
-:host-context(perspective-viewer[settings]) {
+@mixin settings-open {
     .psp-menu-enabled {
         padding: 0 6px;
         font-size: 8px;
@@ -81,12 +87,27 @@ perspective-viewer[settings],
     }
 }
 
-perspective-viewer,
-:host-context(perspective-viewer) {
+perspective-viewer[settings] {
+    @include settings-open;
+}
+
+:host-context(perspective-viewer[settings]) {
+    @include settings-open;
+}
+
+@mixin viewer-table-styles {
     regular-table table thead tr:last-child th {
         border-bottom-width: 1px;
         border-bottom-color: var(--inactive--border-color, #8b868045);
     }
+}
+
+perspective-viewer {
+    @include viewer-table-styles;
+}
+
+:host-context(perspective-viewer) {
+    @include viewer-table-styles;
 }
 
 .psp-sort-enabled:hover {
@@ -123,11 +144,16 @@ td:focus {
     outline-width: 1px;
 }
 
-perspective-viewer.dragging,
-:host-context(perspective-viewer.dragging) {
+@mixin table-no-dragging {
     regular-table {
         pointer-events: none;
     }
+}
+perspective-viewer.dragging {
+    @include table-no-dragging;
+}
+:host-context(perspective-viewer.dragging) {
+    @include table-no-dragging;
 }
 
 .psp-header-border:last-child {
@@ -288,11 +314,16 @@ regular-table table {
 // until the drawing is done. However, this causes the datagrid to draw its
 // _first_ frame as if its in the wrong state, as it detects sidepanel state
 // via HTML attribute checking.
-perspective-viewer:not([settings]),
-:host-context(perspective-viewer:not([settings])) {
+@mixin design-slash-architecture-bug {
     regular-table #psp-column-edit-buttons:after {
         content: none;
     }
+}
+perspective-viewer:not([settings]) {
+    @include design-slash-architecture-bug;
+}
+:host-context(perspective-viewer:not([settings])) {
+    @include design-slash-architecture-bug;
 }
 
 // Style the last row of the `<thead>` so that is has a bottom border.

--- a/rust/perspective-viewer/src/themes/dracula.less
+++ b/rust/perspective-viewer/src/themes/dracula.less
@@ -67,10 +67,8 @@ perspective-dropdown[theme="Dracula"] {
 }
 
 @mixin perspective-viewer-dracula--datagrid {
-    regular-table {
-        --rt-pos-cell--color: var(--theme-blue);
-        --rt-neg-cell--color: var(--theme-red); 
-    }
+    --rt-pos-cell--color: var(--theme-blue);
+    --rt-neg-cell--color: var(--theme-red);
 }
 
 @mixin perspective-viewer-dracula--d3fc {

--- a/rust/perspective-viewer/src/themes/gruvbox-dark.less
+++ b/rust/perspective-viewer/src/themes/gruvbox-dark.less
@@ -75,10 +75,8 @@ perspective-dropdown[theme="Gruvbox Dark"] {
 }
 
 @mixin perspective-viewer-gruvbox-dark--datagrid {
-    regular-table {
-        --rt-pos-cell--color: var(--theme-alt-blue);
-        --rt-neg-cell--color: var(--theme-alt-red); 
-    }
+    --rt-pos-cell--color: var(--theme-alt-blue);
+    --rt-neg-cell--color: var(--theme-alt-red);
 }
 
 @mixin perspective-viewer-gruvbox-dark--d3fc {

--- a/rust/perspective-viewer/src/themes/gruvbox.less
+++ b/rust/perspective-viewer/src/themes/gruvbox.less
@@ -56,8 +56,6 @@ perspective-viewer[theme="Gruvbox Light"] {
     // --gruvbox-light-aqua: #8ec07c;
     // --gruvbox-light-orange: #fe8019;
 
-  
-
     @include perspective-viewer-pro;
     @include perspective-viewer-gruvbox-light--colors;
     @include perspective-viewer-gruvbox-light--animation;
@@ -100,7 +98,7 @@ perspective-dropdown[theme="Gruvbox Light"] {
     --theme-alt-purple: #8f3f71;
     --theme-alt-aqua: #427b58;
     --theme-alt-orange: #af3a03;
-    
+
     color: var(--theme-fg1);
     background-color: var(--theme-bg1);
     --icon--color: var(--theme-fg0);
@@ -113,10 +111,8 @@ perspective-dropdown[theme="Gruvbox Light"] {
 }
 
 @mixin perspective-viewer-gruvbox-light--datagrid {
-    regular-table {
-        --rt-pos-cell--color: var(--theme-blue);
-        --rt-neg-cell--color: var(--theme-red); 
-    }
+    --rt-pos-cell--color: var(--theme-blue);
+    --rt-neg-cell--color: var(--theme-red);
 }
 
 @mixin perspective-viewer-gruvbox-light--d3fc {

--- a/rust/perspective-viewer/src/themes/monokai.less
+++ b/rust/perspective-viewer/src/themes/monokai.less
@@ -64,7 +64,8 @@ perspective-string-column-style[theme="Monokai"] {
     --rt-neg-cell--color: #ff6188 !important;
     --rt--border-color: #444444;
 
-    // TODO: probably doesn't work with shadow DOM
+    // FIXME: broken in shadow DOM.  Can be fixed with a new custom property allowing empty header cell backgrounds
+    // to be styled
     regular-table table tbody th:empty {
         background: linear-gradient(
             to right,

--- a/rust/perspective-viewer/src/themes/monokai.less
+++ b/rust/perspective-viewer/src/themes/monokai.less
@@ -60,17 +60,18 @@ perspective-string-column-style[theme="Monokai"] {
 }
 
 @mixin perspective-viewer-monokai--datagrid {
-    regular-table {
-        --rt-pos-cell--color: #78dce8 !important;
-        --rt-neg-cell--color: #ff6188 !important;
-        --rt--border-color: #444444;
-    }
+    --rt-pos-cell--color: #78dce8 !important;
+    --rt-neg-cell--color: #ff6188 !important;
+    --rt--border-color: #444444;
 
+    // TODO: probably doesn't work with shadow DOM
     regular-table table tbody th:empty {
-        background: linear-gradient(to right,
-                transparent 9px,
-                #444444 10px,
-                transparent 11px);
+        background: linear-gradient(
+            to right,
+            transparent 9px,
+            #444444 10px,
+            transparent 11px
+        );
     }
 }
 
@@ -97,7 +98,9 @@ perspective-string-column-style[theme="Monokai"] {
 
     --d3fc-negative--gradient: linear-gradient(#272822 0%, #ff6188 100%);
     --d3fc-positive--gradient: linear-gradient(#272822 0%, #78dce8 100%);
-    --d3fc-full--gradient: linear-gradient(#ff6188 0%,
-            #272822 50%,
-            #78dce8 100%);
+    --d3fc-full--gradient: linear-gradient(
+        #ff6188 0%,
+        #272822 50%,
+        #78dce8 100%
+    );
 }

--- a/rust/perspective-viewer/src/themes/pro-dark.less
+++ b/rust/perspective-viewer/src/themes/pro-dark.less
@@ -95,16 +95,12 @@ perspective-string-column-style[theme="Pro Dark"] {
     --map-category-8: rgb(221, 99, 103);
     --map-category-9: rgb(120, 104, 206);
     --map-category-10: rgb(23, 166, 123);
-    --map-gradient: linear-gradient(#dd6367 0%,
-            #242526 50%,
-            #3289c8 100%);
+    --map-gradient: linear-gradient(#dd6367 0%, #242526 50%, #3289c8 100%);
 }
 
 @mixin perspective-viewer-pro-dark--datagrid {
-    regular-table {
-        --rt-pos-cell--color: #7dc3f0;
-        --rt-neg-cell--color: #ff9485;
-    }
+    --rt-pos-cell--color: #7dc3f0;
+    --rt-neg-cell--color: #ff9485;
 }
 
 @mixin perspective-viewer-pro-dark--d3fc {
@@ -131,9 +127,11 @@ perspective-string-column-style[theme="Pro Dark"] {
     --d3fc-series-9: rgb(120, 104, 206);
     --d3fc-series-10: rgb(23, 166, 123);
 
-    --d3fc-full--gradient: linear-gradient(#dd6367 0%,
-            #242526 50%,
-            #3289c8 100%);
+    --d3fc-full--gradient: linear-gradient(
+        #dd6367 0%,
+        #242526 50%,
+        #3289c8 100%
+    );
 
     --d3fc-positive--gradient: linear-gradient(#242526 0%, #3289c8 100%);
     --d3fc-negative--gradient: linear-gradient(#dd6367 0%, #242526 100%);

--- a/rust/perspective-viewer/src/themes/pro.less
+++ b/rust/perspective-viewer/src/themes/pro.less
@@ -42,9 +42,9 @@ perspective-string-column-style[theme="Pro Light"] {
     @include perspective-viewer-pro--openlayers;
 }
 
-
 @mixin perspective-modal-pro {
-    font-family: "ui-monospace", "SFMono-Regular", "SF Mono", "Menlo", "Consolas", "Liberation Mono", monospace;
+    font-family: "ui-monospace", "SFMono-Regular", "SF Mono", "Menlo",
+        "Consolas", "Liberation Mono", monospace;
     background-color: white;
     border: 1px solid var(--inactive--color);
     border-radius: 0 0 2px 2px;
@@ -80,8 +80,8 @@ perspective-string-column-style[theme="Pro Light"] {
     color: #161616;
     background-color: transparent;
     --icon--color: #161616;
-    --inactive--color: #ABABAB;
-    --inactive--border-color: #DADADA;
+    --inactive--color: #ababab;
+    --inactive--border-color: #dadada;
 
     --root--background: #ffffff;
     --active--color: #2670a9;
@@ -91,15 +91,17 @@ perspective-string-column-style[theme="Pro Light"] {
     --select--background-color: none;
     --column-drop-container--background: none;
     --warning--background: #042121;
-    --warning--color: #FDFFFD;
+    --warning--color: #fdfffd;
 
     // TODO deprecate me
-    --overflow-hint-icon--color: #FDFFFD;
+    --overflow-hint-icon--color: #fdfffd;
 }
 
 @mixin perspective-viewer-pro--fonts {
-    font-family: "ui-monospace", "SFMono-Regular", "SF Mono", "Menlo", "Consolas", "Liberation Mono", monospace;
-    --interface-monospace--font-family: "ui-monospace", "SFMono-Regular", "SF Mono", "Menlo", "Consolas", "Liberation Mono", monospace;
+    font-family: "ui-monospace", "SFMono-Regular", "SF Mono", "Menlo",
+        "Consolas", "Liberation Mono", monospace;
+    --interface-monospace--font-family: "ui-monospace", "SFMono-Regular",
+        "SF Mono", "Menlo", "Consolas", "Liberation Mono", monospace;
 }
 
 @mixin perspective-viewer-pro--d3fc {
@@ -125,21 +127,27 @@ perspective-string-column-style[theme="Pro Light"] {
     --d3fc-series-8: #7f7f7f;
     --d3fc-series-9: #bcbd22;
     --d3fc-series-10: #17becf;
-    --d3fc-full--gradient: linear-gradient(#4d342f 0%,
-            #e4521b 22.5%,
-            #feeb65 42.5%,
-            #f0f0f0 50%,
-            #dcedc8 57.5%,
-            #42b3d5 67.5%,
-            #1a237e 100%);
-    --d3fc-positive--gradient: linear-gradient(#f0f0f0 0%,
-            #dcedc8 10%,
-            #42b3d5 50%,
-            #1a237e 100%);
-    --d3fc-negative--gradient: linear-gradient(#4d342f 0%,
-            #e4521b 50%,
-            #feeb65 90%,
-            #f0f0f0 100%);
+    --d3fc-full--gradient: linear-gradient(
+        #4d342f 0%,
+        #e4521b 22.5%,
+        #feeb65 42.5%,
+        #f0f0f0 50%,
+        #dcedc8 57.5%,
+        #42b3d5 67.5%,
+        #1a237e 100%
+    );
+    --d3fc-positive--gradient: linear-gradient(
+        #f0f0f0 0%,
+        #dcedc8 10%,
+        #42b3d5 50%,
+        #1a237e 100%
+    );
+    --d3fc-negative--gradient: linear-gradient(
+        #4d342f 0%,
+        #e4521b 50%,
+        #feeb65 90%,
+        #f0f0f0 100%
+    );
 }
 
 @mixin perspective-viewer-pro--openlayers {
@@ -155,17 +163,18 @@ perspective-string-column-style[theme="Pro Light"] {
     --map-category-8: #7f7f7f;
     --map-category-9: #bcbd22;
     --map-category-10: #17becf;
-    --map-gradient: linear-gradient(#4d342f 0%,
-            #e4521b 22.5%,
-            #feeb65 42.5%,
-            #f0f0f0 50%,
-            #dcedc8 57.5%,
-            #42b3d5 67.5%,
-            #1a237e 100%);
+    --map-gradient: linear-gradient(
+        #4d342f 0%,
+        #e4521b 22.5%,
+        #feeb65 42.5%,
+        #f0f0f0 50%,
+        #dcedc8 57.5%,
+        #42b3d5 67.5%,
+        #1a237e 100%
+    );
 }
 
 @mixin perspective-viewer-pro--datagrid {
     --rt-pos-cell--color: #338dcd;
     --rt-neg-cell--color: #ff471e;
 }
-

--- a/rust/perspective-viewer/src/themes/solarized.less
+++ b/rust/perspective-viewer/src/themes/solarized.less
@@ -65,12 +65,10 @@ perspective-string-column-style[theme="Solarized"] {
 }
 
 @mixin perspective-viewer-solarized--datagrid {
-    regular-table {
-        --rt-pos-cell--color: #268bd2 !important;
-        --rt-neg-cell--color: #cb4b16 !important;
-        --rt-hover--border-color: #CCC;
-        --rt--border-color: #93a1a1;
-    }
+    --rt-pos-cell--color: #268bd2 !important;
+    --rt-neg-cell--color: #cb4b16 !important;
+    --rt-hover--border-color: #ccc;
+    --rt--border-color: #93a1a1;
 }
 x {
     color: #cb4b16;
@@ -92,11 +90,13 @@ x {
     --d3fc-series-6: #6c71c4;
     --d3fc-series-7: #d33682;
 
-    --d3fc-positive--gradient: linear-gradient(#268bd2 0%,
-            #2aa198,
-            #859900,
-            #b58900,
-            #cb4b16,
-            #dc322f,
-            #d33682 100%);
+    --d3fc-positive--gradient: linear-gradient(
+        #268bd2 0%,
+        #2aa198,
+        #859900,
+        #b58900,
+        #cb4b16,
+        #dc322f,
+        #d33682 100%
+    );
 }

--- a/rust/perspective-viewer/src/themes/vaporwave.less
+++ b/rust/perspective-viewer/src/themes/vaporwave.less
@@ -60,18 +60,19 @@ perspective-string-column-style[theme="Vaporwave"] {
 }
 
 @mixin perspective-viewer-vaporwave--datagrid {
-    regular-table {
-        --pp-color-1: rgb(9, 33, 50);
-        --pp-color-2: rgb(66, 182, 230);
-        --rt-pos-cell--color: rgb(66, 182, 230) !important;
-        --rt-hover--border-color: var(--pp-color-1) !important;
-    }
+    --pp-color-1: rgb(9, 33, 50);
+    --pp-color-2: rgb(66, 182, 230);
+    --rt-pos-cell--color: rgb(66, 182, 230) !important;
+    --rt-hover--border-color: var(--pp-color-1) !important;
 
+    // TODO: likely broken in shadow DOM
     regular-table table tbody th:empty {
-        background: linear-gradient(to right,
-                transparent 9px,
-                rgb(19, 33, 50) 10px,
-                transparent 11px);
+        background: linear-gradient(
+            to right,
+            transparent 9px,
+            rgb(19, 33, 50) 10px,
+            transparent 11px
+        );
         background-repeat: no-repeat;
         background-position: 0px -10px;
     }
@@ -93,45 +94,51 @@ perspective-string-column-style[theme="Vaporwave"] {
     --d3fc-series-9: hsl(157, 100%, 25%);
     --d3fc-series-10: hsl(272, 100%, 35%);
 
-    --d3fc-negative--gradient: linear-gradient(#f3d431,
-            #efb92d,
-            #ed9c25,
-            #eb7e20,
-            #e75d1e,
-            #d14632,
-            #b03e38,
-            #8c3a36,
-            #643633,
-            #07081d) !important;
+    --d3fc-negative--gradient: linear-gradient(
+        #f3d431,
+        #efb92d,
+        #ed9c25,
+        #eb7e20,
+        #e75d1e,
+        #d14632,
+        #b03e38,
+        #8c3a36,
+        #643633,
+        #07081d
+    ) !important;
 
-    --d3fc-positive--gradient: linear-gradient(#07081d,
-            #2e4463,
-            #1e588a,
-            #086da7,
-            #0082b9,
-            #039ac7,
-            #12b1d4,
-            #2bc8e2,
-            #3ddff0,
-            #61f4fb) !important;
+    --d3fc-positive--gradient: linear-gradient(
+        #07081d,
+        #2e4463,
+        #1e588a,
+        #086da7,
+        #0082b9,
+        #039ac7,
+        #12b1d4,
+        #2bc8e2,
+        #3ddff0,
+        #61f4fb
+    ) !important;
 
-    --d3fc-full--gradient: linear-gradient(#f3d431,
-            #efb92d,
-            #ed9c25,
-            #eb7e20,
-            #e75d1e,
-            #d14632,
-            #b03e38,
-            #8c3a36,
-            #643633,
-            #07081d,
-            #2e4463,
-            #1e588a,
-            #086da7,
-            #0082b9,
-            #039ac7,
-            #12b1d4,
-            #2bc8e2,
-            #3ddff0,
-            #61f4fb) !important;
+    --d3fc-full--gradient: linear-gradient(
+        #f3d431,
+        #efb92d,
+        #ed9c25,
+        #eb7e20,
+        #e75d1e,
+        #d14632,
+        #b03e38,
+        #8c3a36,
+        #643633,
+        #07081d,
+        #2e4463,
+        #1e588a,
+        #086da7,
+        #0082b9,
+        #039ac7,
+        #12b1d4,
+        #2bc8e2,
+        #3ddff0,
+        #61f4fb
+    ) !important;
 }

--- a/rust/perspective-viewer/src/themes/vaporwave.less
+++ b/rust/perspective-viewer/src/themes/vaporwave.less
@@ -65,7 +65,8 @@ perspective-string-column-style[theme="Vaporwave"] {
     --rt-pos-cell--color: rgb(66, 182, 230) !important;
     --rt-hover--border-color: var(--pp-color-1) !important;
 
-    // TODO: likely broken in shadow DOM
+    // FIXME: broken in shadow DOM.  Can be fixed with a new custom property allowing empty header cell backgrounds
+    // to be styled
     regular-table table tbody th:empty {
         background: linear-gradient(
             to right,


### PR DESCRIPTION
Moving datagrid's regular-table into shadow DOM caused some CSS regressions. These changes fix a few that we've spotted, particularly in the table header.