### PR TITLE
Cleanup and simplify CMakeLists.txt

### DIFF
--- a/cmake/arrow/CMakeLists.txt
+++ b/cmake/arrow/CMakeLists.txt
@@ -18,7 +18,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 set(ARROW_SRCS
-
     # Base
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/array/array_base.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/array/array_binary.cc
@@ -154,11 +153,11 @@ set(ARROW_SRCS
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/expression.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/function.cc
-    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/function_internal.cc    
+    ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/function_internal.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernel.cc
     ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/ordering.cc
 
-    
+
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/registry.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/aggregate_basic.cc
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -210,7 +209,7 @@ set(ARROW_SRCS
     # ${CMAKE_BINARY_DIR}/arrow-src/cpp/src/arrow/compute/exec/task_util.cc
 )
 
-if(PSP_PYTHON_BUILD AND NOT PSP_PYODIDE)
+if(PSP_PYTHON_BUILD AND NOT PSP_PYODIDE_BUILD)
     set(ARROW_SRCS
         ${ARROW_SRCS}
         # use standard reader in Python builds.
@@ -280,6 +279,9 @@ target_compile_definitions(arrow PUBLIC ARROW_NO_DEPRECATED_API)
 target_compile_definitions(arrow PUBLIC ARROW_STATIC)
 # target_compile_definitions(arrow PUBLIC ARROW_WITH_ZSTD=ON)
 target_compile_definitions(arrow PUBLIC ARROW_WITH_LZ4)
+
+target_include_directories(arrow PRIVATE ${Boost_INCLUDE_DIRS})
+target_include_directories(arrow PUBLIC ${PSP_CPP_SRC}/src/include)
 
 # will need built boost filesystem and system .lib to work, even though
 # perspective itself does not use those dependencies

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -1,44 +1,52 @@
 cmake_minimum_required(VERSION 3.18.2)
-project(psp)
+project(psp CXX)
 include(CheckCCompilerFlag)
 
 set(CMAKE_BUILD_TYPE "Release")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-
-# CMAKE POLICIES
+##################
+# CMAKE POLICIES #
+##################
 # option() should use new cmake behavior wrt variable clobbering
+# https://cmake.org/cmake/help/latest/policy/CMP0077.html
 cmake_policy(SET CMP0077 NEW)
-
-# BOOST_ROOT has been removed on Windows VMs in Azure:
-#
-# - https://github.com/actions/virtual-environments/issues/687
-# - https://github.com/actions/virtual-environments/issues/319
-#
-# `BOOST_ROOT` must be set in the environment, and policy CMP0074
-# must be set to `NEW` to allow BOOST_ROOT to be defined by env var
+# Allow `BOOST_ROOT` from environment
+# https://cmake.org/cmake/help/latest/policy/CMP0074.html
 cmake_policy(SET CMP0074 NEW)
-
-# Set CMP0094 to NEW - find the first version that matches constraints,
-# instead of the latest version installed.
+# Use first matching python version
+# https://cmake.org/cmake/help/latest/policy/CMP0094.html
 cmake_policy(SET CMP0094 NEW)
+# Set MSVC Runtime Library by global flag
+# https://cmake.org/cmake/help/latest/policy/CMP0091.html
+cmake_policy(SET CMP0091 NEW)
 
-if(NOT DEFINED PSP_CMAKE_MODULE_PATH)
-    set(PSP_CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
+#################
+# CMAKE MODULES #
+#################
+if(MACOS)
+    set(CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH};/opt/homebrew;/usr/local/")
 endif()
+if(NOT DEFINED PSP_CMAKE_MODULE_PATH)
+    set(PSP_CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake")
+endif()
+list(PREPEND CMAKE_MODULE_PATH "${PSP_CMAKE_MODULE_PATH}/modules")
 
-
-
-
-set(CMAKE_MODULE_PATH "${PSP_CMAKE_MODULE_PATH}/modules" ${CMAKE_MODULE_PATH})
-set(MSVC_RUNTIME_LIBRARY MultiThreaded)
-
+##########
+# SYSTEM #
+##########
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set(WIN32 ON)
     set(MACOS OFF)
     set(LINUX OFF)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(WIN32 OFF)
+    set(MACOS ON)
+    set(LINUX OFF)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
+    # Emulate MACOS behavior as it will be the same
+    # between linux and macos
     set(WIN32 OFF)
     set(MACOS ON)
     set(LINUX OFF)
@@ -48,19 +56,9 @@ else()
     set(LINUX ON)
 endif()
 
-if (WIN32)
-    add_compile_options("/EHsc")
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-endif()
-
-
-if(WIN32)
-    set(CMAKE_CXX_FLAGS " /EHsc /MP /MT /c /bigobj")
-else()
-    # set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS}")
-endif()
-
-# # Helper function
+###########
+# HELPERS #
+###########
 function(string_starts_with str search)
     string(FIND "${str}" "${search}" out)
 
@@ -71,35 +69,30 @@ function(string_starts_with str search)
 endfunction()
 
 set(BUILD_MESSAGE "")
-
 function(psp_build_message message)
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${message}")
 endfunction()
 
-# ######################
+#######################
 # BUILD CONFIGURATION #
-# ######################
+#######################
 find_package(Color)
 find_package(InstallDependency)
 
-# OPTIONS
 option(CMAKE_BUILD_TYPE "Release/Debug build" RELEASE)
-option(PSP_WASM_BUILD "Build the WebAssembly Project" ON)
-option(PSP_CPP_BUILD "Build the C++ Project" OFF)
-option(PSP_PYTHON_BUILD "Build the Python Bindings" OFF)
-option(PSP_CPP_BUILD_STRICT "Build the C++ with strict warnings" OFF)
+option(PSP_WASM_BUILD "Build the WebAssembly project" ON)
+option(PSP_WASM_EXCEPTIONS "WebAssembly exceptions" ON)
+
+option(PSP_PYTHON_BUILD "Build the Python bindings" OFF)
+option(PSP_PYODIDE_BUILD "Build the Python bindings for Pyodide" OFF)
+option(PSP_MANYLINUX_BUILD "Build the Python bindings for manylinux" OFF)
 option(PSP_SANITIZE "Build with sanitizers" OFF)
+
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     set(PSP_WASM_BUILD ON)
-    set(PSP_CPP_BUILD OFF)
 else()
     set(PSP_WASM_BUILD OFF)
-    set(PSP_CPP_BUILD ON)
-endif()
-
-if(PSP_WASM_BUILD AND PSP_CPP_BUILD)
-    message(FATAL_ERROR "${Red}CPP and Emscripten builds must be done separately${ColorReset}")
 endif()
 
 if(DEFINED ENV{PSP_DEBUG})
@@ -111,9 +104,9 @@ else()
 endif()
 
 if(DEFINED ENV{PSP_MANYLINUX})
-    set(MANYLINUX ON)
+    set(PSP_MANYLINUX_BUILD ON)
 else()
-    set(MANYLINUX OFF)
+    set(PSP_MANYLINUX_BUILD OFF)
 endif()
 
 if(DEFINED ENV{PSP_USE_CCACHE})
@@ -121,35 +114,31 @@ if(DEFINED ENV{PSP_USE_CCACHE})
     set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
 endif()
 
-if(NOT DEFINED PSP_CPP_BUILD)
-    set(PSP_CPP_BUILD ON)
-endif()
-
 if(NOT DEFINED PSP_PYTHON_BUILD)
     set(PSP_PYTHON_BUILD OFF)
 elseif(PSP_PYTHON_BUILD)
     if(NOT DEFINED PSP_PYTHON_VERSION)
-        set(PSP_PYTHON_VERSION 3.10)
+        set(PSP_PYTHON_VERSION 3.11)
     endif()
     if($ENV{PYODIDE})
-        set(PSP_PYODIDE 1)
+        set(PSP_PYODIDE_BUILD ON)
     else()
-        set(PSP_PYODIDE 0)
+        set(PSP_PYODIDE_BUILD OFF)
     endif()
 endif()
 
-if(NOT DEFINED PSP_CPP_BUILD_STRICT)
-    set(PSP_CPP_BUILD_STRICT OFF)
+if(NOT DEFINED PSP_WASM_EXCEPTIONS AND NOT PSP_PYTHON_BUILD)
+    set(PSP_WASM_EXCEPTIONS ON)
 endif()
 
+
+##################
+# PRINT MESSAGES #
+##################
 if(PSP_WASM_BUILD)
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Cyan}Building WASM binding${ColorReset}")
 else()
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Yellow}Skipping WASM binding${ColorReset}")
-endif()
-
-if(NOT DEFINED PSP_CPP_SRC)
-    set(PSP_CPP_SRC "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 if(PSP_CPP_BUILD)
@@ -162,8 +151,7 @@ if(PSP_PYTHON_BUILD)
     if(NOT DEFINED PSP_PYTHON_SRC)
         set(PSP_PYTHON_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../../python/perspective/perspective")
     endif()
-
-    # set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Cyan}Building Python ${Red}${PSP_PYTHON_VERSION}${Cyan} binding${ColorReset}")
+    set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Cyan}Building Python ${Red}${PSP_PYTHON_VERSION}${Cyan} binding${ColorReset}")
 else()
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Yellow}Skipping Python binding${ColorReset}")
 endif()
@@ -183,241 +171,221 @@ else()
     set(BUILD_MESSAGE "${BUILD_MESSAGE}\n${Cyan}Building RELEASE${ColorReset}")
 endif()
 
-if(PSP_PYTHON_BUILD AND MACOS)
-    # fix for threads on osx
-    # assume built-in pthreads on MacOS
+
+##########################
+# SYSTEM-SPECIFIC CONFIG #
+##########################
+if(NOT DEFINED PSP_CPP_SRC)
+    set(PSP_CPP_SRC "${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
+
+if(PSP_PYTHON_BUILD)
+    if(NOT WIN32)
+        # Look for the binary using @loader_path (relative to binary location)
+        set(CMAKE_MACOSX_RPATH TRUE)
+        set(CMAKE_SKIP_BUILD_RPATH FALSE)
+        set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+        set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+        set(CMAKE_INSTALL_NAME_DIR "@rpath/")
+    endif()
+endif()
+if(MACOS)
     set(CMAKE_THREAD_LIBS_INIT "-lpthread")
     set(CMAKE_HAVE_THREADS_LIBRARY 1)
     set(CMAKE_USE_WIN32_THREADS_INIT 0)
     set(CMAKE_USE_PTHREADS_INIT 1)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
-
-    # don't link against build python
-    # https://blog.tim-smith.us/2015/09/python-extension-modules-os-x/
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -undefined dynamic_lookup")
-
-    # # TODO This now needs to be set externally because we cross-compile.
-    # # check_c_compiler_flag("-arch x86_64" x86_64Supported)
-    # check_c_compiler_flag("-arch arm64" arm64Supported)
-
-    # if(x86_64Supported AND arm64Supported)
-    #     set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build universal architecture for OSX" FORCE)
-    # elseif(x86_64Supported)
-    #     set(CMAKE_REQUIRED_LINK_OPTIONS "-arch;x86_64")
-    #     set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "Build x86_64 architecture for OSX" FORCE)
-    # elseif(arm64Supported)
-    #     set(CMAKE_REQUIRED_LINK_OPTIONS "-arch;arm64")
-    #     set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Build arm64 architecture for OSX" FORCE)
-    # endif()
 endif()
 
-# ######################
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src/include")
+find_package(Threads REQUIRED)
+set(Threads_FOUND True)
 
+if(PSP_PYTHON_BUILD AND WIN32)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+if(PSP_WASM_BUILD)
+    set(CMAKE_EXECUTABLE_SUFFIX ".js")
+endif()
+
+
+##########################
+# COMPILE AND LINK FLAGS #
+##########################
 # Needs to be set early so that all translation units use it.
-if (NOT PSP_PYODIDE)
+if (NOT PSP_PYODIDE_BUILD)
     set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -fexceptions")
 endif()
 
-if(NOT DEFINED PSP_WASM_EXCEPTIONS AND NOT PSP_PYTHON_BUILD)
-    set(PSP_WASM_EXCEPTIONS ON)
-endif()
+# Common flags for WASM/JS build and Pyodide
+set(PSP_WASM_LINKER_FLAGS " \
+    --no-entry \
+    --closure=1 \
+    -s NO_FILESYSTEM=1 \
+    -s ALLOW_MEMORY_GROWTH=1 \
+    -s MODULARIZE=1 \
+    -s WASM_BIGINT=1 \
+    -s INCOMING_MODULE_JS_API=locateFile,psp_heap_size,psp_stack_trace,HEAPU8,HEAPU32,instantiateWasm \
+    -s TEXTDECODER=2 \
+    -s STANDALONE_WASM=1 \
+    -s DYNAMIC_EXECUTION=0 \
+    -s BINARYEN_EXTRA_PASSES=--one-caller-inline-max-function-size=19306 \
+    -s EXPORT_NAME=\"load_perspective\" \
+    -s MAXIMUM_MEMORY=4gb \
+    -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
+    -s NODEJS_CATCH_EXIT=0 \
+    -s NODEJS_CATCH_REJECTION=0 \
+    -s USE_ES6_IMPORT_META=1 \
+    -s EXPORT_ES6=1 \
+    -s EXPORTED_FUNCTIONS=_js_poll,_js_new_server,_js_free,_js_alloc,_js_handle_request,_js_new_session,_js_close_session \
+")
 
-if(PSP_PYODIDE)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-        -s RELOCATABLE=1 \
-        -s SIDE_MODULE=2 \
+if(PSP_SANITIZE)
+    set(PSP_SANITIZE_FLAGS " \
+        -sINITIAL_MEMORY=640mb \
+        -sTOTAL_MEMORY=640mb \
+        -sALLOW_MEMORY_GROWTH=1 \
     ")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+else()
+    set(PSP_SANITIZE_FLAGS)
 endif()
 
-# if(NOT WIN32)
-# set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
-# set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
-# endif()
+set(CMAKE_CXX_FLAGS_DEBUG "")
+set(CMAKE_CXX_FLAGS_RELEASE "")
 if(PSP_WASM_BUILD)
-    # ###################
-    # EMSCRIPTEN BUILD #
-    # ###################
-    set(CMAKE_EXECUTABLE_SUFFIX ".js")
-    list(APPEND CMAKE_PREFIX_PATH /usr/local)
-
-    # Assumes that Boost includes will be in this folder.
-    include_directories(SYSTEM "/usr/local/include")
-
-    # Include this docker-only directory.
-    include_directories(SYSTEM "/boost_includes")
-
-    set(EXTENDED_FLAGS " \
-        -Wall \
-        -fcolor-diagnostics \
-        ")
-
     if(CMAKE_BUILD_TYPE_LOWER STREQUAL debug)
-        set(OPT_FLAGS " \
+        # WASM DEBUG
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
             -O0 \
             -g3 \
             -Wcast-align \
             -Wover-aligned \
+            -Wall \
+            -fcolor-diagnostics \
             ")
-        if (PSP_WASM_EXCEPTIONS)
-            set(OPT_FLAGS "${OPT_FLAGS} -fwasm-exceptions ")
-        endif()
         if(PSP_SANITIZE)
-            set(OPT_FLAGS "${OPT_FLAGS} \
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
                 -fsanitize=undefined \
                 -fsanitize=address \
             ")
         endif()
     else()
-        set(OPT_FLAGS " \
+        # WASM RELEASE
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
             -O3 \
             -g0 \
             ")
-        if (PSP_WASM_EXCEPTIONS)
-            set(OPT_FLAGS "${OPT_FLAGS} -fwasm-exceptions ")
-        endif()
     endif()
 
-    set(ASYNC_MODE_FLAGS "")
-elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
+    # Clobber existing linker flags
+    set(CMAKE_EXE_LINKER_FLAGS "${PSP_WASM_LINKER_FLAGS}")
+
+elseif(PSP_PYTHON_BUILD)
+    if(PSP_PYODIDE_BUILD)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
+            -s RELOCATABLE=1 \
+            -s SIDE_MODULE=2 \
+            ${PSP_WASM_LINKER_FLAGS} \
+        ")
+    endif()
     if(WIN32)
+        # WINDOWS PYTHON
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+            /EHsc \
+            /MP \
+            /MT \
+            /c \
+            /bigobj \
+        ")
+
+        foreach(warning 4244 4251 4267 4275 4290 4786 4305 4996)
+            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd${warning}")
+        endforeach(warning)
+
         if(CMAKE_BUILD_TYPE_LOWER STREQUAL debug)
-            set(OPT_FLAGS " \
+            # WINDOWS PYTHON DEBUG
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
                 /DEBUG \
                 /Z7 \
-                /Zi
-                ")
+                /Zi \
+            ")
         else()
-            set(OPT_FLAGS " \
-                /NDEBUG \
+            # WINDOWS PYTHON RELEASE
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
                 /O2 \
-                ")
+            ")
         endif()
     else()
         if(CMAKE_BUILD_TYPE_LOWER STREQUAL debug)
-            if (PSP_PYODIDE)
-                set(OPT_FLAGS " \
-                    -O0 \
-                    -g3 \
+            # PYTHON DEBUG
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+                -O0 \
+                -fexceptions \
+                -g3 \
+            ")
+
+            if (PSP_PYODIDE_BUILD)
+                # PYODIDE PYTHON DEBUG
+                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
                     -gsource-map \
                     --profiling \
                     -Wcast-align \
                     -Wover-aligned \
                     ")
-            else ()
-                 set(OPT_FLAGS " \
-                    -O0 \
-                    -fexceptions \
-                    -g3 \
-                    ")
-                 if (PSP_WASM_EXCEPTIONS)
-                     set(OPT_FLAGS "${OPT_FLAGS} -fwasm-exceptions ")
-                 endif()
             endif ()
         else()
-            set(OPT_FLAGS " \
-                -O3 \
+            # PYTHON RELEASE
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+                -O0 \
                 -fexceptions \
                 -g1 \
-                ")
-            if (PSP_WASM_EXCEPTIONS)
-                set(OPT_FLAGS "${OPT_FLAGS} -fwasm-exceptions ")
-            endif()
+            ")
         endif()
-    endif()
-
-    set(ASYNC_MODE_FLAGS "")
-
-    # Boost is a system dependency and must be present and built on the system.
-    if(PSP_PYODIDE)
-        set(CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH};/usr/local/")
-        find_package(Boost REQUIRED)
-    else()
-        set(Boost_USE_STATIC_LIBS ON)
-        find_package(Boost REQUIRED COMPONENTS system)
-    endif()
-
-    if(NOT Boost_FOUND)
-        message(FATAL_ERROR "${Red}Boost could not be located${ColorReset}")
-    else()
-        psp_build_message("${Cyan}Found Boost: `Boost_INCLUDE_DIRS`: ${Boost_INCLUDE_DIRS}, `Boost_LIBRARY_DIRS` - ${Boost_LIBRARY_DIRS} ${ColorReset}")
-
-        if(WIN32)
-            include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-            add_definitions(-DBOOST_UUID_FORCE_AUTO_LINK)
-        endif()
-    endif()
-
-    if(WIN32)
-        foreach(warning 4244 4251 4267 4275 4290 4786 4305 4996)
-            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd${warning}")
-        endforeach(warning)
-
-    # When linking against Boost on Azure, bcrypt fails to link:
-    # - https://github.com/microsoft/vcpkg/issues/4481
-    # - https://github.com/boostorg/uuid/issues/68
-    # add_definitions("-DBOOST_UUID_FORCE_AUTO_LINK")
-    else()
-        include_directories("/usr/local/include")
-    endif()
-
-    if(PSP_PYTHON_BUILD)
-        # ########################
-        # PYTHON BINDINGS BUILD #
-        # ########################
-        set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-        include_directories("${PSP_PYTHON_SRC}/perspective/include")
-
-        if(MANYLINUX)
-            # Manylinux docker images have no shared libraries
-            # The instead use a statically built python.
-            # Cmake's default FindPython can't find the python headers
-            # without also finding (or failing to find) the python libraries
-            # so we use a custom FindPythonHeaders that is the same as the
-            # default, but ignores when the python libraries can't be found.
-            psp_build_message("${Red}Manylinux build has no python shared libraries${ColorReset}")
-            # find_package(Python ${PSP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
-            # find_package(PythonHeaders ${PSP_PYTHON_VERSION} EXACT REQUIRED)
-        else()
-            # psp_build_message("${Cyan}Use python shared libraries${ColorReset}")
-            # if(PSP_PYODIDE)
-            #     find_package(Python ${PSP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
-            # else()
-            #     find_package(Python ${PSP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development.Module)
-            # endif()
-
-            # link_directories(${Python_LIBRARY_DIRS})
-        endif()
-
-        # psp_build_message("${Cyan}Using Python ${Python_VERSION}, \nPython_INCLUDE_DIRS: ${Python_INCLUDE_DIRS}, \nPython_LIBRARIES: ${Python_LIBRARIES}, \nPython_EXECUTABLE: ${Python_EXECUTABLE} ${ColorReset}")
-        # include_directories(${Python_INCLUDE_DIRS})
-
-        # psp_build_dep("pybind11" "${PSP_CMAKE_MODULE_PATH}/Pybind.txt.in")
-
-        # find_package(NumPy REQUIRED)
-
-        # if(NOT PYTHON_NUMPY_FOUND)
-        #     message(FATAL_ERROR "${Red}Numpy could not be located${ColorReset}")
-        # else()
-        #     psp_build_message("${Cyan}Numpy found: ${PYTHON_NUMPY_INCLUDE_DIR}${ColorReset}")
-        #     include_directories(${PYTHON_NUMPY_INCLUDE_DIR})
-        # endif()
-
-        # ####################
     endif()
 endif()
 
+# Wasm Exceptions
+if (PSP_WASM_EXCEPTIONS AND (PSP_WASM_BUILD OR PSP_PYODIDE_BUILD))
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -fwasm-exceptions \
+    ")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
+        -s EXCEPTION_STACK_TRACES=1 \
+        -fwasm-exceptions \
+    ")
+endif()
+
+###############
+# DEFINITIONS #
+###############
+if(PSP_PYTHON_BUILD AND WIN32)
+    add_definitions(-DBOOST_UUID_FORCE_AUTO_LINK)
+endif()
+
+
+################
+# DEPENDENCIES #
+################
+if(NOT WIN32)
+    # Boost is a system dependency and must be present and built on the system.
+    # This makes sure it can be found in user-installed locations, e.g. via
+    # node tools/perspective-scripts/install_tools.mjs
+    set(CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH};/usr/local/;/opt/homebrew")
+    find_package(Boost REQUIRED)
+endif()
+
+
+if(PSP_PYTHON_BUILD)
+    set(Boost_USE_STATIC_LIBS ON)
+    find_package(Boost REQUIRED COMPONENTS system)
+endif()
+
+if(NOT Boost_FOUND)
+    message(FATAL_ERROR "${Red}Boost could not be located${ColorReset}")
+else()
+    psp_build_message("${Cyan}Found Boost: `Boost_INCLUDE_DIRS`: ${Boost_INCLUDE_DIRS}, `Boost_LIBRARY_DIRS` - ${Boost_LIBRARY_DIRS} ${ColorReset}")
+endif()
+
 set(RAPIDJSON_BUILD_TESTS OFF CACHE BOOL "Disable rapidjson tests")
-
-
-set(CMAKE_C_FLAGS "  \
--O3 \
-")
-set(CMAKE_CXX_FLAGS " \
--O3 \
-")
-
 
 # Build header-only dependencies from external source
 psp_build_dep("date" "${PSP_CMAKE_MODULE_PATH}/date.txt.in")
@@ -447,29 +415,28 @@ psp_build_dep("exprtk" "${PSP_CMAKE_MODULE_PATH}/exprtk.txt.in")
 # Protobuf setup
 add_subdirectory(${PSP_CMAKE_MODULE_PATH}/../cpp/protos "${CMAKE_BINARY_DIR}/protos-build")
 
-# ####################
-set(CMAKE_C_FLAGS_DEBUG "")
-set(CMAKE_C_FLAGS_RELEASE "")
-set(CMAKE_C_FLAGS " \
-    ${CMAKE_C_FLAGS} \
-    ${EXTENDED_FLAGS} \
-    ${OPT_FLAGS} \
-    ")
+############
+# INCLUDES #
+############
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src/include")
 
-# prevents the default debug flags from overriding the debug flags we
-# set in OPT_FLAGS
-set(CMAKE_CXX_FLAGS_DEBUG "")
-set(CMAKE_CXX_FLAGS_RELEASE "")
-set(CMAKE_CXX_FLAGS " \
-    ${CMAKE_CXX_FLAGS} \
-    ${EXTENDED_FLAGS} \
-    ${OPT_FLAGS} \
-    ")
+if(PSP_WASM_BUILD)
+    # Assumes that Boost includes will be in one of these folders.
+    include_directories("/usr/local/include")
+    include_directories("/opt/homebrew/include/")
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c++1y")
+    # Include this docker-only directory.
+    include_directories(SYSTEM "/boost_includes")
 endif()
 
+# On windows we use vcpkg
+if(NOT WIN32)
+    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+endif()
+
+################
+# SOURCE FILES #
+################
 set(SOURCE_FILES
     ${PSP_CPP_SRC}/src/cpp/aggregate.cpp
     ${PSP_CPP_SRC}/src/cpp/aggspec.cpp
@@ -482,7 +449,6 @@ set(SOURCE_FILES
     ${PSP_CPP_SRC}/src/cpp/base_impl_wasm.cpp
     ${PSP_CPP_SRC}/src/cpp/base_impl_win.cpp
     # ${PSP_CPP_SRC}/src/cpp/binding.cpp
-
     # ${PSP_CPP_SRC}/src/cpp/build_filter.cpp
     # ${PSP_CPP_SRC}/src/cpp/calc_agg_dtype.cpp
     ${PSP_CPP_SRC}/src/cpp/column.cpp
@@ -562,89 +528,35 @@ set(SOURCE_FILES
     ${PSP_CPP_SRC}/src/cpp/proto_api.cpp
 )
 
-set(PYTHON_SOURCE_FILES ${SOURCE_FILES})
-set(WASM_SOURCE_FILES ${SOURCE_FILES})
-
+################
+# BUILD ASSETS #
+################
 message("${BUILD_MESSAGE}\n")
 
-if(WIN32)
-    set(CMAKE_CXX_FLAGS " /EHsc /MP /MT /c /bigobj")
-else()
-    # set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS}")
-endif()
-
-# Common flags for WASM/JS build and Pyodide
-set(PSP_WASM_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-    --no-entry \
-    --closure=1 \
-    -s NO_FILESYSTEM=1 \
-    -s ALLOW_MEMORY_GROWTH=1 \
-    -s MODULARIZE=1 \
-    -s WASM_BIGINT=1 \
-    -s INCOMING_MODULE_JS_API=locateFile,psp_heap_size,psp_stack_trace,HEAPU8,HEAPU32,instantiateWasm \
-    -s TEXTDECODER=2 \
-    -s STANDALONE_WASM=1 \
-    -s DYNAMIC_EXECUTION=0 \
-    -s BINARYEN_EXTRA_PASSES=--one-caller-inline-max-function-size=19306 \
-    -s EXPORT_NAME=\"load_perspective\" \
-    -s MAXIMUM_MEMORY=4gb \
-    -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
-    -s NODEJS_CATCH_EXIT=0 \
-    -s NODEJS_CATCH_REJECTION=0 \
-    -s USE_ES6_IMPORT_META=1 \
-    -s EXPORT_ES6=1 \
-    -s EXPORTED_FUNCTIONS=_js_poll,_js_new_server,_js_free,_js_alloc,_js_handle_request,_js_new_session,_js_close_session \
-")
-if (PSP_WASM_EXCEPTIONS)
-    set(PSP_WASM_LINKER_FLAGS "${PSP_WASM_LINKER_FLAGS} -s EXCEPTION_STACK_TRACES=1 ")
-endif()
-
-if(PSP_SANITIZE)
-    set(PSP_SANITIZE_FLAGS
-        -sINITIAL_MEMORY=640mb
-        -sTOTAL_MEMORY=640mb
-        -sALLOW_MEMORY_GROWTH=1
-    )
-else()
-    set(PSP_SANITIZE_FLAGS)
-endif()
 
 if(PSP_WASM_BUILD)
-    set(CMAKE_EXE_LINKER_FLAGS "${PSP_WASM_LINKER_FLAGS} --pre-js \"${PSP_CPP_SRC}/env.js\" ")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --pre-js \"${PSP_CPP_SRC}/env.js\" ")
 
-    add_library(psp ${WASM_SOURCE_FILES})
+    add_library(psp ${SOURCE_FILES})
+
     target_compile_definitions(psp PRIVATE PSP_ENABLE_WASM=1)
     set_target_properties(psp PROPERTIES COMPILE_FLAGS "")
     target_link_libraries(psp PRIVATE arrow re2 protos)
+    target_include_directories(psp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
 
     add_executable(perspective_esm src/cpp/emscripten_api.cpp)
     target_link_libraries(perspective_esm psp protos)
     target_compile_definitions(perspective_esm PRIVATE PSP_ENABLE_WASM=1)
-    target_link_options(perspective_esm PUBLIC -sENVIRONMENT="web"  ${PSP_SANITIZE_FLAGS})
+    target_link_options(perspective_esm PUBLIC -sENVIRONMENT="web" "${PSP_SANITIZE_FLAGS}")
+
     set_target_properties(perspective_esm PROPERTIES RUNTIME_OUTPUT_DIRECTORY "./web/")
     set_target_properties(perspective_esm PROPERTIES OUTPUT_NAME "perspective-server")
-elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
-    if(NOT WIN32)
-        set(CMAKE_SHARED_LIBRARY_SUFFIX .so)
 
-        # Look for the binary using @loader_path (relative to binary location)
-        set(CMAKE_MACOSX_RPATH TRUE)
-        set(CMAKE_SKIP_BUILD_RPATH FALSE)
-        set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-        set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-        set(CMAKE_INSTALL_NAME_DIR "@rpath/")
+elseif(PSP_PYTHON_BUILD)
 
-        # module_origin_path is the location of the binary
-        if(MACOS)
-            set(module_origin_path "@loader_path/")
-        else()
-            set(module_origin_path "\$ORIGIN")
-        endif()
-    else()
-        set(CMAKE_SHARED_LIBRARY_PREFIX lib)
-    endif()
+    if(PSP_PYODIDE_BUILD)
 
-    if(PSP_PYODIDE)
+        # TODO
         add_library(psppy SHARED)
         set(PSP_PYTHON_DEFS PSP_ENABLE_WASM=1)
         target_compile_definitions(psppy PRIVATE ${PSP_PYTHON_DEFS})
@@ -653,63 +565,19 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
         target_compile_options(psppy PRIVATE -fvisibility=hidden)
         target_link_libraries(psppy arrow re2)
         add_custom_command(TARGET psppy POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:psppy> ${PSP_PYTHON_SRC}/table/)
+
     elseif(PSP_PYTHON_BUILD)
-        # #######################
-        # Python extra targets #
-        # #######################
-        add_library(psp STATIC ${PYTHON_SOURCE_FILES})
-        # add_library(psppy SHARED ${PYTHON_BINDING_SOURCE_FILES})
 
-        include_directories(${PSP_PYTHON_SRC}/include)
-
+        add_library(psp STATIC ${SOURCE_FILES})
+        target_include_directories(psp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
         target_compile_definitions(psp PRIVATE PSP_ENABLE_PYTHON=1 PSP_PARALLEL_FOR=1)
-        # target_compile_definitions(psppy PRIVATE PSP_ENABLE_PYTHON=1 PSP_PARALLEL_FOR=1)
+        target_link_libraries(psp PRIVATE arrow re2 protos)
 
         if(WIN32)
-            #target_compile_definitions(psppy PRIVATE WIN32=1)
-            # target_compile_definitions(psppy PRIVATE _WIN32=1)
-
-            # .dll not importable
-            # set_property(TARGET psppy PROPERTY SUFFIX .pyd)
-        elseif(MACOS OR NOT MANYLINUX)
-            # target_compile_options(psppy PRIVATE -Wdeprecated-declarations)
-            set_property(TARGET psp PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${module_origin_path})
-            # set_property(TARGET psppy PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${module_origin_path})
-
-            target_compile_options(psp PRIVATE -fvisibility=hidden)
-            # target_compile_options(psppy PRIVATE -fvisibility=hidden)
-        else()
-            # target_compile_options(psppy PRIVATE -Wdeprecated-declarations)
+            target_compile_definitions(psp PRIVATE PERSPECTIVE_EXPORTS=1)
+            target_compile_definitions(psp PRIVATE WIN32=1)
+            target_compile_definitions(psp PRIVATE _WIN32=1)
         endif()
-
-        # Link against minimal arrow static library
-        target_link_libraries(psp PRIVATE arrow re2 protos)
-        # target_link_libraries(psppy psp)
-
-        # The compiled libraries will be put in CMAKE_LIBRARY_OUTPUT_DIRECTORY by default. In the
-        # setup.py file, we designate this to be in the build/lib.<platform> directory. However,
-        # since we want to be able to test perspective in-source, we also copy the libraries into
-        # the source folder. These two commands do that.
-        # add_custom_command(TARGET psp POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:psp> ${PSP_PYTHON_SRC}/table/)
-        # add_custom_command(TARGET psppy POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:psppy> ${PSP_PYTHON_SRC}/table/)
-
-    # #######################
-    else()
-        add_library(psp STATIC ${WASM_SOURCE_FILES})
-        target_compile_options(psp PRIVATE -fvisibility=hidden)
-        target_link_libraries(psp PRIVATE arrow re2 protos)
-    endif()
-
-    if(PSP_CPP_BUILD_STRICT AND NOT WIN32)
-        target_compile_options(psp PRIVATE -Wall -Werror)
-        target_compile_options(psp PRIVATE $<$<CONFIG:DEBUG>:-fPIC -O0>)
-        if(PSP_PYTHON_BUILD)
-            target_compile_options(psppy PRIVATE $<$<CONFIG:DEBUG>:-fPIC -O0>)
-        endif()
-    elseif(WIN32)
-        target_compile_definitions(psp PRIVATE PERSPECTIVE_EXPORTS=1)
-        target_compile_definitions(psp PRIVATE WIN32=1)
-        target_compile_definitions(psp PRIVATE _WIN32=1)
     endif()
 endif()
 
@@ -720,6 +588,3 @@ if(NOT DEFINED ENV{PSP_DISABLE_CLANGD})
     include(SetupClangd)
 endif()
 
-if(NOT WIN32)
-    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-endif()

--- a/cpp/protos/CMakeLists.txt
+++ b/cpp/protos/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18.2)
-project(perspective-protos)
+project(perspective-protos CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -13,16 +13,18 @@ if(NOT DEFINED psp_build_message)
 endif()
 
 # Include the FindProtobuf.cmake module
-list(APPEND CMAKE_MODULE_PATH "../../cmake/modules")
-
-find_package(Protoc REQUIRED)
-find_package(InstallDependency REQUIRED)
-
 if(NOT DEFINED PSP_CMAKE_MODULE_PATH)
     set(PSP_CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
     message(STATUS "PSP_CMAKE_MODULE_PATH not defined, using ${PSP_CMAKE_MODULE_PATH}")
 endif()
+list(APPEND CMAKE_MODULE_PATH "${PSP_CMAKE_MODULE_PATH}/modules")
 
+find_package(Protoc REQUIRED)
+find_package(InstallDependency REQUIRED)
+
+set(protobuf_BUILD_TESTS OFF)
+set(protobuf_HAVE_BUILTIN_ATOMICS TRUE)
+# https://github.com/open-telemetry/opentelemetry-cpp/issues/2998
 psp_build_dep("protobuf" "${PSP_CMAKE_MODULE_PATH}/protobuf.txt.in")
 
 set(PROTO_FILES perspective.proto)


### PR DESCRIPTION
Now that we build our C++ toolchain via rust, we can remove a bunch of code. Additionally, this PR cleans up a lot of the flag setting which has become quite difficult to track and maintain, most recently causing a lot of annoyance during windows build debugging. 

~~It also partially fixes a tangential issue faced when using protobuf with `cmake >=3.30` (NOTE: rust still fails to compile due to https://github.com/MaterializeInc/rust-protobuf-native/issues/20 which I am following up on)~~