### PR TITLE
Allow `bytes` and `string` for JSON/CSV input data with `format` option

### DIFF
--- a/rust/perspective-client/docs/client/table.md
+++ b/rust/perspective-client/docs/client/table.md
@@ -33,6 +33,10 @@ is stored and all calculation occurs.
         data.
     -   `name` - The name of the table. This will be generated if it is not
         provided.
+    -   `format` - The explicit format of the input data, can be one of
+        `"json"`, `"columns"`, `"csv"` or `"arrow"`. This overrides
+        language-specific type dispatch behavior, which allows stringified and
+        byte array alternative inputs.
 
 <div class="javascript">
 
@@ -49,6 +53,16 @@ Load an Arrow from an `ArrayBuffer`:
 ```javascript
 import * as fs from "node:fs/promises";
 const table2 = await client.table(await fs.readFile("superstore.arrow"));
+```
+
+Load a CSV from a `UInt8Array` (the default for this type is Arrow) using a
+format override:
+
+```javascript
+const enc = new TextEncoder();
+const table = await client.table(enc.encode("x,y\n1,2\n3,4"), {
+    format: "csv",
+});
 ```
 
 Create a table with an `index`:

--- a/rust/perspective-client/src/rust/lib.rs
+++ b/rust/perspective-client/src/rust/lib.rs
@@ -28,7 +28,9 @@ pub mod utils;
 
 pub use crate::client::{Client, ClientHandler, Features, SystemInfo};
 pub use crate::session::{ProxySession, Session};
-pub use crate::table::{Schema, Table, TableInitOptions, UpdateOptions, ValidateExpressionsData};
+pub use crate::table::{
+    Schema, Table, TableInitOptions, TableReadFormat, UpdateOptions, ValidateExpressionsData,
+};
 pub use crate::table_data::{TableData, UpdateData};
 pub use crate::view::{OnUpdateMode, OnUpdateOptions, View, ViewWindow};
 

--- a/rust/perspective-client/src/rust/table.rs
+++ b/rust/perspective-client/src/rust/table.rs
@@ -31,6 +31,34 @@ use crate::view::View;
 
 pub type Schema = HashMap<String, ColumnType>;
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, TS)]
+pub enum TableReadFormat {
+    #[serde(rename = "csv")]
+    Csv,
+
+    #[serde(rename = "json")]
+    JsonString,
+
+    #[serde(rename = "columns")]
+    ColumnsString,
+
+    #[serde(rename = "arrow")]
+    Arrow,
+}
+
+impl TableReadFormat {
+    pub fn parse(value: Option<String>) -> Result<Option<Self>, String> {
+        Ok(match value.as_deref() {
+            Some("csv") => Some(TableReadFormat::Csv),
+            Some("json") => Some(TableReadFormat::JsonString),
+            Some("columns") => Some(TableReadFormat::ColumnsString),
+            Some("arrow") => Some(TableReadFormat::Arrow),
+            None => None,
+            Some(x) => return Err(format!("Unknown format \"{}\"", x)),
+        })
+    }
+}
+
 /// Options which impact the behavior of [`Client::table`], as well as
 /// subsequent calls to [`Table::update`].
 #[derive(Clone, Debug, Default, Serialize, Deserialize, TS)]
@@ -38,6 +66,10 @@ pub struct TableInitOptions {
     #[serde(default)]
     #[ts(optional)]
     pub name: Option<String>,
+
+    #[serde(default)]
+    #[ts(optional)]
+    pub format: Option<TableReadFormat>,
 
     /// This [`Table`] should use the column named by the `index` parameter as
     /// the `index`, which causes [`Table::update`] and [`Client::table`] input
@@ -101,6 +133,7 @@ impl From<TableInitOptions> for TableOptions {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, TS)]
 pub struct UpdateOptions {
     pub port_id: Option<u32>,
+    pub format: Option<TableReadFormat>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/rust/perspective-js/src/rust/client.rs
+++ b/rust/perspective-js/src/rust/client.rs
@@ -76,11 +76,11 @@ impl Client {
         value: &JsTableInitData,
         options: Option<JsTableInitOptions>,
     ) -> ApiResult<Table> {
-        let args = TableData::from_js_value(value)?;
         let options = options
             .into_serde_ext::<Option<TableInitOptions>>()?
             .unwrap_or_default();
 
+        let args = TableData::from_js_value(value, options.format)?;
         Ok(Table(self.client.table(args, options).await?))
     }
 

--- a/rust/perspective-js/src/rust/utils/errors.rs
+++ b/rust/perspective-js/src/rust/utils/errors.rs
@@ -11,6 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 use std::fmt::Display;
+use std::string::FromUtf8Error;
 
 use perspective_client::ClientError;
 use wasm_bindgen::prelude::*;
@@ -84,7 +85,8 @@ define_api_error!(
     futures::channel::oneshot::Canceled,
     base64::DecodeError,
     chrono::ParseError,
-    prost::DecodeError
+    prost::DecodeError,
+    FromUtf8Error
 );
 
 #[wasm_bindgen(inline_js = r#"

--- a/rust/perspective-js/test/js/constructors/csv.spec.ts
+++ b/rust/perspective-js/test/js/constructors/csv.spec.ts
@@ -13,41 +13,11 @@
 import { test, expect } from "@finos/perspective-test";
 import perspective from "../perspective_client";
 
-const TEST_JSON = { x: [1, 4], y: [2, 5], z: [3, 6] };
+const CSV = "x,y,z\n1,2,3\n4,5,6";
 
-test.describe("JSON", function () {
-    test.describe("Integer columns", function () {
-        test("Integer columns can be updated with all JSON numeric types and cousins", async function () {
-            const table = await perspective.table({ x: "integer" });
-            await table.update([{ x: 0 }]);
-            await table.update([{ x: 1 }]);
-            await table.update([{ x: undefined }]);
-            await table.update([{ x: null }]);
-            await table.update([{ x: 7.23 }]);
-            await table.update([{ x: -6 }]);
-            await table.update([{ x: Infinity }]);
-            await table.update([{ x: "100.1" }]);
-            await table.update([{ x: "11" }]);
-            const v = await table.view();
-            const json = await v.to_json();
-            expect(json).toEqual([
-                { x: 0 },
-                { x: 1 },
-                { x: null },
-                { x: null },
-                { x: 7 },
-                { x: -6 },
-                { x: null },
-                { x: 100 },
-                { x: 11 },
-            ]);
-        });
-    });
-
+test.describe("CSV Constructors", function () {
     test("Handles String format", async function () {
-        const table = await perspective.table(JSON.stringify(TEST_JSON), {
-            format: "columns",
-        });
+        const table = await perspective.table(CSV);
         const v = await table.view();
         const json = await v.to_json();
         expect(json).toEqual([
@@ -56,14 +26,10 @@ test.describe("JSON", function () {
         ]);
     });
 
-    test("Handles UInt8Array format", async function () {
-        const enc = new TextEncoder();
-        const table = await perspective.table(
-            enc.encode(JSON.stringify(TEST_JSON)),
-            {
-                format: "columns",
-            }
-        );
+    test("Handles String format with explicit format option", async function () {
+        const table = await perspective.table(CSV, {
+            format: "csv",
+        });
         const v = await table.view();
         const json = await v.to_json();
         expect(json).toEqual([
@@ -73,13 +39,23 @@ test.describe("JSON", function () {
     });
 
     test("Handles ArrayBuffer format", async function () {
-        const enc = new TextEncoder();
-        const table = await perspective.table(
-            enc.encode(JSON.stringify(TEST_JSON)).buffer,
-            {
-                format: "columns",
-            }
-        );
+        var enc = new TextEncoder();
+        const table = await perspective.table(enc.encode(CSV).buffer, {
+            format: "csv",
+        });
+        const v = await table.view();
+        const json = await v.to_json();
+        expect(json).toEqual([
+            { x: 1, y: 2, z: 3 },
+            { x: 4, y: 5, z: 6 },
+        ]);
+    });
+
+    test("Handles UInt8Arry format", async function () {
+        var enc = new TextEncoder();
+        const table = await perspective.table(enc.encode(CSV), {
+            format: "csv",
+        });
         const v = await table.view();
         const json = await v.to_json();
         expect(json).toEqual([

--- a/rust/perspective-python/perspective/tests/table/test_table.py
+++ b/rust/perspective-python/perspective/tests/table/test_table.py
@@ -82,6 +82,15 @@ class TestTable:
             "float": [None, 2.5, None],
         }
 
+    def test_table_records_from_string_with_format_override(self):
+        data = '{"x": [1,2,3], "y": [4,5,6]}'
+        tbl = Table(data, format="columns")
+        view = tbl.view()
+        assert view.to_columns() == {
+            "x": [1, 2, 3],
+            "y": [4, 5, 6],
+        }
+
     def test_table_string_column_with_nulls_update_and_filter(self):
         tbl = Table(
             [

--- a/rust/perspective-python/src/client/client_sync.rs
+++ b/rust/perspective-python/src/client/client_sync.rs
@@ -104,7 +104,7 @@ impl Client {
     }
 
     #[doc = crate::inherit_docs!("client/table.md")]
-    #[pyo3(signature = (input, limit=None, index=None, name=None))]
+    #[pyo3(signature = (input, limit=None, index=None, name=None, format=None))]
     pub fn table(
         &self,
         py: Python<'_>,
@@ -112,9 +112,12 @@ impl Client {
         limit: Option<u32>,
         index: Option<Py<PyString>>,
         name: Option<Py<PyString>>,
+        format: Option<Py<PyString>>,
     ) -> PyResult<Table> {
         Ok(Table(
-            self.0.table(input, limit, index, name).py_block_on(py)?,
+            self.0
+                .table(input, limit, index, name, format)
+                .py_block_on(py)?,
         ))
     }
 
@@ -196,9 +199,10 @@ impl Table {
     }
 
     #[doc = crate::inherit_docs!("table/remove.md")]
-    pub fn remove(&self, input: Py<PyAny>) -> PyResult<()> {
+    #[pyo3(signature = (input, format=None))]
+    pub fn remove(&self, input: Py<PyAny>, format: Option<String>) -> PyResult<()> {
         let table = self.0.clone();
-        table.remove(input).block_on()
+        table.remove(input, format).block_on()
     }
 
     #[doc = crate::inherit_docs!("table/remove_delete.md")]
@@ -231,15 +235,21 @@ impl Table {
     }
 
     #[doc = crate::inherit_docs!("table/update.md")]
-    #[pyo3(signature = (input))]
-    pub fn replace(&self, input: Py<PyAny>) -> PyResult<()> {
-        self.0.replace(input).block_on()
+    #[pyo3(signature = (input, format=None))]
+    pub fn replace(&self, input: Py<PyAny>, format: Option<String>) -> PyResult<()> {
+        self.0.replace(input, format).block_on()
     }
 
     #[doc = crate::inherit_docs!("table/update.md")]
-    #[pyo3(signature = (input, port_id=None))]
-    pub fn update(&self, py: Python<'_>, input: Py<PyAny>, port_id: Option<u32>) -> PyResult<()> {
-        self.0.update(input, port_id).py_block_on(py)
+    #[pyo3(signature = (input, port_id=None, format=None))]
+    pub fn update(
+        &self,
+        py: Python<'_>,
+        input: Py<PyAny>,
+        port_id: Option<u32>,
+        format: Option<String>,
+    ) -> PyResult<()> {
+        self.0.update(input, port_id, format).py_block_on(py)
     }
 }
 


### PR DESCRIPTION
This PR extends Python and JavaScript APIs to allow `String`/`str`/`bytes`/`ArrayBuffer`/`UInt8Array` input data types for JSON Rows/Columns and CSV data, using the new `format` keyword argument to `Client::table`. This is useful several interesting performance optimizations, such as:
* Using `.arrayBuffer()` over `.text()` for `Response` objects containing CSVs (Fixes #2746).
* Reading JSON from a file or other unparsed source without deserializing.

Use it like this:

```javascript
data = '{"x": [1,2,3], "y": [4,5,6]}';
table = await client.table(data, {format: "columns"});
```



Included are tests and keyword argument docs for both Python and JavaScript.