### PR TITLE
reenable minimum height for voila

### DIFF
--- a/packages/perspective-jupyterlab/src/less/index.less
+++ b/packages/perspective-jupyterlab/src/less/index.less
@@ -35,6 +35,11 @@ div.PSPContainer {
     height: 520px;
 }
 
+// Widget height for Voila
+body[data-voila="voila"] .jp-OutputArea-output div.PSPContainer {
+    min-height: 520px;
+}
+
 div.PSPContainer perspective-viewer[theme="Pro Light"] {
     --plugin--border: 1px solid #e0e0e0;
 }


### PR DESCRIPTION
Tweaks and partially reverts https://github.com/finos/perspective/pull/2352


Currently, Perspective works great in voila except that it does not have any height::

<img width="985" alt="Screenshot 2024-04-05 at 17 57 46" src="https://github.com/finos/perspective/assets/3105306/815900f8-9aac-40b7-8224-21c12a1ef05d">

This PR gives it a minimum height:
<img width="983" alt="Screenshot 2024-04-05 at 17 57 26" src="https://github.com/finos/perspective/assets/3105306/9964e9e8-20f8-427b-9fd7-60a979b022f6">


The sentiments in the original PR still hold, ~~I'm looking for an alternative way to tell if specifically in voilà.~~ but with https://github.com/voila-dashboards/voila/pull/1457 we can now disambiguate and apply only in voilà 
