### PR TITLE
[proposal] Rename rust-to-python exports to be cleaner, normalize exception names

### DIFF
--- a/rust/perspective-python/perspective/__init__.py
+++ b/rust/perspective-python/perspective/__init__.py
@@ -12,9 +12,9 @@
 
 __version__ = "2.10.1"
 __all__ = [
-    "PySyncClient",
+    "Client",
+    "PerspectivePythonError",
     "PerspectiveError",
-    "PerspectivePyError",
     "PerspectiveWidget",
     "PerspectiveViewer",
     "PerspectiveTornadoHandler",
@@ -25,8 +25,8 @@ __all__ = [
     "create_sync_client",
 ]
 
-from .perspective import PySyncClient, PerspectivePyError
-from .core.exception import PerspectiveError
+from .perspective import Client, PerspectiveError
+from .core.exception import PerspectivePythonError
 
 from .legacy import (
     PerspectiveManager,

--- a/rust/perspective-python/perspective/__init__.py
+++ b/rust/perspective-python/perspective/__init__.py
@@ -14,6 +14,7 @@ __version__ = "2.10.1"
 __all__ = [
     "Client",
     "PerspectivePythonError",
+    "PerspectiveBaseException",
     "PerspectiveError",
     "PerspectiveWidget",
     "PerspectiveViewer",
@@ -25,7 +26,7 @@ __all__ = [
     "create_sync_client",
 ]
 
-from .perspective import Client, PerspectiveError
+from .perspective import Client, PerspectiveError, PerspectiveBaseException
 from .core.exception import PerspectivePythonError
 
 from .legacy import (

--- a/rust/perspective-python/perspective/core/__init__.py
+++ b/rust/perspective-python/perspective/core/__init__.py
@@ -10,4 +10,4 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-from .exception import PerspectiveError
+from .exception import PerspectivePythonError

--- a/rust/perspective-python/perspective/core/exception.py
+++ b/rust/perspective-python/perspective/core/exception.py
@@ -11,7 +11,7 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 
-class PerspectiveError(Exception):
+class PerspectivePythonError(Exception):
     """Raised for issues within Perspective, i.e. illegal operations."""
 
     pass

--- a/rust/perspective-python/perspective/core/exception.py
+++ b/rust/perspective-python/perspective/core/exception.py
@@ -10,8 +10,10 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
+from ..perspective import PerspectiveBaseException
 
-class PerspectivePythonError(Exception):
+
+class PerspectivePythonError(PerspectiveBaseException):
     """Raised for issues within Perspective, i.e. illegal operations."""
 
     pass

--- a/rust/perspective-python/perspective/core/globalpsp.py
+++ b/rust/perspective-python/perspective/core/globalpsp.py
@@ -13,7 +13,7 @@
 from typing import Awaitable, Callable
 import perspective
 
-_psp_server = perspective.PySyncServer()
+_psp_server = perspective.Server()
 
 
 class Session:

--- a/rust/perspective-python/perspective/handlers/common.py
+++ b/rust/perspective-python/perspective/handlers/common.py
@@ -14,7 +14,7 @@ import asyncio
 from abc import ABC, abstractmethod
 import functools
 
-from ..core.exception import PerspectiveError
+from ..core.exception import PerspectivePythonError
 
 
 class PerspectiveHandlerBase(ABC):
@@ -34,7 +34,7 @@ class PerspectiveHandlerBase(ABC):
         """
         self._manager = kwargs.pop("manager", None)
         if self._manager is None:
-            raise PerspectiveError("A `PerspectiveManager` instance must be provided to the handler!")
+            raise PerspectivePythonError("A `PerspectiveManager` instance must be provided to the handler!")
 
         self._check_origin = kwargs.pop("check_origin", False)
 

--- a/rust/perspective-python/perspective/legacy.py
+++ b/rust/perspective-python/perspective/legacy.py
@@ -10,7 +10,7 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-from .perspective import PySyncServer, PySyncClient
+from .perspective import Server, Client
 import types
 import sys
 
@@ -27,9 +27,9 @@ def create_sync_client(cb=default_loop_cb):
     def handle_new_session(bytes):
         local_sync_client.handle_response(bytes)
 
-    sync_server = PySyncServer()
+    sync_server = Server()
     sync_session = sync_server.new_session(handle_new_session)
-    local_sync_client = PySyncClient(handle_sync_client)
+    local_sync_client = Client(handle_sync_client)
     return local_sync_client
 
 

--- a/rust/perspective-python/perspective/tests/core/test_async.py
+++ b/rust/perspective-python/perspective/tests/core/test_async.py
@@ -16,7 +16,7 @@ import threading
 from functools import partial
 
 import tornado.ioloop
-from perspective import PerspectiveError, PerspectiveManager, Table, create_sync_client
+from perspective import PerspectivePythonError, PerspectiveManager, Table, create_sync_client
 from pytest import mark, raises
 
 
@@ -116,7 +116,7 @@ class TestAsync(object):
         )
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
 
-        with raises(PerspectiveError):
+        with raises(PerspectivePythonError):
             # loop not set - errors
             tbl.update(data)
 

--- a/rust/perspective-python/perspective/tests/manager/test_manager.py
+++ b/rust/perspective-python/perspective/tests/manager/test_manager.py
@@ -17,7 +17,7 @@ import pyarrow as pa
 from datetime import datetime
 from functools import partial
 from pytest import raises, mark
-from perspective import Table, PerspectiveError, PerspectiveManager, create_sync_client
+from perspective import Table, PerspectivePythonError, PerspectiveManager, create_sync_client
 
 data = {"a": [1, 2, 3], "b": ["a", "b", "c"]}
 
@@ -197,7 +197,7 @@ class TestPerspectiveManager(object):
         manager.host_table("table1", table)
         for message in messages:
             manager._process(message, self.post)
-        with raises(PerspectiveError):
+        with raises(PerspectivePythonError):
             manager.clear_views(None)
 
     # locked manager

--- a/rust/perspective-python/perspective/tests/table/test_exception.py
+++ b/rust/perspective-python/perspective/tests/table/test_exception.py
@@ -11,14 +11,14 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 from pytest import raises
-from perspective import Table, PerspectivePyError
+from perspective import Table, PerspectiveError
 
 
 class TestException(object):
     def test_exception_from_core(self):
         tbl = Table({"a": [1, 2, 3]})
 
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             # creating view with unknown column should throw
             tbl.view(group_by=["b"])
 
@@ -35,8 +35,8 @@ class TestException(object):
     def test_exception_from_core_correct_types(self):
         tbl = Table({"a": [1, 2, 3]})
 
-        # `PerspectiveError` should be raised from the Python layer
-        with raises(PerspectivePyError) as ex:
+        # `PerspectivePythonError` should be raised from the Python layer
+        with raises(PerspectiveError) as ex:
             tbl.view()
             tbl.delete()
 
@@ -45,7 +45,7 @@ class TestException(object):
             == "Abort(): Cannot delete table with views"
         )
 
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(group_by=["b"])
 
         assert str(ex.value) == "Abort(): Invalid column 'b' found in View group_by.\n"

--- a/rust/perspective-python/perspective/tests/table/test_table.py
+++ b/rust/perspective-python/perspective/tests/table/test_table.py
@@ -13,7 +13,7 @@
 import sys
 from datetime import date, datetime, timezone
 
-from perspective.core.exception import PerspectiveError
+from perspective.core.exception import PerspectivePythonError
 from perspective import Table
 import perspective
 from pytest import mark, raises, skip
@@ -434,7 +434,7 @@ class TestTable:
 
     def test_table_index_bool_with_none(self):
         # bools cannot be used as primary key columns
-        with raises(perspective.PerspectivePyError):
+        with raises(perspective.PerspectiveError):
             Table({"a": [True, False, None, True], "b": [4, 3, 2, 1]}, index="a")
 
     def test_table_index_date_with_none(self):
@@ -527,7 +527,7 @@ class TestTable:
         failed = False
         try:
             tbl.delete()
-        except PerspectiveError:
+        except PerspectivePythonError:
             failed = True
         assert failed
         v3.delete()

--- a/rust/perspective-python/perspective/tests/table/test_table_datetime.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_datetime.py
@@ -19,7 +19,7 @@ import pandas as pd
 from datetime import date, datetime, timedelta
 from dateutil import tz
 from pytest import mark, raises
-from perspective import Table, PerspectivePyError
+from perspective import Table, PerspectiveError
 
 LOCAL_DATETIMES = [
     datetime(2019, 1, 11, 0, 10, 20),
@@ -212,7 +212,7 @@ if os.name != "nt":
         def test_table_datetime_cant_convert_from_int(self):
             data = pd.DataFrame({"a": [0]})
             table = Table({"a": "datetime"})
-            with raises(PerspectivePyError) as ex:
+            with raises(PerspectiveError) as ex:
                 table.update(data)
             # assert str(ex.value) == "..."
 

--- a/rust/perspective-python/perspective/tests/table/test_table_numpy.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_numpy.py
@@ -14,7 +14,7 @@ from datetime import date, datetime
 
 import numpy as np
 import pandas as pd
-from perspective import PerspectiveError
+from perspective import PerspectivePythonError
 from perspective.table import Table
 from pytest import raises, mark
 
@@ -497,7 +497,7 @@ class TestTableNumpy(object):
         }
 
         # should not be able to parse mixed dicts of numpy array with list
-        with raises(PerspectiveError):
+        with raises(PerspectivePythonError):
             Table(data)
 
     def test_table_np_promote(self):

--- a/rust/perspective-python/perspective/tests/table/test_view.py
+++ b/rust/perspective-python/perspective/tests/table/test_view.py
@@ -13,7 +13,7 @@
 import random
 import pandas as pd
 import numpy as np
-from perspective import PerspectivePyError, Table
+from perspective import PerspectiveError, Table
 from datetime import date, datetime
 from pytest import approx, mark, raises
 
@@ -1558,7 +1558,7 @@ class TestView(object):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
         view = tbl.view()
-        with raises(PerspectivePyError):
+        with raises(PerspectiveError):
             tbl.delete()
         view.delete()
         tbl.delete()
@@ -2113,7 +2113,7 @@ class TestView(object):
     def test_invalid_column_should_throw(self):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(columns=["x"])
         assert str(ex.value) == "Abort(): Invalid column 'x' found in View columns.\n"
 
@@ -2121,7 +2121,7 @@ class TestView(object):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
 
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(columns=["x"])
         assert str(ex.value) == "Abort(): Invalid column 'x' found in View columns.\n"
 
@@ -2137,7 +2137,7 @@ class TestView(object):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
 
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(columns=["x"], aggregates={"x": "sum"})
 
         assert str(ex.value) == "Abort(): Invalid column 'x' found in View columns.\n"
@@ -2146,7 +2146,7 @@ class TestView(object):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
 
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(columns=["x"], aggregates={"x": "sum"})
 
         assert str(ex.value) == "Abort(): Invalid column 'x' found in View columns.\n"
@@ -2162,35 +2162,35 @@ class TestView(object):
     def test_invalid_group_by_should_throw(self):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(group_by=["x"])
         assert str(ex.value) == "Abort(): Invalid column 'x' found in View group_by.\n"
 
     def test_invalid_split_by_should_throw(self):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(split_by=["x"])
         assert str(ex.value) == "Abort(): Invalid column 'x' found in View split_by.\n"
 
     def test_invalid_filters_should_throw(self):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(filter=[["x", "==", "abc"]])
         assert str(ex.value) == "Abort(): Filter column not in schema: x"
 
     def test_invalid_sorts_should_throw(self):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(sort=[["x", "desc"]])
         assert str(ex.value) == "Abort(): Invalid column 'x' found in View sorts.\n"
 
     def test_should_throw_on_first_invalid(self):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(
                 group_by=["a"],
                 split_by=["c"],
@@ -2203,7 +2203,7 @@ class TestView(object):
     def test_invalid_columns_not_in_expression_should_throw(self):
         data = [{"a": 1, "b": 2, "c": "a"}, {"a": 3, "b": 4, "c": "b"}]
         tbl = Table(data)
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             tbl.view(columns=["abc", "x"], expressions={"abc": "1 + 2"})
         assert str(ex.value) == "Abort(): Invalid column 'x' found in View columns.\n"
 

--- a/rust/perspective-python/perspective/tests/table/test_view_expression.py
+++ b/rust/perspective-python/perspective/tests/table/test_view_expression.py
@@ -16,7 +16,7 @@ from string import ascii_letters
 from pytest import raises
 from datetime import date, datetime
 from time import mktime
-from perspective import Table, PerspectivePyError
+from perspective import Table, PerspectiveError
 import pytest
 from .test_view import compare_delta
 
@@ -516,7 +516,7 @@ class TestViewExpression(object):
 
     def test_view_expression_should_not_overwrite_real(self):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-        with raises(PerspectivePyError) as ex:
+        with raises(PerspectiveError) as ex:
             table.view(expressions={"a": 'upper("a")'})
 
         assert (

--- a/rust/perspective-python/perspective/tests/viewer/test_validate.py
+++ b/rust/perspective-python/perspective/tests/viewer/test_validate.py
@@ -12,7 +12,7 @@
 
 from pytest import raises
 
-from perspective.core import PerspectiveError
+from perspective.core import PerspectivePythonError
 
 # from perspective.core import Plugin
 # import perspective.viewer.validate as validate
@@ -30,11 +30,11 @@ from perspective.core._version import __version__
 #         assert validate.validate_plugin("X Bar") == "X Bar"
 
 #     def test_validate_plugin_invalid_string(self):
-#         with raises(PerspectiveError):
+#         with raises(PerspectivePythonError):
 #             validate.validate_plugin("invalid")
 
 #     def test_validate_plugin_invalid_string_hypergrid(self):
-#         with raises(PerspectiveError):
+#         with raises(PerspectivePythonError):
 #             validate.validate_plugin("hypergrid")
 
 #     def test_validate_filter_valid(self):
@@ -42,7 +42,7 @@ from perspective.core._version import __version__
 #         assert validate.validate_filter(filters) == filters
 
 #     def test_validate_filter_invalid(self):
-#         with raises(PerspectiveError):
+#         with raises(PerspectivePythonError):
 #             filters = [["a", ">"], ["b", "invalid" "abc"]]
 #             validate.validate_filter(filters)
 
@@ -55,12 +55,12 @@ from perspective.core._version import __version__
 #         assert validate.validate_filter(filters) == filters
 
 #     def test_validate_expressions(self):
-#         # with raises(PerspectiveError):
+#         # with raises(PerspectivePythonError):
 #         computed = {"expression1": " 'Hello'"}
 #         validate.validate_expressions(computed)
 
 #     def test_validate_expressions_invalid(self):
-#         with raises(PerspectiveError):
+#         with raises(PerspectivePythonError):
 #             assert validate.validate_expressions("test")
 
 #     def test_validate_version(self):

--- a/rust/perspective-python/perspective/tests/widget/test_widget.py
+++ b/rust/perspective-python/perspective/tests/widget/test_widget.py
@@ -15,7 +15,7 @@ from functools import partial
 from types import MethodType
 
 import numpy as np
-from perspective import PerspectiveError, PerspectiveWidget, Table
+from perspective import PerspectivePythonError, PerspectiveWidget, Table
 from pytest import raises
 
 import pytest
@@ -78,12 +78,12 @@ class TestWidget:
 
     def test_widget_no_data_with_index(self):
         # should fail
-        with raises(PerspectiveError):
+        with raises(PerspectivePythonError):
             PerspectiveWidget(None, index="a")
 
     def test_widget_no_data_with_limit(self):
         # should fail
-        with raises(PerspectiveError):
+        with raises(PerspectivePythonError):
             PerspectiveWidget(None, limit=5)
 
     def test_widget_eventual_data(self):
@@ -91,7 +91,7 @@ class TestWidget:
         widget = PerspectiveWidget(None, plugin="X Bar")
         assert widget.plugin == "X Bar"
 
-        with raises(PerspectiveError):
+        with raises(PerspectivePythonError):
             widget._make_load_message()
 
         widget.load(table)
@@ -178,7 +178,7 @@ class TestWidget:
 
     def test_widget_pass_options_invalid(self):
         data = {"a": np.arange(0, 50)}
-        with raises(PerspectiveError):
+        with raises(PerspectivePythonError):
             PerspectiveWidget(data, index="index", limit=1)
 
     # server mode
@@ -195,14 +195,14 @@ class TestWidget:
     def test_widget_no_data_with_server(self):
         # should fail
         widget = PerspectiveWidget(None, server=True)
-        with raises(PerspectiveError):
+        with raises(PerspectivePythonError):
             widget._make_load_message()
 
     def test_widget_eventual_data_with_server(self):
         # should fail
         widget = PerspectiveWidget(None, server=True)
 
-        with raises(PerspectiveError):
+        with raises(PerspectivePythonError):
             widget._make_load_message()
 
         # then succeed

--- a/rust/perspective-python/perspective/viewer/viewer.py
+++ b/rust/perspective-python/perspective/viewer/viewer.py
@@ -13,7 +13,7 @@
 from random import random
 from .viewer_traitlets import PerspectiveTraitlets
 
-from ..core.exception import PerspectiveError
+from ..core.exception import PerspectivePythonError
 from ..legacy import PerspectiveManager, Table
 
 
@@ -183,7 +183,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         if isinstance(data, Table):
             table = data
         elif isinstance(data, View):
-            raise PerspectiveError("Only `Table` or data can be loaded.")
+            raise PerspectivePythonError("Only `Table` or data can be loaded.")
         else:
             table = Table(data, **options)
 

--- a/rust/perspective-python/perspective/widget/widget.py
+++ b/rust/perspective-python/perspective/widget/widget.py
@@ -23,7 +23,7 @@ from ipywidgets import DOMWidget
 from traitlets import Unicode, observe
 
 from ..core._version import __version__
-from ..core.exception import PerspectiveError
+from ..core.exception import PerspectivePythonError
 from ..viewer import PerspectiveViewer
 
 
@@ -45,7 +45,7 @@ def _type_to_string(t):
     elif t is bytes or t is str:
         return "string"
     else:
-        raise PerspectiveError(
+        raise PerspectivePythonError(
             "Unsupported type `{0}` in schema - Perspective supports `int`, `float`, `bool`, `date`, `datetime`, and `str` (or `unicode`).".format(
                 str(t)
             )
@@ -81,7 +81,7 @@ def _serialize(data):
         # Check if any values are `datetime.date`
         for row in data:
             if not isinstance(row, dict):
-                raise PerspectiveError(
+                raise PerspectivePythonError(
                     "Received {} in list dataset, expected `dict`!".format(type(row))
                 )
 
@@ -282,7 +282,7 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
         self._options = {}
 
         if index is not None and limit is not None:
-            raise PerspectiveError("Index and Limit cannot be set at the same time!")
+            raise PerspectivePythonError("Index and Limit cannot be set at the same time!")
 
         # Parse the dataset we pass in - if it's Pandas, preserve pivots
         if isinstance(data, pandas.DataFrame) or isinstance(data, pandas.Series):
@@ -312,7 +312,7 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
                 from ..libpsp import Table
 
                 if isinstance(data, Table):
-                    raise PerspectiveError(
+                    raise PerspectivePythonError(
                         "Client mode PerspectiveWidget expects data or schema, not a `perspective.Table`!"
                     )
 
@@ -331,7 +331,7 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
             # for the user to call `load()`.
             if data is None:
                 if index is not None or limit is not None:
-                    raise PerspectiveError(
+                    raise PerspectivePythonError(
                         "Cannot initialize PerspectiveWidget `index` or `limit` without a Table, data, or schema!"
                     )
             else:
@@ -533,7 +533,7 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
         if msg_data is not None:
             return _PerspectiveWidgetMessage(-2, "table", msg_data)
         else:
-            raise PerspectiveError(
+            raise PerspectivePythonError(
                 "Widget does not have any data loaded - use the `load()` method to provide it with data."
             )
 

--- a/rust/perspective-python/src/client/client_async.rs
+++ b/rust/perspective-python/src/client/client_async.rs
@@ -19,7 +19,7 @@ use pyo3_asyncio::tokio::future_into_py;
 use super::python::*;
 use crate::server::PyAsyncServer;
 
-#[pyclass]
+#[pyclass(name="AsyncClient")]
 pub struct PyAsyncClient(PyClient);
 
 #[pymethods]
@@ -76,7 +76,7 @@ pub fn create_async_client(
     })
 }
 
-#[pyclass]
+#[pyclass(name="AsyncTable")]
 #[repr(transparent)]
 pub struct PyAsyncTable(PyTable);
 
@@ -199,7 +199,7 @@ impl PyAsyncTable {
     }
 }
 
-#[pyclass]
+#[pyclass("AsyncView")]
 pub struct PyAsyncView(PyView);
 
 assert_view_api!(PyAsyncView);

--- a/rust/perspective-python/src/client/client_sync.rs
+++ b/rust/perspective-python/src/client/client_sync.rs
@@ -34,7 +34,7 @@ trait PyFutureExt: Future {
 
 impl<F: Future> PyFutureExt for F {}
 
-#[pyclass]
+#[pyclass(name="Client")]
 pub struct PySyncClient(PyClient);
 
 #[pymethods]
@@ -82,7 +82,7 @@ impl PySyncClient {
     }
 }
 
-#[pyclass]
+#[pyclass(name="Table")]
 pub struct PySyncTable(PyTable);
 
 assert_table_api!(PySyncTable);
@@ -179,7 +179,7 @@ impl PySyncTable {
     }
 }
 
-#[pyclass]
+#[pyclass(name="View")]
 pub struct PySyncView(PyView);
 
 assert_view_api!(PySyncView);

--- a/rust/perspective-python/src/client/mod.rs
+++ b/rust/perspective-python/src/client/mod.rs
@@ -15,4 +15,4 @@ pub mod client_sync;
 
 mod python;
 
-pub use python::PerspectivePyError;
+pub use python::{PyPerspectiveError, PyPerspectiveBaseException};

--- a/rust/perspective-python/src/client/python.rs
+++ b/rust/perspective-python/src/client/python.rs
@@ -39,15 +39,21 @@ pub impl<T> Result<T, ClientError> {
     fn into_pyerr(self) -> PyResult<T> {
         match self {
             Ok(x) => Ok(x),
-            Err(x) => Err(PerspectivePyError::new_err(format!("{}", x))),
+            Err(x) => Err(PyPerspectiveError::new_err(format!("{}", x))),
         }
     }
 }
 
 create_exception!(
     perspective,
-    PerspectivePyError,
+    PyPerspectiveBaseException,
     pyo3::exceptions::PyException
+);
+
+create_exception!(
+    perspective,
+    PyPerspectiveError,
+    PyPerspectiveBaseException
 );
 
 #[extend::ext]

--- a/rust/perspective-python/src/lib.rs
+++ b/rust/perspective-python/src/lib.rs
@@ -47,8 +47,13 @@ fn perspective(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<server::PySyncServer>()?;
     m.add_class::<server::PySyncSession>()?;
     m.add(
+        "PerspectiveBaseException",
+        py.get_type_bound::<client::PyPerspectiveBaseException>(),
+    )?;
+
+    m.add(
         "PerspectiveError",
-        py.get_type_bound::<client::PerspectivePyError>(),
+        py.get_type_bound::<client::PyPerspectiveError>(),
     )?;
 
     // m.add_function(wrap_pyfunction!(client_async::create_async_client, m)?)?;

--- a/rust/perspective-python/src/lib.rs
+++ b/rust/perspective-python/src/lib.rs
@@ -47,7 +47,7 @@ fn perspective(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<server::PySyncServer>()?;
     m.add_class::<server::PySyncSession>()?;
     m.add(
-        "PerspectivePyError",
+        "PerspectiveError",
         py.get_type_bound::<client::PerspectivePyError>(),
     )?;
 

--- a/rust/perspective-python/src/server/server_sync.rs
+++ b/rust/perspective-python/src/server/server_sync.rs
@@ -18,13 +18,13 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyFunction};
 
-#[pyclass]
+#[pyclass(name="Session")]
 #[derive(Clone)]
 pub struct PySyncSession {
     session: Arc<Session>,
 }
 
-#[pyclass]
+#[pyclass(name="Server")]
 #[derive(Clone, Default)]
 pub struct PySyncServer {
     pub server: Server,


### PR DESCRIPTION
I think `PySyncClient` et al are a bit weird in python land, so I propose normalizing on:
- `Client`/`Table`/etc for synchronous
- `ClientAsync` / `TableAsync`/etc for asynchronous 
This is pretty trivial to do it seems, so little downside


Separately, I propose using the following names:
- `PerspectiveError`: Error in the C++/Rust perspective engine
- `PerspectivePythonError`: error in just the python slice of the codebase

Ideally these should inherit from a common base class (maybe `PerspectivePythonError` can inherit from `PerspectiveError`, but it would be nice to very clearly disambiguate engine errors from python land errors (e.g. web server or other utilities' errors)