### PR TITLE
Update to pyodide 0.25.1 for pyodide/pyodide#4655

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1186,11 +1186,11 @@ jobs:
         runs-on: ${{ matrix.os }}
         needs: [initialize]
         env:
-            PYODIDE_VERSION: 0.25.0
+            PYODIDE_VERSION: 0.25.1
             # PYTHON_VERSION and EMSCRIPTEN_VERSION are determined by PYODIDE_VERSION.
             # The appropriate versions can be found in the Pyodide repodata.json
             # "info" field, or in Makefile.envs:
-            # https://github.com/pyodide/pyodide/blob/0.25.0/Makefile.envs#L2
+            # https://github.com/pyodide/pyodide/blob/0.25.1/Makefile.envs#L2
             PYTHON_VERSION: 3.11.3
             EMSCRIPTEN_VERSION: 3.1.46
         steps:


### PR DESCRIPTION
CI is currently failing due to https://github.com/pyodide/pyodide/issues/4655

This PR bumps pyodide to 0.25.1 to fix CI. 