### PR TITLE
Column type icon matches the datatype type of the field in column selectors (where, group by, sortby, filter)

### DIFF
--- a/rust/perspective-viewer/src/rust/components/column_selector/config_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/config_selector.rs
@@ -514,6 +514,7 @@ impl Component for ConfigSelector {
                             html_nested! {
                                 <PivotColumn
                                     dragdrop={ &ctx.props().dragdrop }
+                                    session={ &ctx.props().session }
                                     action={ DragTarget::GroupBy }
                                     column={ group_by.clone() }>
                                 </PivotColumn>
@@ -540,6 +541,7 @@ impl Component for ConfigSelector {
                             html_nested! {
                                 <PivotColumn
                                     dragdrop={ &ctx.props().dragdrop }
+                                    session={ &ctx.props().session }
                                     action={ DragTarget::SplitBy }
                                     column={ split_by.clone() }>
                                 </PivotColumn>

--- a/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
@@ -468,7 +468,7 @@ impl Component for FilterColumn {
                 <LocalStyle href={css!("filter-item")} />
                 <div class="pivot-column-border">
                     // <TypeIcon ty={ColumnType::String} />
-                    <TypeIcon ty={final_col_type}/>
+                    <TypeIcon ty={final_col_type} />
                     <span class="column_name">{ filter.column().to_owned() }</span>
                     <FilterOpSelector
                         class="filterop-selector"

--- a/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
@@ -456,6 +456,8 @@ impl Component for FilterColumn {
         }
         .unwrap_or_default();
 
+        let final_col_type = col_type.expect("Unknown column");
+
         html! {
             <div
                 class="pivot-column-draggable"
@@ -465,7 +467,8 @@ impl Component for FilterColumn {
             >
                 <LocalStyle href={css!("filter-item")} />
                 <div class="pivot-column-border">
-                    <TypeIcon ty={ColumnType::String} />
+                    // <TypeIcon ty={ColumnType::String} />
+                    <TypeIcon ty={final_col_type}/>
                     <span class="column_name">{ filter.column().to_owned() }</span>
                     <FilterOpSelector
                         class="filterop-selector"

--- a/rust/perspective-viewer/src/rust/components/column_selector/pivot_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/pivot_column.rs
@@ -64,11 +64,11 @@ impl Component for PivotColumn {
         });
 
         let col_type = ctx
-        .props()
-        .session
-        .metadata()
-        .get_column_table_type(&ctx.props().column)
-        .expect("Unknown column");
+            .props()
+            .session
+            .metadata()
+            .get_column_table_type(&ctx.props().column)
+            .expect("Unknown column");
 
         html! {
             <div

--- a/rust/perspective-viewer/src/rust/components/column_selector/pivot_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/pivot_column.rs
@@ -10,18 +10,20 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-use perspective_client::ColumnType;
+// use perspective_client::ColumnType;
 use web_sys::*;
 use yew::prelude::*;
 
 use crate::components::containers::dragdrop_list::*;
 use crate::components::type_icon::TypeIcon;
 use crate::dragdrop::*;
+use crate::session::*;
 
 pub struct PivotColumn {}
 
 #[derive(Properties)]
 pub struct PivotColumnProps {
+    pub session: Session,
     pub column: String,
     pub dragdrop: DragDrop,
     pub action: DragTarget,
@@ -61,6 +63,13 @@ impl Component for PivotColumn {
             move |_event| dragdrop.notify_drag_end()
         });
 
+        let col_type = ctx
+        .props()
+        .session
+        .metadata()
+        .get_column_table_type(&ctx.props().column)
+        .expect("Unknown column");
+
         html! {
             <div
                 class="pivot-column-draggable"
@@ -69,7 +78,8 @@ impl Component for PivotColumn {
                 ondragend={dragend}
             >
                 <div class="pivot-column-border">
-                    <TypeIcon ty={ColumnType::String} />
+                    <TypeIcon ty={col_type} />
+                    // <TypeIcon ty={ColumnType::String} />
                     <span class="column_name">{ ctx.props().column.clone() }</span>
                 </div>
             </div>

--- a/rust/perspective-viewer/src/rust/components/column_selector/sort_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/sort_column.rs
@@ -11,7 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 use perspective_client::config::*;
-use perspective_client::ColumnType;
+// use perspective_client::ColumnType;
 use web_sys::*;
 use yew::prelude::*;
 
@@ -101,6 +101,13 @@ impl Component for SortColumn {
             move |_event| dragdrop.notify_drag_end()
         });
 
+        let col_type = ctx
+            .props()
+            .session
+            .metadata()
+            .get_column_table_type(&ctx.props().sort.0.to_owned())
+            .expect("Unknown column");
+
         html! {
             <div
                 class="pivot-column-draggable"
@@ -109,7 +116,8 @@ impl Component for SortColumn {
                 ondragend={dragend}
             >
                 <div class="pivot-column-border">
-                    <TypeIcon ty={ColumnType::String} />
+                    <TypeIcon ty={col_type} />
+                    // <TypeIcon ty={ColumnType::String} />
                     <span class="column_name">{ ctx.props().sort.0.to_owned() }</span>
                     <span
                         class={format!("sort-icon {}", ctx.props().sort.1)}


### PR DESCRIPTION
This PR fixes the issue of icons of columns defaulting to string icon instead of the right data type in issue #2580