### PR TITLE
Fix incorrect WebSocket example in Python documentation

### DIFF
--- a/docs/docs/python.md
+++ b/docs/docs/python.md
@@ -415,24 +415,28 @@ _*index.html*_
     window.addEventListener("DOMContentLoaded", async function () {
         // Create a client that expects a Perspective server
         // to accept connections at the specified URL.
-        const websocket = perspective.websocket(
-            "ws://localhost:8888/websocket"
-        );
+        const websocket = perspective.websocket("ws://localhost:8888/websocket");
 
         // Get a handle to the Table on the server
-        const server_table = websocket.open_table("data_source_one");
+        const server_table = await websocket.open_table("data_source_one");
 
-        // Create a new view
-        const server_view = await table.view();
+        // Create a new view from the server table
+        const server_view = await server_table.view();
 
         // Create a Table on the client using `perspective.worker()`
         const worker = perspective.worker();
-        const client_table = await worker.table(view);
+        
+        // Convert the server view to JSON
+        const view_data = await server_view.to_json();
+        
+        // Create a client-side table with the data from the server view
+        const client_table = await worker.table(view_data);
 
-        // Load the client table in the `<perspective-viewer>`.
+        // Load the client-side table in the `<perspective-viewer>`.
         document.getElementById("viewer").load(client_table);
     });
 </script>
+
 ```
 
 For a more complex example that offers distributed editing of the server


### PR DESCRIPTION
## Description of Issue
The Python documentation on the Perspective website provided an incorrect WebSocket example under the Tornado section. The example had a few critical issues:
- The variable `table` was used instead of `server_table` when creating a new view.
- The `view()` method was incorrectly called on `table` instead of `server_table`.
- The `client_table` was being created with `view` instead of `server_view.to_json()` data.

These errors would cause confusion for users trying to implement Perspective with Tornado WebSockets, as the provided code would not function as intended.

## Solution
This pull request addresses the issues by correcting the example code. Here are the specific changes made:
- Updated `const server_view = await table.view();` to `const server_view = await server_table.view();` to use the correct variable.
- Modified `const client_table = await worker.table(view);` to `const client_table = await worker.table(await server_view.to_json());` so it creates the client-side table with the correct data.

## Testing the Fix
To test the fix, I set up a local Tornado server using the corrected code and verified that the WebSocket connection was established successfully and the Perspective viewer loaded and displayed data as expected.

These corrections ensure that the example provided in the documentation is accurate and functional, thus improving the reliability of the documentation and helping prevent implementation issues for future users.
