### PR TITLE
New color selector component

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -8,6 +8,10 @@
     "rust-analyzer.linkedProjects": [
         "${workspaceFolder}/rust/perspective-viewer/Cargo.toml"
     ],
+    "rust-analyzer.server.extraEnv": {
+        "RA_LOG": "rust_analyzer::reload=info",
+        "CARGO_TARGET_DIR": "rust/perspective-viewer/dist/analyzer"
+    },
     "rust-analyzer.rustfmt.overrideCommand": [
         "cargo",
         "run",

--- a/packages/perspective-viewer-datagrid/src/less/scrollbar.less
+++ b/packages/perspective-viewer-datagrid/src/less/scrollbar.less
@@ -12,9 +12,6 @@
 
 // Scrollbar styling
 regular-table {
-    // firefox scrollbar styling
-    scrollbar-color: transparent transparent;
-    scrollbar-width: thin;
     outline: none;
 
     // webkit (chrome, safari, etc) scrollbar styling

--- a/rust/perspective-viewer/src/less/column-settings-panel.less
+++ b/rust/perspective-viewer/src/less/column-settings-panel.less
@@ -28,6 +28,10 @@
         font-size: 9px;
     }
 
+    .radio-list-item label {
+        margin-top: 6px;
+    }
+
     input {
         &[type="text"],
         &[type="search"] {

--- a/rust/perspective-viewer/src/less/column-settings-panel.less
+++ b/rust/perspective-viewer/src/less/column-settings-panel.less
@@ -24,6 +24,7 @@
     }
 
     .item_title {
+        flex: 0 0 auto;
         font-size: 9px;
     }
 

--- a/rust/perspective-viewer/src/less/column-style.less
+++ b/rust/perspective-viewer/src/less/column-style.less
@@ -131,24 +131,47 @@
             flex-wrap: wrap;
         }
 
+        .color-gradient-container {
+            display: flex;
+            flex-wrap: nowrap;
+            flex: 1 1 auto;
+            .color-thermometer {
+                flex: 1 1 auto;
+                height: 24px;
+            }
+        }
+
         input[type="color"] {
             width: 36px;
-            height: 36px;
+            height: 24px;
             cursor: pointer;
             padding: 0;
-            margin-right: 4px;
             font-family: inherit;
             overflow: hidden;
-            border-radius: 3px;
+            border-radius: 6px;
+
+            &:hover {
+                opacity: 0.8;
+            }
 
             &:before {
                 position: absolute;
                 font-family: var(--button--font-family, inherit);
-                margin-top: 4px;
+                margin-top: -1px;
                 margin-left: 12px;
                 font-size: 20px;
                 content: var(--column-style-pos-color--content, "+");
-                color: white;
+                color: var(--sign--color, white);
+            }
+
+            &#pos-color-param {
+                border-radius: 6px 0 0 6px;
+                margin: 0 1px 0 0;
+            }
+
+            &#neg-color-param {
+                border-radius: 0 6px 6px 0;
+                margin: 0 0 0 1px;
             }
 
             &#neg-color-param:before {

--- a/rust/perspective-viewer/src/less/column-style.less
+++ b/rust/perspective-viewer/src/less/column-style.less
@@ -53,7 +53,7 @@
         }
 
         label {
-            font-size: 8px;
+            font-size: 9px;
             width: 100%;
         }
 

--- a/rust/perspective-viewer/src/less/dom/checkbox.less
+++ b/rust/perspective-viewer/src/less/dom/checkbox.less
@@ -65,7 +65,7 @@
         padding: 0px;
         cursor: pointer;
         outline: none;
-        margin: 0 5px;
+        margin: 0 5px 0 0;
 
         &:checked:before {
             -webkit-mask-image: var(--column-checkbox-on--mask-image);

--- a/rust/perspective-viewer/src/less/expression-editor.less
+++ b/rust/perspective-viewer/src/less/expression-editor.less
@@ -57,6 +57,7 @@
 
     .item_title {
         margin-bottom: 3px;
+        margin-top: 4px;
     }
 
     input#expression-name {

--- a/rust/perspective-viewer/src/less/expression-editor.less
+++ b/rust/perspective-viewer/src/less/expression-editor.less
@@ -27,6 +27,9 @@
             font-size: 12px;
             min-height: 1.5em;
             color: var(--error--color);
+            top: 0;
+            position: absolute;
+            width: calc(100% - 24px);
         }
 
         &.disabled {
@@ -102,6 +105,8 @@
         flex-direction: column;
         padding: 0.5em;
         gap: 0.25em;
+        height: 24px;
+        position: relative;
     }
 
     #save-settings,

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/save_settings.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/save_settings.rs
@@ -21,18 +21,19 @@ pub struct SaveSettingsProps {
     pub on_delete: Callback<()>,
     pub show_danger_zone: bool,
     pub disable_delete: bool,
+    pub is_save: bool,
 }
 
 #[function_component(SaveSettings)]
-pub fn save_settings(p: &SaveSettingsProps) -> Html {
-    let reset = p.on_reset.reform(|_| ());
-    let save = p.on_save.reform(|_| ());
-    let delete = p.on_delete.reform(|_| ());
+pub fn save_settings(props: &SaveSettingsProps) -> Html {
+    let reset = props.on_reset.reform(|_| ());
+    let save = props.on_save.reform(|_| ());
+    let delete = props.on_delete.reform(|_| ());
     html! {
         <div
             id="save-settings-wrapper"
         >
-            if p.show_danger_zone {
+            if props.show_danger_zone {
                 <div
                     id="danger-zone"
                 >
@@ -40,7 +41,7 @@ pub fn save_settings(p: &SaveSettingsProps) -> Html {
                         id="psp-expression-editor-button-delete"
                         class="psp-expression-editor__button"
                         onmousedown={delete}
-                        disabled={p.disable_delete}
+                        disabled={props.disable_delete}
                     >
                         { "Delete Column" }
                     </button>
@@ -49,21 +50,23 @@ pub fn save_settings(p: &SaveSettingsProps) -> Html {
             <div
                 id="save-settings"
             >
-                <button
-                    id="psp-expression-editor-button-reset"
-                    class="psp-expression-editor__button"
-                    onmousedown={reset}
-                    disabled={!p.reset_enabled}
-                >
-                    { "Reset" }
-                </button>
+                if props.is_save {
+                    <button
+                        id="psp-expression-editor-button-reset"
+                        class="psp-expression-editor__button"
+                        onmousedown={reset}
+                        disabled={!props.reset_enabled}
+                    >
+                        { "Reset" }
+                    </button>
+                }
                 <button
                     id="psp-expression-editor-button-save"
                     class="psp-expression-editor__button"
                     onmousedown={save}
-                    disabled={!p.save_enabled}
+                    disabled={!props.save_enabled}
                 >
-                    { "Save" }
+                    { if props.is_save { "Save" } else { "Create" } }
                 </button>
             </div>
         </div>

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/sidebar.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/sidebar.rs
@@ -340,6 +340,7 @@ impl Component for ColumnSettingsSidebar {
         let save_section = SaveSettingsProps {
             save_enabled: self.save_enabled,
             reset_enabled: self.reset_enabled,
+            is_save: ctx.props().selected_column.name().is_some(),
             on_reset: ctx.link().callback(ColumnSettingsMsg::OnResetAttributes),
             on_save: ctx.link().callback(ColumnSettingsMsg::OnSaveAttributes),
             on_delete: ctx.link().callback(ColumnSettingsMsg::OnDelete),

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/column_style.rs
@@ -78,7 +78,6 @@ pub fn ColumnStyle(props: &ColumnStyleProps) -> Html {
     let (config, attrs) = (config.unwrap(), attrs.unwrap());
     let view_type = props.view_type;
 
-    let title = format!("{} Styling", view_type.to_capitalized());
     let opt_html = match view_type {
         Type::String => get_column_style::<_, StringColumnStyleDefaultConfig>(
             config.clone(),
@@ -96,7 +95,6 @@ pub fn ColumnStyle(props: &ColumnStyleProps) -> Html {
 
             html! {
                 <>
-                    <div class="item_title">{ title.clone() }</div>
                     <div
                         class="style_contents"
                     >
@@ -121,19 +119,16 @@ pub fn ColumnStyle(props: &ColumnStyleProps) -> Html {
             });
 
             html! {
-                <>
-                    <div class="item_title">{ title.clone() }</div>
-                    <div
-                        class="style_contents"
-                    >
-                        <DatetimeColumnStyle
-                            {enable_time_config}
-                            {config}
-                            {default_config}
-                            {on_change}
-                        />
-                    </div>
-                </>
+                <div
+                    class="style_contents"
+                >
+                    <DatetimeColumnStyle
+                        {enable_time_config}
+                        {config}
+                        {default_config}
+                        {on_change}
+                    />
+                </div>
             }
         }),
         Type::Integer | Type::Float => get_column_style::<_, NumberColumnStyleDefaultConfig>(
@@ -154,20 +149,17 @@ pub fn ColumnStyle(props: &ColumnStyleProps) -> Html {
             };
 
             html! {
-                <>
-                    <div class="item_title">{ title.clone() }</div>
-                    <div
-                        class="style_contents"
-                    >
-                        <NumberColumnStyle
-                            session={props.session.clone()}
-                            column_name={props.column_name.clone()}
-                            {config}
-                            {default_config}
-                            {on_change}
-                        />
-                    </div>
-                </>
+                <div
+                    class="style_contents"
+                >
+                    <NumberColumnStyle
+                        session={props.session.clone()}
+                        column_name={props.column_name.clone()}
+                        {config}
+                        {default_config}
+                        {on_change}
+                    />
+                </div>
             }
         }),
         _ => Err("Booleans aren't styled yet.".into()),

--- a/rust/perspective-viewer/src/rust/components/form/color_range_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/form/color_range_selector.rs
@@ -18,44 +18,90 @@ use yew::prelude::*;
 pub struct ColorRangeProps {
     pub pos_color: String,
     pub neg_color: String,
+    pub is_gradient: bool,
     pub on_pos_color: Callback<String>,
     pub on_neg_color: Callback<String>,
 }
 
+fn infer_fg(color: &str) -> &'static str {
+    let r = i32::from_str_radix(&color[1..3], 16).unwrap() as f64;
+    let g = i32::from_str_radix(&color[3..5], 16).unwrap() as f64;
+    let b = i32::from_str_radix(&color[5..7], 16).unwrap() as f64;
+    if (r * r * 0.299 + g * g * 0.587 + b * b * 0.114).sqrt() > 130.0 {
+        "--sign--color:#161616"
+    } else {
+        "--sign--color:#FFFFFF"
+    }
+}
+
 #[function_component(ColorRangeSelector)]
 pub fn color_chooser_component(props: &ColorRangeProps) -> Html {
-    let on_pos_color = props.on_pos_color.reform(|event: InputEvent| {
-        event
-            .target()
-            .unwrap()
-            .unchecked_into::<HtmlInputElement>()
-            .value()
-    });
+    let gradient = use_state_eq(|| (props.pos_color.to_owned(), props.neg_color.to_owned()));
+    let on_pos_color = use_callback(
+        (gradient.clone(), props.on_pos_color.clone()),
+        |event: InputEvent, (gradient, on_pos_color)| {
+            let color = event
+                .target()
+                .unwrap()
+                .unchecked_into::<HtmlInputElement>()
+                .value();
+            gradient.set((color.clone(), gradient.1.to_owned()));
+            on_pos_color.emit(color);
+        },
+    );
 
-    let on_neg_color = props.on_neg_color.reform(|event: InputEvent| {
-        event
-            .target()
-            .unwrap()
-            .unchecked_into::<HtmlInputElement>()
-            .value()
-    });
+    let on_neg_color = use_callback(
+        (gradient.clone(), props.on_neg_color.clone()),
+        |event: InputEvent, (gradient, on_neg_color)| {
+            let color = event
+                .target()
+                .unwrap()
+                .unchecked_into::<HtmlInputElement>()
+                .value();
+            gradient.set((gradient.0.to_owned(), color.clone()));
+            on_neg_color.emit(color);
+        },
+    );
+
+    let fg_pos = infer_fg(&gradient.0);
+    let fg_neg = infer_fg(&gradient.1);
+
+    let style = if props.is_gradient {
+        format!(
+            "background:linear-gradient(to right, {} 0%, transparent 50%, {} 100%)",
+            gradient.0, gradient.1
+        )
+    } else {
+        format!(
+            "background:linear-gradient(to right, {} 0%, {} 50%, {} 50%,  {} 100%)",
+            gradient.0, gradient.0, gradient.1, gradient.1
+        )
+    };
 
     html! {
-        <>
+        <div
+            class="color-gradient-container"
+        >
             <input
-                id="color-param"
+                id="pos-color-param"
+                style={fg_pos}
                 class="parameter"
                 type="color"
-                value={props.pos_color.to_owned()}
+                value={gradient.0.to_owned()}
                 oninput={on_pos_color}
+            />
+            <div
+                class="color-thermometer"
+                {style}
             />
             <input
                 id="neg-color-param"
+                style={fg_neg}
                 class="parameter"
                 type="color"
-                value={props.neg_color.to_owned()}
+                value={gradient.1.to_owned()}
                 oninput={on_neg_color}
             />
-        </>
+        </div>
     }
 }

--- a/rust/perspective-viewer/src/rust/components/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/number_column_style.rs
@@ -360,7 +360,7 @@ impl Component for NumberColumnStyle {
                     <div
                         class="row inner_section"
                     >
-                        <ColorRangeSelector ..self.color_props(Fg, ctx) />
+                        <ColorRangeSelector ..self.color_props(Fg, false, ctx) />
                     </div>
                 }
             </>
@@ -373,7 +373,7 @@ impl Component for NumberColumnStyle {
                     <div
                         class="row inner_section"
                     >
-                        <ColorRangeSelector ..self.color_props(Fg, ctx) />
+                        <ColorRangeSelector ..self.color_props(Fg, false, ctx) />
                         <NumberInput ..self.max_value_props(Fg, ctx) />
                     </div>
                 }
@@ -387,7 +387,7 @@ impl Component for NumberColumnStyle {
                     <div
                         class="row inner_section"
                     >
-                        <ColorRangeSelector ..self.color_props(Bg, ctx) />
+                        <ColorRangeSelector ..self.color_props(Bg,false, ctx) />
                     </div>
                 }
             </>
@@ -400,7 +400,7 @@ impl Component for NumberColumnStyle {
                     <div
                         class="row inner_section"
                     >
-                        <ColorRangeSelector ..self.color_props(Bg, ctx) />
+                        <ColorRangeSelector ..self.color_props(Bg, true, ctx) />
                         <NumberInput ..self.max_value_props(Bg, ctx) />
                     </div>
                 }
@@ -414,7 +414,7 @@ impl Component for NumberColumnStyle {
                     <div
                         class="row inner_section"
                     >
-                        <ColorRangeSelector ..self.color_props(Bg, ctx) />
+                        <ColorRangeSelector ..self.color_props(Bg, true, ctx) />
                     </div>
                 }
             </>
@@ -567,7 +567,7 @@ impl NumberColumnStyle {
         ctx.props().on_change.emit(config);
     }
 
-    fn color_props(&self, side: Side, ctx: &Context<Self>) -> ColorRangeProps {
+    fn color_props(&self, side: Side, is_gradient: bool, ctx: &Context<Self>) -> ColorRangeProps {
         let on_pos_color = ctx
             .link()
             .callback(move |x| NumberColumnStyleMsg::PosColorChanged(side, x));
@@ -576,6 +576,7 @@ impl NumberColumnStyle {
             .callback(move |x| NumberColumnStyleMsg::NegColorChanged(side, x));
 
         props!(ColorRangeProps {
+            is_gradient,
             pos_color: if side == Fg {
                 &self.pos_fg_color
             } else {

--- a/rust/perspective-viewer/test/js/column_settings.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings.spec.ts
@@ -138,10 +138,11 @@ test.describe("Plugin Styles", () => {
         await page.locator("tbody tr").nth(1).waitFor();
         await expect(view.columnSettingsSidebar.container).toBeVisible();
     });
-    test("Column settings should not shrink", async ({ page }) => {
+
+    test("Column settings should not expand", async ({ page }) => {
         let view = new PageView(page);
 
-        const MAX_WIDTH = 300;
+        const MAX_WIDTH = 200;
         let checkWidth = async () => {
             let width = await view.columnSettingsSidebar.container.evaluate(
                 (sidebar) => sidebar.getBoundingClientRect().width
@@ -155,8 +156,7 @@ test.describe("Plugin Styles", () => {
         let editor = view.columnSettingsSidebar.attributesTab.expressionEditor;
         await editor.textarea.focus();
         await editor.textarea.clear();
-        // NOTE: We should find another way to test this as the trick used here is probably not a desired feature.
-        // This creates an error which then expands the sidebar to max width.
+
         await editor.textarea.type(
             "'0000000000000000000000000000000000000000000000000000000000"
         );
@@ -164,6 +164,7 @@ test.describe("Plugin Styles", () => {
         await editor.textarea.clear();
         await checkWidth();
     });
+
     test("Selected tab stays selected when manipulating column", async ({
         page,
     }) => {


### PR DESCRIPTION
* Implements a new color selector component, featuring:
    * Gradient controls thermometer previews the `linear-gradient` for the current settings.
    * Contrast-appropriate auto indicator foreground.
    * More ornate styling + hover styles.

<img width="199" alt="Screenshot 2024-02-16 at 12 31 12 AM" src="https://github.com/finos/perspective/assets/60666/91c709d1-ccf2-40e7-bee3-06e881ee1df8">



Also:

* Fixes missing scrollbars in datagrid.
* Fixes expression editor error overflow causing panel resize.
* Fixes `Expression` title jitter on vertical panel resize.
* Adds VSCode default settings to build cargo in a dedicated output dir (so local builds do not cause `rust-analyzer` to rebuild the project form scratch on save).
* Removes `Styling` title from column styling sidebar.
