### PR TITLE
Fix get_hosted_table_names in Python client

### DIFF
--- a/python/perspective/perspective/client/base.py
+++ b/python/perspective/perspective/client/base.py
@@ -97,7 +97,9 @@ class PerspectiveClient(object):
 
     def get_hosted_table_names(self):
         msg = {"cmd": "get_hosted_table_names"}
-        return self.post(msg)
+        future = asyncio.Future()
+        self.post(msg, future=future)
+        return future
 
     def post(self, msg, future=None, keep_alive=False):
         """Given a message and an associated `Future` object, store the future

--- a/python/perspective/perspective/tests/handlers/test_starlette_handler.py
+++ b/python/perspective/perspective/tests/handlers/test_starlette_handler.py
@@ -59,15 +59,12 @@ class TestPerspectiveStarletteHandler(object):
         MANAGER._tables = {}
         MANAGER._views = {}
 
-    async def websocket_client(self):
-        """Connect and initialize a websocket client connection to the
-        Perspective starlette server.
-        """
-        return await websocket(CLIENT, "/websocket")
-
     @asynccontextmanager
     async def managed_websocket_client(self):
-        client = await self.websocket_client()
+        """Connect and manage a websocket client connection to the
+        Perspective starlette server.
+        """
+        client = await websocket(CLIENT, "/websocket")
         try:
             yield client
         finally:
@@ -80,8 +77,9 @@ class TestPerspectiveStarletteHandler(object):
 
         All test methods must import `app`, `http_client`, and `http_port`,
         otherwise a mysterious timeout will occur."""
-        client = await self.websocket_client()
-        await client.terminate()
+        async with self.managed_websocket_client() as client:
+            # terminate() is called by the context manager
+            assert client is not None
 
     @pytest.mark.asyncio
     async def test_starlette_handler_table_method(self):
@@ -89,37 +87,33 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data)
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
 
-        schema = await table.schema()
-        size = await table.size()
+            schema = await table.schema()
+            size = await table.size()
 
-        assert schema == {
-            "a": "integer",
-            "b": "float",
-            "c": "string",
-            "d": "datetime",
-        }
+            assert schema == {
+                "a": "integer",
+                "b": "float",
+                "c": "string",
+                "d": "datetime",
+            }
 
-        assert size == 10
-
-        await client.terminate()
+            assert size == 10
 
     @pytest.mark.asyncio
     async def test_starlette_handler_make_table(self):
-        client = await self.websocket_client()
-        table = await client.table(data)
-        size = await table.size()
+        async with self.managed_websocket_client() as client:
+            table = await client.table(data)
+            size = await table.size()
 
-        assert size == 10
+            assert size == 10
 
-        table.update(data)
+            table.update(data)
 
-        size2 = await table.size()
-        assert size2 == 20
-
-        await client.terminate()
+            size2 = await table.size()
+            assert size2 == 20
 
     @pytest.mark.asyncio
     async def test_starlette_handler_table_update(self):
@@ -127,18 +121,16 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data)
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
-        size = await table.size()
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
+            size = await table.size()
 
-        assert size == 10
+            assert size == 10
 
-        table.update(data)
+            table.update(data)
 
-        size2 = await table.size()
-        assert size2 == 20
-
-        await client.terminate()
+            size2 = await table.size()
+            assert size2 == 20
 
     @pytest.mark.asyncio
     async def test_starlette_handler_table_update_port(self, sentinel):
@@ -146,34 +138,32 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data)
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
-        view = await table.view()
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
+            view = await table.view()
 
-        size = await table.size()
+            size = await table.size()
 
-        assert size == 10
+            assert size == 10
 
-        for i in range(5):
-            await table.make_port()
+            for i in range(5):
+                await table.make_port()
 
-        port = await table.make_port()
+            port = await table.make_port()
 
-        s = sentinel(False)
+            s = sentinel(False)
 
-        def updater(port_id):
-            s.set(True)
-            assert port_id == port
+            def updater(port_id):
+                s.set(True)
+                assert port_id == port
 
-        view.on_update(updater)
+            view.on_update(updater)
 
-        table.update(data, port_id=port)
+            table.update(data, port_id=port)
 
-        size2 = await table.size()
-        assert size2 == 20
-        assert s.get() is True
-
-        await client.terminate()
+            size2 = await table.size()
+            assert size2 == 20
+            assert s.get() is True
 
     @pytest.mark.asyncio
     async def test_starlette_handler_table_update_row_delta(self, sentinel):
@@ -181,31 +171,29 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data)
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
-        view = await table.view()
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
+            view = await table.view()
 
-        size = await table.size()
+            size = await table.size()
 
-        assert size == 10
+            assert size == 10
 
-        s = sentinel(False)
+            s = sentinel(False)
 
-        def updater(port_id, delta):
-            s.set(True)
-            assert port_id == 0
-            t2 = Table(delta)
-            assert t2.view().to_dict() == data
+            def updater(port_id, delta):
+                s.set(True)
+                assert port_id == 0
+                t2 = Table(delta)
+                assert t2.view().to_dict() == data
 
-        view.on_update(updater, mode="row")
+            view.on_update(updater, mode="row")
 
-        table.update(data)
+            table.update(data)
 
-        size2 = await table.size()
-        assert size2 == 20
-        assert s.get() is True
-
-        await client.terminate()
+            size2 = await table.size()
+            assert size2 == 20
+            assert s.get() is True
 
     @pytest.mark.asyncio
     async def test_starlette_handler_table_update_row_delta_port(self, sentinel):
@@ -213,37 +201,35 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data)
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
-        view = await table.view()
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
+            view = await table.view()
 
-        size = await table.size()
+            size = await table.size()
 
-        assert size == 10
+            assert size == 10
 
-        for i in range(5):
-            await table.make_port()
+            for i in range(5):
+                await table.make_port()
 
-        port = await table.make_port()
+            port = await table.make_port()
 
-        s = sentinel(False)
+            s = sentinel(False)
 
-        def updater(port_id, delta):
-            s.set(True)
-            assert port_id == port
+            def updater(port_id, delta):
+                s.set(True)
+                assert port_id == port
 
-            t2 = Table(delta)
-            assert t2.view().to_dict() == data
+                t2 = Table(delta)
+                assert t2.view().to_dict() == data
 
-        view.on_update(updater, mode="row")
+            view.on_update(updater, mode="row")
 
-        table.update(data, port_id=port)
+            table.update(data, port_id=port)
 
-        size2 = await table.size()
-        assert size2 == 20
-        assert s.get() is True
-
-        await client.terminate()
+            size2 = await table.size()
+            assert size2 == 20
+            assert s.get() is True
 
     @pytest.mark.asyncio
     async def test_starlette_handler_table_remove(self):
@@ -251,20 +237,18 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data, index="a")
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
-        size = await table.size()
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
+            size = await table.size()
 
-        assert size == 10
+            assert size == 10
 
-        table.remove([i for i in range(5)])
+            table.remove([i for i in range(5)])
 
-        view = await table.view(columns=["a"])
-        output = await view.to_dict()
+            view = await table.view(columns=["a"])
+            output = await view.to_dict()
 
-        assert output == {"a": [i for i in range(5, 10)]}
-
-        await client.terminate()
+            assert output == {"a": [i for i in range(5, 10)]}
 
     @pytest.mark.asyncio
     async def test_starlette_handler_create_view(self):
@@ -272,16 +256,14 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data)
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
-        view = await table.view(columns=["a"])
-        output = await view.to_dict()
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
+            view = await table.view(columns=["a"])
+            output = await view.to_dict()
 
-        assert output == {
-            "a": [i for i in range(10)],
-        }
-
-        await client.terminate()
+            assert output == {
+                "a": [i for i in range(10)],
+            }
 
     @pytest.mark.asyncio
     async def test_starlette_handler_create_view_errors(self):
@@ -289,15 +271,13 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data)
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
 
-        with pytest.raises(PerspectiveError) as exc:
-            await table.view(columns=["abcde"])
+            with pytest.raises(PerspectiveError) as exc:
+                await table.view(columns=["abcde"])
 
-        assert str(exc.value) == "Invalid column 'abcde' found in View columns.\n"
-
-        await client.terminate()
+            assert str(exc.value) == "Invalid column 'abcde' found in View columns.\n"
 
     @pytest.mark.asyncio
     async def test_starlette_handler_create_view_to_arrow(self):
@@ -305,15 +285,13 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data)
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
-        view = await table.view()
-        output = await view.to_arrow()
-        expected = await table.schema()
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
+            view = await table.view()
+            output = await view.to_arrow()
+            expected = await table.schema()
 
-        assert Table(output).schema(as_string=True) == expected
-
-        await client.terminate()
+            assert Table(output).schema(as_string=True) == expected
 
     @pytest.mark.asyncio
     async def test_starlette_handler_create_view_to_arrow_update(self):
@@ -321,19 +299,17 @@ class TestPerspectiveStarletteHandler(object):
         _table = Table(data)
         MANAGER.host_table(table_name, _table)
 
-        client = await self.websocket_client()
-        table = client.open_table(table_name)
-        view = await table.view()
+        async with self.managed_websocket_client() as client:
+            table = client.open_table(table_name)
+            view = await table.view()
 
-        output = await view.to_arrow()
+            output = await view.to_arrow()
 
-        for _ in range(10):
-            await table.update(output)
+            for _ in range(10):
+                await table.update(output)
 
-        size2 = await table.size()
-        assert size2 == 110
-
-        await client.terminate()
+            size2 = await table.size()
+            assert size2 == 110
 
     @pytest.mark.asyncio
     async def test_starlette_handler_get_hosted_table_names(self):


### PR DESCRIPTION
It was returning None. It now returns a future which resolves to the list of hosted table names.