### PR TITLE
Fix `delete()` Python async call not resolving

### DIFF
--- a/python/perspective/perspective/manager/manager_internal.py
+++ b/python/perspective/perspective/manager/manager_internal.py
@@ -212,6 +212,7 @@ class _PerspectiveManagerInternal(object):
                         # calls to `delete` on the view and return.
                         self._views[msg["name"]].delete()
                         self._views.pop(msg["name"], None)
+                        post_callback(self._message_to_json(msg["id"], {"id": msg["id"]}))
                         return
                     else:
                         # Return an error when `table.delete()` is called


### PR DESCRIPTION
This PR fixes `perspective-python`'s `Table.delete()` and `View.delete()` methods, which do not resolve in their clients when awaited. While this does not leak _data_, it does leak await-ed `delete()` handlers.