### PR TITLE
Support packaging in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,6 +20,7 @@ frequency = 'never'
 
 [unstable]
 bindeps = true
+package-workspace = true
 
 [term]
 quiet = false

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -148,7 +148,7 @@ runs:
           uses: dtolnay/rust-toolchain@nightly
           if: ${{ inputs.rust == 'true' && inputs.arch != 'aarch64' }}
           with:
-              toolchain: nightly-2024-05-07
+              toolchain: nightly-2024-08-29
               targets: wasm32-unknown-unknown
               components: rustfmt, clippy, rust-src
 
@@ -156,7 +156,7 @@ runs:
           uses: dtolnay/rust-toolchain@nightly
           if: ${{ inputs.rust == 'true' && inputs.arch == 'aarch64' && runner.os == 'macOS' }}
           with:
-              toolchain: nightly-2024-05-07
+              toolchain: nightly-2024-08-29
               targets: aarch64-apple-darwin
               components: rustfmt, clippy, rust-src
 
@@ -164,7 +164,7 @@ runs:
           uses: dtolnay/rust-toolchain@nightly
           if: ${{ inputs.rust == 'true' && inputs.arch == 'aarch64' && runner.os == 'Linux' }}
           with:
-              toolchain: nightly-2024-05-07
+              toolchain: nightly-2024-08-29
               targets: aarch64-unknown-linux-gnu
               components: rustfmt, clippy, rust-src
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -11,6 +11,6 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 [toolchain]
-channel = "nightly-2024-05-07"
+channel = "nightly-2024-08-29"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["wasm32-unknown-unknown", "wasm32-unknown-emscripten"]

--- a/rust/bootstrap-runtime/lib.rs
+++ b/rust/bootstrap-runtime/lib.rs
@@ -37,6 +37,7 @@ use alloc::vec::Vec;
 
 use zune_inflate::DeflateDecoder;
 
+#[allow(unused_unsafe)]
 #[global_allocator]
 static ALLOCATOR: talc::Talck<talc::locking::AssumeUnlockable, talc::ClaimOnOom> = {
     static mut MEMORY: [u8; 64000000] = [0; 64000000];

--- a/rust/perspective-client/src/rust/config/plugin.rs
+++ b/rust/perspective-client/src/rust/config/plugin.rs
@@ -46,9 +46,11 @@ pub struct DefaultStyleAttributes {
     pub bool: serde_json::Value,
 }
 
-/// The data needed to populate a column's settings. These are typically default
-/// values, a listing of possible values, or other basic configuration settings
-/// for the plugin. This is the result of calling plugin.plugin_attributes
+/// The data needed to populate a column's settings.
+///
+/// These are typically default values, a listing of possible values, or other
+/// basic configuration settings for the plugin. This is the result of calling
+/// plugin.plugin_attributes
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct PluginAttributes {
     pub symbol: Option<SymbolAttributes>,

--- a/rust/perspective-client/src/rust/session.rs
+++ b/rust/perspective-client/src/rust/session.rs
@@ -22,12 +22,12 @@ use crate::{Client, ClientError};
 #[cfg(doc)]
 use crate::{Table, View};
 
-/// The server-side representation of a connection to a
-/// [`Client`]. For each [`Client`] that
-/// wants to connect to a `perspective_server::Server`, a dedicated [`Session`]
-/// must be created. The [`Session`] handles routing messages emitted by the
-/// `perspective_server::Server`ve_server::Server`, as well as owning any
-/// resources the [`Client`] may request.
+/// The server-side representation of a connection to a [`Client`].
+///
+/// For each [`Client`] that wants to connect to a `perspective_server::Server`,
+/// a dedicated [`Session`] must be created. The [`Session`] handles routing
+/// messages emitted by the `perspective_server::Server`ve_server::Server`, as
+/// well as owning any resources the [`Client`] may request.
 pub trait Session<E> {
     /// Handle an incoming request from the [`Client`]. Calling
     /// [`Session::handle_request`] will result in the `send_response` parameter

--- a/rust/perspective-client/src/rust/table.rs
+++ b/rust/perspective-client/src/rust/table.rs
@@ -32,9 +32,7 @@ use crate::view::View;
 pub type Schema = HashMap<String, ColumnType>;
 
 /// Options which impact the behavior of [`Client::table`], as well as
-/// subsequent calls to [`Table::update`], even though this latter method
-/// itself does not take [`TableInitOptions`] as an argument, since this
-/// parameter is fixed at creation.
+/// subsequent calls to [`Table::update`].
 #[derive(Clone, Debug, Default, Serialize, Deserialize, TS)]
 pub struct TableInitOptions {
     #[serde(default)]

--- a/rust/perspective-js/src/rust/utils/console_logger.rs
+++ b/rust/perspective-js/src/rust/utils/console_logger.rs
@@ -200,11 +200,12 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WasmLogger {
     }
 }
 
-/// Configure `WasmLogger` as a global default for tracing. This operation will
-/// conflict with any other library which sets a global default
-/// `tracing::Subscriber`, so it should not be called when `perspective` is used
-/// as a library from a larger app; in this case the app itself should configure
-/// `tracing` explicitly.
+/// Configure `WasmLogger` as a global default for tracing.
+///
+/// This operation will conflict with any other library which sets a global
+/// default `tracing::Subscriber`, so it should not be called when `perspective`
+/// is used as a library from a larger app; in this case the app itself should
+/// configure `tracing` explicitly.
 pub fn set_global_logging() {
     static INIT_LOGGING: OnceLock<()> = OnceLock::new();
     INIT_LOGGING.get_or_init(|| {

--- a/rust/perspective-js/src/rust/utils/errors.rs
+++ b/rust/perspective-js/src/rust/utils/errors.rs
@@ -15,7 +15,9 @@ use std::fmt::Display;
 use wasm_bindgen::prelude::*;
 
 /// A bespoke error class for chaining a litany of various error types with the
-/// `?` operator.  `anyhow`, `web_sys::JsError` are candidates for replacing
+/// `?` operator.  
+///
+/// `anyhow`, `web_sys::JsError` are candidates for replacing
 /// this, but we'd need a way to get around syntacitc conveniences we get
 /// from avoiding orphan instance issues (e.g. converting `JsValue` to an error
 /// in `anyhow`).
@@ -23,6 +25,7 @@ use wasm_bindgen::prelude::*;
 /// We'd still like to implement this, but instead must independently implement
 /// the instance for each error, as otherwise `rustc` will complain that the
 /// `wasm_bindgen` authors may themselves implement `Error` for `JsValue`.
+///
 /// ```
 /// impl<T> From<T> for ApiError
 /// where

--- a/rust/perspective-js/src/rust/utils/futures.rs
+++ b/rust/perspective-js/src/rust/utils/futures.rs
@@ -25,7 +25,9 @@ use wasm_bindgen_futures::{future_to_promise, JsFuture};
 use super::errors::*;
 
 /// A newtype wrapper for a `Future` trait object which supports being
-/// marshalled to a `JsPromise`, avoiding an API which requires type casting to
+/// marshalled to a `JsPromise`.
+///
+/// This avoids implementing an API which requires type casting to
 /// and from `JsValue` and the associated loss of type safety.
 #[must_use]
 pub struct ApiFuture<T>(Pin<Box<dyn Future<Output = ApiResult<T>>>>)

--- a/rust/perspective-viewer/src/less/status-bar.less
+++ b/rust/perspective-viewer/src/less/status-bar.less
@@ -140,10 +140,6 @@
             flex: 0 1000000 auto;
             .button {
                 height: 22px;
-                select {
-                    height: 20px;
-                    font-size: var(--label--font-size, 0.75em);
-                }
             }
         }
 
@@ -295,10 +291,15 @@
         }
 
         #theme {
+            height: 48px;
             &:before {
                 -webkit-mask-image: url("../svg/theme-icon.svg");
                 mask-image: url("../svg/theme-icon.svg");
             }
+        }
+
+        #menu-bar .button select#theme_selector {
+            height: 48px;
         }
 
         .button {

--- a/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
@@ -81,7 +81,9 @@ pub enum DragDropListMsg {
 }
 
 /// A sub-selector for a list-like component of a `JsViewConfig`, such as
-/// `filters` and `sort`.  `DragDropList` is parameterized by two `Component`
+/// `filters` and `sort`.  
+///
+/// `DragDropList` is parameterized by two `Component`
 /// types, the parent component `T` and the inner item compnent `U`, which must
 /// additionally implement `DragDropListItemProps` trait on its own `Properties`
 /// associated type.

--- a/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/datetime_column_style.rs
@@ -94,9 +94,7 @@ impl PartialEq for DatetimeColumnStyleProps {
     }
 }
 
-/// The `ColumnStyle` component stores its UI state privately in its own struct,
-/// rather than its props (which has two version of this data itself, the
-/// JSON serializable config record and the defaults record).
+/// Column style controls for the `datetime` type.
 #[derive(Debug)]
 pub struct DatetimeColumnStyle {
     config: DatetimeColumnStyleConfig,

--- a/rust/perspective-viewer/src/rust/components/form/mod.rs
+++ b/rust/perspective-viewer/src/rust/components/form/mod.rs
@@ -11,9 +11,10 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 //! A module for form controls (though form controls like `<Select>` which are
-//! also container elements should go in the `containers` module).  Components
-//! in this module should not be imported from the `components` parent module
-//! directly.
+//! also container elements should go in the `containers` module).
+//!
+//! Components in this module should not be imported from the `components`
+//! parent module directly.
 
 pub mod code_editor;
 pub mod color_range_selector;

--- a/rust/perspective-viewer/src/rust/components/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/number_column_style.rs
@@ -43,8 +43,10 @@ pub enum NumberColumnStyleMsg {
 }
 
 /// A `ColumnStyle` component is mounted to the window anchored at the screen
-/// position of `elem`.  It needs two input configs, the current configuration
-/// object and a default version without `Option<>`
+/// position of `elem`.
+///
+/// It needs two input configs, the current configuration object and a default
+/// version without `Option<>`
 #[derive(Properties)]
 pub struct NumberColumnStyleProps {
     #[cfg_attr(test, prop_or_default)]
@@ -97,9 +99,7 @@ impl NumberColumnStyleProps {
     }
 }
 
-/// The `ColumnStyle` component stores its UI state privately in its own struct,
-/// rather than its props (which has two version of this data itself, the
-/// JSON serializable config record and the defaults record).
+/// A column style form control for `number` columns.
 pub struct NumberColumnStyle {
     config: NumberColumnStyleConfig,
     default_config: NumberColumnStyleDefaultConfig,

--- a/rust/perspective-viewer/src/rust/components/string_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/string_column_style.rs
@@ -52,9 +52,7 @@ impl PartialEq for StringColumnStyleProps {
     }
 }
 
-/// The `ColumnStyle` component stores its UI state privately in its own struct,
-/// rather than its props (which has two version of this data itself, the
-/// JSON serializable config record and the defaults record).
+/// A component for the style form control for [`String`] columns.
 pub struct StringColumnStyle {
     config: StringColumnStyleConfig,
     default_config: StringColumnStyleDefaultConfig,

--- a/rust/perspective-viewer/src/rust/components/style/mod.rs
+++ b/rust/perspective-viewer/src/rust/components/style/mod.rs
@@ -11,12 +11,14 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 //! A micro-framework for associating local CSS snippets with `yew::Component`s
-//! in a Custom Element's `ShadowRoot`.  Embedding a `<LocalStyle>` element
-//! will only create the underlying `<style>` tag once (when `Component::view()`
-//! is called the first time), even if multiple copies of the `Component`
-//! exist in the tree.
+//! in a Custom Element's `ShadowRoot`.
+//!
+//! Embedding a `<LocalStyle>` element will only create the underlying `<style>`
+//! tag once (when `Component::view()` is called the first time), even if
+//! multiple copies of the `Component` exist in the tree.
 //!
 //! # Example
+//!
 //! ```
 //! html! {
 //!     <StyleProvider>

--- a/rust/perspective-viewer/src/rust/components/style/style_provider.rs
+++ b/rust/perspective-viewer/src/rust/components/style/style_provider.rs
@@ -24,9 +24,10 @@ pub struct StyleProviderProps {
 }
 
 /// A context which injects any CSS snippet registered within its tree, doing
-/// so only once for each unqiue snippet name.  CSS can be registered within
-/// sub-components via the `<LocalStyle>` component and `css!()` resource
-/// inlining macro.
+/// so only once for each unqiue snippet name.
+///
+/// CSS can be registered within sub-components via the `<LocalStyle>` component
+/// and `css!()` resource inlining macro.
 pub struct StyleProvider {
     cache: StyleCache,
 }

--- a/rust/perspective-viewer/src/rust/config/columns_config.rs
+++ b/rust/perspective-viewer/src/rust/config/columns_config.rs
@@ -86,6 +86,7 @@ impl ColumnConfigValues {
 }
 
 /// The controls returned by plugin.column_style_controls.
+///
 /// This is a way to fill out default values for the given controls.
 /// If a control is not given, it will not be rendered. I would like to
 /// eventually show these as inactive values.

--- a/rust/perspective-viewer/src/rust/config/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/config/number_column_style.rs
@@ -118,10 +118,11 @@ pub struct NumberColumnStyleConfig {
 
 derive_wasm_abi!(NumberColumnStyleConfig, FromWasmAbi, IntoWasmAbi);
 
-/// Exactly like a `ColumnStyleConfig`, except without `Option<>` fields, as
-/// this struct represents the default values we should use in the GUI when they
-/// are `None` in the real config.  It is also used to decide when to omit a
-/// field when serialized a `ColumnStyleConfig` to JSON.
+/// Exactly like a `ColumnStyleConfig`, except without `Option<>` fields.
+///
+/// Necessary because this struct represents the default values we should use in
+/// the GUI when they are `None` in the real config.  It is also used to decide
+/// when to omit a field when serialized a `ColumnStyleConfig` to JSON.
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
 pub struct NumberColumnStyleDefaultConfig {
     pub fg_gradient: f64,

--- a/rust/perspective-viewer/src/rust/custom_elements/debug_plugin.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/debug_plugin.rs
@@ -15,12 +15,13 @@ use wasm_bindgen::prelude::*;
 use crate::utils::*;
 use crate::*;
 
-/// The `<perspective-viewer-plugin>` element, the default perspective plugin
-/// which is registered and activated automcatically when a
-/// `<perspective-viewer>` is loaded without plugins.  While you will not
-/// typically instantiate this class directly, it is simple enough to function
-/// as a good "default" plugin implementation which can be extended to create
-/// custom plugins.
+/// The `<perspective-viewer-plugin>` element.
+///
+/// The default perspective plugin which is registered and activated
+/// automcatically when a `<perspective-viewer>` is loaded without plugins.
+/// While you will not typically instantiate this class directly, it is simple
+/// enough to function as a good "default" plugin implementation which can be
+/// extended to create custom plugins.
 ///
 /// # Example
 /// ```javascript

--- a/rust/perspective-viewer/src/rust/custom_elements/modal.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/modal.rs
@@ -28,8 +28,10 @@ use crate::utils::*;
 type BlurHandlerType = Rc<RefCell<Option<Closure<dyn FnMut(FocusEvent)>>>>;
 
 /// A `ModalElement` wraps the parameterized yew `Component` in a Custom
-/// Element. Via the `open()` and `close()` methods, a `ModalElement` can be
-/// positioned next to any existing on-page elements, accounting for viewport,
+/// Element.
+///
+/// Via the `open()` and `close()` methods, a `ModalElement` can be positioned
+/// next to any existing on-page elements, accounting for viewport,
 /// scroll position, etc.
 ///
 /// `#[derive(Clone)]` generates the trait bound `T: Clone`, which is not

--- a/rust/perspective-viewer/src/rust/exprtk/cursor.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/cursor.rs
@@ -13,6 +13,8 @@
 use perspective_client::ExprValidationError;
 use yew::prelude::*;
 
+/// A tokenizer cursor for ExprTK parsing.
+///
 /// Because ExprTK reports errors in column/row coordinates and visually needs
 /// to be applied to an entire token rather than a single character, we need
 /// fairly obnoxious counter logic to figure out how to generate the resulting

--- a/rust/perspective-viewer/src/rust/exprtk/tokenize.rs
+++ b/rust/perspective-viewer/src/rust/exprtk/tokenize.rs
@@ -28,10 +28,11 @@ use self::number::*;
 use self::string::*;
 use self::symbol::*;
 
-/// Syntax-highlightable ExprTK tokens. We had the option of implemnting this
-/// alternatively as `pub struct Token(TokenType, &'a str);`, but I felt this
-/// was less ergonomic for the frequent pattern matching necessary when handling
-/// enum tokens.
+/// Syntax-highlightable ExprTK tokens.
+///
+///  We had the option of implemnting this alternatively as `pub struct
+/// Token(TokenType, &'a str);`, but I felt this was less ergonomic for the
+/// frequent pattern matching necessary when handling enum tokens.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Token<'a> {
     Comment(&'a str),

--- a/rust/perspective-viewer/src/rust/js/testing.rs
+++ b/rust/perspective-viewer/src/rust/js/testing.rs
@@ -60,8 +60,10 @@ extern "C" {
 
 /// A macro which set a property called `weak_link` on the container
 /// `Properties` when `cfg(test)`, such that unit tests may send messages to a
-/// component. This macro needs to be called in `create()` on any Component
-/// which needs to receive messages in a test.
+/// component.
+///
+/// This macro needs to be called in `create()` on any Component which needs to
+/// receive messages in a test.
 #[macro_export]
 macro_rules! enable_weak_link_test {
     ($props:expr, $link:expr) => {

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -13,7 +13,6 @@
 // Required by yew's `html` macro.
 #![recursion_limit = "1024"]
 #![feature(const_type_name)]
-#![feature(lazy_cell)]
 #![feature(let_chains)]
 #![feature(macro_metavar_expr)]
 #![feature(iter_intersperse)]
@@ -120,6 +119,7 @@ pub fn registerPlugin(name: &str) {
 // }
 
 /// Register this crate's Custom Elements in the browser's current session.
+///
 /// This must occur before calling any public API methods on these Custom
 /// Elements from JavaScript, as the methods themselves won't be defined yet.
 /// By default, this crate does not register `PerspectiveViewerElement` (as to
@@ -133,7 +133,9 @@ pub fn js_init() {
 }
 
 /// Register Web Components with the global registry, given a Perspective
-/// module.  This function shouldn't be called directly;  instead, use the
+/// module.
+///
+/// This function shouldn't be called directly;  instead, use the
 /// `define_web_components!` macro to both call this method and hook the
 /// wasm_bindgen module object.
 pub fn bootstrap_web_components(psp: &JsValue) {

--- a/rust/perspective-viewer/src/rust/model/columns_iter_set.rs
+++ b/rust/perspective-viewer/src/rust/model/columns_iter_set.rs
@@ -58,6 +58,8 @@ impl ActiveColumnState {
 
 type Label = Option<String>;
 
+/// An iterator for columns state.
+///
 /// Encapsulates the logic of determining which columns go in the "Active" and
 /// "Inactive" column sections of the `ColumnSelector` component, via the
 /// iterator returning functions `active()`, `inactive()` and `expression()`.

--- a/rust/perspective-viewer/src/rust/model/copy_export.rs
+++ b/rust/perspective-viewer/src/rust/model/copy_export.rs
@@ -32,6 +32,8 @@ fn tag_name_to_package(plugin: &JsPerspectiveViewerPlugin) -> String {
     Itertools::intersperse(tag_parts, "-".to_owned()).collect::<String>()
 }
 
+/// A model trait for Copy/Export UI task behavior,
+///
 /// Export functionality, for downloads and copy-to-clipboard, are mostly shared
 /// behavior, but require access to a few state objects depending on which
 /// format is desired.  The `CopyExportModel` groups this functionality in a

--- a/rust/perspective-viewer/src/rust/model/get_viewer_config.rs
+++ b/rust/perspective-viewer/src/rust/model/get_viewer_config.rs
@@ -25,12 +25,15 @@ use crate::session::*;
 use crate::*;
 
 /// A `ViewerConfig` is constructed from various properties acrosss the
-/// application state, including the current `Plugin`, `ViewConfig`, and
-/// `Theme`.  `GetViewerConfigModel` provides methods which should be used to
-/// get the applications `ViewerConfig` from across these state objects.
+/// application state
+///
+/// For example, the current `Plugin`, `ViewConfig`, and `Theme`.
+/// `GetViewerConfigModel` provides methods which should be used to get the
+/// applications `ViewerConfig` from across these state objects.
 pub trait GetViewerConfigModel: HasSession + HasRenderer + HasPresentation {
     /// As these methods are asynchronous, it is commonly useful to be able to
     /// discretely `.clone()` the state objects for dispatching to `async`.
+    ///
     /// Calling `.cloned()` yields just the state object clones of
     /// `GetViewerConfigModel` which itself implements this trait and other
     /// `crate::model` traits.

--- a/rust/perspective-viewer/src/rust/model/plugin_column_styles.rs
+++ b/rust/perspective-viewer/src/rust/model/plugin_column_styles.rs
@@ -19,19 +19,20 @@ use crate::derive_model;
 use crate::renderer::Renderer;
 use crate::session::Session;
 
-/// TODO: This pattern of creating query objects to pass around would be
-/// redundant if we had a grab-bag of models to clone around.
-/// We could easily generate all the needed types for this in a proc_macro
-/// crate. e.g. create structs like `SessionAndRendererModel {session,
-/// renderer}` which are then called through a proc_macro like
-/// `get_model!(Session, Renderer for self)` where the function is defined as
-/// `get_model! => {($($name:ty),+ for $owner:ident)}`
-///
-/// Or, we could just lump
-/// all the state into a single object where all these model functions are
-/// defined. Generally, we could keep the hub-and-spoke architecture "under the
-/// hood", but just not expose it to the yew framework, since it requires a lot
-/// of unecessary prop-drilling and complexity.
+// TODO: This pattern of creating query objects to pass around would be
+// redundant if we had a grab-bag of models to clone around.
+// We could easily generate all the needed types for this in a proc_macro
+// crate. e.g. create structs like `SessionAndRendererModel {session,
+// renderer}` which are then called through a proc_macro like
+// `get_model!(Session, Renderer for self)` where the function is defined as
+// `get_model! => {($($name:ty),+ for $owner:ident)}`
+//
+// Or, we could just lump
+// all the state into a single object where all these model functions are
+// defined. Generally, we could keep the hub-and-spoke architecture "under the
+// hood", but just not expose it to the yew framework, since it requires a lot
+// of unecessary prop-drilling and complexity.
+
 #[derive(Clone)]
 pub struct PluginColumnStylesQuery {
     session: Session,

--- a/rust/perspective-viewer/src/rust/model/update_and_render.rs
+++ b/rust/perspective-viewer/src/rust/model/update_and_render.rs
@@ -19,6 +19,8 @@ use crate::session::Session;
 use crate::utils::*;
 use crate::*;
 
+/// A model trait for updating both `View` state and completing a render.
+///
 /// While `Renderer` manages the plugin and thus the render call itself, the
 /// current `View` is handled by the `Session` which must be validated and
 /// locked while drawing is in progress.  `UpdateAndRender` provides methods

--- a/rust/perspective-viewer/src/rust/utils/mod.rs
+++ b/rust/perspective-viewer/src/rust/utils/mod.rs
@@ -11,9 +11,10 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 //! A catch all for project-wide macros and general-purpose functions that are
-//! not directly related to Perspective.  Modules below `crate::utils` strive
-//! to be single-responsibility, but some reference other `crate::utils`
-//! modules when it helps reduce boiler-plate.
+//! not directly related to Perspective.
+//!
+//! Modules below `crate::utils` strive to be single-responsibility, but some
+//! reference other `crate::utils` modules when it helps reduce boiler-plate.
 
 mod browser;
 

--- a/rust/perspective-viewer/src/rust/utils/pubsub.rs
+++ b/rust/perspective-viewer/src/rust/utils/pubsub.rs
@@ -79,8 +79,10 @@ impl<T: Clone> PubSubInternal<T> {
 }
 
 /// A pub/sub struct which allows many listeners to subscribe to many
-/// publishers, without leaking callbacks as listeners are dropped. Unlike
-/// `mpsc` etc., `PubSub` has no internal queue and is completely synchronous.
+/// publishers, without leaking callbacks as listeners are dropped.
+///
+/// Unlike `mpsc` etc., `PubSub` has no internal queue and is completely
+/// synchronous.
 #[derive(Derivative)]
 #[derivative(Default(bound = ""))]
 pub struct PubSub<T: Clone>(Rc<PubSubInternal<T>>);
@@ -198,9 +200,10 @@ impl<T: Clone> PartialEq for Subscriber<T> {
 }
 
 /// Manages the lifetime of a listener registered to a `PubSub<T>` by
-/// deregistering the associated listener when dropped.  The wrapped `Fn` of
-/// `Subscriptions` is the deregister closure provided by the issuing
-/// `PubSub<T>`.
+/// deregistering the associated listener when dropped.
+///
+/// The wrapped `Fn` of `Subscriptions` is the deregister closure provided by
+/// the issuing `PubSub<T>`.
 #[must_use]
 pub struct Subscription(Box<dyn Fn()>);
 

--- a/rust/perspective-viewer/src/rust/utils/tee.rs
+++ b/rust/perspective-viewer/src/rust/utils/tee.rs
@@ -11,6 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 /// Trait for polymorphic return value via turbofish-const-generic syntax.
+///
 /// The associated type `Output` is a functional dependency of the const generic
 /// parameter `N`, so there's typically no need to specify this parameter when
 /// invoking, which is what we want - this parameter is quite verbose and
@@ -21,15 +22,17 @@ pub trait TeeInternal<const N: usize> {
 }
 
 pub trait Tee {
-    /// Extension method to add `tee()` method to all `T: Clone`. This can't be
-    /// done directly as part of `TeeInternal` because it makes specifying the
-    /// const param at the `tee()` invocation site cumbersome:
-    /// `TeeInternal::<N>::tee(&obj)` as opposed to `obj.tee::<N>()`. The
-    /// constraint `Self: TeeInternal<N>` collapses the potential `impl` matches
-    /// to exactly 1, which makes the call to `tee_internal()` unambiguous.
-    /// This constraint is also allowed to contain the generic parameter `N`
-    /// because it is specified as a constraint to the method (as opposed to
-    /// a constraint on the trait). I'm honestly quite surprised this works ...
+    /// Extension method to add `tee()` method to all `T: Clone`.
+    ///
+    /// This can't be done directly as part of `TeeInternal` because it makes
+    /// specifying the const param at the `tee()` invocation site
+    /// cumbersome: `TeeInternal::<N>::tee(&obj)` as opposed to
+    /// `obj.tee::<N>()`. The constraint `Self: TeeInternal<N>` collapses
+    /// the potential `impl` matches to exactly 1, which makes the call to
+    /// `tee_internal()` unambiguous. This constraint is also allowed to
+    /// contain the generic parameter `N` because it is specified as a
+    /// constraint to the method (as opposed to a constraint on the trait).
+    /// I'm honestly quite surprised this works ...
     ///
     /// # Examples
     ///


### PR DESCRIPTION
#2734 introduced packaging in CI for `perspective` and other Rust crates, but apparently [`cargo package` does not work correctly inside a workspace](https://github.com/rust-lang/cargo/issues/10948) due to the unpublished version numbers of sibling crates being verified against the upstream repo.

This PR updates the rust toolchain to version which supports the cargo feature `package-workspace`, which fixes this issue. Upgrading caused some new lint violations, which also needed correction.