### PR TITLE
Switch to ruff, fix ruff errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,9 @@
         "prepush": "npm run lint",
         "prepare": "husky install",
         "lint": "node tools/perspective-scripts/lint.mjs",
+        "lint_python": "node tools/perspective-scripts/lint_python.mjs",
         "fix": "node tools/perspective-scripts/fix.mjs",
+        "fix_python": "node tools/perspective-scripts/fix_python.mjs",
         "version": "node tools/perspective-scripts/version.mjs",
         "jlab_link": "pip3 install ./python/perspective --no-build-isolation"
     }

--- a/rust/perspective-python/bench/tornado/server/new_api.py
+++ b/rust/perspective-python/bench/tornado/server/new_api.py
@@ -11,13 +11,11 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import multiprocessing
-import asyncio
 import os
 import os.path
 import time
 from perspective.core.globalpsp import shared_client
 from perspective.handlers.new_tornado import PerspectiveTornadoHandler
-from tornado.websocket import websocket_connect
 import tornado
 import threading
 import numpy
@@ -55,6 +53,7 @@ async def session():
 
 # Server
 
+
 def make_app(queue: multiprocessing.Queue, port: int = 8080):
     """Make a tornado server for the thread local event loop."""
     app = tornado.web.Application(
@@ -68,7 +67,7 @@ def make_app(queue: multiprocessing.Queue, port: int = 8080):
                 r"/(.*)",
                 tornado.web.StaticFileHandler,
                 {"path": os.path.join(os.path.dirname(__file__), "../client/dist"), "default_filename": "index.html"},
-            )
+            ),
         ]
     )
 
@@ -88,6 +87,7 @@ def start_server(queue: multiprocessing.Queue):
     server_process.daemon = True
     server_process.start()
     return server_process
+
 
 def main():
     """Runs an entire test scenario, server and client pool, then prints run

--- a/rust/perspective-python/bench/tornado/server/old_api.py
+++ b/rust/perspective-python/bench/tornado/server/old_api.py
@@ -23,9 +23,7 @@ from perspective import Table, PerspectiveManager, PerspectiveTornadoHandler
 
 
 here = os.path.abspath(os.path.dirname(__file__))
-file_path = os.path.join(
-    here, "..", "..", "..", "..", "..", "node_modules", "superstore-arrow", "superstore.lz4.arrow"
-)
+file_path = os.path.join(here, "..", "..", "..", "..", "..", "node_modules", "superstore-arrow", "superstore.lz4.arrow")
 
 IS_MULTI_THREADED = True
 
@@ -44,18 +42,26 @@ def perspective_thread(manager, table):
         manager.set_loop_callback(psp_loop.add_callback)
         psp_loop.start()
 
+
 old_on_message = PerspectiveTornadoHandler.on_message
+
+
 def new_on_message(*args, **kwargs):
-    print('PerspectiveTornadoHandler.on_message', args, kwargs)
+    print("PerspectiveTornadoHandler.on_message", args, kwargs)
     return old_on_message(*args, **kwargs)
 
+
 old_write_message = PerspectiveTornadoHandler.write_message
+
+
 def new_write_message(*args, **kwargs):
-    print('PerspectiveTornadoHandler.write_message', args, kwargs)
+    print("PerspectiveTornadoHandler.write_message", args, kwargs)
     return old_write_message(*args, **kwargs)
+
 
 # PerspectiveTornadoHandler.on_message = new_on_message
 # PerspectiveTornadoHandler.write_message = new_write_message
+
 
 def make_app():
     with open(file_path, mode="rb") as file:
@@ -96,6 +102,7 @@ def main():
     logging.critical("Listening on http://localhost:8080")
     loop = tornado.ioloop.IOLoop.current()
     loop.start()
+
 
 if __name__ == "__main__":
     server = threading.Thread(target=main)

--- a/rust/perspective-python/perspective/tests/client_mode/test_client_mode.py
+++ b/rust/perspective-python/perspective/tests/client_mode/test_client_mode.py
@@ -66,7 +66,7 @@ def rename_libraries():
     assert not os.path.exists(psp)
 
     # import
-    import perspective
+    import perspective  # noqa: F401
 
     # defer to test
     yield
@@ -83,7 +83,7 @@ def rename_libraries():
     unload()
 
     # import again
-    import perspective
+    import perspective  # noqa: F811, F401
 
 
 @pytest.mark.skip
@@ -142,11 +142,7 @@ class TestClient(object):
         import perspective
 
         assert perspective.is_libpsp() is False
-        data = {
-            "a": np.array(
-                [date(2020, i, 1) for i in range(1, 13)], dtype="datetime64[D]"
-            )
-        }
+        data = {"a": np.array([date(2020, i, 1) for i in range(1, 13)], dtype="datetime64[D]")}
         widget = perspective.PerspectiveWidget(data)
         assert hasattr(widget, "table") is False
         assert widget._data == {"a": ["2020-{:02d}-01".format(i) for i in range(1, 13)]}
@@ -164,9 +160,7 @@ class TestClient(object):
         import perspective
 
         assert perspective.is_libpsp() is False
-        data = pd.DataFrame(
-            {"a": [date(2020, i, 1) for i in range(1, 13)]}, dtype="datetime64[ns]"
-        )
+        data = pd.DataFrame({"a": [date(2020, i, 1) for i in range(1, 13)]}, dtype="datetime64[ns]")
         widget = perspective.PerspectiveWidget(data)
         assert hasattr(widget, "table") is False
         assert widget._data == {
@@ -178,9 +172,7 @@ class TestClient(object):
         import perspective
 
         assert perspective.is_libpsp() is False
-        data = pd.DataFrame(
-            {"a": [date(2020, i, 1) for i in range(1, 13)]}, dtype="object"
-        )
+        data = pd.DataFrame({"a": [date(2020, i, 1) for i in range(1, 13)]}, dtype="object")
         widget = perspective.PerspectiveWidget(data)
         assert hasattr(widget, "table") is False
         assert widget._data == {
@@ -195,9 +187,7 @@ class TestClient(object):
         data = {"a": [datetime(2020, i, 1, 12, 30, 45) for i in range(1, 13)]}
         widget = perspective.PerspectiveWidget(data)
         assert hasattr(widget, "table") is False
-        assert widget._data == {
-            "a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]
-        }
+        assert widget._data == {"a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]}
 
     def test_widget_client_np_datetime(self, rename_libraries):
         import perspective
@@ -211,24 +201,16 @@ class TestClient(object):
         }
         widget = perspective.PerspectiveWidget(data)
         assert hasattr(widget, "table") is False
-        assert widget._data == {
-            "a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]
-        }
+        assert widget._data == {"a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]}
 
     def test_widget_client_np_datetime_object(self, rename_libraries):
         import perspective
 
         assert perspective.is_libpsp() is False
-        data = {
-            "a": np.array(
-                [datetime(2020, i, 1, 12, 30, 45) for i in range(1, 13)], dtype="object"
-            )
-        }
+        data = {"a": np.array([datetime(2020, i, 1, 12, 30, 45) for i in range(1, 13)], dtype="object")}
         widget = perspective.PerspectiveWidget(data)
         assert hasattr(widget, "table") is False
-        assert widget._data == {
-            "a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]
-        }
+        assert widget._data == {"a": ["2020-{:02d}-01 12:30:45".format(i) for i in range(1, 13)]}
 
     def test_widget_client_df_datetime(self, rename_libraries):
         import perspective
@@ -273,9 +255,7 @@ class TestClient(object):
         import perspective
 
         assert perspective.is_libpsp() is False
-        data = np.array([(1, 2), (3, 4)], dtype=[("a", "int64"), ("b", "int64")]).view(
-            np.recarray
-        )
+        data = np.array([(1, 2), (3, 4)], dtype=[("a", "int64"), ("b", "int64")]).view(np.recarray)
         widget = perspective.PerspectiveWidget(data)
         assert hasattr(widget, "table") is False
         assert widget._data == {"a": [1, 3], "b": [2, 4]}
@@ -356,9 +336,7 @@ class TestClient(object):
         import perspective
 
         assert perspective.is_libpsp() is False
-        widget = perspective.PerspectiveWidget(
-            {"a": "integer", "b": "float", "c": "boolean", "d": "date", "e": "datetime", "f": "string"}
-        )
+        widget = perspective.PerspectiveWidget({"a": "integer", "b": "float", "c": "boolean", "d": "date", "e": "datetime", "f": "string"})
         assert hasattr(widget, "table") is False
         assert widget._data == {
             "a": "integer",
@@ -376,9 +354,7 @@ class TestClient(object):
         data = {"a": np.arange(0, 50)}
         comparison_data = {"a": [i for i in range(50)]}
         widget = perspective.PerspectiveWidget(data)
-        mocked_post = partial(
-            mock_post, assert_msg={"cmd": "update", "data": comparison_data}
-        )
+        mocked_post = partial(mock_post, assert_msg={"cmd": "update", "data": comparison_data})
         widget.post = MethodType(mocked_post, widget)
         widget.update(data)
         assert hasattr(widget, "table") is False
@@ -390,9 +366,7 @@ class TestClient(object):
         data = {"a": np.arange(0, 50)}
         new_data = {"a": [1]}
         widget = perspective.PerspectiveWidget(data)
-        mocked_post = partial(
-            mock_post, assert_msg={"cmd": "replace", "data": new_data}
-        )
+        mocked_post = partial(mock_post, assert_msg={"cmd": "replace", "data": new_data})
         widget.post = MethodType(mocked_post, widget)
         widget.replace(new_data)
         assert widget._data is new_data
@@ -476,9 +450,7 @@ class TestClient(object):
         ]
         tuples = list(zip(*arrays))
         index = pd.MultiIndex.from_tuples(tuples, names=["first", "second", "third"])
-        df_both = pd.DataFrame(
-            np.random.randn(3, 16), index=["A", "B", "C"], columns=index
-        )
+        df_both = pd.DataFrame(np.random.randn(3, 16), index=["A", "B", "C"], columns=index)
         widget = perspective.PerspectiveWidget(df_both)
         assert hasattr(widget, "table") is False
         assert widget.columns == ["value"]

--- a/rust/perspective-python/perspective/tests/core/test_async.py
+++ b/rust/perspective-python/perspective/tests/core/test_async.py
@@ -16,7 +16,7 @@ import threading
 from functools import partial
 
 import tornado.ioloop
-from perspective import PerspectiveError, PerspectiveManager, Table, create_sync_client
+from perspective import PerspectiveError, create_sync_client
 from pytest import mark, raises
 
 
@@ -62,9 +62,7 @@ class TestAsync(object):
         return cls.loop.asyncio_loop.is_running()
 
     def test_async_queue_process(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
 
         @syncify
@@ -79,9 +77,7 @@ class TestAsync(object):
 
     def test_async_queue_process_csv(self):
         """Make sure GIL release during CSV loading works"""
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
         tbl = client.table("x,y,z\n1,a,true\n2,b,false\n3,c,true\n4,d,false")
 
         @syncify
@@ -96,9 +92,7 @@ class TestAsync(object):
         tbl.delete()
 
     def test_async_call_loop(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl.update(data)
 
@@ -111,9 +105,7 @@ class TestAsync(object):
 
     @mark.skip(reason="We take a loop to construct the client now")
     def test_async_call_loop_error_if_no_loop(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
 
         with raises(PerspectiveError):
@@ -132,12 +124,8 @@ class TestAsync(object):
         tbl.delete()
 
     def test_async_multiple_managers_queue_process(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
-        client2 = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
+        client2 = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl2 = client2.table({"a": "integer", "b": "float", "c": "string"})
 
@@ -169,9 +157,7 @@ class TestAsync(object):
 
         _delete_task()
 
-    @mark.skip(
-        reason="This test is failing because we're not calling process after each update like before"
-    )
+    @mark.skip(reason="This test is failing because we're not calling process after each update like before")
     def test_async_multiple_managers_mixed_queue_process(self):
         sentinel = {"called": 0}
 
@@ -179,9 +165,7 @@ class TestAsync(object):
             sentinel["called"] += 1
             f(*args, **kwargs)
 
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
         client2 = create_sync_client(sync_queue_process)
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl2 = client2.table({"a": "integer", "b": "float", "c": "string"})
@@ -215,9 +199,7 @@ class TestAsync(object):
         view.delete()
         tbl2.delete()
 
-    @mark.skip(
-        reason="This test is failing because we're not calling process after each update like before"
-    )
+    @mark.skip(reason="This test is failing because we're not calling process after each update like before")
     def test_async_multiple_managers_delayed_process(self):
         sentinel = {"async": 0, "sync": 0}
 
@@ -226,16 +208,10 @@ class TestAsync(object):
             return f(*args, **kwargs)
 
         short_delay_queue_process = partial(_counter, "sync")
-        long_delay_queue_process = partial(
-            TestAsync.loop.add_timeout, 1, _counter, "async"
-        )
+        long_delay_queue_process = partial(TestAsync.loop.add_timeout, 1, _counter, "async")
 
-        client = create_sync_client(
-            lambda fn, *args: short_delay_queue_process(fn, *args)
-        )
-        client2 = create_sync_client(
-            lambda fn, *args: long_delay_queue_process(fn, *args)
-        )
+        client = create_sync_client(lambda fn, *args: short_delay_queue_process(fn, *args))
+        client2 = create_sync_client(lambda fn, *args: long_delay_queue_process(fn, *args))
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl2 = client2.table({"a": "integer", "b": "float", "c": "string"})
 
@@ -299,9 +275,7 @@ class TestAsync(object):
         tbl2.delete()
 
     def test_async_queue_process_multiple_ports(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         port_ids = [0]
         port_data = [{"a": 0, "b": 0, "c": "0"}]
@@ -330,12 +304,8 @@ class TestAsync(object):
         assert _tbl_task() == 11
 
     def test_async_multiple_managers_queue_process_multiple_ports(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
-        client2 = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
+        client2 = create_sync_client(lambda fn, *args: TestAsync.loop.add_callback(fn, *args))
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl2 = client2.table({"a": "integer", "b": "float", "c": "string"})
         port_ids = [0]
@@ -359,9 +329,7 @@ class TestAsync(object):
 
         assert _task() == (11, 11)
 
-    @mark.skip(
-        reason="This test is failing because we're not calling process after each update like before"
-    )
+    @mark.skip(reason="This test is failing because we're not calling process after each update like before")
     def test_async_multiple_managers_mixed_queue_process_multiple_ports(self):
         sentinel = {"async": 0, "sync": 0}
 

--- a/rust/perspective-python/perspective/tests/core/test_threadpool.py
+++ b/rust/perspective-python/perspective/tests/core/test_threadpool.py
@@ -21,7 +21,7 @@ def compare_delta(received, expected):
 
 class TestThreadpool(object):
     def test_set_threadpool_size(self):
-        set_threadpool_size(1) # XXX: This is a no-op now...
+        set_threadpool_size(1)  # XXX: This is a no-op now...
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
         view = tbl.view()

--- a/rust/perspective-python/perspective/tests/manager/test_manager.py
+++ b/rust/perspective-python/perspective/tests/manager/test_manager.py
@@ -11,10 +11,8 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import json
-import time
 import numpy as np
 import pyarrow as pa
-from datetime import datetime
 from functools import partial
 from pytest import raises, mark
 from perspective import Table, PerspectiveError, PerspectiveManager, create_sync_client
@@ -35,7 +33,7 @@ class TestPerspectiveManager(object):
 
     def test_manager_host_table(self):
         manager = PerspectiveManager()
-        table = manager.table(data, name="table1")
+        _ = manager.table(data, name="table1")
         table2 = manager.open_table("table1")
         assert table2.schema() == {"a": "integer", "b": "string"}
 
@@ -62,7 +60,7 @@ class TestPerspectiveManager(object):
 
     def test_manager_get_hosted_table_names_with_cmd(self):
         manager = PerspectiveManager()
-        table = manager.table(data, name="table1")
+        _ = manager.table(data, name="table1")
         assert manager.get_hosted_table_names() == ["table1"]
 
     @mark.skip(reason="Have not implemented locking yet")
@@ -115,7 +113,7 @@ class TestPerspectiveManager(object):
         assert manager._get_view("view1").schema() == {"a": "integer", "b": "string"}
 
     def test_manager_create_view_zero(self):
-        message = {"id": 1, "table_name": "table1", "view_name": "view1", "cmd": "view"}
+        # message = {"id": 1, "table_name": "table1", "view_name": "view1", "cmd": "view"}
         manager = PerspectiveManager()
         manager.table(data, name="table1")
         table = manager.open_table("table1")
@@ -367,9 +365,7 @@ class TestPerspectiveManager(object):
         assert d == {"a": [1], "b": ["a"]}
 
     def test_manager_to_dict_with_nan(self, util, sentinel):
-        data = util.make_arrow(
-            ["a"], [[1.5, np.nan, 2.5, np.nan]], types=[pa.float64()]
-        )
+        data = util.make_arrow(["a"], [[1.5, np.nan, 2.5, np.nan]], types=[pa.float64()])
         manager = PerspectiveManager()
         manager.table(data, name="table1")
         table = manager.open_table("table1")
@@ -977,9 +973,7 @@ class TestPerspectiveManager(object):
         table.update({"a": [7, 8, 9]})
         assert s.get() == 5
 
-    @mark.skip(
-        reason="This method no longer dispatches to the loop_cb because it is sync without an on_update callback"
-    )
+    @mark.skip(reason="This method no longer dispatches to the loop_cb because it is sync without an on_update callback")
     def test_manager_set_queue_process_before_host_table(self, sentinel):
         s = sentinel(0)
         manager = create_sync_client()
@@ -995,9 +989,7 @@ class TestPerspectiveManager(object):
 
         assert s.get() == 2
 
-    @mark.skip(
-        reason="This method no longer dispatches to the loop_cb because it is sync without an on_update callback"
-    )
+    @mark.skip(reason="This method no longer dispatches to the loop_cb because it is sync without an on_update callback")
     def test_manager_set_queue_process_multiple(self, sentinel):
         # manager2's queue process should not affect manager1,
         # provided they manage different tables

--- a/rust/perspective-python/perspective/tests/single_threaded/test_single_threaded.py
+++ b/rust/perspective-python/perspective/tests/single_threaded/test_single_threaded.py
@@ -10,7 +10,6 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import pandas as pd
 from perspective import Table, set_threadpool_size
 
 set_threadpool_size(1)

--- a/rust/perspective-python/perspective/tests/table/object_sequence.py
+++ b/rust/perspective-python/perspective/tests/table/object_sequence.py
@@ -362,9 +362,7 @@ def run2():
             while ind in indexes:
                 ind = randint(1, 100)
 
-            print(
-                "adding", ind, "refcount", t_ref_count, "should be", sys.getrefcount(t)
-            )
+            print("adding", ind, "refcount", t_ref_count, "should be", sys.getrefcount(t))
             tbl.update({"a": [ind], "b": [t]})
             t_ref_count += 1
             indexes.add(ind)

--- a/rust/perspective-python/perspective/tests/table/test_exception.py
+++ b/rust/perspective-python/perspective/tests/table/test_exception.py
@@ -40,10 +40,7 @@ class TestException(object):
             tbl.view()
             tbl.delete()
 
-        assert (
-            str(ex.value)
-            == "Abort(): Cannot delete table with views"
-        )
+        assert str(ex.value) == "Abort(): Cannot delete table with views"
 
         with raises(PerspectivePyError) as ex:
             tbl.view(group_by=["b"])

--- a/rust/perspective-python/perspective/tests/table/test_ports.py
+++ b/rust/perspective-python/perspective/tests/table/test_ports.py
@@ -99,9 +99,7 @@ class TestPorts(object):
 
         view = table.view()
         ports_to_update = [random.randint(0, 10) for i in range(5)]
-        unique_data = {
-            port: [{"a": port, "b": str(port), "c": True}] for port in ports_to_update
-        }
+        unique_data = {port: [{"a": port, "b": str(port), "c": True}] for port in ports_to_update}
 
         def callback(port_id, delta):
             assert port_id in ports_to_update

--- a/rust/perspective-python/perspective/tests/table/test_table.py
+++ b/rust/perspective-python/perspective/tests/table/test_table.py
@@ -10,13 +10,12 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import sys
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 
 from perspective.core.exception import PerspectiveError
 from perspective import Table
 import perspective
-from pytest import mark, raises, skip
+from pytest import mark, raises
 import pytest
 
 
@@ -445,7 +444,7 @@ class TestTable:
             },
             index="a",
         )
-        ts = lambda x: int(datetime.timestamp(x) * 1000)
+        ts = lambda x: int(datetime.timestamp(x) * 1000)  # noqa: E731
         assert tbl.view().to_columns() == {
             "a": [
                 None,

--- a/rust/perspective-python/perspective/tests/table/test_table_arrow.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_arrow.py
@@ -124,9 +124,7 @@ class TestTableArrow(object):
         tbl = Table(arrow_data)
         assert tbl.size() == 10
         assert tbl.schema() == {"a": "date"}
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]}
 
     def test_table_arrow_loads_date64_stream(self, util):
         data = [[date(2019, 2, i) for i in range(1, 11)]]
@@ -134,9 +132,7 @@ class TestTableArrow(object):
         tbl = Table(arrow_data)
         assert tbl.size() == 10
         assert tbl.schema() == {"a": "date"}
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]}
 
     def test_table_arrow_loads_timestamp_all_formats_stream(self, util):
         data = [
@@ -323,9 +319,7 @@ class TestTableArrow(object):
         tbl = Table(arrow_data)
         assert tbl.size() == 10
         assert tbl.schema() == {"a": "date"}
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]}
 
     def test_table_arrow_loads_date64_legacy(self, util):
         data = [[date(2019, 2, i) for i in range(1, 11)]]
@@ -333,9 +327,7 @@ class TestTableArrow(object):
         tbl = Table(arrow_data)
         assert tbl.size() == 10
         assert tbl.schema() == {"a": "date"}
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]}
 
     def test_table_arrow_loads_timestamp_all_formats_legacy(self, util):
         data = [
@@ -399,9 +391,7 @@ class TestTableArrow(object):
 
         # write arrow to stream
         stream = pa.BufferOutputStream()
-        writer = pa.RecordBatchStreamWriter(
-            stream, arrow_table.schema, use_legacy_format=False
-        )
+        writer = pa.RecordBatchStreamWriter(stream, arrow_table.schema, use_legacy_format=False)
         writer.write_table(arrow_table)
         writer.close()
         arrow = stream.getvalue().to_pybytes()

--- a/rust/perspective-python/perspective/tests/table/test_table_datetime.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_datetime.py
@@ -161,71 +161,54 @@ if os.name != "nt":
         def test_table_datetime_min(self, util):
             data = {"a": [datetime.min]}
             table = Table(data)
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(1969, 12, 31, 19, 0))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(1969, 12, 31, 19, 0))]
 
         @mark.skip(reason="Python specific behavior we don't need")
         def test_table_datetime_min_df(self, util):
             data = pd.DataFrame({"a": [datetime.min]})
             table = Table(data)
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(1969, 12, 31, 19, 0))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(1969, 12, 31, 19, 0))]
 
         def test_table_datetime_1900(self, util):
             table = Table({"a": "datetime"})
             table.update({"a": [util.to_timestamp(datetime(1900, 1, 1))]})
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(1900, 1, 1))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(1900, 1, 1))]
 
         def test_table_datetime_1900_df(self, util):
             data = pd.DataFrame({"a": [datetime(1900, 1, 1)]})
             table = Table(data)
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(1899, 12, 31, 19))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(1899, 12, 31, 19))]
 
         def test_table_datetime_1899(self, util: Util):
             table = Table({"a": "datetime"})
             table.update({"a": [datetime(1899, 1, 1)]})
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(1898, 12, 31, 19))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(1898, 12, 31, 19))]
 
         def test_table_datetime_1899_df(self, util):
             data = pd.DataFrame({"a": [datetime(1899, 1, 1)]})
             table = Table(data)
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(1898, 12, 31, 19))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(1898, 12, 31, 19))]
 
         def test_table_datetime_min_epoch(self, util):
             data = {"a": [0]}
             table = Table({"a": "datetime"})
             table.update(data)
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(1969, 12, 31, 19, 0))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(1969, 12, 31, 19, 0))]
 
         def test_table_datetime_cant_convert_from_int(self):
             data = pd.DataFrame({"a": [0]})
             table = Table({"a": "datetime"})
-            with raises(PerspectivePyError) as ex:
+            # with raises(PerspectivePyError) as ex:
+            with raises(PerspectivePyError):
                 table.update(data)
             # assert str(ex.value) == "..."
 
-        @mark.skip(
-            reason="we do not support this conversion, wrote a test above to ensure it fails"
-        )
+        @mark.skip(reason="we do not support this conversion, wrote a test above to ensure it fails")
         def test_table_datetime_min_epoch_df(self, util):
             data = pd.DataFrame({"a": [0]})
             table = Table({"a": "datetime"})
             table.update(data)
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(1969, 12, 31, 19, 0))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(1969, 12, 31, 19, 0))]
 
         @mark.skip
         def test_table_datetime_max(self, util):
@@ -233,17 +216,13 @@ if os.name != "nt":
             table = Table(data)
 
             # lol - result is converted from UTC to EST (local time)
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(9999, 12, 31, 18, 59, 59))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(9999, 12, 31, 18, 59, 59))]
 
         @mark.skip
-        def test_table_datetime_max_df(self):
+        def test_table_datetime_max_df(self, util: Util):
             data = pd.DataFrame({"a": [datetime.max]})
             table = Table(data)
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(datetime(9999, 12, 31, 18, 59, 59))
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(datetime(9999, 12, 31, 18, 59, 59))]
 
     class TestTableDateTimeUTCToLocal(object):
         def teardown_method(self):
@@ -264,9 +243,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in PST now
-            assert table.view().to_columns() == {
-                "a": [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]
-            }
+            assert table.view().to_columns() == {"a": [d.astimezone(PST).replace(tzinfo=None) for d in data["a"]]}
 
         def test_table_should_convert_UTC_to_local_time_pytz_central(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -276,12 +253,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in CST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(CST).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(CST).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_UTC_to_local_time_pytz_eastern(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -291,12 +263,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(EST).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(EST).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_UTC_to_local_time_pytz_GMT(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -306,12 +273,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in GMT now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_UTC_to_local_time_pytz_HKT(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -320,12 +282,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Hong_Kong"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_UTC_to_local_time_pytz_JPT(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -334,12 +291,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Tokyo"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_UTC_to_local_time_pytz_ACT(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -348,16 +300,9 @@ if os.name != "nt":
             os.environ["TZ"] = "Australia/Sydney"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None)) for d in data["a"]]}
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_pacific(
-            self, util: Util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_pacific(self, util: Util):
             data = {"a": UTC_DATETIMES}
             table = Table(data)
 
@@ -365,16 +310,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in PST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(PST).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(PST).replace(tzinfo=None)) for d in data["a"]]}
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_central(
-            self, util: Util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_central(self, util: Util):
             data = {"a": UTC_DATETIMES}
             table = Table(data)
 
@@ -382,16 +320,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in CST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(CST).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(CST).replace(tzinfo=None)) for d in data["a"]]}
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_eastern(
-            self, util: Util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_eastern(self, util: Util):
             data = {"a": UTC_DATETIMES}
             table = Table(data)
 
@@ -399,12 +330,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(EST).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(EST).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_UTC_to_local_time_dateutil_GMT(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -414,16 +340,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in GMT now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None)) for d in data["a"]]}
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_pacific_DST(
-            self, util: Util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_pacific_DST(self, util: Util):
             data = {"a": UTC_DATETIMES_DST}
             table = Table(data)
 
@@ -431,16 +350,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in PST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.replace(tzinfo=None))
-                    for d in TZ_DATETIMES_DST["US/Pacific"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.replace(tzinfo=None)) for d in TZ_DATETIMES_DST["US/Pacific"]]}
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_central_DST(
-            self, util: Util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_central_DST(self, util: Util):
             data = {"a": UTC_DATETIMES_DST}
             table = Table(data)
 
@@ -448,16 +360,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in CST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.replace(tzinfo=None))
-                    for d in TZ_DATETIMES_DST["US/Central"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.replace(tzinfo=None)) for d in TZ_DATETIMES_DST["US/Central"]]}
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_eastern_DST(
-            self, util: Util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_eastern_DST(self, util: Util):
             data = {"a": UTC_DATETIMES_DST}
             table = Table(data)
 
@@ -465,16 +370,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.replace(tzinfo=None))
-                    for d in TZ_DATETIMES_DST["US/Eastern"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.replace(tzinfo=None)) for d in TZ_DATETIMES_DST["US/Eastern"]]}
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_GMT_DST(
-            self, util: Util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_GMT_DST(self, util: Util):
             data = {"a": UTC_DATETIMES_DST}
             table = Table(data)
 
@@ -482,16 +380,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in GMT now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.replace(tzinfo=None))
-                    for d in TZ_DATETIMES_DST["GMT"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.replace(tzinfo=None)) for d in TZ_DATETIMES_DST["GMT"]]}
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_pacific_DST_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_pacific_DST_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS_DST})
             table = Table(data)
 
@@ -499,14 +390,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in PST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(d.replace(tzinfo=None))
-                for d in TZ_DATETIMES_DST["US/Pacific"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.replace(tzinfo=None)) for d in TZ_DATETIMES_DST["US/Pacific"]]
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_central_DST_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_central_DST_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS_DST})
             table = Table(data)
 
@@ -514,14 +400,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in CST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(d.replace(tzinfo=None))
-                for d in TZ_DATETIMES_DST["US/Central"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.replace(tzinfo=None)) for d in TZ_DATETIMES_DST["US/Central"]]
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_eastern_DST_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_eastern_DST_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS_DST})
             table = Table(data)
 
@@ -529,14 +410,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(d.replace(tzinfo=None))
-                for d in TZ_DATETIMES_DST["US/Eastern"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.replace(tzinfo=None)) for d in TZ_DATETIMES_DST["US/Eastern"]]
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_GMT_DST_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_GMT_DST_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS_DST})
             table = Table(data)
 
@@ -544,10 +420,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in GMT now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(d.replace(tzinfo=None))
-                for d in TZ_DATETIMES_DST["GMT"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.replace(tzinfo=None)) for d in TZ_DATETIMES_DST["GMT"]]
 
         def test_table_should_convert_UTC_to_local_time_dateutil_HKT(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -556,12 +429,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Hong_Kong"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_UTC_to_local_time_dateutil_JPT(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -570,12 +438,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Tokyo"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_UTC_to_local_time_dateutil_ACT(self, util: Util):
             data = {"a": UTC_DATETIMES}
@@ -586,16 +449,9 @@ if os.name != "nt":
 
             ACT = tz.gettz("Australia/Sydney")
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None)) for d in data["a"]]}
 
-        def test_table_should_convert_UTC_to_local_time_pytz_pacific_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_pytz_pacific_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
             table = Table(data)
 
@@ -603,16 +459,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in PST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(PST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(PST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_UTC_to_local_time_pytz_central_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_pytz_central_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
             table = Table(data)
 
@@ -620,16 +469,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in CST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(CST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(CST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_UTC_to_local_time_pytz_eastern_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_pytz_eastern_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
             table = Table(data)
 
@@ -637,12 +479,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(EST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(EST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
         def test_table_should_convert_UTC_to_local_time_pytz_GMT_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
@@ -652,12 +489,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in GMT now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(GMT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
         def test_table_should_convert_UTC_to_local_time_pytz_HKT_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
@@ -666,12 +498,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Hong_Kong"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(HKT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
         def test_table_should_convert_UTC_to_local_time_pytz_JPT_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
@@ -680,12 +507,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Tokyo"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(JPT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
         def test_table_should_convert_UTC_to_local_time_pytz_ACT_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
@@ -694,16 +516,9 @@ if os.name != "nt":
             os.environ["TZ"] = "Australia/Sydney"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(ACT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_pacific_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_pacific_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
             table = Table(data)
 
@@ -711,12 +526,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in PST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(PST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(PST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
         def test_table_should_convert_UTC_to_local_time_dateutil_central_timestamp(
             self,
@@ -731,16 +541,9 @@ if os.name != "nt":
             CST = tz.gettz("US/Central")
 
             # Should be in CST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(CST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(CST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_eastern_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_eastern_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
             table = Table(data)
 
@@ -748,16 +551,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(EST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(EST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_GMT_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_GMT_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
             table = Table(data)
 
@@ -767,60 +563,34 @@ if os.name != "nt":
             GMT = tz.gettz("GMT")
 
             # Should be in GMT now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(GMT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_HKT_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_HKT_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
             table = Table(data)
 
             os.environ["TZ"] = "Asia/Hong_Kong"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(HKT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_JPT_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_JPT_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
             table = Table(data)
 
             os.environ["TZ"] = "Asia/Tokyo"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(JPT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_UTC_to_local_time_dateutil_ACT_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_UTC_to_local_time_dateutil_ACT_timestamp(self, util):
             data = pd.DataFrame({"a": UTC_TIMESTAMPS})
             table = Table(data)
 
             os.environ["TZ"] = "Australia/Sydney"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(ACT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
     class TestTableDateTimeArbitaryToLocal(object):
         def teardown_method(self):
@@ -836,12 +606,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in CST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(CST).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(CST).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_CST_to_local_time_pytz_eastern(self, util: Util):
             data = {"a": TZ_DATETIMES["US/Central"]}
@@ -851,12 +616,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(EST).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(EST).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_EST_to_local_time_pytz_GMT(self, util: Util):
             data = {"a": TZ_DATETIMES["US/Eastern"]}
@@ -866,12 +626,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in GMT now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_GMT_to_local_time_pytz_HKT(self, util: Util):
             data = {"a": TZ_DATETIMES["GMT"]}
@@ -880,12 +635,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Hong_Kong"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_HKT_to_local_time_pytz_JPT(self, util: Util):
             data = {"a": TZ_DATETIMES["Asia/Hong_Kong"]}
@@ -894,12 +644,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Tokyo"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_JPT_to_local_time_pytz_ACT(self, util: Util):
             data = {"a": TZ_DATETIMES["Asia/Tokyo"]}
@@ -908,16 +653,9 @@ if os.name != "nt":
             os.environ["TZ"] = "Australia/Sydney"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None)) for d in data["a"]]}
 
-        def test_table_should_convert_PST_to_local_time_dateutil_central(
-            self, util: Util
-        ):
+        def test_table_should_convert_PST_to_local_time_dateutil_central(self, util: Util):
             data = {"a": TZ_DATETIMES["US/Pacific"]}
             table = Table(data)
 
@@ -925,16 +663,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in CST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(CST).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(CST).replace(tzinfo=None)) for d in data["a"]]}
 
-        def test_table_should_convert_CST_to_local_time_dateutil_eastern(
-            self, util: Util
-        ):
+        def test_table_should_convert_CST_to_local_time_dateutil_eastern(self, util: Util):
             data = {"a": TZ_DATETIMES["US/Central"]}
             table = Table(data)
 
@@ -942,12 +673,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(EST).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(EST).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_EST_to_local_time_dateutil_GMT(self, util: Util):
             data = {"a": TZ_DATETIMES["US/Eastern"]}
@@ -957,12 +683,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in GMT now
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_GMT_to_local_time_dateutil_HKT(self, util: Util):
             data = {"a": TZ_DATETIMES["GMT"]}
@@ -971,12 +692,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Hong_Kong"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_HKT_to_local_time_dateutil_JPT(self, util: Util):
             data = {"a": TZ_DATETIMES["Asia/Hong_Kong"]}
@@ -985,12 +701,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Tokyo"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None)) for d in data["a"]]}
 
         def test_table_should_convert_JPT_to_local_time_dateutil_ACT(self, util: Util):
             data = {"a": TZ_DATETIMES["Asia/Tokyo"]}
@@ -999,16 +710,9 @@ if os.name != "nt":
             os.environ["TZ"] = "Australia/Sydney"
             time.tzset()
 
-            assert table.view().to_columns() == {
-                "a": [
-                    util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None))
-                    for d in data["a"]
-                ]
-            }
+            assert table.view().to_columns() == {"a": [util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None)) for d in data["a"]]}
 
-        def test_table_should_convert_PST_to_local_time_pytz_central_timestamp(
-            self, util: Util
-        ):
+        def test_table_should_convert_PST_to_local_time_pytz_central_timestamp(self, util: Util):
             data = {"a": TZ_TIMESTAMPS["US/Pacific"]}
             table = Table(pd.DataFrame(data))
 
@@ -1016,16 +720,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in CST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(CST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(CST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_CST_to_local_time_pytz_eastern_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_CST_to_local_time_pytz_eastern_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["US/Central"]}
             table = Table(pd.DataFrame(data))
 
@@ -1033,12 +730,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(EST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(EST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
         def test_table_should_convert_EST_to_local_time_pytz_GMT_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["US/Eastern"]}
@@ -1048,12 +740,7 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in GMT now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(GMT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
         def test_table_should_convert_GMT_to_local_time_pytz_HKT_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["GMT"]}
@@ -1062,12 +749,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Hong_Kong"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(HKT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
         def test_table_should_convert_HKT_to_local_time_pytz_JPT_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["Asia/Hong_Kong"]}
@@ -1076,12 +758,7 @@ if os.name != "nt":
             os.environ["TZ"] = "Asia/Tokyo"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(JPT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
         def test_table_should_convert_JPT_to_local_time_pytz_ACT_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["Asia/Tokyo"]}
@@ -1090,16 +767,9 @@ if os.name != "nt":
             os.environ["TZ"] = "Australia/Sydney"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(ACT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_PST_to_local_time_dateutil_central_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_PST_to_local_time_dateutil_central_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["US/Pacific"]}
             table = Table(pd.DataFrame(data))
 
@@ -1107,16 +777,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in CST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(CST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(CST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_CST_to_local_time_dateutil_eastern_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_CST_to_local_time_dateutil_eastern_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["US/Central"]}
             table = Table(pd.DataFrame(data))
 
@@ -1124,16 +787,9 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in EST now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(EST).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(EST).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_EST_to_local_time_dateutil_GMT_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_EST_to_local_time_dateutil_GMT_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["US/Eastern"]}
             table = Table(pd.DataFrame(data))
 
@@ -1141,60 +797,34 @@ if os.name != "nt":
             time.tzset()
 
             # Should be in GMT now
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(GMT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(GMT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_GMT_to_local_time_dateutil_HKT_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_GMT_to_local_time_dateutil_HKT_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["GMT"]}
             table = Table(pd.DataFrame(data))
 
             os.environ["TZ"] = "Asia/Hong_Kong"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(HKT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(HKT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_HKT_to_local_time_dateutil_JPT_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_HKT_to_local_time_dateutil_JPT_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["Asia/Hong_Kong"]}
             table = Table(pd.DataFrame(data))
 
             os.environ["TZ"] = "Asia/Tokyo"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(JPT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(JPT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
-        def test_table_should_convert_JPT_to_local_time_dateutil_ACT_timestamp(
-            self, util
-        ):
+        def test_table_should_convert_JPT_to_local_time_dateutil_ACT_timestamp(self, util):
             data = {"a": TZ_TIMESTAMPS["Asia/Tokyo"]}
             table = Table(pd.DataFrame(data))
 
             os.environ["TZ"] = "Australia/Sydney"
             time.tzset()
 
-            assert table.view().to_columns()["a"] == [
-                util.to_timestamp(
-                    d.astimezone(ACT).replace(tzinfo=None).to_pydatetime()
-                )
-                for d in data["a"]
-            ]
+            assert table.view().to_columns()["a"] == [util.to_timestamp(d.astimezone(ACT).replace(tzinfo=None).to_pydatetime()) for d in data["a"]]
 
     class TestTableDateTimeRowColumnPaths(object):
         """Assert correctness of row and column paths in different timezones."""
@@ -1325,9 +955,7 @@ if os.name != "nt":
             result = view.to_columns()
 
             for item in result["now()"]:
-                in_range = (
-                    now - timedelta(seconds=2) < item < now + timedelta(seconds=2)
-                )
+                in_range = now - timedelta(seconds=2) < item < now + timedelta(seconds=2)
                 assert in_range is True
 
         @mark.skip(reason="Unsupported non-UTC timezone")
@@ -1343,9 +971,7 @@ if os.name != "nt":
             result = view.to_columns()
 
             for item in result["now()"]:
-                in_range = (
-                    now - timedelta(seconds=2) < item < now + timedelta(seconds=2)
-                )
+                in_range = now - timedelta(seconds=2) < item < now + timedelta(seconds=2)
                 assert in_range is True
 
         @mark.skip(reason="Unsupported non-UTC timezone")
@@ -1361,9 +987,7 @@ if os.name != "nt":
             result = view.to_columns()
 
             for item in result["now()"]:
-                in_range = (
-                    now - timedelta(seconds=2) < item < now + timedelta(seconds=2)
-                )
+                in_range = now - timedelta(seconds=2) < item < now + timedelta(seconds=2)
                 assert in_range is True
 
         @mark.skip(reason="Unsupported non-UTC timezone")
@@ -1474,9 +1098,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'D')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'D')"] == [
-                util.to_timestamp(datetime(2020, 1, 31))
-            ]
+            assert result["bucket(\"a\", 'D')"] == [util.to_timestamp(datetime(2020, 1, 31))]
 
         def test_table_day_bucket_edge_in_CST(self, util):
             os.environ["TZ"] = "US/Central"
@@ -1487,9 +1109,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'D')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'D')"] == [
-                util.to_timestamp(datetime(2020, 1, 31))
-            ]
+            assert result["bucket(\"a\", 'D')"] == [util.to_timestamp(datetime(2020, 1, 31))]
 
         def test_table_day_bucket_edge_in_PST(self, util):
             os.environ["TZ"] = "US/Pacific"
@@ -1500,9 +1120,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'D')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'D')"] == [
-                util.to_timestamp(datetime(2020, 1, 31))
-            ]
+            assert result["bucket(\"a\", 'D')"] == [util.to_timestamp(datetime(2020, 1, 31))]
 
         def test_table_week_bucket_edge_in_EST(self, util):
             """Make sure edge cases are fixed for week_bucket - if a local
@@ -1513,9 +1131,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 1, 27))
-            ]
+            assert result["bucket(\"a\", 'W')"] == [util.to_timestamp(datetime(2020, 1, 27))]
 
         def test_table_week_bucket_edge_in_CST(self, util):
             os.environ["TZ"] = "US/Central"
@@ -1526,9 +1142,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 1, 27))
-            ]
+            assert result["bucket(\"a\", 'W')"] == [util.to_timestamp(datetime(2020, 1, 27))]
 
         def test_table_week_bucket_edge_in_PST(self, util):
             os.environ["TZ"] = "US/Pacific"
@@ -1539,9 +1153,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 1, 27))
-            ]
+            assert result["bucket(\"a\", 'W')"] == [util.to_timestamp(datetime(2020, 1, 27))]
 
         def test_table_week_bucket_edge_flip_in_EST(self, util):
             """Week bucket should flip backwards to last month."""
@@ -1550,9 +1162,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 2, 24))
-            ]
+            assert result["bucket(\"a\", 'W')"] == [util.to_timestamp(datetime(2020, 2, 24))]
 
         def test_table_week_bucket_edge_flip_in_CST(self, util):
             os.environ["TZ"] = "US/Central"
@@ -1562,9 +1172,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 2, 24))
-            ]
+            assert result["bucket(\"a\", 'W')"] == [util.to_timestamp(datetime(2020, 2, 24))]
 
         def test_table_week_bucket_edge_flip_in_PST(self, util):
             os.environ["TZ"] = "US/Pacific"
@@ -1574,9 +1182,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'W')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'W')"] == [
-                util.to_timestamp(datetime(2020, 2, 24))
-            ]
+            assert result["bucket(\"a\", 'W')"] == [util.to_timestamp(datetime(2020, 2, 24))]
 
         def test_table_month_bucket_edge_in_EST(self, util):
             """Make sure edge cases are fixed for month_bucket - if a local
@@ -1587,9 +1193,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'M')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'M')"] == [
-                util.to_timestamp(datetime(2020, 6, 1))
-            ]
+            assert result["bucket(\"a\", 'M')"] == [util.to_timestamp(datetime(2020, 6, 1))]
 
         def test_table_month_bucket_edge_in_CST(self, util):
             os.environ["TZ"] = "US/Central"
@@ -1600,9 +1204,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'M')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'M')"] == [
-                util.to_timestamp(datetime(2020, 6, 1))
-            ]
+            assert result["bucket(\"a\", 'M')"] == [util.to_timestamp(datetime(2020, 6, 1))]
 
         def test_table_month_bucket_edge_in_PST(self, util):
             os.environ["TZ"] = "US/Pacific"
@@ -1613,9 +1215,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'M')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'M')"] == [
-                util.to_timestamp(datetime(2020, 6, 1))
-            ]
+            assert result["bucket(\"a\", 'M')"] == [util.to_timestamp(datetime(2020, 6, 1))]
 
         def test_table_year_bucket_edge_in_EST(self, util):
             """Make sure edge cases are fixed for year_bucket - if a local
@@ -1626,9 +1226,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'Y')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'Y')"] == [
-                util.to_timestamp(datetime(2019, 1, 1))
-            ]
+            assert result["bucket(\"a\", 'Y')"] == [util.to_timestamp(datetime(2019, 1, 1))]
 
         def test_table_year_bucket_edge_in_CST(self, util):
             os.environ["TZ"] = "US/Central"
@@ -1638,9 +1236,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'Y')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'Y')"] == [
-                util.to_timestamp(datetime(2019, 1, 1))
-            ]
+            assert result["bucket(\"a\", 'Y')"] == [util.to_timestamp(datetime(2019, 1, 1))]
 
         def test_table_year_bucket_edge_in_PST(self, util):
             os.environ["TZ"] = "US/Pacific"
@@ -1650,9 +1246,7 @@ if os.name != "nt":
             table = Table(data)
             view = table.view(expressions=["bucket(\"a\", 'Y')"])
             result = view.to_columns()
-            assert result["bucket(\"a\", 'Y')"] == [
-                util.to_timestamp(datetime(2019, 1, 1))
-            ]
+            assert result["bucket(\"a\", 'Y')"] == [util.to_timestamp(datetime(2019, 1, 1))]
 
 
 class TestTableDateTimePivots(object):

--- a/rust/perspective-python/perspective/tests/table/test_table_infer.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_infer.py
@@ -33,6 +33,11 @@ class TestTableInfer(object):
         assert tbl.size() == 2
         assert tbl.schema() == {"a": "boolean", "b": "boolean"}
 
+    def test_table_infer_bool_nones(self):
+        data = {"a": [None, None, None, None, True, True, True]}
+        tbl = Table(data)
+        assert tbl.schema() == {"a": "boolean"}
+
     def test_table_infer_bool_str(self):
         bool_data = [{"a": "True", "b": "False"}, {"a": "True", "b": "True"}]
         tbl = Table(bool_data)
@@ -55,11 +60,6 @@ class TestTableInfer(object):
             "a": [True, True, True, True, True],
             "b": [False, False, False, False, False],
         }
-
-    def test_table_infer_bool(self):
-        data = {"a": [None, None, None, None, True, True, True]}
-        tbl = Table(data)
-        assert tbl.schema() == {"a": "boolean"}
 
     def test_table_infer_str(self):
         data = {"a": [None, None, None, None, None, None, "abc"]}

--- a/rust/perspective-python/perspective/tests/table/test_table_limit.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_limit.py
@@ -10,10 +10,7 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-from datetime import date, datetime
-
 import perspective
-from pytest import mark
 
 
 class TestTableInfer(object):

--- a/rust/perspective-python/perspective/tests/table/test_table_numpy.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_numpy.py
@@ -235,9 +235,7 @@ class TestTableNumpy(object):
         }
 
     def test_table_np_datetime_default(self, util):
-        tbl = Table(
-            {"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ns]")}
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ns]")})
 
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
@@ -245,9 +243,7 @@ class TestTableNumpy(object):
         data = ["2019/07/11 15:30:05", "2019/07/11 15:30:05"]
         tbl = Table({"a": np.array(data)})
 
-        assert tbl.view().to_columns() == {
-            "a": [datetime(2019, 7, 11, 15, 30, 5), datetime(2019, 7, 11, 15, 30, 5)]
-        }
+        assert tbl.view().to_columns() == {"a": [datetime(2019, 7, 11, 15, 30, 5), datetime(2019, 7, 11, 15, 30, 5)]}
 
     def test_table_np_datetime_string_on_schema(self):
         data = ["2019/07/11 15:30:05", "2019/07/11 15:30:05"]
@@ -255,65 +251,47 @@ class TestTableNumpy(object):
 
         tbl.update({"a": data})
 
-        assert tbl.view().to_columns() == {
-            "a": [datetime(2019, 7, 11, 15, 30, 5), datetime(2019, 7, 11, 15, 30, 5)]
-        }
+        assert tbl.view().to_columns() == {"a": [datetime(2019, 7, 11, 15, 30, 5), datetime(2019, 7, 11, 15, 30, 5)]}
 
     def test_table_np_datetime_ns(self, util):
-        tbl = Table(
-            {"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ns]")}
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ns]")})
 
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_table_np_datetime_us(self, util):
-        tbl = Table(
-            {"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[us]")}
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[us]")})
 
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_table_np_datetime_ms(self, util):
-        tbl = Table(
-            {"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ms]")}
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ms]")})
 
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_table_np_datetime_s(self, util):
-        tbl = Table(
-            {"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[s]")}
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[s]")})
 
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_table_np_datetime_m(self, util):
-        tbl = Table(
-            {"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[m]")}
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[m]")})
 
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_table_np_datetime_h(self, util):
-        tbl = Table(
-            {"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[h]")}
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[h]")})
 
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_table_np_datetime_D(self, util):
-        tbl = Table(
-            {"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[D]")}
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[D]")})
 
         assert tbl.schema() == {"a": "date"}
 
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 0, 0))]}
 
     def test_table_np_datetime_W(self, util):
-        tbl = Table(
-            {"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[W]")}
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[W]")})
 
         assert tbl.schema() == {"a": "date"}
 
@@ -392,98 +370,56 @@ class TestTableNumpy(object):
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 11, 0)), None]}
 
     def test_table_np_timedelta(self):
-        tbl = Table(
-            {
-                "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ns]")
-                - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[ns]")
-            }
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ns]") - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[ns]")})
 
         assert tbl.schema() == {"a": "string"}
 
         assert tbl.view().to_columns() == {"a": ["950400000000000 nanoseconds"]}
 
     def test_table_np_timedelta_us(self):
-        tbl = Table(
-            {
-                "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[us]")
-                - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[us]")
-            }
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[us]") - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[us]")})
 
         assert tbl.schema() == {"a": "string"}
 
         assert tbl.view().to_columns() == {"a": ["950400000000 microseconds"]}
 
     def test_table_np_timedelta_ms(self):
-        tbl = Table(
-            {
-                "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ms]")
-                - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[ms]")
-            }
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ms]") - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[ms]")})
 
         assert tbl.schema() == {"a": "string"}
 
         assert tbl.view().to_columns() == {"a": ["950400000 milliseconds"]}
 
     def test_table_np_timedelta_s(self):
-        tbl = Table(
-            {
-                "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[s]")
-                - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[s]")
-            }
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[s]") - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[s]")})
 
         assert tbl.schema() == {"a": "string"}
 
         assert tbl.view().to_columns() == {"a": ["950400 seconds"]}
 
     def test_table_np_timedelta_m(self):
-        tbl = Table(
-            {
-                "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[m]")
-                - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[m]")
-            }
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[m]") - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[m]")})
 
         assert tbl.schema() == {"a": "string"}
 
         assert tbl.view().to_columns() == {"a": ["15840 minutes"]}
 
     def test_table_np_timedelta_h(self):
-        tbl = Table(
-            {
-                "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[h]")
-                - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[h]")
-            }
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[h]") - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[h]")})
 
         assert tbl.schema() == {"a": "string"}
 
         assert tbl.view().to_columns() == {"a": ["264 hours"]}
 
     def test_table_np_timedelta_d(self):
-        tbl = Table(
-            {
-                "a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[D]")
-                - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[D]")
-            }
-        )
+        tbl = Table({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype="datetime64[D]") - np.array([datetime(2019, 7, 1, 11, 0)], dtype="datetime64[D]")})
 
         assert tbl.schema() == {"a": "string"}
 
         assert tbl.view().to_columns() == {"a": ["11 days"]}
 
     def test_table_np_timedelta_with_none(self):
-        tbl = Table(
-            {
-                "a": np.array(
-                    [None, datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ns]"
-                )
-                - np.array([datetime(2019, 7, 1, 11, 0), None], dtype="datetime64[ns]")
-            }
-        )
+        tbl = Table({"a": np.array([None, datetime(2019, 7, 12, 11, 0)], dtype="datetime64[ns]") - np.array([datetime(2019, 7, 1, 11, 0), None], dtype="datetime64[ns]")})
 
         assert tbl.schema() == {"a": "string"}
 
@@ -763,9 +699,7 @@ class TestTableNumpy(object):
     # recarray
 
     def test_table_recarray(self):
-        d = np.array([(1.0, 2), (3.0, 4)], dtype=[("x", "<f8"), ("y", "<i8")]).view(
-            np.recarray
-        )
+        d = np.array([(1.0, 2), (3.0, 4)], dtype=[("x", "<f8"), ("y", "<i8")]).view(np.recarray)
         table = Table(d)
         assert table.schema() == {"x": "float", "y": "integer"}
         assert table.view().to_columns() == {"x": [1.0, 3.0], "y": [2, 4]}

--- a/rust/perspective-python/perspective/tests/table/test_table_pandas.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_pandas.py
@@ -535,17 +535,13 @@ class TestTablePandas(object):
         assert table.view().to_columns()["a"] == [None, 1.0, None, 2.0, None, 3.0, 4.0]
 
     def test_table_pandas_object_to_bool(self):
-        df = pd.DataFrame(
-            {"a": np.array([True, False, True, False, True, False], dtype=object)}
-        )
+        df = pd.DataFrame({"a": np.array([True, False, True, False, True, False], dtype=object)})
         table = Table(df)
         assert table.schema() == {"index": "integer", "a": "boolean"}
         assert table.view().to_columns()["a"] == [True, False, True, False, True, False]
 
     def test_table_pandas_object_to_date(self, util):
-        df = pd.DataFrame(
-            {"a": np.array([date(2019, 7, 11), date(2019, 7, 12), None], dtype=object)}
-        )
+        df = pd.DataFrame({"a": np.array([date(2019, 7, 11), date(2019, 7, 12), None], dtype=object)})
         table = Table(df)
         assert table.schema() == {"index": "integer", "a": "date"}
         assert table.view().to_columns()["a"] == [
@@ -622,9 +618,7 @@ class TestTablePandas(object):
 
         assert table.schema() == {"a": "date"}
 
-        assert table.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 7, 11))]
-        }
+        assert table.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 11))]}
 
     @mark.skip(reason="Not supported by pyarrow (?)")
     def test_table_pandas_update_datetime_schema_with_date(self, util):
@@ -632,9 +626,7 @@ class TestTablePandas(object):
         table = Table({"a": "datetime"})
         table.update(df)
         assert table.schema() == {"a": "datetime"}
-        assert table.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 7, 11, 0, 0))]
-        }
+        assert table.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 11, 0, 0))]}
 
     # Timestamps
 
@@ -713,9 +705,7 @@ class TestTablePandas(object):
         assert table.view().to_columns()["a"] == [None, 1.5, None, 2.5]
 
     def test_table_read_nan_int_col(self):
-        data = pd.DataFrame(
-            {"str": ["abc", float("nan"), "def"], "int": [np.nan, 1, 2]}
-        )
+        data = pd.DataFrame({"str": ["abc", float("nan"), "def"], "int": [np.nan, 1, 2]})
         tbl = Table(data)
         assert tbl.schema() == {
             "index": "integer",
@@ -730,9 +720,7 @@ class TestTablePandas(object):
         }
 
     def test_table_read_nan_float_col(self):
-        data = pd.DataFrame(
-            {"str": [float("nan"), "abc", float("nan")], "float": [np.nan, 1.5, 2.5]}
-        )
+        data = pd.DataFrame({"str": [float("nan"), "abc", float("nan")], "float": [np.nan, 1.5, 2.5]})
         tbl = Table(data)
         assert tbl.schema() == {
             "index": "integer",
@@ -747,9 +735,7 @@ class TestTablePandas(object):
         }
 
     def test_table_read_nan_bool_col(self):
-        data = pd.DataFrame(
-            {"bool": [np.nan, True, np.nan], "bool2": [False, np.nan, True]}
-        )
+        data = pd.DataFrame({"bool": [np.nan, True, np.nan], "bool2": [False, np.nan, True]})
         tbl = Table(data)
         # if np.nan begins a column, it is inferred as float and then can be promoted. if np.nan is in the values (but not at start), the column type is whatever is inferred.
         assert tbl.schema() == {
@@ -766,9 +752,7 @@ class TestTablePandas(object):
         }
 
     def test_table_read_nan_date_col(self):
-        data = pd.DataFrame(
-            {"str": ["abc", "def"], "date": [float("nan"), date(2019, 7, 11)]}
-        )
+        data = pd.DataFrame({"str": ["abc", "def"], "date": [float("nan"), date(2019, 7, 11)]})
         tbl = Table(data)
         assert tbl.schema() == {
             "index": "integer",
@@ -803,9 +787,7 @@ class TestTablePandas(object):
         }
 
     def test_table_read_nat_datetime_col(self, util):
-        data = pd.DataFrame(
-            {"str": ["abc", "def"], "datetime": ["NaT", datetime(2019, 7, 11, 11, 0)]}
-        )
+        data = pd.DataFrame({"str": ["abc", "def"], "datetime": ["NaT", datetime(2019, 7, 11, 11, 0)]})
         # datetime col is `datetime` in pandas<2, `object` in pandas>=2, so convert
         data.datetime = pd.to_datetime(data.datetime)
         tbl = Table(data)
@@ -822,9 +804,7 @@ class TestTablePandas(object):
         }
 
     def test_table_read_nan_datetime_as_date_col(self, util):
-        data = pd.DataFrame(
-            {"str": ["abc", "def"], "datetime": [float("nan"), datetime(2019, 7, 11)]}
-        )
+        data = pd.DataFrame({"str": ["abc", "def"], "datetime": [float("nan"), datetime(2019, 7, 11)]})
         tbl = Table(data)
         assert tbl.schema() == {
             "index": "integer",
@@ -1009,8 +989,6 @@ class TestTablePandas(object):
         ]
         tuples = list(zip(*arrays))
         index = pd.MultiIndex.from_tuples(tuples, names=["first", "second", "third"])
-        df_both = pd.DataFrame(
-            np.random.randn(3, 16), index=["A", "B", "C"], columns=index
-        )
+        df_both = pd.DataFrame(np.random.randn(3, 16), index=["A", "B", "C"], columns=index)
         table = Table(df_both)
         assert table.size() == 48

--- a/rust/perspective-python/perspective/tests/table/test_to_arrow.py
+++ b/rust/perspective-python/perspective/tests/table/test_to_arrow.py
@@ -90,11 +90,9 @@ class TestToArrow(object):
         assert tbl.schema() == {"a": "date"}
         arr = tbl.view().to_arrow()
         tbl2 = Table(arr)
-        ts = lambda x: int(datetime.timestamp(x) * 1000)
+        ts = lambda x: int(datetime.timestamp(x) * 1000)  # noqa: E731
         assert tbl2.schema() == tbl.schema()
-        assert tbl2.view().to_columns() == {
-            "a": [ts(datetime(2019, 7, 11)), ts(datetime(2016, 2, 29)), ts(datetime(2019, 12, 10))]
-        }
+        assert tbl2.view().to_columns() == {"a": [ts(datetime(2019, 7, 11)), ts(datetime(2016, 2, 29)), ts(datetime(2019, 12, 10))]}
 
     def test_to_arrow_date_symmetric_january(self, util):
         data = {"a": [date(2019, 1, 1), date(2016, 1, 1), date(2019, 1, 1)]}
@@ -103,9 +101,7 @@ class TestToArrow(object):
         arr = tbl.view().to_arrow()
         tbl2 = Table(arr)
         assert tbl2.schema() == tbl.schema()
-        assert tbl2.view().to_columns() == {
-            "a": [util.to_timestamp(x) for x in [datetime(2019, 1, 1), datetime(2016, 1, 1), datetime(2019, 1, 1)]]
-        }
+        assert tbl2.view().to_columns() == {"a": [util.to_timestamp(x) for x in [datetime(2019, 1, 1), datetime(2016, 1, 1), datetime(2019, 1, 1)]]}
 
     def test_to_arrow_datetime_symmetric(self, util):
         data = {
@@ -121,11 +117,14 @@ class TestToArrow(object):
         tbl2 = Table(arr)
         assert tbl2.schema() == tbl.schema()
         assert tbl2.view().to_columns() == {
-            "a": [util.to_timestamp(x) for x in [
-                datetime(2019, 7, 11, 12, 30),
-                datetime(2016, 2, 29, 11, 0),
-                datetime(2019, 12, 10, 12, 0),
-            ]]
+            "a": [
+                util.to_timestamp(x)
+                for x in [
+                    datetime(2019, 7, 11, 12, 30),
+                    datetime(2016, 2, 29, 11, 0),
+                    datetime(2019, 12, 10, 12, 0),
+                ]
+            ]
         }
 
     def test_to_arrow_one_symmetric(self):
@@ -145,9 +144,7 @@ class TestToArrow(object):
         tbl2 = Table(arrow)
         assert tbl2.schema() == {"a (Group by 1)": "integer", "a": "integer", "b": "integer", "c": "integer"}
         d = view.to_columns()
-        d["a (Group by 1)"] = [
-            x[0] if len(x) > 0 else None for x in d.pop("__ROW_PATH__")
-        ]
+        d["a (Group by 1)"] = [x[0] if len(x) > 0 else None for x in d.pop("__ROW_PATH__")]
         assert tbl2.view().to_columns() == d
 
     def test_to_arrow_two_symmetric(self):
@@ -176,9 +173,7 @@ class TestToArrow(object):
             "world2|c": "integer",
         }
         d = view.to_columns()
-        d["a (Group by 1)"] = [
-            x[0] if len(x) > 0 else None for x in d.pop("__ROW_PATH__")
-        ]
+        d["a (Group by 1)"] = [x[0] if len(x) > 0 else None for x in d.pop("__ROW_PATH__")]
         assert tbl2.view().to_columns() == d
 
     def test_to_arrow_column_only_symmetric(self):
@@ -341,9 +336,7 @@ class TestToArrow(object):
         assert tbl.schema() == {"a": "integer", "b": "float"}
         arr = tbl.view().to_arrow(end_col=1, start_row=2, end_row=3)
         tbl2 = Table(arr)
-        assert tbl2.view().to_columns() == tbl.view().to_columns(
-            end_col=1, start_row=2, end_row=3
-        )
+        assert tbl2.view().to_columns() == tbl.view().to_columns(end_col=1, start_row=2, end_row=3)
 
     def test_to_arrow_start_end_col_start_row(self):
         data = {
@@ -355,9 +348,7 @@ class TestToArrow(object):
         assert tbl.schema() == {"a": "integer", "b": "float", "c": "float"}
         arr = tbl.view().to_arrow(start_col=1, end_col=2, start_row=2)
         tbl2 = Table(arr)
-        assert tbl2.view().to_columns() == tbl.view().to_columns(
-            start_col=1, end_col=2, start_row=2
-        )
+        assert tbl2.view().to_columns() == tbl.view().to_columns(start_col=1, end_col=2, start_row=2)
 
     def test_to_arrow_start_end_col_end_row(self):
         data = {
@@ -369,9 +360,7 @@ class TestToArrow(object):
         assert tbl.schema() == {"a": "integer", "b": "float", "c": "float"}
         arr = tbl.view().to_arrow(start_col=1, end_col=2, end_row=2)
         tbl2 = Table(arr)
-        assert tbl2.view().to_columns() == tbl.view().to_columns(
-            start_col=1, end_col=2, end_row=2
-        )
+        assert tbl2.view().to_columns() == tbl.view().to_columns(start_col=1, end_col=2, end_row=2)
 
     def test_to_arrow_one_mean(self):
         data = {"a": [1, 2, 3, 4], "b": ["a", "a", "b", "b"]}

--- a/rust/perspective-python/perspective/tests/table/test_to_arrow_lz4.py
+++ b/rust/perspective-python/perspective/tests/table/test_to_arrow_lz4.py
@@ -10,7 +10,6 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import os
 from perspective import Table
 
 

--- a/rust/perspective-python/perspective/tests/table/test_to_format.py
+++ b/rust/perspective-python/perspective/tests/table/test_to_format.py
@@ -682,9 +682,7 @@ class TestToFormat(object):
     def test_to_records_two_sorted_start_gt_end_col_overage(self):
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
         tbl = Table(data)
-        view = tbl.view(
-            columns=[], group_by=["a"], split_by=["b"], sort=[["a", "desc"]]
-        )
+        view = tbl.view(columns=[], group_by=["a"], split_by=["b"], sort=[["a", "desc"]])
         records = view.to_records(end_row=12, start_col=1, end_col=3)
         assert records == [
             {"__ROW_PATH__": []},

--- a/rust/perspective-python/perspective/tests/table/test_update.py
+++ b/rust/perspective-python/perspective/tests/table/test_update.py
@@ -31,9 +31,7 @@ class TestUpdate(object):
 
         # write arrow to stream
         stream = pa.BufferOutputStream()
-        writer = pa.RecordBatchStreamWriter(
-            stream, arrow_table.schema, use_legacy_format=False
-        )
+        writer = pa.RecordBatchStreamWriter(stream, arrow_table.schema, use_legacy_format=False)
         writer.write_table(arrow_table)
         writer.close()
         arrow = stream.getvalue().to_pybytes()
@@ -102,9 +100,7 @@ class TestUpdate(object):
         assert tbl.view().to_records() == [{"a": "abc", "b": 456, "c": 2}]
 
     def test_update_partial_unset(self):
-        tbl = Table(
-            [{"a": "abc", "b": 1, "c": 2}, {"a": "def", "b": 3, "c": 4}], index="a"
-        )
+        tbl = Table([{"a": "abc", "b": 1, "c": 2}, {"a": "def", "b": 3, "c": 4}], index="a")
         tbl.update([{"a": "abc"}, {"a": "def", "c": None}])
         assert tbl.view().to_records() == [
             {"a": "abc", "b": 1, "c": 2},
@@ -130,9 +126,7 @@ class TestUpdate(object):
         assert tbl.view().to_records() == [{"a": "abc", "b": 456, "c": 2}]
 
     def test_update_columnar_partial_unset(self):
-        tbl = Table(
-            [{"a": "abc", "b": 1, "c": 2}, {"a": "def", "b": 3, "c": 4}], index="a"
-        )
+        tbl = Table([{"a": "abc", "b": 1, "c": 2}, {"a": "def", "b": 3, "c": 4}], index="a")
 
         tbl.update({"a": ["abc"], "b": [None]})
 
@@ -271,7 +265,7 @@ class TestUpdate(object):
             {"a": util.to_timestamp(datetime(2019, 7, 12))},
         ]
 
-    @mark.skip # We do not support numpy.
+    @mark.skip  # We do not support numpy.
     def test_update_date_np(self, util):
         tbl = Table({"a": [date(2019, 7, 11)]})
         tbl.update([{"a": np.datetime64(date(2019, 7, 12))}])
@@ -288,7 +282,7 @@ class TestUpdate(object):
             {"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0))},
         ]
 
-    @mark.skip # We do not support numpy.
+    @mark.skip  # We do not support numpy.
     def test_update_datetime_np(self, util):
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)]})
         tbl.update([{"a": np.datetime64(datetime(2019, 7, 12, 11, 0))}])
@@ -297,7 +291,7 @@ class TestUpdate(object):
             {"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0))},
         ]
 
-    @mark.skip # We do not support numpy.
+    @mark.skip  # We do not support numpy.
     def test_update_datetime_np_ts(self, util):
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)]})
         tbl.update([{"a": np.datetime64("2019-07-12T11:00")}])
@@ -331,7 +325,7 @@ class TestUpdate(object):
         tbl.update([{"a": date(2019, 7, 12), "b": 1}])
         assert tbl.view().to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12)), "b": 1}]
 
-    @mark.skip # We do not support numpy anymore.
+    @mark.skip  # We do not support numpy anymore.
     def test_update_date_np_partial(self, util):
         tbl = Table({"a": [date(2019, 7, 11)], "b": [1]}, index="b")
         tbl.update([{"a": np.datetime64(date(2019, 7, 12)), "b": 1}])
@@ -342,13 +336,13 @@ class TestUpdate(object):
         tbl.update([{"a": datetime(2019, 7, 12, 11, 0), "b": 1}])
         assert tbl.view().to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0)), "b": 1}]
 
-    @mark.skip # We do not support numpy anymore.
+    @mark.skip  # We do not support numpy anymore.
     def test_update_datetime_np_partial(self, util):
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)], "b": [1]}, index="b")
         tbl.update([{"a": np.datetime64(datetime(2019, 7, 12, 11, 0)), "b": 1}])
         assert tbl.view().to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0)), "b": 1}]
 
-    @mark.skip # We do not support numpy anymore.
+    @mark.skip  # We do not support numpy anymore.
     def test_update_datetime_np_ts_partial(self, util):
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)], "b": [1]}, index="b")
         tbl.update([{"a": np.datetime64("2019-07-12T11:00"), "b": 1}])
@@ -358,17 +352,13 @@ class TestUpdate(object):
         ts = util.to_timestamp(datetime(2019, 7, 12, 11, 0, 0))
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)], "idx": [1]}, index="idx")
         tbl.update([{"a": ts, "idx": 1}])
-        assert tbl.view().to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0)), "idx": 1}
-        ]
+        assert tbl.view().to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0)), "idx": 1}]
 
     def test_update_datetime_timestamp_ms_partial(self, util):
         ts = util.to_timestamp(datetime(2019, 7, 12, 11, 0, 0))
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)], "idx": [1]}, index="idx")
         tbl.update([{"a": ts, "idx": 1}])
-        assert tbl.view().to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0)), "idx": 1}
-        ]
+        assert tbl.view().to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0)), "idx": 1}]
 
     # updating dates using implicit index
 
@@ -377,7 +367,7 @@ class TestUpdate(object):
         tbl.update([{"a": date(2019, 7, 12), "__INDEX__": 0}])
         assert tbl.view().to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12))}]
 
-    @mark.skip # We do not support numpy anymore.
+    @mark.skip  # We do not support numpy anymore.
     def test_update_date_np_partial_implicit(self, util):
         tbl = Table({"a": [date(2019, 7, 11)]})
         tbl.update([{"a": np.datetime64(date(2019, 7, 12)), "__INDEX__": 0}])
@@ -388,13 +378,13 @@ class TestUpdate(object):
         tbl.update([{"a": datetime(2019, 7, 12, 11, 0), "__INDEX__": 0}])
         assert tbl.view().to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0))}]
 
-    @mark.skip # We do not support numpy anymore.
+    @mark.skip  # We do not support numpy anymore.
     def test_update_datetime_np_partial_implicit(self, util):
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)]})
         tbl.update([{"a": np.datetime64(datetime(2019, 7, 12, 11, 0)), "__INDEX__": 0}])
         assert tbl.view().to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12, 11, 0))}]
 
-    @mark.skip # We do not support numpy anymore.
+    @mark.skip  # We do not support numpy anymore.
     def test_update_datetime_np_ts_partial_implicit(self, util):
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)]})
         tbl.update([{"a": np.datetime64("2019-07-12T11:00"), "__INDEX__": 0}])
@@ -456,7 +446,7 @@ class TestUpdate(object):
         tbl = Table(data)
         view = tbl.view()
         records = view.to_records(index=True)
-        idx = records[0]["__INDEX__"][0] # XXX: How should we grab this?
+        idx = records[0]["__INDEX__"][0]  # XXX: How should we grab this?
         tbl.update([{"__INDEX__": idx, "a": 3}])
         assert view.to_records() == [{"a": 3, "b": 2}, {"a": 2, "b": 3}]
 
@@ -513,7 +503,5 @@ class TestUpdate(object):
         data = [{"a": 1, "b": 2}, {"a": 2, "b": 3}]
         tbl = Table(data, index="a")
         view = tbl.view()
-        tbl.update(
-            [{"__INDEX__": 1, "a": 1, "b": 3}]
-        )  # should ignore re-specification of pkey
+        tbl.update([{"__INDEX__": 1, "a": 1, "b": 3}])  # should ignore re-specification of pkey
         assert view.to_records() == [{"a": 1, "b": 3}, {"a": 2, "b": 3}]

--- a/rust/perspective-python/perspective/tests/table/test_update_arrow.py
+++ b/rust/perspective-python/perspective/tests/table/test_update_arrow.py
@@ -20,19 +20,11 @@ from datetime import date, datetime
 from pytest import mark
 from perspective import Table
 
-SOURCE_STREAM_ARROW = os.path.join(
-    os.path.dirname(__file__), "arrow", "int_float_str.arrow"
-)
-SOURCE_FILE_ARROW = os.path.join(
-    os.path.dirname(__file__), "arrow", "int_float_str.arrow"
-)
-PARTIAL_ARROW = os.path.join(
-    os.path.dirname(__file__), "arrow", "int_float_str_update.arrow"
-)
+SOURCE_STREAM_ARROW = os.path.join(os.path.dirname(__file__), "arrow", "int_float_str.arrow")
+SOURCE_FILE_ARROW = os.path.join(os.path.dirname(__file__), "arrow", "int_float_str.arrow")
+PARTIAL_ARROW = os.path.join(os.path.dirname(__file__), "arrow", "int_float_str_update.arrow")
 DICT_ARROW = os.path.join(os.path.dirname(__file__), "arrow", "dict.arrow")
-DICT_UPDATE_ARROW = os.path.join(
-    os.path.dirname(__file__), "arrow", "dict_update.arrow"
-)
+DICT_UPDATE_ARROW = os.path.join(os.path.dirname(__file__), "arrow", "dict_update.arrow")
 
 names = ["a", "b", "c", "d"]
 
@@ -159,9 +151,7 @@ class TestUpdateArrow(object):
         with open(DICT_UPDATE_ARROW, mode="rb") as partial:
             tbl.update(partial.read())
             assert tbl.size() == 8
-            assert tbl.view().to_columns() == {
-                "a": ["abc", "def", "def", None, "abc", None, "update1", "update2"]
-            }
+            assert tbl.view().to_columns() == {"a": ["abc", "def", "def", None, "abc", None, "update1", "update2"]}
 
     @mark.skip
     def test_update_arrow_updates_dict_more_columns_partial_file(self):
@@ -174,9 +164,7 @@ class TestUpdateArrow(object):
         with open(DICT_UPDATE_ARROW, mode="rb") as partial:
             tbl.update(partial.read())
             assert tbl.size() == 4
-            assert tbl.view().to_columns() == {
-                "a": ["abc", "def", "update1", "update2"]
-            }
+            assert tbl.view().to_columns() == {"a": ["abc", "def", "update1", "update2"]}
 
     # update with file arrow with less columns than in schema
 
@@ -440,9 +428,7 @@ class TestUpdateArrow(object):
         assert tbl.view().to_columns()["a"] == [int(x) for x in array]
 
     def test_update_arrow_update_int_schema_with_float64(self, util):
-        array = [
-            random.randint(-20000000, 20000000) * random.random() for i in range(100)
-        ]
+        array = [random.randint(-20000000, 20000000) * random.random() for i in range(100)]
         data = pd.DataFrame({"a": np.array(array, dtype=np.float64)})
 
         schema = pa.schema({"a": pa.float64()})
@@ -466,9 +452,7 @@ class TestUpdateArrow(object):
         assert tbl.view().to_columns()["a"] == array
 
     def test_update_arrow_update_float_schema_with_float64(self, util):
-        array = [
-            random.randint(-20000000, 20000000) * random.random() for i in range(100)
-        ]
+        array = [random.randint(-20000000, 20000000) * random.random() for i in range(100)]
         data = pd.DataFrame({"a": np.array(array, dtype=np.float64)})
 
         schema = pa.schema({"a": pa.float64()})
@@ -492,9 +476,7 @@ class TestUpdateArrow(object):
 
         tbl.update(arrow)
 
-        assert tbl.view().to_columns()["a"] == [
-            util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)
-        ]
+        assert tbl.view().to_columns()["a"] == [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]
 
     def test_update_arrow_update_date_schema_with_date64(self, util):
         array = [date(2019, 2, i) for i in range(1, 11)]
@@ -508,9 +490,7 @@ class TestUpdateArrow(object):
 
         tbl.update(arrow)
 
-        assert tbl.view().to_columns()["a"] == [
-            util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)
-        ]
+        assert tbl.view().to_columns()["a"] == [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]
 
     def test_update_arrow_update_datetime_schema_with_timestamp(self, util):
         data = [
@@ -599,9 +579,7 @@ class TestUpdateArrow(object):
         tbl = Table({"a": "date"})
         tbl.update(arrow_data)
         assert tbl.size() == 10
-        assert tbl.view().to_columns() == {
-            "a": [int(1000 * datetime(2019, 2, i).timestamp()) for i in range(1, 11)]
-        }
+        assert tbl.view().to_columns() == {"a": [int(1000 * datetime(2019, 2, i).timestamp()) for i in range(1, 11)]}
 
     def test_update_arrow_updates_date64_stream(self, util):
         data = [[date(2019, 2, i) for i in range(1, 11)]]
@@ -609,9 +587,7 @@ class TestUpdateArrow(object):
         tbl = Table({"a": "date"})
         tbl.update(arrow_data)
         assert tbl.size() == 10
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 2, i)) for i in range(1, 11)]}
 
     def test_update_arrow_updates_timestamp_all_formats_stream(self, util):
         data = [
@@ -630,9 +606,7 @@ class TestUpdateArrow(object):
                 pa.timestamp("ns"),
             ],
         )
-        tbl = Table(
-            {"a": "datetime", "b": "datetime", "c": "datetime", "d": "datetime"}
-        )
+        tbl = Table({"a": "datetime", "b": "datetime", "c": "datetime", "d": "datetime"})
         tbl.update(arrow_data)
         assert tbl.size() == 10
         assert tbl.view().to_columns() == {
@@ -784,9 +758,7 @@ class TestUpdateArrow(object):
         tbl = Table(arrow_data)
         tbl.update(arrow_data)
         assert tbl.size() == 20
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(d) for d in out_data + out_data]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(d) for d in out_data + out_data]}
 
     def test_update_arrow_updates_append_date64_stream(self, util):
         data = [[date(2019, 2, i) for i in range(1, 11)]]
@@ -795,9 +767,7 @@ class TestUpdateArrow(object):
         tbl = Table(arrow_data)
         tbl.update(arrow_data)
         assert tbl.size() == 20
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(d) for d in out_data + out_data]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(d) for d in out_data + out_data]}
 
     def test_update_arrow_updates_append_timestamp_all_formats_stream(self, util):
         data = [

--- a/rust/perspective-python/perspective/tests/table/test_update_numpy.py
+++ b/rust/perspective-python/perspective/tests/table/test_update_numpy.py
@@ -48,9 +48,7 @@ class TestUpdateNumpy(object):
 
         tbl.update({"a": np.array([date(2019, 7, 12)])})
 
-        assert tbl.view().to_columns() == {
-            "a": [datetime(2019, 7, 11), datetime(2019, 7, 12)]
-        }
+        assert tbl.view().to_columns() == {"a": [datetime(2019, 7, 11), datetime(2019, 7, 12)]}
 
     def test_update_np_date_timestamp(self, util):
         tbl = Table({"a": [date(2019, 7, 11)]})
@@ -61,47 +59,35 @@ class TestUpdateNumpy(object):
 
         tbl.update({"a": np.array([ts])})
 
-        assert tbl.view().to_columns() == {
-            "a": [datetime(2019, 7, 11), datetime(2019, 7, 12)]
-        }
+        assert tbl.view().to_columns() == {"a": [datetime(2019, 7, 11), datetime(2019, 7, 12)]}
 
     def test_update_np_datetime(self):
         tbl = Table({"a": [np.datetime64(datetime(2019, 7, 11, 11, 0))]})
 
         tbl.update({"a": np.array([datetime(2019, 7, 12, 11, 0)], dtype=datetime)})
 
-        assert tbl.view().to_columns() == {
-            "a": [datetime(2019, 7, 11, 11, 0), datetime(2019, 7, 12, 11, 0)]
-        }
+        assert tbl.view().to_columns() == {"a": [datetime(2019, 7, 11, 11, 0), datetime(2019, 7, 12, 11, 0)]}
 
     def test_update_np_datetime_str(self):
         tbl = Table({"a": [np.datetime64(datetime(2019, 7, 11, 11, 0))]})
 
         tbl.update({"a": np.array(["2019/7/12 11:00:00"])})
 
-        assert tbl.view().to_columns() == {
-            "a": [datetime(2019, 7, 11, 11, 0), datetime(2019, 7, 12, 11, 0)]
-        }
+        assert tbl.view().to_columns() == {"a": [datetime(2019, 7, 11, 11, 0), datetime(2019, 7, 12, 11, 0)]}
 
     def test_update_np_datetime_timestamp_s(self, util):
         tbl = Table({"a": [np.datetime64(datetime(2019, 7, 11, 11, 0))]})
 
         tbl.update({"a": np.array([util.to_timestamp(datetime(2019, 7, 12, 11, 0))])})
 
-        assert tbl.view().to_columns() == {
-            "a": [datetime(2019, 7, 11, 11, 0), datetime(2019, 7, 12, 11, 0)]
-        }
+        assert tbl.view().to_columns() == {"a": [datetime(2019, 7, 11, 11, 0), datetime(2019, 7, 12, 11, 0)]}
 
     def test_update_np_datetime_timestamp_ms(self, util):
         tbl = Table({"a": [np.datetime64(datetime(2019, 7, 11, 11, 0))]})
 
-        tbl.update(
-            {"a": np.array([util.to_timestamp(datetime(2019, 7, 12, 11, 0)) * 1000])}
-        )
+        tbl.update({"a": np.array([util.to_timestamp(datetime(2019, 7, 12, 11, 0)) * 1000])})
 
-        assert tbl.view().to_columns() == {
-            "a": [datetime(2019, 7, 11, 11, 0), datetime(2019, 7, 12, 11, 0)]
-        }
+        assert tbl.view().to_columns() == {"a": [datetime(2019, 7, 11, 11, 0), datetime(2019, 7, 12, 11, 0)]}
 
     def test_update_np_partial(self):
         tbl = Table({"a": [1, 2, 3, 4], "b": ["a", "b", "c", "d"]}, index="b")
@@ -147,9 +133,7 @@ class TestUpdateNumpy(object):
         assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_update_np_datetime_partial(self, util):
-        tbl = Table(
-            {"a": [np.datetime64(datetime(2019, 7, 11, 11, 0))], "b": [1]}, index="b"
-        )
+        tbl = Table({"a": [np.datetime64(datetime(2019, 7, 11, 11, 0))], "b": [1]}, index="b")
 
         tbl.update(
             {
@@ -193,9 +177,7 @@ class TestUpdateNumpy(object):
     @pytest.mark.skip
     def test_update_np_nonseq_partial(self):
         tbl = Table({"a": [1, 2, 3, 4], "b": ["a", "b", "c", "d"]}, index="b")
-        tbl.update(
-            {"a": np.array([5, 6, 7]), "b": np.array(["a", "c", "d"], dtype=object)}
-        )
+        tbl.update({"a": np.array([5, 6, 7]), "b": np.array(["a", "c", "d"], dtype=object)})
 
         assert tbl.view().to_columns() == {"a": [5, 2, 6, 7], "b": ["a", "b", "c", "d"]}
 
@@ -211,23 +193,18 @@ class TestUpdateNumpy(object):
     @pytest.mark.skip
     def test_update_np_unset_partial(self):
         tbl = Table({"a": [1, 2, 3], "b": ["a", "b", "c"]}, index="b")
-        tbl.update(
-            {"a": np.array([None, None]), "b": np.array(["a", "c"], dtype=object)}
-        )
+        tbl.update({"a": np.array([None, None]), "b": np.array(["a", "c"], dtype=object)})
 
         assert tbl.view().to_columns() == {"a": [None, 2, None], "b": ["a", "b", "c"]}
 
     @pytest.mark.skip
     def test_update_np_nan_partial(self):
         tbl = Table({"a": [1, 2, 3], "b": ["a", "b", "c"]}, index="b")
-        tbl.update(
-            {"a": np.array([None, None]), "b": np.array(["a", "c"], dtype=object)}
-        )
+        tbl.update({"a": np.array([None, None]), "b": np.array(["a", "c"], dtype=object)})
 
         assert tbl.view().to_columns() == {"a": [None, 2, None], "b": ["a", "b", "c"]}
 
     def test_numpy_dict(self):
-        x = {"index": [1], "a": np.empty((1,), str)}
         tbl = Table({"index": "integer", "a": "string"}, index="index")
         tbl.update({"index": np.arange(5)})
         assert tbl.view().to_columns() == {

--- a/rust/perspective-python/perspective/tests/table/test_update_pandas.py
+++ b/rust/perspective-python/perspective/tests/table/test_update_pandas.py
@@ -44,9 +44,7 @@ class TestUpdatePandas(object):
 
         tbl.update(update_data)
 
-        assert tbl.view().to_columns() == {
-            "a": [True, False, True, False, True, False, True, False]
-        }
+        assert tbl.view().to_columns() == {"a": [True, False, True, False, True, False, True, False]}
 
     def test_update_df_str(self):
         tbl = Table({"a": ["a", "b", "c", "d"]})
@@ -63,13 +61,10 @@ class TestUpdatePandas(object):
 
         assert tbl.schema() == {"a": "date"}
 
-
         update_data = pd.DataFrame({"a": [date(2019, 7, 12)]})
 
         tbl.update(update_data)
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(d) for d in [datetime(2019, 7, 11), datetime(2019, 7, 12)]]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(d) for d in [datetime(2019, 7, 11), datetime(2019, 7, 12)]]}
 
     @mark.skip(reason="this test relies on a lossy conversion from datetime -> date.")
     def test_update_df_date_timestamp(self, util):
@@ -77,15 +72,10 @@ class TestUpdatePandas(object):
 
         assert tbl.schema() == {"a": "date"}
 
-        update_data = pd.DataFrame(
-            {"a": [datetime(2019, 7, 12, 0, 0, 0)]}
-        )
+        update_data = pd.DataFrame({"a": [datetime(2019, 7, 12, 0, 0, 0)]})
 
         tbl.update(update_data)
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 7, 11)),
-                  util.to_timestamp(datetime(2019, 7, 12))]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 11)), util.to_timestamp(datetime(2019, 7, 12))]}
 
     def test_update_df_datetime(self, util):
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)]})
@@ -93,36 +83,23 @@ class TestUpdatePandas(object):
         update_data = pd.DataFrame({"a": [datetime(2019, 7, 12, 11, 0)]})
 
         tbl.update(update_data)
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 7, 11, 11, 0)),
-                  util.to_timestamp(datetime(2019, 7, 12, 11, 0))]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 11, 11, 0)), util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_update_df_datetime_timestamp_seconds(self, util):
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)]})
 
-        update_data = pd.DataFrame(
-            {"a": [datetime(2019, 7, 12, 11, 0)]}
-        )
+        update_data = pd.DataFrame({"a": [datetime(2019, 7, 12, 11, 0)]})
 
         tbl.update(update_data)
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 7, 11, 11, 0)),
-                  util.to_timestamp(datetime(2019, 7, 12, 11, 0))]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 11, 11, 0)), util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_update_df_datetime_timestamp_ms(self, util):
         tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)]})
 
-        update_data = pd.DataFrame(
-            {"a": [datetime(2019, 7, 12, 11, 0)]}
-        )
+        update_data = pd.DataFrame({"a": [datetime(2019, 7, 12, 11, 0)]})
 
         tbl.update(update_data)
-        assert tbl.view().to_columns() == {
-            "a": [util.to_timestamp(datetime(2019, 7, 11, 11, 0)),
-                  util.to_timestamp(datetime(2019, 7, 12, 11, 0))]
-        }
+        assert tbl.view().to_columns() == {"a": [util.to_timestamp(datetime(2019, 7, 11, 11, 0)), util.to_timestamp(datetime(2019, 7, 12, 11, 0))]}
 
     def test_update_df_partial(self):
         tbl = Table({"a": [1, 2, 3, 4], "b": ["a", "b", "c", "d"]}, index="b")
@@ -137,7 +114,7 @@ class TestUpdatePandas(object):
         tbl = Table(pd.DataFrame({"a": [1, 2, 3, 4]}))
         update_data = pd.DataFrame({"a": [5, 6, 7, 8], "__INDEX__": [0, 1, 2, 3]})
         tbl.update(update_data)
-        assert tbl.view().to_columns() == {"a": [5, 6, 7, 8], "index": [0,1,2,3]}
+        assert tbl.view().to_columns() == {"a": [5, 6, 7, 8], "index": [0, 1, 2, 3]}
 
     def test_update_df_partial_implicit(self):
         tbl = Table({"a": [1, 2, 3, 4]})
@@ -149,9 +126,7 @@ class TestUpdatePandas(object):
         assert tbl.view().to_columns() == {"a": [5, 6, 7, 8]}
 
     def test_update_df_datetime_partial(self, util):
-        tbl = Table(
-            {"a": [datetime(2019, 7, 11, 11, 0)], "b": [1]}, index="b"
-        )
+        tbl = Table({"a": [datetime(2019, 7, 11, 11, 0)], "b": [1]}, index="b")
 
         update_data = pd.DataFrame({"a": [datetime(2019, 7, 12, 11, 0)], "b": [1]})
 
@@ -176,7 +151,7 @@ class TestUpdatePandas(object):
 
     @pytest.mark.skip
     def test_update_df_with_none_partial(self):
-        tbl = Table({"a": [1, float('nan'), 3], "b": ["a", None, "d"]}, index="b")
+        tbl = Table({"a": [1, float("nan"), 3], "b": ["a", None, "d"]}, index="b")
         update_data = pd.DataFrame({"a": [4, 5], "b": ["a", "d"]})
         tbl.update(update_data)
         assert tbl.view().to_columns() == {

--- a/rust/perspective-python/perspective/tests/table/test_view.py
+++ b/rust/perspective-python/perspective/tests/table/test_view.py
@@ -10,7 +10,6 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import random
 import pandas as pd
 import numpy as np
 from perspective import PerspectivePyError, Table
@@ -190,9 +189,7 @@ class TestView(object):
     def test_two_view_schema(self):
         data = [{"a": "abc", "b": "def"}, {"a": "abc", "b": "def"}]
         tbl = Table(data)
-        view = tbl.view(
-            group_by=["a"], split_by=["b"], aggregates={"a": "count", "b": "count"}
-        )
+        view = tbl.view(group_by=["a"], split_by=["b"], aggregates={"a": "count", "b": "count"})
         assert view.schema() == {"a": "integer", "b": "integer"}
 
     # aggregates and column specification
@@ -274,9 +271,7 @@ class TestView(object):
     def test_view_aggregates_with_no_columns(self):
         data = [{"a": 1, "b": 2, "c": 3, "d": 4}, {"a": 3, "b": 4, "c": 5, "d": 6}]
         tbl = Table(data)
-        view = tbl.view(
-            group_by=["a"], aggregates={"c": "avg", "a": "last"}, columns=[]
-        )
+        view = tbl.view(group_by=["a"], aggregates={"c": "avg", "a": "last"}, columns=[])
         assert view.column_paths() == ["__ROW_PATH__"]
         assert view.to_records() == [
             {"__ROW_PATH__": []},
@@ -443,9 +438,7 @@ class TestView(object):
             {"a": "a", "x": 3, "y": None},
         ]
         tbl = Table(data)
-        view = tbl.view(
-            aggregates={"y": ["weighted mean", "x"]}, group_by=["a"], columns=["y"]
-        )
+        view = tbl.view(aggregates={"y": ["weighted mean", "x"]}, group_by=["a"], columns=["y"])
         assert view.to_records() == [
             {"__ROW_PATH__": [], "y": (1.0 * 200 + 2 * 100) / (1.0 + 2)},
             {"__ROW_PATH__": ["a"], "y": (1.0 * 200 + 2 * 100) / (1.0 + 2)},
@@ -458,9 +451,7 @@ class TestView(object):
             {"a": "a", "x": 3, "y": None},
         ]
         tbl = Table(data)
-        view = tbl.view(
-            aggregates={"y": ["weighted mean", "x"]}, group_by=["a"], columns=["y"]
-        )
+        view = tbl.view(aggregates={"y": ["weighted mean", "x"]}, group_by=["a"], columns=["y"])
         assert view.to_records() == [
             {"__ROW_PATH__": [], "y": (1 * 200 + (-2) * 100) / (1 - 2)},
             {"__ROW_PATH__": ["a"], "y": (1 * 200 + (-2) * 100) / (1 - 2)},
@@ -498,12 +489,8 @@ class TestView(object):
 
         result = view.to_columns()
         expected_total = np.var(data["a"])
-        expected_zero = np.var(
-            [data["a"][1], data["a"][3], data["a"][5], data["a"][7], data["a"][9]]
-        )
-        expected_one = np.var(
-            [data["a"][0], data["a"][2], data["a"][4], data["a"][6], data["a"][8]]
-        )
+        expected_zero = np.var([data["a"][1], data["a"][3], data["a"][5], data["a"][7], data["a"][9]])
+        expected_one = np.var([data["a"][0], data["a"][2], data["a"][4], data["a"][6], data["a"][8]])
 
         assert result["a"] == approx([expected_total, expected_zero, expected_one])
 
@@ -519,9 +506,7 @@ class TestView(object):
         table.update({"a": [0.3], "c": [3]})
 
         result = view.to_columns()
-        assert result["a"] == approx(
-            [np.var([0.1, 0.5, 0.3, 0.8]), np.var([0.1, 0.3]), np.var([0.5, 0.8])]
-        )
+        assert result["a"] == approx([np.var([0.1, 0.5, 0.3, 0.8]), np.var([0.1, 0.3]), np.var([0.5, 0.8])])
 
         table.update({"a": [None], "c": [1]})
 
@@ -566,9 +551,7 @@ class TestView(object):
             data["a"][8],
         ]
 
-        assert result["a"] == approx(
-            [np.var(expected_total), np.var(expected_zero), np.var(expected_one)]
-        )
+        assert result["a"] == approx([np.var(expected_total), np.var(expected_zero), np.var(expected_one)])
 
         # 2 here should result in null var because the group size is 1
         update_data = {"a": [15.12, 9.102, 0.99, 12.8], "b": [1, 0, 1, 2]}
@@ -580,9 +563,7 @@ class TestView(object):
         expected_one += [update_data["a"][0], update_data["a"][2]]
 
         assert result["__ROW_PATH__"] == [[], [0], [1], [2]]
-        assert result["a"][:-1] == approx(
-            [np.var(expected_total), np.var(expected_zero), np.var(expected_one)]
-        )
+        assert result["a"][:-1] == approx([np.var(expected_total), np.var(expected_zero), np.var(expected_one)])
         assert result["a"][-1] is None
 
     def test_view_variance_multi_update_delta(self):
@@ -621,9 +602,7 @@ class TestView(object):
             data["a"][8],
         ]
 
-        assert result["a"] == approx(
-            [np.var(expected_total), np.var(expected_zero), np.var(expected_one)]
-        )
+        assert result["a"] == approx([np.var(expected_total), np.var(expected_zero), np.var(expected_one)])
 
         # 2 here should result in null var because the group size is 1
         update_data = {"a": [15.12, 9.102, 0.99, 12.8], "b": [1, 0, 1, 2]}
@@ -693,9 +672,7 @@ class TestView(object):
             data["a"][8],
         ]
 
-        assert result["a"] == approx(
-            [np.var(expected_total), np.var(expected_zero), np.var(expected_one)]
-        )
+        assert result["a"] == approx([np.var(expected_total), np.var(expected_zero), np.var(expected_one)])
 
         # "b" = 2 here should result in null var because the group size is 1
         update_data = {
@@ -722,9 +699,7 @@ class TestView(object):
                 expected_zero.append(val)
 
         assert result["__ROW_PATH__"] == [[], [0], [1], [2]]
-        assert result["a"][:-1] == approx(
-            [np.var(expected_total), np.var(expected_zero), np.var(expected_one)]
-        )
+        assert result["a"][:-1] == approx([np.var(expected_total), np.var(expected_zero), np.var(expected_one)])
         assert result["a"][-1] is None
 
     def test_view_variance_multi_update_indexed_delta(self):
@@ -745,9 +720,7 @@ class TestView(object):
             "c": [i for i in range(10)],
         }
         table = Table(data, index="c")
-        view = table.view(
-            aggregates={"a": "var", "b": "last", "c": "last"}, group_by=["b"]
-        )
+        view = table.view(aggregates={"a": "var", "b": "last", "c": "last"}, group_by=["b"])
 
         result = view.to_columns()
         expected_total = data["a"]
@@ -766,9 +739,7 @@ class TestView(object):
             data["a"][8],
         ]
 
-        assert result["a"] == approx(
-            [np.var(expected_total), np.var(expected_zero), np.var(expected_one)]
-        )
+        assert result["a"] == approx([np.var(expected_total), np.var(expected_zero), np.var(expected_one)])
 
         # 2 here should result in null var because the group size is 1
         update_data = {
@@ -858,12 +829,8 @@ class TestView(object):
 
         result = view.to_columns()
         expected_total = np.std(data["a"])
-        expected_zero = np.std(
-            [data["a"][1], data["a"][3], data["a"][5], data["a"][7], data["a"][9]]
-        )
-        expected_one = np.std(
-            [data["a"][0], data["a"][2], data["a"][4], data["a"][6], data["a"][8]]
-        )
+        expected_zero = np.std([data["a"][1], data["a"][3], data["a"][5], data["a"][7], data["a"][9]])
+        expected_one = np.std([data["a"][0], data["a"][2], data["a"][4], data["a"][6], data["a"][8]])
 
         assert result["a"] == approx([expected_total, expected_zero, expected_one])
 
@@ -879,9 +846,7 @@ class TestView(object):
         table.update({"a": [0.3], "c": [3]})
 
         result = view.to_columns()
-        assert result["a"] == approx(
-            [np.std([0.1, 0.5, 0.3, 0.8]), np.std([0.1, 0.3]), np.std([0.5, 0.8])]
-        )
+        assert result["a"] == approx([np.std([0.1, 0.5, 0.3, 0.8]), np.std([0.1, 0.3]), np.std([0.5, 0.8])])
 
         table.update({"a": [None], "c": [1]})
 
@@ -926,9 +891,7 @@ class TestView(object):
             data["a"][8],
         ]
 
-        assert result["a"] == approx(
-            [np.std(expected_total), np.std(expected_zero), np.std(expected_one)]
-        )
+        assert result["a"] == approx([np.std(expected_total), np.std(expected_zero), np.std(expected_one)])
 
         # 2 here should result in null stddev because the group size is 1
         update_data = {"a": [15.12, 9.102, 0.99, 12.8], "b": [1, 0, 1, 2]}
@@ -940,9 +903,7 @@ class TestView(object):
         expected_one += [update_data["a"][0], update_data["a"][2]]
 
         assert result["__ROW_PATH__"] == [[], [0], [1], [2]]
-        assert result["a"][:-1] == approx(
-            [np.std(expected_total), np.std(expected_zero), np.std(expected_one)]
-        )
+        assert result["a"][:-1] == approx([np.std(expected_total), np.std(expected_zero), np.std(expected_one)])
         assert result["a"][-1] is None
 
     def test_view_standard_deviation_multi_update_delta(self):
@@ -981,9 +942,7 @@ class TestView(object):
             data["a"][8],
         ]
 
-        assert result["a"] == approx(
-            [np.std(expected_total), np.std(expected_zero), np.std(expected_one)]
-        )
+        assert result["a"] == approx([np.std(expected_total), np.std(expected_zero), np.std(expected_one)])
 
         # 2 here should result in null stddev because the group size is 1
         update_data = {"a": [15.12, 9.102, 0.99, 12.8], "b": [1, 0, 1, 2]}
@@ -1053,9 +1012,7 @@ class TestView(object):
             data["a"][8],
         ]
 
-        assert result["a"] == approx(
-            [np.std(expected_total), np.std(expected_zero), np.std(expected_one)]
-        )
+        assert result["a"] == approx([np.std(expected_total), np.std(expected_zero), np.std(expected_one)])
 
         # "b" = 2 here should result in null stddev because the group size is 1
         update_data = {
@@ -1082,9 +1039,7 @@ class TestView(object):
                 expected_zero.append(val)
 
         assert result["__ROW_PATH__"] == [[], [0], [1], [2]]
-        assert result["a"][:-1] == approx(
-            [np.std(expected_total), np.std(expected_zero), np.std(expected_one)]
-        )
+        assert result["a"][:-1] == approx([np.std(expected_total), np.std(expected_zero), np.std(expected_one)])
         assert result["a"][-1] is None
 
     def test_view_standard_deviation_multi_update_indexed_delta(self):
@@ -1105,9 +1060,7 @@ class TestView(object):
             "c": [i for i in range(10)],
         }
         table = Table(data, index="c")
-        view = table.view(
-            aggregates={"a": "stddev", "b": "last", "c": "last"}, group_by=["b"]
-        )
+        view = table.view(aggregates={"a": "stddev", "b": "last", "c": "last"}, group_by=["b"])
 
         result = view.to_columns()
         expected_total = data["a"]
@@ -1126,9 +1079,7 @@ class TestView(object):
             data["a"][8],
         ]
 
-        assert result["a"] == approx(
-            [np.std(expected_total), np.std(expected_zero), np.std(expected_one)]
-        )
+        assert result["a"] == approx([np.std(expected_total), np.std(expected_zero), np.std(expected_one)])
 
         # 2 here should result in null stddev because the group size is 1
         update_data = {
@@ -1387,34 +1338,26 @@ class TestView(object):
         data = [{"a": date(2019, 7, 11), "b": 2}, {"a": date(2019, 7, 12), "b": 4}]
         tbl = Table(data)
         view = tbl.view(filter=[["a", "==", str(date(2019, 7, 12))]])
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 12)), "b": 4}
-        ]
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12)), "b": 4}]
 
     # @mark.skip # We do not support using `datetime.date` in operators.
     def test_view_filter_date_neq(self, util):
         data = [{"a": date(2019, 7, 11), "b": 2}, {"a": date(2019, 7, 12), "b": 4}]
         tbl = Table(data)
         view = tbl.view(filter=[["a", "!=", str(date(2019, 7, 12))]])
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 11)), "b": 2}
-        ]
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 11)), "b": 2}]
 
     def test_view_filter_date_str_eq(self, util):
         data = [{"a": date(2019, 7, 11), "b": 2}, {"a": date(2019, 7, 12), "b": 4}]
         tbl = Table(data)
         view = tbl.view(filter=[["a", "==", "2019/7/12"]])
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 12)), "b": 4}
-        ]
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 12)), "b": 4}]
 
     def test_view_filter_date_str_neq(self, util):
         data = [{"a": date(2019, 7, 11), "b": 2}, {"a": date(2019, 7, 12), "b": 4}]
         tbl = Table(data)
         view = tbl.view(filter=[["a", "!=", "2019/7/12"]])
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 11)), "b": 2}
-        ]
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 11)), "b": 2}]
 
     @mark.skip  # We do not support using `datetime.datetime` in operators
     def test_view_filter_datetime_eq(self, util):
@@ -1424,9 +1367,7 @@ class TestView(object):
         ]
         tbl = Table(data)
         view = tbl.view(filter=[["a", "==", datetime(2019, 7, 11, 8, 15)]])
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 11, () * 1000)), "b": 2}
-        ]
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 11, () * 1000)), "b": 2}]
 
     @mark.skip  # We do not support using `datetime.datetime` in operators
     def test_view_filter_datetime_neq(self, util):
@@ -1436,9 +1377,7 @@ class TestView(object):
         ]
         tbl = Table(data)
         view = tbl.view(filter=[["a", "!=", datetime(2019, 7, 11, 8, 15)]])
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 11, () * 1000)), "b": 4}
-        ]
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 11, () * 1000)), "b": 4}]
 
     @mark.skip  # We do not support numpy anymore
     def test_view_filter_datetime_np_eq(self, util):
@@ -1447,12 +1386,8 @@ class TestView(object):
             {"a": datetime(2019, 7, 11, 8, 16), "b": 4},
         ]
         tbl = Table(data)
-        view = tbl.view(
-            filter=[["a", "==", np.datetime64(datetime(2019, 7, 11, 8, 15))]]
-        )
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 11, () * 1000)), "b": 2}
-        ]
+        view = tbl.view(filter=[["a", "==", np.datetime64(datetime(2019, 7, 11, 8, 15))]])
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 11, () * 1000)), "b": 2}]
 
     @mark.skip  # We do not support numpy anymore.
     def test_view_filter_datetime_np_neq(self, util):
@@ -1461,12 +1396,8 @@ class TestView(object):
             {"a": datetime(2019, 7, 11, 8, 16), "b": 4},
         ]
         tbl = Table(data)
-        view = tbl.view(
-            filter=[["a", "!=", np.datetime64(datetime(2019, 7, 11, 8, 15))]]
-        )
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 11, () * 1000)), "b": 4}
-        ]
+        view = tbl.view(filter=[["a", "!=", np.datetime64(datetime(2019, 7, 11, 8, 15))]])
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 11, () * 1000)), "b": 4}]
 
     def test_view_filter_datetime_str_eq(self, util):
         data = [
@@ -1475,9 +1406,7 @@ class TestView(object):
         ]
         tbl = Table(data)
         view = tbl.view(filter=[["a", "==", "2019/7/11 8:15"]])
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 11, 8, 15)), "b": 2}
-        ]
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 11, 8, 15)), "b": 2}]
 
     def test_view_filter_datetime_str_neq(self, util):
         data = [
@@ -1486,24 +1415,18 @@ class TestView(object):
         ]
         tbl = Table(data)
         view = tbl.view(filter=[["a", "!=", "2019/7/11 8:15"]])
-        assert view.to_records() == [
-            {"a": util.to_timestamp(datetime(2019, 7, 11, 8, 16)), "b": 4}
-        ]
+        assert view.to_records() == [{"a": util.to_timestamp(datetime(2019, 7, 11, 8, 16)), "b": 4}]
 
     def test_view_filter_string_is_none(self):
         data = [{"a": None, "b": 2}, {"a": "abc", "b": 4}]
         tbl = Table(data)
-        view = tbl.view(
-            filter=[["a", "is null", ""]]
-        )  # XXX: Having to add this "" is not soooo great.
+        view = tbl.view(filter=[["a", "is null", ""]])  # XXX: Having to add this "" is not soooo great.
         assert view.to_records() == [{"a": None, "b": 2}]
 
     def test_view_filter_string_is_not_none(self):
         data = [{"a": None, "b": 2}, {"a": "abc", "b": 4}]
         tbl = Table(data)
-        view = tbl.view(
-            filter=[["a", "is not null", ""]]
-        )  # XXX: Having to add this "" is not soooo great.
+        view = tbl.view(filter=[["a", "is not null", ""]])  # XXX: Having to add this "" is not soooo great.
         assert view.to_records() == [{"a": "abc", "b": 4}]
 
     # on_update

--- a/rust/perspective-python/perspective/tests/table/test_view_expression.py
+++ b/rust/perspective-python/perspective/tests/table/test_view_expression.py
@@ -17,7 +17,6 @@ from pytest import raises
 from datetime import date, datetime
 from time import mktime
 from perspective import Table, PerspectivePyError
-import pytest
 from .test_view import compare_delta
 
 
@@ -164,12 +163,7 @@ class TestViewExpression(object):
     def test_view_expression_string_per_page(self):
         table = Table({"a": [i for i in range(100)]})
         big_strings = [randstr(6400) for _ in range(4)]
-        view = table.view(
-            expressions={
-                "computed{}".format(i): "var x := '{}'; lower(x)".format(big_strings[i])
-                for i in range(4)
-            }
-        )
+        view = table.view(expressions={"computed{}".format(i): "var x := '{}'; lower(x)".format(big_strings[i]) for i in range(4)})
 
         result = view.to_columns()
         schema = view.expression_schema()
@@ -189,13 +183,7 @@ class TestViewExpression(object):
             "".join(["d" for _ in range(640)]),
         ]
 
-        view = table.view(
-            expressions={
-                "computed": "var a := '{}'; var b := '{}'; var c := '{}'; var d := '{}'; concat(a, b, c, d)".format(
-                    *big_strings
-                )
-            }
-        )
+        view = table.view(expressions={"computed": "var a := '{}'; var b := '{}'; var c := '{}'; var d := '{}'; concat(a, b, c, d)".format(*big_strings)})
 
         result = view.to_columns()
         schema = view.expression_schema()
@@ -258,12 +246,8 @@ class TestViewExpression(object):
 
         view = table.view(
             expressions={
-                "computed": " var w := '{}'; var x := '{}'; var y := '{}'; var z := '{}'; concat(w, x, y, z)".format(
-                    *strings[:4]
-                ),
-                "computed2": " var w := '{}'; var x := '{}'; var y := '{}'; var z := '{}'; concat(w, x, y, z)".format(
-                    *strings[4:]
-                ),
+                "computed": " var w := '{}'; var x := '{}'; var y := '{}'; var z := '{}'; concat(w, x, y, z)".format(*strings[:4]),
+                "computed2": " var w := '{}'; var x := '{}'; var y := '{}'; var z := '{}'; concat(w, x, y, z)".format(*strings[4:]),
             }
         )
 
@@ -302,11 +286,7 @@ class TestViewExpression(object):
         for _ in range(5):
             exprs = [make_expression() for _ in range(5)]
             output_map = {expr["expression_name"]: expr["output"] for expr in exprs}
-            view = table.view(
-                expressions={
-                    expr["expression_name"]: expr["expression"] for expr in exprs
-                }
-            )
+            view = table.view(expressions={expr["expression_name"]: expr["expression"] for expr in exprs})
             expression_schema = view.expression_schema()
             result = view.to_columns()
             for expr in output_map.keys():
@@ -381,13 +361,9 @@ class TestViewExpression(object):
                 ]
             }
         )
-        validated = table.validate_expressions(
-            {"computed": " \"a\" == 'abcdefghijklmnopqrstuvwxyz'"}
-        )
+        validated = table.validate_expressions({"computed": " \"a\" == 'abcdefghijklmnopqrstuvwxyz'"})
         assert validated["expression_schema"] == {"computed": "boolean"}
-        view = table.view(
-            expressions={"computed": "\"a\" == 'abcdefghijklmnopqrstuvwxyz'"}
-        )
+        view = table.view(expressions={"computed": "\"a\" == 'abcdefghijklmnopqrstuvwxyz'"})
         result = view.to_columns()
         assert result["computed"] == [True, False, True, False, False]
         assert view.expression_schema() == {"computed": "boolean"}
@@ -404,15 +380,9 @@ class TestViewExpression(object):
                 ]
             }
         )
-        validated = table.validate_expressions(
-            {"computed": " var xyz := 'abcdefghijklmnopqrstuvwxyz'; \"a\" == xyz"}
-        )
+        validated = table.validate_expressions({"computed": " var xyz := 'abcdefghijklmnopqrstuvwxyz'; \"a\" == xyz"})
         assert validated["expression_schema"] == {"computed": "boolean"}
-        view = table.view(
-            expressions={
-                "computed": "var xyz := 'abcdefghijklmnopqrstuvwxyz'; \"a\" == xyz"
-            }
-        )
+        view = table.view(expressions={"computed": "var xyz := 'abcdefghijklmnopqrstuvwxyz'; \"a\" == xyz"})
         result = view.to_columns()
         assert result["computed"] == [True, False, True, False, False]
         assert view.expression_schema() == {"computed": "boolean"}
@@ -433,11 +403,7 @@ class TestViewExpression(object):
         table = Table({"a": [1, 2, 3]})
 
         for _ in range(10):
-            view = table.view(
-                expressions=[
-                    "var x := 'Eabcdefghijklmn'; var y := '0123456789'; concat(x, y)"
-                ]
-            )
+            view = table.view(expressions=["var x := 'Eabcdefghijklmn'; var y := '0123456789'; concat(x, y)"])
             assert view.to_columns() == {
                 "a": [1, 2, 3],
                 "var x := 'Eabcdefghijklmn'; var y := '0123456789'; concat(x, y)": [
@@ -519,10 +485,7 @@ class TestViewExpression(object):
         with raises(PerspectivePyError) as ex:
             table.view(expressions={"a": 'upper("a")'})
 
-        assert (
-            str(ex.value)
-            == 'Abort(): Value Error - expression "a" cannot overwrite an existing column.'
-        )
+        assert str(ex.value) == 'Abort(): Value Error - expression "a" cannot overwrite an existing column.'
 
     def test_legacy_view_duplicate_expression_should_resolve_to_last_alias(self):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
@@ -611,12 +574,7 @@ class TestViewExpression(object):
         today = date.today()
 
         month_bucketed = datetime(today.year, today.month, 1).timestamp() * 1000
-        minute_bucketed = (
-            datetime(
-                now.year, now.month, now.day, now.hour, now.minute, 0, 0
-            ).timestamp()
-            * 1000
-        )
+        minute_bucketed = datetime(now.year, now.month, now.day, now.hour, now.minute, 0, 0).timestamp() * 1000
 
         table = Table(
             {
@@ -732,9 +690,7 @@ class TestViewExpression(object):
 
     def test_view_expression_multiple_dependents_replace(self):
         table = Table({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-        view = table.view(
-            expressions={"computed": '"a" + "b"', "final": '("a" + "b") ^ 2'}
-        )
+        view = table.view(expressions={"computed": '"a" + "b"', "final": '("a" + "b") ^ 2'})
         assert view.to_columns() == {
             "a": [1, 2, 3, 4],
             "b": [5, 6, 7, 8],
@@ -1114,9 +1070,7 @@ class TestViewExpression(object):
 
     def test_view_expression_with_sort(self):
         table = Table({"a": ["a", "ab", "abc", "abcd"]})
-        view = table.view(
-            sort=[["computed", "desc"]], expressions={"computed": 'length("a")'}
-        )
+        view = table.view(sort=[["computed", "desc"]], expressions={"computed": 'length("a")'})
         assert view.to_columns() == {
             "a": ["abcd", "abc", "ab", "a"],
             "computed": [4, 3, 2, 1],
@@ -1124,9 +1078,7 @@ class TestViewExpression(object):
 
     def test_view_expression_with_filter(self):
         table = Table({"a": ["a", "ab", "abc", "abcd"]})
-        view = table.view(
-            filter=[["computed", ">=", 3]], expressions={"computed": 'length("a")'}
-        )
+        view = table.view(filter=[["computed", ">=", 3]], expressions={"computed": 'length("a")'})
         assert view.to_columns() == {"a": ["abc", "abcd"], "computed": [3, 4]}
 
     def test_view_day_of_week_date(self, util):
@@ -1149,9 +1101,7 @@ class TestViewExpression(object):
         view = table.view(expressions={"bucket": 'day_of_week("a")'})
         assert view.schema() == {"a": "datetime", "bucket": "string"}
         assert view.to_columns() == {
-            "a": [
-                util.to_timestamp(datetime(2020, 3, i, 12, 30)) for i in range(9, 14)
-            ],
+            "a": [util.to_timestamp(datetime(2020, 3, i, 12, 30)) for i in range(9, 14)],
             "bucket": [
                 "2 Monday",
                 "3 Tuesday",
@@ -1458,9 +1408,7 @@ class TestViewExpression(object):
 
         dt = datetime(2018, 8, 12, 15, 32, 55)
 
-        table.update(
-            {"w": [dt], "x": [12136582], "y": [date(2020, 6, 30)], "z": [1.23456]}
-        )
+        table.update({"w": [dt], "x": [12136582], "y": [date(2020, 6, 30)], "z": [1.23456]})
 
         assert view.expression_schema() == {
             "computed": "float",
@@ -1507,18 +1455,14 @@ class TestViewExpression(object):
         view = table.view(expressions={"computed": "datetime({})".format(ms_timestamp)})
         assert view.expression_schema() == {"computed": "datetime"}
         result = view.to_columns()
-        assert result["computed"] == [
-            util.to_timestamp(datetime(2015, 11, 29, 23, 59, 59))
-        ]
+        assert result["computed"] == [util.to_timestamp(datetime(2015, 11, 29, 23, 59, 59))]
 
     def test_view_datetime_expression_roundtrip(self, util):
         table = Table({"x": [datetime(2015, 11, 29, 23, 59, 59)]})
         view = table.view(expressions={"computed": 'datetime(float("x"))'})
         assert view.expression_schema() == {"computed": "datetime"}
         result = view.to_columns()
-        assert result["computed"] == [
-            util.to_timestamp(datetime(2015, 11, 29, 23, 59, 59))
-        ]
+        assert result["computed"] == [util.to_timestamp(datetime(2015, 11, 29, 23, 59, 59))]
 
     def test_view_string_expression(self):
         table = Table(
@@ -1581,9 +1525,7 @@ class TestViewExpression(object):
     def test_view_expession_multicomment(self):
         table = Table({"a": [1, 2, 3, 4]})
         view = table.view(expressions=["var x := 1 + 2;\n// def\nx + 100 // cdefghijk"])
-        assert view.expression_schema() == {
-            "var x := 1 + 2;\n// def\nx + 100 // cdefghijk": "float"
-        }
+        assert view.expression_schema() == {"var x := 1 + 2;\n// def\nx + 100 // cdefghijk": "float"}
         assert view.to_columns() == {
             "var x := 1 + 2;\n// def\nx + 100 // cdefghijk": [103, 103, 103, 103],
             "a": [1, 2, 3, 4],
@@ -1624,8 +1566,8 @@ class TestViewExpression(object):
             expected_domain = re.search(r"@([a-zA-Z.]+)$", source).group(1)
             assert results["address"][i] == expected_address
             assert results["domain"][i] == expected_domain
-            assert results["is_email?"][i] == True
-            assert results["has_at?"][i] == True
+            assert results["is_email?"][i] is True
+            assert results["has_at?"][i] is True
 
     def test_view_expression_number(self):
         def digits():
@@ -1669,7 +1611,7 @@ class TestViewExpression(object):
             source = results["a"][i]
             expected = re.sub(r"[ -]", "", source)
             assert results["parsed"][i] == expected
-            assert results["is_number?"][i] == True
+            assert results["is_number?"][i] is True
 
     def test_view_expression_newlines(self):
         table = Table(
@@ -1837,9 +1779,7 @@ class TestViewExpression(object):
             assert results["w"][i] == "abcdef-hijk"
             assert results["x"][i] == re.sub(r"[0-9]{4}$", idx, source, 1)
             assert results["y"][i] == source
-            assert results["z"][i] == re.sub(
-                r"^[0-9]{4}", "long string, very cool!", source, 1
-            )
+            assert results["z"][i] == re.sub(r"^[0-9]{4}", "long string, very cool!", source, 1)
 
     def test_view_replace_invalid(self):
         table = Table({"a": "string", "b": "string"})
@@ -1915,11 +1855,9 @@ class TestViewExpression(object):
             assert results["w"][i] == "abcdefhijk"
             assert results["x"][i] == re.sub(r"[0-9]{4}$", idx, source)
             assert results["y"][i] == source
-            assert results["z"][i] == re.sub(
-                r"^[0-9]{4}", "long string, very cool!", source
-            )
+            assert results["z"][i] == re.sub(r"^[0-9]{4}", "long string, very cool!", source)
 
-    def test_view_replace_invalid(self):
+    def test_view_replace_invalid2(self):
         table = Table({"a": "string", "b": "string"})
         expressions = [
             """//v

--- a/rust/perspective-python/perspective/tests/viewer/test_validate.py
+++ b/rust/perspective-python/perspective/tests/viewer/test_validate.py
@@ -10,13 +10,13 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-from pytest import raises
+# from pytest import raises
 
-from perspective.core import PerspectiveError
+# from perspective.core import PerspectiveError
 
 # from perspective.core import Plugin
 # import perspective.viewer.validate as validate
-from perspective.core._version import __version__
+# from perspective.core._version import __version__
 
 
 # class TestValidate:

--- a/rust/perspective-python/perspective/tests/viewer/test_viewer.py
+++ b/rust/perspective-python/perspective/tests/viewer/test_viewer.py
@@ -201,9 +201,7 @@ class TestViewer:
 
     def test_save_restore(self):
         table = Table({"a": [1, 2, 3]})
-        viewer = PerspectiveViewer(
-            plugin="X Bar", filter=[["a", "==", 2]], expressions={'"a" * 2': '"a" * 2'}
-        )
+        viewer = PerspectiveViewer(plugin="X Bar", filter=[["a", "==", 2]], expressions={'"a" * 2': '"a" * 2'})
         viewer.load(table)
 
         # Save config
@@ -227,9 +225,7 @@ class TestViewer:
         assert viewer.expressions == {'"a" * 2': '"a" * 2'}
 
     def test_save_restore_plugin_config(self):
-        viewer = PerspectiveViewer(
-            plugin="Datagrid", plugin_config={"columns": {"a": {"fixed": 4}}}
-        )
+        viewer = PerspectiveViewer(plugin="Datagrid", plugin_config={"columns": {"a": {"fixed": 4}}})
         config = viewer.save()
 
         assert config["plugin_config"] == {"columns": {"a": {"fixed": 4}}}

--- a/rust/perspective-python/perspective/tests/widget/test_widget.py
+++ b/rust/perspective-python/perspective/tests/widget/test_widget.py
@@ -10,7 +10,6 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-from datetime import date, datetime
 from functools import partial
 from types import MethodType
 

--- a/rust/perspective-python/perspective/tests/widget/test_widget_pandas.py
+++ b/rust/perspective-python/perspective/tests/widget/test_widget_pandas.py
@@ -10,7 +10,6 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-from datetime import date
 import pandas as pd
 import numpy as np
 from perspective import Table, PerspectiveWidget
@@ -287,9 +286,7 @@ class TestWidgetPandas:
         ]
         tuples = list(zip(*arrays))
         index = pd.MultiIndex.from_tuples(tuples, names=["first", "second", "third"])
-        df_both = pd.DataFrame(
-            np.random.randn(3, 16), index=["A", "B", "C"], columns=index
-        )
+        df_both = pd.DataFrame(np.random.randn(3, 16), index=["A", "B", "C"], columns=index)
         widget = PerspectiveWidget(df_both)
         assert widget.columns == ["value"]
         assert widget.split_by == ["first", "second", "third"]
@@ -360,9 +357,7 @@ class TestWidgetPandas:
         ]
         tuples = list(zip(*arrays))
         index = pd.MultiIndex.from_tuples(tuples, names=["first", "second", "third"])
-        df_both = pd.DataFrame(
-            np.random.randn(3, 16), index=["A", "B", "C"], columns=index
-        )
+        df_both = pd.DataFrame(np.random.randn(3, 16), index=["A", "B", "C"], columns=index)
         widget = PerspectiveWidget(df_both, columns=["first", "third"])
         assert widget.columns == ["first", "third"]
         assert widget.split_by == ["first", "second", "third"]
@@ -428,9 +423,7 @@ class TestWidgetPandas:
         }
 
         df = pd.DataFrame(arrays)
-        df_pivot = df.pivot_table(
-            values=["D"], index=["A"], columns=["B", "C"], aggfunc={"D": "count"}
-        )
+        df_pivot = df.pivot_table(values=["D"], index=["A"], columns=["B", "C"], aggfunc={"D": "count"})
         widget = PerspectiveWidget(df_pivot)
         assert widget.columns == ["value"]
         assert widget.split_by == ["B", "C"]

--- a/rust/perspective-python/perspective/viewer/validate.py
+++ b/rust/perspective-python/perspective/viewer/validate.py
@@ -14,9 +14,4 @@
 def validate_version(version):
     # basic semver of form \d+\.\d+\.\d+(\+.+)?
     spl = version.split(".", 2)
-    return (
-        len(spl) == 3
-        and spl[0].isdigit()
-        and spl[1].isdigit()
-        and (spl[2].split("+")[0]).isdigit()
-    )
+    return len(spl) == 3 and spl[0].isdigit() and spl[1].isdigit() and (spl[2].split("+")[0]).isdigit()

--- a/rust/perspective-python/perspective/viewer/viewer.py
+++ b/rust/perspective-python/perspective/viewer/viewer.py
@@ -13,7 +13,7 @@
 from random import random
 from .viewer_traitlets import PerspectiveTraitlets
 
-from ..core.exception import PerspectiveError
+# from ..core.exception import PerspectiveError
 from ..legacy import PerspectiveManager, Table
 
 
@@ -110,15 +110,15 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
         self.table_name = None
 
         # Viewer configuration
-        self.plugin = plugin # validate_plugin(plugin)
-        self.columns = columns or [] # validate_columns(columns) or []
-        self.group_by = group_by or [] # validate_group_by(group_by) or []
-        self.split_by = split_by or [] # validate_split_by(split_by) or []
-        self.aggregates = aggregates or {} # validate_aggregates(aggregates) or {}
-        self.sort = sort or [] # validate_sort(sort) or []
-        self.filter = filter or [] # validate_filter(filter) or []
-        self.expressions = expressions or {} # validate_expressions(expressions) or {}
-        self.plugin_config = plugin_config or {} # validate_plugin_config(plugin_config) or {}
+        self.plugin = plugin  # validate_plugin(plugin)
+        self.columns = columns or []  # validate_columns(columns) or []
+        self.group_by = group_by or []  # validate_group_by(group_by) or []
+        self.split_by = split_by or []  # validate_split_by(split_by) or []
+        self.aggregates = aggregates or {}  # validate_aggregates(aggregates) or {}
+        self.sort = sort or []  # validate_sort(sort) or []
+        self.filter = filter or []  # validate_filter(filter) or []
+        self.expressions = expressions or {}  # validate_expressions(expressions) or {}
+        self.plugin_config = plugin_config or {}  # validate_plugin_config(plugin_config) or {}
         self.settings = settings
         self.theme = theme
         self.title = title
@@ -182,8 +182,9 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
 
         if isinstance(data, Table):
             table = data
-        elif isinstance(data, View):
-            raise PerspectiveError("Only `Table` or data can be loaded.")
+        # TODO
+        # elif isinstance(data, View):
+        #     raise PerspectiveError("Only `Table` or data can be loaded.")
         else:
             table = Table(data, **options)
 
@@ -229,10 +230,7 @@ class PerspectiveViewer(PerspectiveTraitlets, object):
     def save(self):
         """Get the viewer's attribute as a dictionary, symmetric with `restore`
         so that a viewer's configuration can be reproduced."""
-        return {
-            attr: getattr(self, attr)
-            for attr in PerspectiveViewer.PERSISTENT_ATTRIBUTES
-        }
+        return {attr: getattr(self, attr) for attr in PerspectiveViewer.PERSISTENT_ATTRIBUTES}
 
     def restore(self, **kwargs):
         """Restore a given set of attributes, passed as kwargs

--- a/rust/perspective-python/perspective/viewer/viewer_traitlets.py
+++ b/rust/perspective-python/perspective/viewer/viewer_traitlets.py
@@ -13,9 +13,9 @@
 from traitlets import HasTraits, Unicode, List, Bool, Dict, validate
 from ..core._version import __version__
 
-from .validate import (
-    validate_version,
-)
+# from .validate import (
+#     validate_version,
+# )
 
 
 class PerspectiveTraitlets(HasTraits):
@@ -51,44 +51,66 @@ class PerspectiveTraitlets(HasTraits):
 
     @validate("plugin")
     def _validate_plugin(self, proposal):
-        return validate_plugin(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_plugin(proposal.value)
 
     @validate("columns")
     def _validate_columns(self, proposal):
-        return validate_columns(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_columns(proposal.value)
 
     @validate("group_by")
     def _validate_group_by(self, proposal):
-        return validate_group_by(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_group_by(proposal.value)
 
     @validate("split_by")
     def _validate_split_by(self, proposal):
-        return validate_split_by(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_split_by(proposal.value)
 
     @validate("aggregates")
     def _validate_aggregates(self, proposal):
-        return validate_aggregates(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_aggregates(proposal.value)
 
     @validate("sort")
     def _validate_sort(self, proposal):
-        return validate_sort(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_sort(proposal.value)
 
     @validate("filter")
     def _validate_filter(self, proposal):
-        return validate_filter(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_filter(proposal.value)
 
     @validate("expressions")
     def _validate_expressions(self, proposal):
-        return validate_expressions(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_expressions(proposal.value)
 
     @validate("plugin_config")
     def _validate_plugin_config(self, proposal):
-        return validate_plugin_config(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_plugin_config(proposal.value)
 
     @validate("title")
     def _validate_title(self, proposal):
-        return validate_title(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_title(proposal.value)
 
     @validate("version")
     def _validate_version(self, proposal):
-        return validate_version(proposal.value)
+        # TODO
+        return proposal.value
+        # return validate_version(proposal.value)

--- a/rust/perspective-python/perspective/widget/widget.py
+++ b/rust/perspective-python/perspective/widget/widget.py
@@ -45,11 +45,7 @@ def _type_to_string(t):
     elif t is bytes or t is str:
         return "string"
     else:
-        raise PerspectiveError(
-            "Unsupported type `{0}` in schema - Perspective supports `int`, `float`, `bool`, `date`, `datetime`, and `str` (or `unicode`).".format(
-                str(t)
-            )
-        )
+        raise PerspectiveError("Unsupported type `{0}` in schema - Perspective supports `int`, `float`, `bool`, `date`, `datetime`, and `str` (or `unicode`).".format(str(t)))
 
 
 def _serialize_datetime(values):
@@ -81,9 +77,7 @@ def _serialize(data):
         # Check if any values are `datetime.date`
         for row in data:
             if not isinstance(row, dict):
-                raise PerspectiveError(
-                    "Received {} in list dataset, expected `dict`!".format(type(row))
-                )
+                raise PerspectiveError("Received {} in list dataset, expected `dict`!".format(type(row)))
 
             for k in row.keys():
                 if type(row[k]) is datetime:
@@ -97,15 +91,10 @@ def _serialize(data):
         for v in data.values():
             if isinstance(v, type):
                 # serialize schema values to string
-                return {
-                    column_name: _type_to_string(data[column_name])
-                    for column_name in data
-                }
+                return {column_name: _type_to_string(data[column_name]) for column_name in data}
             elif isinstance(v, numpy.ndarray):
                 # Convert dicts of numpy arrays to dicts of lists
-                formatted = {
-                    column_name: data[column_name].tolist() for column_name in data
-                }
+                formatted = {column_name: data[column_name].tolist() for column_name in data}
                 break
 
         for column_name in formatted.keys():
@@ -116,9 +105,7 @@ def _serialize(data):
     elif isinstance(data, numpy.ndarray):
         # structured or record array
         if not isinstance(data.dtype.names, tuple):
-            raise NotImplementedError(
-                "Data should be dict of numpy.ndarray or a structured array."
-            )
+            raise NotImplementedError("Data should be dict of numpy.ndarray or a structured array.")
 
         columns = [data[col].tolist() for col in data.dtype.names]
         formatted = dict(zip(data.dtype.names, columns))
@@ -149,9 +136,7 @@ def _serialize(data):
                 d[name] = values.tolist()
         return d
     else:
-        raise NotImplementedError(
-            "Cannot serialize a dataset of `{0}`.".format(str(type(data)))
-        )
+        raise NotImplementedError("Cannot serialize a dataset of `{0}`.".format(str(type(data))))
 
 
 class _PerspectiveWidgetMessage(object):
@@ -271,7 +256,8 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
         # If `self.client` is True, the front-end `<perspective-viewer>` is
         # given a copy of the data serialized to JSON, and the Python kernel
         # does not create a `perspective.Table.`
-        self.client = client
+        # TODO
+        self.client = False
 
         # If `self.server` is True, the widget runs in server-only mode where
         # the front-end `<perspective-viewer>` does not create a Table, and
@@ -286,16 +272,19 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
 
         # Parse the dataset we pass in - if it's Pandas, preserve pivots
         if isinstance(data, pandas.DataFrame) or isinstance(data, pandas.Series):
-            data, config = deconstruct_pandas(data)
+            # TODO
+            raise NotImplementedError()
 
-            if config.get("group_by", None) and "group_by" not in kwargs:
-                kwargs.update({"group_by": config["group_by"]})
+            # data, config = deconstruct_pandas(data)
 
-            if config.get("split_by", None) and "split_by" not in kwargs:
-                kwargs.update({"split_by": config["split_by"]})
+            # if config.get("group_by", None) and "group_by" not in kwargs:
+            #     kwargs.update({"group_by": config["group_by"]})
 
-            if config.get("columns", None) and "columns" not in kwargs:
-                kwargs.update({"columns": config["columns"]})
+            # if config.get("split_by", None) and "split_by" not in kwargs:
+            #     kwargs.update({"split_by": config["split_by"]})
+
+            # if config.get("columns", None) and "columns" not in kwargs:
+            #     kwargs.update({"columns": config["columns"]})
 
         # Initialize the viewer
         super(PerspectiveWidget, self).__init__(**kwargs)
@@ -308,32 +297,32 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
         self.on_msg(self.handle_message)
 
         if self.client:
-            if is_libpsp():
-                from ..libpsp import Table
+            # TODO
+            raise NotImplementedError()
+            # if is_libpsp():
+            #     from ..libpsp import Table
 
-                if isinstance(data, Table):
-                    raise PerspectiveError(
-                        "Client mode PerspectiveWidget expects data or schema, not a `perspective.Table`!"
-                    )
+            #     if isinstance(data, Table):
+            #         raise PerspectiveError(
+            #             "Client mode PerspectiveWidget expects data or schema, not a `perspective.Table`!"
+            #         )
 
-            if index is not None:
-                self._options["index"] = index
+            # if index is not None:
+            #     self._options["index"] = index
 
-            if limit is not None:
-                self._options["limit"] = limit
+            # if limit is not None:
+            #     self._options["limit"] = limit
 
-            # cache self._data so creating multiple views don't reserialize the
-            # same data
-            if not hasattr(self, "_data") or self._data is None:
-                self._data = _serialize(data)
+            # # cache self._data so creating multiple views don't reserialize the
+            # # same data
+            # if not hasattr(self, "_data") or self._data is None:
+            #     self._data = _serialize(data)
         else:
             # If an empty dataset is provided, don't call `load()` and wait
             # for the user to call `load()`.
             if data is None:
                 if index is not None or limit is not None:
-                    raise PerspectiveError(
-                        "Cannot initialize PerspectiveWidget `index` or `limit` without a Table, data, or schema!"
-                    )
+                    raise PerspectiveError("Cannot initialize PerspectiveWidget `index` or `limit` without a Table, data, or schema!")
             else:
                 if index is not None:
                     self._options.update({"index": index})
@@ -351,7 +340,9 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
         if self.client is True:
             # serialize the data and send a custom message to the browser
             if isinstance(data, pandas.DataFrame) or isinstance(data, pandas.Series):
-                data, _ = deconstruct_pandas(data)
+                # TODO
+                raise NotImplementedError()
+                # data, _ = deconstruct_pandas(data)
             d = _serialize(data)
             self._data = d
         else:
@@ -370,7 +361,9 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
         if self.client is True:
             # serialize the data and send a custom message to the browser
             if isinstance(data, pandas.DataFrame) or isinstance(data, pandas.Series):
-                data, _ = deconstruct_pandas(data)
+                # TODO
+                raise NotImplementedError()
+                # data, _ = deconstruct_pandas(data)
             d = _serialize(data)
             self.post({"cmd": "update", "data": d})
         else:
@@ -394,7 +387,9 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
         """
         if self.client is True:
             if isinstance(data, pandas.DataFrame) or isinstance(data, pandas.Series):
-                data, _ = deconstruct_pandas(data)
+                # TODO
+                raise NotImplementedError()
+                # data, _ = deconstruct_pandas(data)
             d = _serialize(data)
             self.post({"cmd": "replace", "data": d})
             self._data = d
@@ -533,9 +528,7 @@ class PerspectiveWidget(DOMWidget, PerspectiveViewer):
         if msg_data is not None:
             return _PerspectiveWidgetMessage(-2, "table", msg_data)
         else:
-            raise PerspectiveError(
-                "Widget does not have any data loaded - use the `load()` method to provide it with data."
-            )
+            raise PerspectiveError("Widget does not have any data loaded - use the `load()` method to provide it with data.")
 
     def _repr_mimebundle_(self, **kwargs):
         super_bundle = super(DOMWidget, self)._repr_mimebundle_(**kwargs)

--- a/rust/perspective-python/pyproject.toml
+++ b/rust/perspective-python/pyproject.toml
@@ -33,3 +33,9 @@ python_classes = ["Test", "Describe"]
 python_functions = ["test_", "it_", "and_", "but_", "they_"]
 python_files = ["test_*.py"]
 testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 200
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "F403"]

--- a/rust/perspective-python/requirements.txt
+++ b/rust/perspective-python/requirements.txt
@@ -1,5 +1,3 @@
-pytest>=7.4.3
-ruff>=0.4.6
 Faker==26.0.0
 ipywidgets==8.1.3
 Jinja2==3.1.4

--- a/tools/perspective-scripts/fix_python.mjs
+++ b/tools/perspective-scripts/fix_python.mjs
@@ -15,12 +15,12 @@ import * as url from "url";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url)).slice(0, -1);
 
-const cmd = sh`black perspective bench setup.py`;
+const cmd = sh`ruff format perspective bench`;
 
 if (process.env.PSP_DOCKER) {
-    cmd = sh`cd python/perspective`.sh(cmd);
+    cmd = sh`cd rust/perspective-python`.sh(cmd);
     sh.docker(cmd).log().runSync();
 } else {
-    const python_path = sh.path`${__dirname}/../../python/perspective`;
+    const python_path = sh.path`${__dirname}/../../rust/perspective-python`;
     cmd.cwd(python_path).log().runSync();
 }

--- a/tools/perspective-scripts/lint_python.mjs
+++ b/tools/perspective-scripts/lint_python.mjs
@@ -15,12 +15,16 @@ import * as url from "url";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url)).slice(0, -1);
 
-const cmd = sh`flake8 perspective bench setup.py`;
+const cmd_check = sh`ruff check perspective bench`;
+const cmd_format = sh`ruff format --check perspective bench`;
 
 if (process.env.PSP_DOCKER) {
-    cmd = sh`cd python/perspective`.sh(cmd);
-    sh.docker(cmd).log().runSync();
+    cmd_check = sh`cd rust/perspective-python`.sh(cmd_check);
+    sh.docker(cmd_check).log().runSync();
+    cmd_format = sh`cd rust/perspective-python`.sh(cmd_format);
+    sh.docker(cmd_format).log().runSync();
 } else {
-    const python_path = sh.path`${__dirname}/../../python/perspective`;
-    cmd.cwd(python_path).log().runSync();
+    const python_path = sh.path`${__dirname}/../../rust/perspective-python`;
+    cmd_check.cwd(python_path).log().runSync();
+    cmd_format.cwd(python_path).log().runSync();
 }


### PR DESCRIPTION
Fixes the python listing scripts, looks like we decided to move to ruff so this updates the JS scripts to use ruff and then fixes a bunch of ruff errors, almost all of which were little things in the tests like reusing method names, unnecessary imports, things we've commented out, etc. 