### PR TITLE
Fix missing data on tooltip

### DIFF
--- a/packages/perspective-viewer-d3fc/src/ts/tooltip/selectionData.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/tooltip/selectionData.ts
@@ -70,7 +70,7 @@ export function getDataValues(data, settings) {
         }
         return settings.mainValues.map((main) => ({
             name: main.name,
-            value: toValue(main.type, data.row[main.name]),
+            value: toValue(main.type, data.row[getDataRowKey(data.key, main)]),
         }));
     }
     return [
@@ -85,4 +85,19 @@ export function getDataValues(data, settings) {
             ),
         },
     ];
+}
+
+function getDataRowKey(key, main) {
+    if (!key) {
+        return main.name;
+    }
+
+    let splitValues = key.split("|");
+    splitValues =
+        splitValues.length === 1
+            ? splitValues
+            : splitValues.slice(0, splitValues.length - 1);
+    const prefix = splitValues.join("|");
+
+    return `${prefix}|${main.name}`;
 }


### PR DESCRIPTION
This PR addresses the bug reported in #2575 and #2254 where tooltip data labels were missing their corresponding values when multiple data values are configured. The issue stemmed from an invalid property used to fetch tooltip data from the `data.row` JSON, which was missing a required “prefix”. This has now been corrected.