### PR TITLE
<TAB> key press inserts '\t' character in code editor as indentation

### DIFF
--- a/rust/perspective-viewer/src/rust/components/form/code_editor.rs
+++ b/rust/perspective-viewer/src/rust/components/form/code_editor.rs
@@ -74,6 +74,25 @@ fn on_keydown(event: KeyboardEvent, deps: &(UseStateSetter<u32>, Callback<()>)) 
     if event.shift_key() && event.key_code() == 13 {
         event.prevent_default();
         deps.1.emit(())
+    }    
+
+    // handle the tab key press
+    if event.key() == "Tab" {
+        event.prevent_default();
+
+        let caret_pos = elem.selection_start().unwrap().unwrap_or_default() as usize;
+
+        let mut initial_text = elem.value();
+
+        // insert "\t" at the caret_pos
+        initial_text.insert_str(caret_pos, "\t");
+
+        elem.set_value(&initial_text);
+
+        // place caret after inserted tab
+        let new_caret_pos = Some((caret_pos + 1) as u32).unwrap_or_default();
+        let _ = elem.set_selection_range(new_caret_pos, new_caret_pos);
+        
     }
 }
 


### PR DESCRIPTION
Hi all,
This PR fixes #2703.
I updated the function `on_keydown` to ignore the default behavior of the <TAB> key.