### PR TITLE
Fix `PerspectiveTornadoHandler` misnamed `close()`

### DIFF
--- a/rust/perspective-python/perspective/__init__.py
+++ b/rust/perspective-python/perspective/__init__.py
@@ -71,8 +71,11 @@ class Client(PySyncClient):
         def handle_response(bytes):
             client.handle_response(bytes)
 
+        def handle_close():
+            session.close()
+
         session = server.new_session(handle_response)
-        client = Client(handle_request)
+        client = Client(handle_request, handle_close)
         return client
 
 

--- a/rust/perspective-python/perspective/psp_cffi.py
+++ b/rust/perspective-python/perspective/psp_cffi.py
@@ -77,7 +77,7 @@ class Session:
         self._server: "ServerBase" = server
         self._session_id = lib.psp_new_session(server._server)
 
-    def __del__(self):
+    def close(self):
         lib.psp_close_session(self._server._server, self._session_id)
 
     def handle_request(self, bytes_msg):

--- a/rust/perspective-python/perspective/tests/core/test_async.py
+++ b/rust/perspective-python/perspective/tests/core/test_async.py
@@ -48,7 +48,6 @@ class TestAsync(object):
     @classmethod
     def setup_class(cls):
         cls.loop = tornado.ioloop.IOLoop()
-        cls.loop.make_current()
         cls.thread = threading.Thread(target=cls.loop.start)
         cls.thread.daemon = True
         cls.thread.start()
@@ -56,7 +55,6 @@ class TestAsync(object):
     @classmethod
     def teardown_class(cls):
         cls.loop.add_callback(lambda: tornado.ioloop.IOLoop.current().stop())
-        cls.loop.clear_current()
         cls.thread.join()
         cls.loop.close(all_fds=True)
 

--- a/rust/perspective-python/perspective/tests/server/test_server.py
+++ b/rust/perspective-python/perspective/tests/server/test_server.py
@@ -43,6 +43,12 @@ class TestServer(object):
         table2 = client.open_table("table1")
         assert table2.schema() == {"a": "integer", "b": "string"}
 
+    def test_session_close(self):
+        server = Server()
+        client = Client.from_server(server)
+        client.table(data)
+        client.terminate()
+
     def test_server_host(self):
         server = Server()
         client = Client.from_server(server)

--- a/rust/perspective-python/perspective/tests/server/test_session.py
+++ b/rust/perspective-python/perspective/tests/server/test_session.py
@@ -32,7 +32,7 @@ class TestProxySession(object):
             sub_client.handle_response(bytes)
 
         sub_session = ProxySession(client, handle_response)
-        sub_client = Client(handle_request)
+        sub_client = Client(handle_request, sub_session.close)
         table = sub_client.table(data, name="table1")
         assert table.schema() == {"a": "integer", "b": "string"}
 
@@ -47,7 +47,7 @@ class TestProxySession(object):
             sub_client.handle_response(bytes)
 
         sub_session = ProxySession(client, handle_response)
-        sub_client = Client(handle_request)
+        sub_client = Client(handle_request, sub_session.close)
         table = sub_client.table(data, name="table1")
         table2 = client.open_table("table1")
         assert table.size() == 3

--- a/rust/perspective-python/perspective/tests/table/test_table_pandas.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_pandas.py
@@ -117,7 +117,7 @@ class TestTablePandas(object):
 
     @mark.skip(reason="pyarrow dataframe does not support date inference")
     def test_table_dataframe_infer_date(self, util):
-        data = util.make_dataframe(freq="M")
+        data = util.make_dataframe(freq="ME")
 
         tbl = Table(data)
         assert tbl.size() == 10
@@ -143,7 +143,7 @@ class TestTablePandas(object):
         ]
 
     def test_table_dataframe_infer_date_fixed(self, util):
-        data = util.make_dataframe(freq="M")
+        data = util.make_dataframe(freq="ME")
 
         tbl = Table(data)
         assert tbl.size() == 10
@@ -169,7 +169,7 @@ class TestTablePandas(object):
         ]
 
     def test_table_dataframe_infer_time(self, util):
-        data = util.make_dataframe(freq="H")
+        data = util.make_dataframe(freq="h")
 
         tbl = Table(data)
         assert tbl.size() == 10
@@ -196,7 +196,7 @@ class TestTablePandas(object):
 
     @mark.skip(reason="pyarrow dataframe does not support date inference")
     def test_table_dataframe_year_start_index(self, util):
-        data = util.make_dataframe(freq="AS")
+        data = util.make_dataframe(freq="YS")
 
         tbl = Table(data)
         assert tbl.size() == 10
@@ -222,7 +222,7 @@ class TestTablePandas(object):
         ]
 
     def test_table_dataframe_year_start_index_fixed(self, util):
-        data = util.make_dataframe(freq="AS")
+        data = util.make_dataframe(freq="YS")
 
         tbl = Table(data)
         assert tbl.size() == 10
@@ -249,7 +249,7 @@ class TestTablePandas(object):
 
     @mark.skip(reason="pyarrow dataframe does not support date inference")
     def test_table_dataframe_quarter_index(self, util):
-        data = util.make_dataframe(size=4, freq="Q")
+        data = util.make_dataframe(size=4, freq="QE")
 
         tbl = Table(data)
         assert tbl.size() == 4
@@ -269,7 +269,7 @@ class TestTablePandas(object):
         ]
 
     def test_table_dataframe_quarter_index_fixed(self, util):
-        data = util.make_dataframe(size=4, freq="Q")
+        data = util.make_dataframe(size=4, freq="QE")
 
         tbl = Table(data)
         assert tbl.size() == 4

--- a/rust/perspective-python/perspective/viewer/viewer_traitlets.py
+++ b/rust/perspective-python/perspective/viewer/viewer_traitlets.py
@@ -52,7 +52,7 @@ class PerspectiveTraitlets(HasTraits):
     table_name = Unicode(None, allow_none=True).tag(sync=True)
 
     server = Bool(False).tag(sync=True)
-    binding_mode = Enum(("server", "client-server"), default="server").tag(sync=True)
+    binding_mode = Enum(("server", "client-server")).tag(default="server", sync=True)
     title = Unicode(None, allow_none=True).tag(sync=True)
     version = Unicode(__version__).tag(sync=True)
 

--- a/rust/perspective-python/src/client/client_sync.rs
+++ b/rust/perspective-python/src/client/client_sync.rs
@@ -84,8 +84,8 @@ pub struct Client(PyClient);
 #[pymethods]
 impl Client {
     #[new]
-    pub fn new(callback: Py<PyAny>) -> PyResult<Self> {
-        let client = PyClient::new(callback);
+    pub fn new(handle_request: Py<PyAny>, close_cb: Py<PyAny>) -> PyResult<Self> {
+        let client = PyClient::new(handle_request, close_cb);
         Ok(Client(client))
     }
 
@@ -124,6 +124,11 @@ impl Client {
     pub fn set_loop_callback(&self, loop_cb: Py<PyAny>) -> PyResult<()> {
         self.0.set_loop_cb(loop_cb).block_on()
     }
+
+    #[doc = crate::inherit_docs!("client/terminate.md")]
+    pub fn terminate(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        self.0.terminate(py).block_on()
+    }
 }
 
 #[doc = crate::inherit_docs!("table.md")]
@@ -140,8 +145,8 @@ impl Table {
     }
 
     #[doc = crate::inherit_docs!("table/get_client.md")]
-    pub fn get_client(&self, loop_cb: Option<Py<PyAny>>) -> Client {
-        Client(self.0.get_client(loop_cb).block_on())
+    pub fn get_client(&self) -> Client {
+        Client(self.0.get_client().block_on())
     }
 
     #[doc = crate::inherit_docs!("table/get_client.md")]

--- a/rust/perspective/src/lib.rs
+++ b/rust/perspective/src/lib.rs
@@ -33,10 +33,23 @@
 //!     .iter()
 //!     .map(|x| Some(x.to_string()))
 //!     .collect();
-
+//!
 //! let view = table.view(Some(view_config)).await?;
 //! let arrow = view.to_arrow(ViewWindow::default()).await?;
 //! ```
+//!
+//! # See also
+//!
+//! - [`perspective-js`](https://docs.rs/perspective-js/latest/) for the
+//!   JavaScript API.
+//! - [`perspective-python`](https://docs.rs/perspective-python/latest/) for the
+//!   Python API.
+//! - [`perspective-server`](https://docs.rs/perspective-python/latest/) for
+//!   Data Binding details.
+//! - [`perspective-client`](https://docs.rs/perspective-python/latest/) for the
+//!   Rust Client API
+//! - [`perspective-viewer`](https://docs.rs/perspective-viewer/latest/) for the
+//!   WebAssembly `<perspective-viewer>` Custom Element API.
 
 #[cfg(feature = "axum-ws")]
 pub mod axum;


### PR DESCRIPTION
* #2707 moved the C++ API from `perspective-server`, but also changed the API (from `close` to `__del__`). 
Fixes #2719
* Added `Client::terminate` to the Python client (so `Session::close` can be tested with the (only) synchronous `Client`).
* Added tests and removed test warnings.
