### PR TITLE
Let callback in python client be any callable

### DIFF
--- a/rust/perspective-python/perspective/tests/core/test_async.py
+++ b/rust/perspective-python/perspective/tests/core/test_async.py
@@ -62,9 +62,7 @@ class TestAsync(object):
         return cls.loop.asyncio_loop.is_running()
 
     def test_async_queue_process(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(TestAsync.loop.add_callback)
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
 
         @syncify
@@ -79,9 +77,7 @@ class TestAsync(object):
 
     def test_async_queue_process_csv(self):
         """Make sure GIL release during CSV loading works"""
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(TestAsync.loop.add_callback)
         tbl = client.table("x,y,z\n1,a,true\n2,b,false\n3,c,true\n4,d,false")
 
         @syncify
@@ -96,9 +92,7 @@ class TestAsync(object):
         tbl.delete()
 
     def test_async_call_loop(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(TestAsync.loop.add_callback)
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl.update(data)
 
@@ -111,9 +105,7 @@ class TestAsync(object):
 
     @mark.skip(reason="We take a loop to construct the client now")
     def test_async_call_loop_error_if_no_loop(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(TestAsync.loop.add_callback)
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
 
         with raises(PerspectiveError):
@@ -132,12 +124,8 @@ class TestAsync(object):
         tbl.delete()
 
     def test_async_multiple_managers_queue_process(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
-        client2 = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(TestAsync.loop.add_callback)
+        client2 = create_sync_client(TestAsync.loop.add_callback)
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl2 = client2.table({"a": "integer", "b": "float", "c": "string"})
 
@@ -179,9 +167,7 @@ class TestAsync(object):
             sentinel["called"] += 1
             f(*args, **kwargs)
 
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(TestAsync.loop.add_callback)
         client2 = create_sync_client(sync_queue_process)
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl2 = client2.table({"a": "integer", "b": "float", "c": "string"})
@@ -230,12 +216,8 @@ class TestAsync(object):
             TestAsync.loop.add_timeout, 1, _counter, "async"
         )
 
-        client = create_sync_client(
-            lambda fn, *args: short_delay_queue_process(fn, *args)
-        )
-        client2 = create_sync_client(
-            lambda fn, *args: long_delay_queue_process(fn, *args)
-        )
+        client = create_sync_client(short_delay_queue_process)
+        client2 = create_sync_client(long_delay_queue_process)
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl2 = client2.table({"a": "integer", "b": "float", "c": "string"})
 
@@ -299,9 +281,7 @@ class TestAsync(object):
         tbl2.delete()
 
     def test_async_queue_process_multiple_ports(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(TestAsync.loop.add_callback)
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         port_ids = [0]
         port_data = [{"a": 0, "b": 0, "c": "0"}]
@@ -330,12 +310,8 @@ class TestAsync(object):
         assert _tbl_task() == 11
 
     def test_async_multiple_managers_queue_process_multiple_ports(self):
-        client = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
-        client2 = create_sync_client(
-            lambda fn, *args: TestAsync.loop.add_callback(fn, *args)
-        )
+        client = create_sync_client(TestAsync.loop.add_callback)
+        client2 = create_sync_client(TestAsync.loop.add_callback)
         tbl = client.table({"a": "integer", "b": "float", "c": "string"})
         tbl2 = client2.table({"a": "integer", "b": "float", "c": "string"})
         port_ids = [0]
@@ -371,8 +347,8 @@ class TestAsync(object):
 
         sync_process = partial(_counter, "sync")
         async_process = partial(TestAsync.loop.add_timeout, 1, _counter, "async")
-        sync_client = create_sync_client(lambda *args: sync_process(*args))
-        async_client = create_sync_client(lambda *args: async_process(*args))
+        sync_client = create_sync_client(sync_process)
+        async_client = create_sync_client(async_process)
         tbl = async_client.table({"a": "integer", "b": "float", "c": "string"})
         tbl2 = sync_client.table({"a": "integer", "b": "float", "c": "string"})
         port_ids = [0]

--- a/rust/perspective-python/src/client/client_sync.rs
+++ b/rust/perspective-python/src/client/client_sync.rs
@@ -40,7 +40,7 @@ pub struct PySyncClient(PyClient);
 #[pymethods]
 impl PySyncClient {
     #[new]
-    pub fn new(callback: Py<PyFunction>) -> PyResult<Self> {
+    pub fn new(callback: Py<PyAny>) -> PyResult<Self> {
         let client = PyClient::new(callback);
         Ok(PySyncClient(client))
     }

--- a/rust/perspective-python/src/client/python.rs
+++ b/rust/perspective-python/src/client/python.rs
@@ -259,7 +259,7 @@ fn pandas_to_arrow_bytes<'py>(
 }
 
 impl PyClient {
-    pub fn new(handle_request: Py<PyFunction>) -> Self {
+    pub fn new(handle_request: Py<PyAny>) -> Self {
         let client = Client::new_with_callback({
             move |msg| {
                 clone!(handle_request);


### PR DESCRIPTION
Tests updated now that lambdas are spurious. We should probably throw a check `if hasattr("__call__")` somewhere in the mix rather than fail on first client callback attempt. 