### PR TITLE
Bump github actions to use newer node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   # for pull_request so we can do HEAD^2
                   fetch-depth: 2
@@ -191,7 +191,7 @@ jobs:
                     - ubuntu-22.04 # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
                 python-version:
                     - 3.9
-                node-version: [18.x]
+                node-version: [20.x]
 
             # NOTE: don't fail fast as sometimes npm blocks the burst of fetches from GHA
             fail-fast: false
@@ -203,7 +203,7 @@ jobs:
 
         steps:
             - name: Clean System
-              uses: AdityaGarg8/remove-unwanted-software@v2
+              uses: AdityaGarg8/remove-unwanted-software@v3
               if: ${{ runner.os == 'Linux' }}
               with:
                   remove-android: "true"
@@ -212,7 +212,7 @@ jobs:
                   remove-codeql: "true"
 
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             ##########
             # Caches #
@@ -226,7 +226,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup yarn cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: |
@@ -238,7 +238,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup emsdk cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: emsdk-cache
               with:
                   path: .emsdk
@@ -250,7 +250,7 @@ jobs:
             ################
             # Pip Cache
             - name: Setup pip cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/pip
                   key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
@@ -261,7 +261,7 @@ jobs:
             ################
             # Cargo Cache
             - name: Setup cargo cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       ~/.cargo/bin/
@@ -284,13 +284,13 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "yarn"
@@ -308,7 +308,7 @@ jobs:
             ################
             ################
             - name: Install LLVM 17
-              uses: KyleMayes/install-llvm-action@v1
+              uses: KyleMayes/install-llvm-action@v2
               with:
                   version: "17"
                   directory: "./.llvm"
@@ -361,65 +361,65 @@ jobs:
             # Upload built JS artifacts for tests
             #
             # (listed here in the same order they appear in the directory)
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-dist
                   path: packages/perspective/dist/
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-jupyterlab-dist
                   path: packages/perspective-jupyterlab/dist/
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-viewer-d3fc-dist
                   path: packages/perspective-viewer-d3fc/dist
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-viewer-datagrid-dist
                   path: packages/perspective-viewer-datagrid/dist
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-viewer-openlayers-dist
                   path: packages/perspective-viewer-openlayers/dist
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-esbuild-plugin-dist
                   path: packages/perspective-esbuild-plugin/dist
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-webpack-plugin-dist
                   path: packages/perspective-webpack-plugin/dist
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-cli-dist
                   path: packages/perspective-cli/dist
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-workspace-dist
                   path: packages/perspective-workspace/dist
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-viewer-dist
                   path: rust/perspective-viewer/dist
 
             ######################################################
             # Upload Jupyter artifacts for python build/test/dist
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: nbextension-dist
                   path: python/perspective/perspective/nbextension
                   if-no-files-found: error # TODO
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: labextension-dist
                   path: python/perspective/perspective/labextension
@@ -460,10 +460,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install LLVM 17
-              uses: KyleMayes/install-llvm-action@v1
+              uses: KyleMayes/install-llvm-action@v2
               with:
                   version: "17"
                   directory: "./.llvm"
@@ -480,7 +480,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup yarn cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: |
@@ -494,7 +494,7 @@ jobs:
             ################
             # Pip Cache
             - name: Setup pip cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/pip
                   key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
@@ -506,13 +506,13 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "yarn"
@@ -580,7 +580,7 @@ jobs:
                     - ubuntu-20.04 # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
                 python-version:
                     - 3.9
-                node-version: [18.x]
+                node-version: [20.x]
 
             # NOTE: don't fail fast as sometimes npm blocks the burst of fetches from GHA
             fail-fast: false
@@ -592,7 +592,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             ##########
             # Caches #
@@ -606,7 +606,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup yarn cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: |
@@ -620,7 +620,7 @@ jobs:
             ################
             # Pip Cache
             - name: Setup pip cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/pip
                   key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
@@ -631,7 +631,7 @@ jobs:
             ################
             # Cargo Cache
             - name: Setup cargo cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       ~/.cargo/bin/
@@ -646,13 +646,13 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "yarn"
@@ -688,37 +688,37 @@ jobs:
             #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
             #~~~~~~~~~ Build Pipelines ~~~~~~~~~#
             #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-dist
                   path: packages/perspective/dist/
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-jupyterlab-dist
                   path: packages/perspective-jupyterlab/dist/
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-d3fc-dist
                   path: packages/perspective-viewer-d3fc/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-datagrid-dist
                   path: packages/perspective-viewer-datagrid/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-openlayers-dist
                   path: packages/perspective-viewer-openlayers/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-workspace-dist
                   path: packages/perspective-workspace/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-dist
                   path: rust/perspective-viewer/dist
@@ -732,7 +732,7 @@ jobs:
             ######################
             # Fancy HTML reports #
             ######################
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               if: failure()
               with:
                   name: playwright-report
@@ -757,12 +757,12 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-20.04]
-                node-version: [18.x]
+                node-version: [20.x]
         runs-on: ${{ matrix.os }}
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             ##########
             # Caches #
@@ -776,7 +776,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup yarn cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: |
@@ -788,7 +788,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "yarn"
@@ -810,37 +810,37 @@ jobs:
             #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
             #~~~~~~~~~ Build Pipelines ~~~~~~~~~#
             #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-dist
                   path: packages/perspective/dist/
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-jupyterlab-dist
                   path: packages/perspective-jupyterlab/dist/
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-d3fc-dist
                   path: packages/perspective-viewer-d3fc/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-datagrid-dist
                   path: packages/perspective-viewer-datagrid/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-openlayers-dist
                   path: packages/perspective-viewer-openlayers/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-workspace-dist
                   path: packages/perspective-workspace/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-dist
                   path: rust/perspective-viewer/dist
@@ -848,7 +848,7 @@ jobs:
             - name: Benchmarks
               run: yarn bench
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-js-benchmarks
                   path: tools/perspective-bench/dist/benchmark-js.arrow
@@ -895,7 +895,7 @@ jobs:
                 container:
                     - none # Not manylinux, we will use this space to build the WASM assets
                     - 2014
-                node-version: [18.x]
+                node-version: [20.x]
                 is-full-run:
                     - ${{ needs.initialize.outputs.FULL_RUN == 'true' }}
                 include-windows-run:
@@ -948,7 +948,7 @@ jobs:
 
         steps:
             - name: Clean System
-              uses: AdityaGarg8/remove-unwanted-software@v2
+              uses: AdityaGarg8/remove-unwanted-software@v3
               if: ${{ runner.os == 'Linux' }}
               with:
                   remove-android: "true"
@@ -957,7 +957,7 @@ jobs:
                   remove-codeql: "true"
 
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             #####################################################
             # Conditionals                                      #
@@ -974,12 +974,12 @@ jobs:
             ################
             # JS Artifacts #
             ################
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: nbextension-dist
                   path: python/perspective/perspective/nbextension
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: labextension-dist
                   path: python/perspective/perspective/labextension
@@ -996,7 +996,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup yarn cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: |
@@ -1010,7 +1010,7 @@ jobs:
             ################
             # Pip Cache
             - name: Setup pip cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/pip
                   key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
@@ -1021,7 +1021,7 @@ jobs:
             ################
             # Homebrew Cache
             - name: Setup homebrew cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       ~/Library/Caches/Homebrew/boost--*
@@ -1033,7 +1033,7 @@ jobs:
             ################
             # vcpkg Cache
             - name: Setup vcpkg cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       C:\Users\runneradmin\AppData\Local\vcpkg\archives
@@ -1049,14 +1049,14 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
               if: ${{ runner.os != 'Linux' }} # skip on manylinux2014
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "yarn"
@@ -1068,7 +1068,7 @@ jobs:
             ################
             ################
             # - name: Install LLVM 17
-            #   uses: KyleMayes/install-llvm-action@v1
+            #   uses: KyleMayes/install-llvm-action@v2
             #   if: false
             #   with:
             #       version: "17"
@@ -1161,19 +1161,19 @@ jobs:
             ####################
             # Upload artifacts #
             ####################
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-python-dist-${{ matrix.os }}-${{ matrix.python-version }}
                   path: python/perspective/dist/*.whl
               if: ${{ runner.os == 'Windows' }}
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-python-dist-${{ matrix.os }}-${{ matrix.python-version }}
                   path: python/perspective/wheelhouse/*.whl
               if: ${{ runner.os != 'Windows' }}
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-python-sdist
                   path: python/perspective/dist/*.tar.gz
@@ -1227,7 +1227,7 @@ jobs:
               run: pyodide build python/perspective --exports=pyinit
 
             - name: Upload pyodide wheel
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: perspective-python-dist-pyodide
                   path: dist/*.whl
@@ -1259,7 +1259,7 @@ jobs:
                     - ubuntu-20.04 # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
                 python-version:
                     - 3.9
-                node-version: [18.x]
+                node-version: [20.x]
             # NOTE: don't fail fast as sometimes npm blocks the burst of fetches from GHA
             fail-fast: false
 
@@ -1271,44 +1271,44 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-dist
                   path: packages/perspective/dist/
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-jupyterlab-dist
                   path: packages/perspective-jupyterlab/dist/
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-d3fc-dist
                   path: packages/perspective-viewer-d3fc/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-datagrid-dist
                   path: packages/perspective-viewer-datagrid/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-workspace-dist
                   path: packages/perspective-workspace/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-dist
                   path: rust/perspective-viewer/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: nbextension-dist
                   path: python/perspective/perspective/nbextension
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: labextension-dist
                   path: python/perspective/perspective/labextension
@@ -1325,7 +1325,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup yarn cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: |
@@ -1339,7 +1339,7 @@ jobs:
             ################
             # Pip Cache
             - name: Setup pip cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/pip
                   key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
@@ -1351,13 +1351,13 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "yarn"
@@ -1385,7 +1385,7 @@ jobs:
               run: yarn _requires_python
 
             # Download artifact
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-${{ matrix.os }}-${{ matrix.python-version }}
 
@@ -1437,7 +1437,7 @@ jobs:
                     - 3.9
                     - "3.10"
                     - 3.11
-                node-version: [18.x]
+                node-version: [20.x]
                 is-full-run:
                     - ${{ needs.initialize.outputs.FULL_RUN == 'true' }}
                 include-windows-run:
@@ -1482,7 +1482,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             ##########
             # Caches #
@@ -1496,7 +1496,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup yarn cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: |
@@ -1510,7 +1510,7 @@ jobs:
             ################
             # Pip Cache
             - name: Setup pip cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/pip
                   key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
@@ -1522,13 +1522,13 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "yarn"
@@ -1559,7 +1559,7 @@ jobs:
             # Python - Test #
             #################
             # Download artifact
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-${{ matrix.os }}-${{ matrix.python-version }}
 
@@ -1622,7 +1622,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             ##########
             # Caches #
@@ -1636,7 +1636,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup yarn cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: |
@@ -1650,7 +1650,7 @@ jobs:
             ################
             # Pip Cache
             - name: Setup pip cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/pip
                   key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
@@ -1662,13 +1662,13 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "yarn"
@@ -1701,7 +1701,7 @@ jobs:
             #~~~~~~~~~ Build Pipelines ~~~~~~~~~#
             #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
             # Download sdist
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-sdist
 
@@ -1737,12 +1737,12 @@ jobs:
             matrix:
                 os: [ubuntu-20.04]
                 python-version: [3.11]
-                node-version: [18.x]
+                node-version: [20.x]
         if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ${{ matrix.os }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             ##########
             # Caches #
@@ -1756,7 +1756,7 @@ jobs:
               if: ${{ needs.initialize.outputs.SKIP_CACHE == 'false' }}
 
             - name: Setup yarn cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: |
@@ -1770,7 +1770,7 @@ jobs:
             ################
             # Pip Cache
             - name: Setup pip cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/pip
                   key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
@@ -1782,13 +1782,13 @@ jobs:
             # Language and Compiler Setup #
             ###############################
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "yarn"
@@ -1819,7 +1819,7 @@ jobs:
             # Python - Test #
             #################
             # Download artifact
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-${{ matrix.os }}-${{ matrix.python-version }}
 
@@ -1834,7 +1834,7 @@ jobs:
               env:
                   PSP_PROJECT: python
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: perspective-python-benchmarks
                   path: tools/perspective-bench/dist/benchmark-python.arrow
@@ -1878,139 +1878,139 @@ jobs:
             # path is empty, but `actions/downlaod-artifact` fails, and 3 JS
             # packages have no `dist`.
 
-            # - uses: actions/download-artifact@v3
+            # - uses: actions/download-artifact@v4
             #   with:
             #       name: perspective-cli-dist
             #       path: packages/perspective-cli/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-dist
                   path: packages/perspective/dist/
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-jupyterlab-dist
                   path: packages/perspective-jupyterlab/dist/
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-d3fc-dist
                   path: packages/perspective-viewer-d3fc/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-datagrid-dist
                   path: packages/perspective-viewer-datagrid/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-openlayers-dist
                   path: packages/perspective-viewer-openlayers/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-workspace-dist
                   path: packages/perspective-workspace/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-viewer-dist
                   path: rust/perspective-viewer/dist
 
-            # - uses: actions/download-artifact@v3
+            # - uses: actions/download-artifact@v4
             #   with:
             #       name: perspective-esbuild-plugin-dist
             #       path: packages/perspective-esbuild-plugin/dist
 
-            # - uses: actions/download-artifact@v3
+            # - uses: actions/download-artifact@v4
             #   with:
             #       name: perspective-webpack-plugin-dist
             #       path: packages/perspective-webpack-plugin/dist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: nbextension-dist
                   path: python/perspective/perspective/nbextension
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: labextension-dist
                   path: python/perspective/perspective/labextension
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-ubuntu-20.04-3.7
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-ubuntu-20.04-3.8
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-ubuntu-20.04-3.9
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-ubuntu-20.04-3.10
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-ubuntu-20.04-3.11
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-macos-11-3.7
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-macos-11-3.8
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-macos-11-3.9
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-macos-11-3.10
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-macos-11-3.11
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-windows-2022-3.7
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-windows-2022-3.8
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-windows-2022-3.9
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-windows-2022-3.10
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-windows-2022-3.11
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-dist-pyodide
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-sdist
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-js-benchmarks
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: perspective-python-benchmarks
 
@@ -2032,7 +2032,7 @@ jobs:
               run: ls -lah
 
             - name: Release wheels
-              uses: softprops/action-gh-release@v1
+              uses: softprops/action-gh-release@v2
               with:
                   draft: true
                   generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "emscripten": "3.1.48",
     "llvm": "17.0.6",
     "engines": {
-        "node": ">=14.18.2"
+        "node": ">=14.18.2 <22"
     },
     "workspaces": [
         "tools/perspective-test",


### PR DESCRIPTION
We are currently using some older GitHub actions that raise deprecation warnings, to avoid disruption to CI this PR upgrades them to newer versions. 

<img width="455" alt="Screenshot 2024-05-16 at 09 20 53" src="https://github.com/finos/perspective/assets/3105306/dc6f2ca5-ffb6-4188-a5c2-2f9f01a608c9">


This PR also limits the node upper bound to `22` to avoid the `assert { type: "json" }` / `with { type: "json" }` change (proposal here https://github.com/tc39/proposal-import-attributes/pull/131 ) which affects Node 22. 