### PR TITLE
Settings panel width is inconsistent for columns moved to `Config`

### DIFF
--- a/rust/perspective-viewer/src/less/aggregate-selector.less
+++ b/rust/perspective-viewer/src/less/aggregate-selector.less
@@ -16,7 +16,7 @@
     .aggregate-selector-wrapper {
         height: 19px;
         display: flex;
-        padding-left: 5px;
+        padding-left: 23px;
         width: 85px;
         min-width: 85px;
         max-width: 85px;

--- a/rust/perspective-viewer/src/less/column-selector.less
+++ b/rust/perspective-viewer/src/less/column-selector.less
@@ -33,9 +33,10 @@
         overflow: hidden;
         text-overflow: ellipsis;
         flex: 0 1 auto;
-        padding-left: 5px;
+        padding-left: 23px;
         display: inline-block;
         align-items: center;
+        line-height: normal;
 
         &:only-child {
             padding-right: 12px;
@@ -53,8 +54,8 @@
     // Inactive columns need to account for expression buttons, which won't be
     // the last child if it has a button
     #sub-columns .column-selector--spacer:last-child {
-        width: 94px;
-        flex: 0 100000000 94px;
+        width: 93px;
+        flex: 0 100000000 93px;
     }
 
     .show-aggregate .column-selector--spacer {

--- a/rust/perspective-viewer/src/less/type-icon.less
+++ b/rust/perspective-viewer/src/less/type-icon.less
@@ -10,20 +10,21 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
+:host #selected-columns .type-icon,
+:host #sub-columns .type-icon {
+    position: absolute;
+    left: 15px;
+}
+
 :host .type-icon {
     height: 13px;
     width: 13px;
-    // position: absolute;
-    // left: 15px;
-    // top: 4.5px;
-    // @include icon;
     background-repeat: no-repeat;
     background-color: var(--icon--color);
     content: "";
     display: inline-block;
     -webkit-mask-size: cover;
     mask-size: cover;
-    margin-left: 5px;
     flex-shrink: 0;
 
     &.none {

--- a/rust/perspective-viewer/src/rust/components/column_selector/active_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/active_column.rs
@@ -403,9 +403,7 @@ impl Component for ActiveColumn {
                             { ondragend }>
 
                             <div class="column-selector-column-border">
-
-                                <TypeIcon ty={col_type} />
-
+                                <TypeIcon ty={ col_type }/>
                                 if ctx.props().is_aggregated {
                                     <AggregateSelector
                                         column={ name.clone() }

--- a/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
@@ -480,7 +480,7 @@ impl Component for FilterColumn {
 
                 <LocalStyle href={ css!("filter-item") } />
                 <div class="pivot-column-border">
-                    <TypeIcon ty={Type::String} />
+                    <TypeIcon ty={ Type::String }/>
                     <span class="column_name">
                         { filter.0.to_owned() }
                     </span>

--- a/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
@@ -205,7 +205,7 @@ impl Component for InactiveColumn {
                     { ondragend }>
 
                     <div class="column-selector-column-border">
-                        <TypeIcon ty={col_type} />
+                        <TypeIcon ty={ col_type }/>
                         <span class={"column_name"}>
                             { ctx.props().name.clone() }
                         </span>

--- a/rust/perspective-viewer/src/rust/components/column_selector/pivot_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/pivot_column.rs
@@ -68,7 +68,7 @@ impl Component for PivotColumn {
                 ondragstart={ dragstart }
                 ondragend={ dragend }>
                 <div class="pivot-column-border">
-                    <TypeIcon ty={Type::String} />
+                    <TypeIcon ty={ Type::String }/>
                     <span class="column_name">
                         { ctx.props().column.clone() }
                     </span>

--- a/rust/perspective-viewer/src/rust/components/column_selector/sort_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/sort_column.rs
@@ -108,7 +108,7 @@ impl Component for SortColumn {
                 ondragstart={ dragstart }
                 ondragend={ dragend }>
                 <div class="pivot-column-border">
-                    <TypeIcon ty={Type::String} />
+                    <TypeIcon ty={ Type::String }/>
                     <span
                         class="column_name">
                         { ctx.props().sort.0.to_owned() }

--- a/rust/perspective-viewer/src/rust/components/editable_header.rs
+++ b/rust/perspective-viewer/src/rust/components/editable_header.rs
@@ -148,9 +148,11 @@ impl Component for EditableHeader {
         if ctx.props().editable {
             classes.push("editable");
         }
+
         if !self.valid {
             classes.push("invalid");
         }
+
         if self.edited {
             classes.push("edited");
         }
@@ -159,28 +161,30 @@ impl Component for EditableHeader {
             let value = e.target_unchecked_into::<HtmlInputElement>().value();
             EditableHeaderMsg::SetNewValue(value)
         });
+
         let onblur = ctx.link().callback(|e: FocusEvent| {
             let value = e.target_unchecked_into::<HtmlInputElement>().value();
             EditableHeaderMsg::SetNewValue(value)
         });
+
         html! {
             <div
-                class={classes}
-                onclick={ctx.link().callback(|_| EditableHeaderMsg::OnClick(()))}
-            >
+                class={ classes }
+                onclick={ ctx.link().callback(|_| EditableHeaderMsg::OnClick(())) }>
+
                 if let Some(icon) = ctx.props().icon_type {
-                    <TypeIcon ty={icon}/>
+                    <TypeIcon ty={ icon }/>
                 }
+
                 <input
-                    ref={self.noderef.clone()}
+                    ref={ self.noderef.clone() }
                     type="search"
                     class="sidebar_header_title"
-                    disabled={!ctx.props().editable}
-                    {onblur}
-                    {onkeyup}
-                    value={self.value.clone()}
-                    placeholder={self.placeholder.clone()}
-                />
+                    disabled={ !ctx.props().editable }
+                    { onblur }
+                    { onkeyup }
+                    value={ self.value.clone() }
+                    placeholder={ self.placeholder.clone() }/>
             </div>
         }
     }

--- a/rust/perspective-viewer/src/rust/components/type_icon.rs
+++ b/rust/perspective-viewer/src/rust/components/type_icon.rs
@@ -48,10 +48,9 @@ pub struct TypeIconProps {
 
 #[function_component(TypeIcon)]
 pub fn type_icon(p: &TypeIconProps) -> yew::Html {
+    let class = classes!(p.ty.to_string(), "type-icon");
     html_template! {
-        <LocalStyle href={css!("type-icon")} />
-        <span
-            class={classes!(p.ty.to_string(), "type-icon")}
-        ></span>
+        <LocalStyle href={ css!("type-icon") } />
+        <span { class }></span>
     }
 }


### PR DESCRIPTION
This PR (original @ada-x64) addresses inconsistent column width for the setting panel introduces partially in #2459

Fixed version of #2525