### PR TITLE
Fix pyodide release step.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -573,6 +573,10 @@ jobs:
 
             - uses: actions/download-artifact@v4
               with:
+                  name: perspective-python-dist-wasm32-emscripten-3.9
+
+            - uses: actions/download-artifact@v4
+              with:
                   name: perspective-python-sdist
 
             - uses: actions/download-artifact@v4


### PR DESCRIPTION
We need to upload the emscripten wheel in our publish step.