### PR TITLE
Fix link error in emscripten wheel

### DIFF
--- a/cpp/perspective/src/cpp/vendor/arrow_single_threaded_reader.cpp
+++ b/cpp/perspective/src/cpp/vendor/arrow_single_threaded_reader.cpp
@@ -998,8 +998,8 @@ namespace csv {
 
     Result<std::shared_ptr<TableReader>>
     TableReader::Make(
-        const io::IOContext& io_context,
-        const std::shared_ptr<io::InputStream>& input,
+        const io::IOContext io_context,
+        const std::shared_ptr<io::InputStream> input,
         const ReadOptions& read_options,
         const ParseOptions& parse_options,
         const ConvertOptions& convert_options

--- a/cpp/perspective/src/include/perspective/vendor/arrow_single_threaded_reader.h
+++ b/cpp/perspective/src/include/perspective/vendor/arrow_single_threaded_reader.h
@@ -59,7 +59,7 @@ namespace csv {
 
         /// Create a TableReader instance
         static Result<std::shared_ptr<TableReader>>
-        Make(const io::IOContext& io_context, const std::shared_ptr<io::InputStream>& input, const ReadOptions&, const ParseOptions&, const ConvertOptions&);
+        Make(io::IOContext io_context, std::shared_ptr<io::InputStream> input, const ReadOptions&, const ParseOptions&, const ConvertOptions&);
 
         ARROW_DEPRECATED(
             "Use MemoryPool-less variant (the IOContext holds a pool already)"

--- a/packages/perspective-jupyterlab/test/jupyter/widget.spec.mts
+++ b/packages/perspective-jupyterlab/test/jupyter/widget.spec.mts
@@ -167,15 +167,12 @@ describe_jupyter(
                 let edit_mode = await getEditMode(viewer);
                 expect(edit_mode).toEqual("READ_ONLY");
 
-                console.error("Fuck1");
                 await add_and_execute_cell(
                     page,
                     'w.plugin_config = {"edit_mode": "EDIT"}'
                 );
 
-                console.error("Fuck2");
                 edit_mode = await getEditMode(viewer);
-                console.error("Fuck3");
                 expect(edit_mode).toEqual("EDIT");
             }
         );

--- a/rust/perspective-server/build/main.rs
+++ b/rust/perspective-server/build/main.rs
@@ -32,7 +32,6 @@ fn main() -> Result<(), std::io::Error> {
 
     std::fs::write("docs/lib_gen.md", markdown.as_ref())?;
     if std::option_env!("PSP_DISABLE_CPP").is_none() {
-        println!("cargo:warning=MESSAGE FUCKED");
         if let Some(artifact_dir) = psp::cmake_build()? {
             psp::cmake_link_deps(&artifact_dir)?;
             psp::cxx_bridge_build();


### PR DESCRIPTION
Fixes an issue with `perspective-python`'s emscripten wheel which caused some functions to fail with missing symbol errors.