### PR TITLE
Added new decimal decoration for chart tooltips 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
+# [v3.0.2](https://github.com/finos/perspective/releases/tag/v3.0.2)
+
+_30 August 2024_ ([Full changelog](https://github.com/finos/perspective/compare/v3.0.1...v3.0.2))
+
+Fixes
+
+- Fix link error in emscripten wheel [#2726](https://github.com/finos/perspective/pull/2726)
+- Fix `PerspectiveTornadoHandler` misnamed `close()` [#2720](https://github.com/finos/perspective/pull/2720)
+- fix: Doctype in html export [#2690](https://github.com/finos/perspective/pull/2690)
+
 # [v3.0.1](https://github.com/finos/perspective/releases/tag/v3.0.1)
 
-_26 August 2024_ ([Full changelog](https://github.com/finos/perspective/compare/v3.0.0...v3.0.1))
+_25 August 2024_ ([Full changelog](https://github.com/finos/perspective/compare/v3.0.0...v3.0.1))
 
 Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "perspective"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "async-lock",
  "axum",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "perspective-client"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "async-lock",
  "futures",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "perspective-js"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "perspective-lint"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "glob",
  "yew-fmt",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "perspective-python"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "async-lock",
  "cmake",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "perspective-server"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "async-lock",
  "base64 0.22.1",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "perspective-viewer"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "async-lock",

--- a/cpp/perspective/package.json
+++ b/cpp/perspective/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "author": "The Perspective Authors",
     "license": "Apache-2.0",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "main": "./dist/esm/perspective.cpp.js",
     "files": [
         "dist/esm/**/*",

--- a/cpp/perspective/src/cpp/vendor/arrow_single_threaded_reader.cpp
+++ b/cpp/perspective/src/cpp/vendor/arrow_single_threaded_reader.cpp
@@ -998,8 +998,8 @@ namespace csv {
 
     Result<std::shared_ptr<TableReader>>
     TableReader::Make(
-        const io::IOContext& io_context,
-        const std::shared_ptr<io::InputStream>& input,
+        const io::IOContext io_context,
+        const std::shared_ptr<io::InputStream> input,
         const ReadOptions& read_options,
         const ParseOptions& parse_options,
         const ConvertOptions& convert_options

--- a/cpp/perspective/src/include/perspective/vendor/arrow_single_threaded_reader.h
+++ b/cpp/perspective/src/include/perspective/vendor/arrow_single_threaded_reader.h
@@ -59,7 +59,7 @@ namespace csv {
 
         /// Create a TableReader instance
         static Result<std::shared_ptr<TableReader>>
-        Make(const io::IOContext& io_context, const std::shared_ptr<io::InputStream>& input, const ReadOptions&, const ParseOptions&, const ConvertOptions&);
+        Make(io::IOContext io_context, std::shared_ptr<io::InputStream> input, const ReadOptions&, const ParseOptions&, const ConvertOptions&);
 
         ARROW_DEPRECATED(
             "Use MemoryPool-less variant (the IOContext holds a pool already)"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-docs",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "private": true,
     "scripts": {
         "docusaurus": "docusaurus",

--- a/docs/src/components/Demo/layouts.js
+++ b/docs/src/components/Demo/layouts.js
@@ -12,7 +12,7 @@
 
 export const LAYOUTS = {
     sparkgrid: {
-        version: "3.0.1",
+        version: "3.0.2",
         plugin: "Datagrid",
         plugin_config: {
             columns: {},

--- a/examples/blocks/package.json
+++ b/examples/blocks/package.json
@@ -1,7 +1,7 @@
 {
     "name": "blocks",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "A collection of simple client-side Perspective examples for `http://bl.ocks.org`.",
     "scripts": {
         "start": "mkdirp dist && node --experimental-modules server.mjs",

--- a/examples/esbuild-example/package.json
+++ b/examples/esbuild-example/package.json
@@ -1,7 +1,7 @@
 {
     "name": "esbuild-example",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An esbuild example app built using `@finos/perspective-viewer`.",
     "scripts": {
         "build": "node build.js",

--- a/examples/esbuild-remote/package.json
+++ b/examples/esbuild-remote/package.json
@@ -1,7 +1,7 @@
 {
     "name": "esbuild-remote",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An example of 2 Perspectives, one client and one server, streaming via Apache Arrow.",
     "scripts": {
         "start": "node build.js && node server/index.mjs"

--- a/examples/python-aiohttp/package.json
+++ b/examples/python-aiohttp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "python-aiohttp",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An example of editing a `perspective-python` server from the browser.",
     "scripts": {
         "start": "PYTHONPATH=../../python/perspective python3 server.py"

--- a/examples/python-starlette/package.json
+++ b/examples/python-starlette/package.json
@@ -1,7 +1,7 @@
 {
     "name": "python-starlette",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An example of editing a `perspective-python` server from the browser.",
     "scripts": {
         "start": "PYTHONPATH=../../python/perspective python3 server.py"

--- a/examples/python-tornado-streaming/package.json
+++ b/examples/python-tornado-streaming/package.json
@@ -1,7 +1,7 @@
 {
     "name": "python-tornado-streaming",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An example of streaming a `perspective-python` server to the browser.",
     "scripts": {
         "start": "PYTHONPATH=../../python/perspective python3 server.py"

--- a/examples/python-tornado/package.json
+++ b/examples/python-tornado/package.json
@@ -1,7 +1,7 @@
 {
     "name": "python-tornado",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An example of editing a `perspective-python` server from the browser.",
     "scripts": {
         "start": "PYTHONPATH=../../python/perspective python3 server.py"

--- a/examples/react-example/package.json
+++ b/examples/react-example/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-example",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An example app built using `@finos/perspective-viewer`.",
     "scripts": {
         "start": "webpack serve --open",

--- a/examples/rust-axum/Cargo.toml
+++ b/examples/rust-axum/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-perspective = { version = "3.0.1", path = "../../rust/perspective" }
+perspective = { version = "3.0.2", path = "../../rust/perspective" }
 axum = { version = ">=0.7,<2", features = ["ws"] }
 futures = "0.3"
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/rust-axum/package.json
+++ b/examples/rust-axum/package.json
@@ -1,7 +1,7 @@
 {
     "name": "rust-axum",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An example of a Rust/Axum virtual Perspective server",
     "scripts": {
         "start": "cargo run"

--- a/examples/webpack-example/package.json
+++ b/examples/webpack-example/package.json
@@ -1,7 +1,7 @@
 {
     "name": "webpack-example",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An example app built using `@finos/perspective-viewer`.",
     "scripts": {
         "webpack_build": "webpack",

--- a/examples/workspace/package.json
+++ b/examples/workspace/package.json
@@ -1,7 +1,7 @@
 {
     "name": "workspace",
     "private": true,
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "An example app built using `@finos/perspective-workspace`.",
     "scripts": {
         "start": "webpack serve --open",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/finos/perspective"
     },
-    "version": "3.0.1",
+    "version": "3.0.2",
     "changelog": {
         "labels": {
             "enhancement": "Added",

--- a/packages/perspective-cli/package.json
+++ b/packages/perspective-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-cli",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Perspective.js CLI",
     "main": "src/js/index.js",
     "publishConfig": {

--- a/packages/perspective-esbuild-plugin/package.json
+++ b/packages/perspective-esbuild-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-esbuild-plugin",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "esbuild plugin for Perspective",
     "author": "",
     "license": "Apache-2.0",

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-jupyterlab",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "A Jupyterlab extension for the Perspective library, designed to be used with perspective-python.",
     "files": [
         "dist/**/*",

--- a/packages/perspective-jupyterlab/test/jupyter/widget.spec.mts
+++ b/packages/perspective-jupyterlab/test/jupyter/widget.spec.mts
@@ -167,15 +167,12 @@ describe_jupyter(
                 let edit_mode = await getEditMode(viewer);
                 expect(edit_mode).toEqual("READ_ONLY");
 
-                console.error("Fuck1");
                 await add_and_execute_cell(
                     page,
                     'w.plugin_config = {"edit_mode": "EDIT"}'
                 );
 
-                console.error("Fuck2");
                 edit_mode = await getEditMode(viewer);
-                console.error("Fuck3");
                 expect(edit_mode).toEqual("EDIT");
             }
         );

--- a/packages/perspective-viewer-d3fc/package.json
+++ b/packages/perspective-viewer-d3fc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-viewer-d3fc",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Perspective.js D3FC Plugin",
     "unpkg": "./dist/cdn/perspective-viewer-d3fc.js",
     "jsdelivr": "./dist/cdn/perspective-viewer-d3fc.js",

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -523,7 +523,7 @@
         color: var(--d3fc-tooltip--color, black);
         border: 1px solid var(--d3fc-tooltip--border-color, #777777);
         box-shadow: var(--d3fc-tooltip--box-shadow, none);
-        pointer-events: none;
+        pointer-events: none
     }
 
     div.tooltip ul {

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -523,7 +523,7 @@
         color: var(--d3fc-tooltip--color, black);
         border: 1px solid var(--d3fc-tooltip--border-color, #777777);
         box-shadow: var(--d3fc-tooltip--box-shadow, none);
-        pointer-events: none
+        pointer-events: none;
     }
 
     div.tooltip ul {

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -523,7 +523,7 @@
         color: var(--d3fc-tooltip--color, black);
         border: 1px solid var(--d3fc-tooltip--border-color, #777777);
         box-shadow: var(--d3fc-tooltip--box-shadow, none);
-        pointer-events: none;
+        pointer-events: none
     }
 
     div.tooltip ul {
@@ -531,4 +531,11 @@
         padding: 0;
         list-style-type: none;
     }
+
+    span.decimal-spacing {
+        padding-left: 0.15em;
+        padding-right: 0.15em;
+        font-weight: bold;  
+    }
+
 }

--- a/packages/perspective-viewer-d3fc/src/ts/tooltip/generateHTML.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/tooltip/generateHTML.ts
@@ -38,8 +38,9 @@ function addDataValues(tooltipDiv, values) {
 const formatNumber = (value) =>
     value === null || value === undefined
         ? "-"
-        : value.toLocaleString(undefined, {
+        : (value.toLocaleString(undefined, {
               style: "decimal",
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
-          });
+            // allow for decimal character decoration 
+          })).replace(".","<span class='decimal-spacing'>.</span>");

--- a/packages/perspective-viewer-datagrid/package.json
+++ b/packages/perspective-viewer-datagrid/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-viewer-datagrid",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Perspective datagrid plugin based on `regular-table`",
     "unpkg": "dist/cdn/perspective-viewer-datagrid.js",
     "jsdelivr": "dist/cdn/perspective-viewer-datagrid.js",

--- a/packages/perspective-viewer-openlayers/package.json
+++ b/packages/perspective-viewer-openlayers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-viewer-openlayers",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "unpkg": "dist/cdn/perspective-viewer-openlayers.js",
     "jsdelivr": "dist/cdn/perspective-viewer-openlayers.js",
     "exports": {

--- a/packages/perspective-webpack-plugin/package.json
+++ b/packages/perspective-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-webpack-plugin",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Perspective.js Webpack Plugin",
     "main": "index.js",
     "publishConfig": {

--- a/packages/perspective-workspace/package.json
+++ b/packages/perspective-workspace/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-workspace",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Perspective Workspace",
     "files": [
         "dist/**/*",

--- a/rust/lint/Cargo.toml
+++ b/rust/lint/Cargo.toml
@@ -13,7 +13,7 @@
 [package]
 name = "perspective-lint"
 description = "A CLI utility to lint rust code"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 publish = false
 

--- a/rust/perspective-client/Cargo.toml
+++ b/rust/perspective-client/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "perspective-client"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Andrew Stein <steinlink@gmail.com>"]
 edition = "2021"
 description = "A data visualization and analytics component, especially well-suited for large and/or streaming datasets."

--- a/rust/perspective-js/Cargo.toml
+++ b/rust/perspective-js/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "perspective-js"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Andrew Stein <steinlink@gmail.com>"]
 edition = "2021"
 description = "A data visualization and analytics component, especially well-suited for large and/or streaming datasets."
@@ -48,7 +48,7 @@ anyhow = "1.0.66"
 wasm-bindgen-test = "0.3.13"
 
 [dependencies]
-perspective-client = { path = "../perspective-client", version = "3.0.1" }
+perspective-client = { path = "../perspective-client", version = "3.0.2" }
 base64 = "0.13.0"
 chrono = "0.4"
 extend = "1.1.2"

--- a/rust/perspective-js/package.json
+++ b/rust/perspective-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "",
     "repository": {
         "type": "git",

--- a/rust/perspective-python/Cargo.toml
+++ b/rust/perspective-python/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "perspective-python"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 description = "A data visualization and analytics component, especially well-suited for large and/or streaming datasets."
 repository = "https://github.com/finos/perspective"
@@ -54,8 +54,8 @@ python-config-rs = "0.1.2"
 
 [dependencies]
 async-lock = "2.5.0"
-perspective-client = { version = "3.0.1", path = "../perspective-client" }
-# perspective-server = { version = "3.0.1", path = "../perspective-server" }
+perspective-client = { version = "3.0.2", path = "../perspective-client" }
+# perspective-server = { version = "3.0.2", path = "../perspective-server" }
 pollster = "0.3.0"
 extend = "1.1.2"
 futures = "0.3.28"

--- a/rust/perspective-python/package.json
+++ b/rust/perspective-python/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-python",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "",
     "private": true,
     "repository": {

--- a/rust/perspective-python/perspective/__init__.py
+++ b/rust/perspective-python/perspective/__init__.py
@@ -10,7 +10,7 @@
 #  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 __all__ = [
     "_jupyter_labextension_paths",
     "PerspectiveError",

--- a/rust/perspective-python/pyproject.toml
+++ b/rust/perspective-python/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = ["Jinja2>=2.0,<4", "ipywidgets>=7.5.1,<9"]
 
 [tool.maturin]
 module-name = "perspective"
-data = "perspective_python-3.0.1.data"
+data = "perspective_python-3.0.2.data"
 features = ["pyo3/extension-module"]
 include = [
     { path = "perspective/*libpsp.so", format = "wheel" },

--- a/rust/perspective-server/Cargo.toml
+++ b/rust/perspective-server/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "perspective-server"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Andrew Stein <steinlink@gmail.com>"]
 edition = "2021"
 description = "A data visualization and analytics component, especially well-suited for large and/or streaming datasets."
@@ -47,7 +47,7 @@ regex = "~1"
 base64 = ">=0.22.1"
 
 [dependencies]
-perspective-client = { version = "3.0.1", path = "../perspective-client" }
+perspective-client = { version = "3.0.2", path = "../perspective-client" }
 async-lock = "2.5.0"
 cxx = { version = "1.0.92", features = ["c++17"] }
 tracing = { version = ">=0.1.36" }

--- a/rust/perspective-server/build/main.rs
+++ b/rust/perspective-server/build/main.rs
@@ -32,7 +32,6 @@ fn main() -> Result<(), std::io::Error> {
 
     std::fs::write("docs/lib_gen.md", markdown.as_ref())?;
     if std::option_env!("PSP_DISABLE_CPP").is_none() {
-        println!("cargo:warning=MESSAGE FUCKED");
         if let Some(artifact_dir) = psp::cmake_build()? {
             psp::cmake_link_deps(&artifact_dir)?;
             psp::cxx_bridge_build();

--- a/rust/perspective-viewer/Cargo.toml
+++ b/rust/perspective-viewer/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "perspective-viewer"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Andrew Stein <steinlink@gmail.com>"]
 edition = "2021"
 description = "A data visualization and analytics component, especially well-suited for large and/or streaming datasets."
@@ -50,8 +50,8 @@ anyhow = "1.0.66"
 wasm-bindgen-test = "0.3.13"
 
 [dependencies]
-perspective-client = { path = "../perspective-client", version = "3.0.1" }
-perspective-js = { path = "../perspective-js", version = "3.0.1" }
+perspective-client = { path = "../perspective-client", version = "3.0.2" }
+perspective-js = { path = "../perspective-js", version = "3.0.2" }
 
 # Provides async `Mutex` for locked sections such as `render`
 async-lock = "2.5.0"

--- a/rust/perspective-viewer/package.json
+++ b/rust/perspective-viewer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-viewer",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "The `<perspective-viewer>` Custom Element, frontend for Perspective.js",
     "repository": {
         "type": "git",

--- a/rust/perspective/Cargo.toml
+++ b/rust/perspective/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "perspective"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Andrew Stein <steinlink@gmail.com>"]
 edition = "2021"
 description = "A data visualization and analytics component, especially well-suited for large and/or streaming datasets."
@@ -36,8 +36,8 @@ external-cpp = [
 
 [dependencies]
 async-lock = "2.5.0"
-perspective-client = { version = "3.0.1", path = "../perspective-client" }
-perspective-server = { version = "3.0.1", path = "../perspective-server" }
+perspective-client = { version = "3.0.2", path = "../perspective-client" }
+perspective-server = { version = "3.0.2", path = "../perspective-server" }
 tracing = { version = ">=0.1.36" }
 
 axum = { version = ">=0.7,<2", features = ["ws"], optional = true }

--- a/tools/perspective-bench/basic_suite.mjs
+++ b/tools/perspective-bench/basic_suite.mjs
@@ -280,7 +280,7 @@ suite(
             const { default: perspective } = await import("@finos/perspective");
             client = await perspective.websocket(path);
             metadata = {
-                version: "3.0.1",
+                version: "3.0.2",
                 version_idx,
             };
         } else {

--- a/tools/perspective-scripts/package.json
+++ b/tools/perspective-scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-scripts",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Build scripts based on perspective",
     "private": true,
     "files": [

--- a/tools/perspective-test/package.json
+++ b/tools/perspective-test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@finos/perspective-test",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Test utility based on perspective",
     "private": true,
     "main": "src/js/index.ts",


### PR DESCRIPTION
This change resolves #1006 by adding simple padding and bold decoration to presented decimal numbers. 
It is a non-breaking feature, that allows easy visibility of a decimal place at first glance that works with any theme or colour. 

This is with decoration: 
![Screenshot 2024-09-03 170207](https://github.com/user-attachments/assets/c7b6ab01-b611-4044-9d6e-604cd78b7efa)
This is without: 
![undecoratedScreenshot 2024-09-03 170246](https://github.com/user-attachments/assets/6a9b07d8-6fad-44ce-9668-af914274930e)

