### PR TITLE
Update toolchain, and update macro metavar syntax 

### DIFF
--- a/rust/perspective-viewer/rust-toolchain.toml
+++ b/rust/perspective-viewer/rust-toolchain.toml
@@ -11,6 +11,6 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 [toolchain]
-channel = "nightly-2023-10-12"
+channel = "nightly-2024-05-07"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["wasm32-unknown-unknown"]

--- a/rust/perspective-viewer/src/rust/components/column_selector/config_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/config_selector.rs
@@ -51,7 +51,7 @@ derive_model!(Renderer, Session for ConfigSelectorProps);
 
 #[derive(Debug)]
 pub enum ConfigSelectorMsg {
-    DragStart(DragEffect),
+    DragStart,
     DragEnd,
     DragOver(usize, DragTarget),
     DragLeave(DragTarget),
@@ -173,7 +173,7 @@ impl Component for ConfigSelector {
     type Properties = ConfigSelectorProps;
 
     fn create(ctx: &Context<Self>) -> Self {
-        let cb = ctx.link().callback(ConfigSelectorMsg::DragStart);
+        let cb = ctx.link().callback(|_| ConfigSelectorMsg::DragStart);
         let drag_sub = Rc::new(ctx.props().dragdrop.dragstart_received.add_listener(cb));
 
         let cb = ctx.link().callback(|_| ConfigSelectorMsg::DragEnd);
@@ -201,7 +201,7 @@ impl Component for ConfigSelector {
 
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
-            ConfigSelectorMsg::DragStart(_) | ConfigSelectorMsg::ViewCreated => true,
+            ConfigSelectorMsg::DragStart | ConfigSelectorMsg::ViewCreated => true,
             ConfigSelectorMsg::DragEnd => true,
             ConfigSelectorMsg::DragOver(index, action) => {
                 let should_render = ctx.props().dragdrop.notify_drag_enter(action, index);

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/sidebar.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/sidebar.rs
@@ -69,7 +69,7 @@ pub struct ColumnSettingsProps {
     pub is_active: bool,
 }
 
-derive_model!(CustomEvents, Session, Renderer, Presentation for ColumnSettingsProps);
+derive_model!(Session, Renderer, Presentation for ColumnSettingsProps);
 
 impl PartialEq for ColumnSettingsProps {
     fn eq(&self, other: &Self) -> bool {
@@ -258,8 +258,8 @@ impl Component for ColumnSettingsSidebar {
                 rerender
             },
             ColumnSettingsMsg::OnResetAttributes(()) => {
-                self.header_value = self.initial_header_value.clone();
-                self.expr_value = self.initial_expr_value.clone();
+                self.header_value.clone_from(&self.initial_header_value);
+                self.expr_value.clone_from(&self.initial_expr_value);
                 self.save_enabled = false;
                 self.reset_enabled = false;
                 self.reset_count += 1;
@@ -280,8 +280,8 @@ impl Component for ColumnSettingsSidebar {
                     ColumnLocator::NewExpression => ctx.props().save_expr(new_expr),
                 }
 
-                self.initial_expr_value = self.expr_value.clone();
-                self.initial_header_value = self.header_value.clone();
+                self.initial_expr_value.clone_from(&self.expr_value);
+                self.initial_header_value.clone_from(&self.header_value);
                 self.save_enabled = false;
                 self.reset_enabled = false;
                 self.save_count += 1;

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab.rs
@@ -41,7 +41,7 @@ pub struct StyleTabProps {
     pub ty: Option<Type>,
     pub column_name: String,
 }
-derive_model!(Session, Renderer, Presentation, CustomEvents for StyleTabProps);
+derive_model!(Session, Renderer, Presentation for StyleTabProps);
 
 impl StyleTabProps {
     fn send_plugin_config(&self, update: ColumnConfigValueUpdate) {

--- a/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/split_panel.rs
@@ -306,7 +306,7 @@ impl Component for SplitPanel {
         match msg {
             SplitPanelMsg::Reset(index) => {
                 self.styles[index] = None;
-                self.on_reset = ctx.props().on_reset.clone();
+                self.on_reset.clone_from(&ctx.props().on_reset);
             },
             SplitPanelMsg::StartResizing(index, client_offset, pointer_id, pointer_elem) => {
                 let elem = self.refs[index].cast::<HtmlElement>().unwrap();

--- a/rust/perspective-viewer/src/rust/components/editable_header.rs
+++ b/rust/perspective-viewer/src/rust/components/editable_header.rs
@@ -84,11 +84,11 @@ impl Component for EditableHeader {
 
     fn changed(&mut self, ctx: &yew::prelude::Context<Self>, old_props: &Self::Properties) -> bool {
         if ctx.props().reset_count != old_props.reset_count {
-            self.value = ctx.props().initial_value.clone();
+            self.value.clone_from(&ctx.props().initial_value);
         }
         if ctx.props().initial_value != old_props.initial_value {
             self.edited = false;
-            self.value = ctx.props().initial_value.clone();
+            self.value.clone_from(&ctx.props().initial_value);
         }
         if !ctx.props().editable {
             self.edited = false;
@@ -125,7 +125,7 @@ impl Component for EditableHeader {
                 })
                 .unwrap_or(true);
 
-                self.value = maybe_value.clone();
+                self.value.clone_from(&maybe_value);
                 ctx.props().on_change.emit((maybe_value, self.valid));
 
                 true

--- a/rust/perspective-viewer/src/rust/components/font_loader.rs
+++ b/rust/perspective-viewer/src/rust/components/font_loader.rs
@@ -145,7 +145,7 @@ impl FontLoaderProps {
 
         let mut block_promises: PromiseSet = vec![];
         let preload_fonts = parse_fonts(&txt);
-        *self.state.fonts.borrow_mut() = preload_fonts.clone();
+        self.state.fonts.borrow_mut().clone_from(&preload_fonts);
         self.state.status.set(FontLoaderStatus::Loading);
         self.state.on_update.emit(());
 

--- a/rust/perspective-viewer/src/rust/components/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/number_column_style.rs
@@ -86,7 +86,9 @@ impl PartialEq for NumberColumnStyleProps {
 
 impl NumberColumnStyleProps {
     fn set_default_gradient(&self, ctx: &Context<NumberColumnStyle>) {
-        if let Some(session) = self.session.clone() && let Some(column_name) = self.column_name.clone() {
+        if let Some(session) = self.session.clone()
+            && let Some(column_name) = self.column_name.clone()
+        {
             ctx.link().send_future(async move {
                 let view = session.get_view().unwrap();
                 let min_max = view.get_min_max(&column_name).await.unwrap();

--- a/rust/perspective-viewer/src/rust/components/style/style_cache.rs
+++ b/rust/perspective-viewer/src/rust/components/style/style_cache.rs
@@ -68,7 +68,9 @@ impl StyleCache {
             map.insert(name, style.clone());
             let mut values = map.values();
             if let Some(mut x) = first {
-                while let Some(y) = values.next() && y.get_attribute("name").as_deref() < Some(name) {
+                while let Some(y) = values.next()
+                    && y.get_attribute("name").as_deref() < Some(name)
+                {
                     x = y.clone();
                 }
 

--- a/rust/perspective-viewer/src/rust/components/viewer.rs
+++ b/rust/perspective-viewer/src/rust/components/viewer.rs
@@ -354,7 +354,7 @@ impl Component for PerspectiveViewer {
                     self.selected_column = None;
                     (false, None)
                 } else {
-                    self.selected_column = locator.clone();
+                    self.selected_column.clone_from(&locator);
 
                     locator
                         .clone()
@@ -363,7 +363,9 @@ impl Component for PerspectiveViewer {
                 };
 
                 let mut open_column_settings = ctx.props().presentation.get_open_column_settings();
-                open_column_settings.locator = self.selected_column.clone();
+                open_column_settings
+                    .locator
+                    .clone_from(&self.selected_column);
                 ctx.props()
                     .presentation
                     .set_open_column_settings(Some(open_column_settings));

--- a/rust/perspective-viewer/src/rust/config/expressions.rs
+++ b/rust/perspective-viewer/src/rust/config/expressions.rs
@@ -42,13 +42,19 @@ impl std::ops::DerefMut for Expressions {
 
 fn upgrade_legacy_format(expressions: &[String]) -> HashMap<String, String> {
     tracing::warn!("Legacy `expressions` format: {:?}", expressions);
-    expressions.iter().map(|s| {
-        if let Some((name, expression)) = s.split_once('\n') && !expression.is_empty() && name.starts_with("//") {
-            (name.split_at(2).1.trim().to_owned(), expression.to_owned())
-        } else {
-            (s.to_owned(), s.to_owned())
-        }
-    }).collect::<HashMap<_, _>>()
+    expressions
+        .iter()
+        .map(|s| {
+            if let Some((name, expression)) = s.split_once('\n')
+                && !expression.is_empty()
+                && name.starts_with("//")
+            {
+                (name.split_at(2).1.trim().to_owned(), expression.to_owned())
+            } else {
+                (s.to_owned(), s.to_owned())
+            }
+        })
+        .collect::<HashMap<_, _>>()
 }
 
 impl From<ExpressionsDeserde> for Expressions {

--- a/rust/perspective-viewer/src/rust/custom_elements/filter_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/filter_dropdown.rs
@@ -93,7 +93,9 @@ impl FilterDropDownElement {
                         FilterDropDownMsg::SetValues(values),
                     ]);
 
-                    if let Some(x) = self.target.borrow().clone() && !self.modal.is_open() {
+                    if let Some(x) = self.target.borrow().clone()
+                        && !self.modal.is_open()
+                    {
                         ApiFuture::spawn(self.modal.clone().open(x, None))
                     }
                 }

--- a/rust/perspective-viewer/src/rust/exprtk/language.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/language.rs
@@ -22,7 +22,7 @@ pub struct CompletionItemSuggestion {
 }
 
 thread_local! {
-    pub static COMPLETION_COLUMN_NAMES: RefCell<Vec<String>> = RefCell::new(vec![]);
+    pub static COMPLETION_COLUMN_NAMES: RefCell<Vec<String>> = const { RefCell::new(vec![]) };
 
     pub static COMPLETIONS: Vec<CompletionItemSuggestion> = vec![
             CompletionItemSuggestion {

--- a/rust/perspective-viewer/src/rust/js/testing.rs
+++ b/rust/perspective-viewer/src/rust/js/testing.rs
@@ -38,7 +38,7 @@ extern "C" {
 #[cfg(test)]
 pub async fn get_mock_table() -> JsPerspectiveTable {
     thread_local! {
-        static WORKER: RefCell<Option<JsPerspectiveWorker>> = RefCell::new(None);
+        static WORKER: RefCell<Option<JsPerspectiveWorker>> = const { RefCell::new(None) };
     }
 
     let worker: JsPerspectiveWorker = match WORKER.with(|x| x.borrow().clone()) {

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -12,13 +12,11 @@
 
 // Required by yew's `html` macro.
 #![recursion_limit = "1024"]
-#![feature(async_fn_in_trait)]
 #![feature(const_type_name)]
 #![feature(lazy_cell)]
 #![feature(let_chains)]
 #![feature(macro_metavar_expr)]
 #![feature(iter_intersperse)]
-#![feature(return_position_impl_trait_in_trait)]
 #![feature(stmt_expr_attributes)]
 #![warn(
     clippy::all,

--- a/rust/perspective-viewer/src/rust/model/structural.rs
+++ b/rust/perspective-viewer/src/rust/model/structural.rs
@@ -15,7 +15,6 @@
 //! `struct`s only if the define accessors for the necessary applications state
 //! objects (which are conviently derivable with the `derive_model!` macro).
 
-use crate::custom_events::*;
 use crate::dragdrop::*;
 use crate::presentation::*;
 use crate::renderer::*;
@@ -35,10 +34,6 @@ pub trait HasPresentation {
 
 pub trait HasDragDrop {
     fn dragdrop(&self) -> &'_ DragDrop;
-}
-
-pub trait HasCustomEvents {
-    fn custom_events(&self) -> &'_ CustomEvents;
 }
 
 #[macro_export]
@@ -68,13 +63,6 @@ macro_rules! derive_model {
         impl $crate::model::HasPresentation for $key {
             fn presentation(&self) -> &'_ Presentation {
                 &self.presentation
-            }
-        }
-    };
-    (CustomEvents for $key:ty) => {
-        impl $crate::model::HasCustomEvents for $key {
-            fn custom_events(&self) -> &'_ CustomEvents {
-                &self.custom_events
             }
         }
     };

--- a/rust/perspective-viewer/src/rust/presentation.rs
+++ b/rust/perspective-viewer/src/rust/presentation.rs
@@ -110,7 +110,7 @@ impl Presentation {
     }
 
     pub fn set_title(&self, title: Option<String>) {
-        *self.name.borrow_mut() = title.clone();
+        self.name.borrow_mut().clone_from(&title);
         self.title_changed.emit(title);
     }
 
@@ -155,7 +155,7 @@ impl Presentation {
     pub fn set_open_column_settings(&self, settings: Option<OpenColumnSettings>) {
         let settings = settings.unwrap_or_default();
         if *(self.open_column_settings.borrow()) != settings {
-            *(self.open_column_settings.borrow_mut()) = settings.to_owned();
+            settings.clone_into(&mut (self.open_column_settings.borrow_mut()));
             self.column_settings_open_changed
                 .emit((true, settings.name()));
         }
@@ -224,7 +224,7 @@ impl Presentation {
             self.set_theme_attribute(Some(theme))?;
             themes.iter().position(|x| x == theme)
         } else if !themes.is_empty() {
-            self.set_theme_attribute(themes.get(0).map(|x| x.as_str()))?;
+            self.set_theme_attribute(themes.first().map(|x| x.as_str()))?;
             Some(0)
         } else {
             self.set_theme_attribute(None)?;

--- a/rust/perspective-viewer/src/rust/session/metadata.rs
+++ b/rust/perspective-viewer/src/rust/session/metadata.rs
@@ -115,7 +115,7 @@ impl SessionMetadata {
             .map(|x| x.edited)
             .unwrap_or_default();
 
-        edited.retain(|k, _| expression_alias.get(k).is_some());
+        edited.retain(|k, _| expression_alias.contains_key(k));
         self.as_mut().unwrap().expr_meta = Some(SessionViewExpressionMetadata {
             schema: expression_schema,
             alias: expression_alias,

--- a/rust/perspective-viewer/src/rust/utils/tee.rs
+++ b/rust/perspective-viewer/src/rust/utils/tee.rs
@@ -54,10 +54,10 @@ impl<T: Clone> Tee for T {
 
 macro_rules! gen_tee {
     ($($x:ty),*) => {
-        impl<T: Clone> TeeInternal<{${count(x)} + 1}> for T {
+        impl<T: Clone> TeeInternal<{${count($x)} + 1}> for T {
             type Output = ($($x),*, T);
             fn tee_internal(self) -> Self::Output {
-                ($( ${ignore(x)} self.clone() ),*, self)
+                ($( ${ignore($x)} self.clone() ),*, self)
             }
         }
     };


### PR DESCRIPTION
The syntax change is needed for perspective to compile on newer toolchains

the relevant rust repo change is here:
https://github.com/rust-lang/rust/commit/027850569165192ce8912a985e9489e2ca5e8b65

I also updated some code to address new lints from the toolchain update, in a separate commit for readability