### PR TITLE
Fix filter values for non-interned strings

### DIFF
--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -512,6 +512,9 @@ t_data_table::filter_cpp(
                         break;
                     }
 
+                    // TODO we can make this faster by not constructing these on
+                    // every iteration?
+
                     const auto& ft = fterms[cidx];
                     bool tval;
 

--- a/cpp/perspective/src/cpp/view_config.cpp
+++ b/cpp/perspective/src/cpp/view_config.cpp
@@ -17,6 +17,7 @@
 namespace perspective {
 
 t_view_config::t_view_config(
+    t_vocab vocab,
     const std::vector<std::string>& row_pivots,
     const std::vector<std::string>& column_pivots,
     const tsl::ordered_map<std::string, std::vector<std::string>>& aggregates,
@@ -29,6 +30,7 @@ t_view_config::t_view_config(
     bool column_only
 ) :
     m_init(false),
+    m_vocab(std::move(vocab)),
     m_row_pivots(row_pivots),
     m_column_pivots(column_pivots),
     m_aggregates(aggregates),

--- a/cpp/perspective/src/include/perspective/view_config.h
+++ b/cpp/perspective/src/include/perspective/view_config.h
@@ -45,6 +45,7 @@ public:
      * @param sort
      */
     t_view_config(
+        t_vocab vocab,
         const std::vector<std::string>& row_pivots,
         const std::vector<std::string>& column_pivots,
         const tsl::ordered_map<std::string, std::vector<std::string>>&
@@ -178,8 +179,12 @@ private:
         t_dtype dtype
     );
 
+    // Global dictionary for `t_tscalar` in filter terms.
+    t_vocab m_vocab;
+
     // containers for primitive data that does not need transformation into
     // abstractions
+
     std::vector<std::string> m_row_pivots;
     std::vector<std::string> m_column_pivots;
     tsl::ordered_map<std::string, std::vector<std::string>> m_aggregates;

--- a/rust/bootstrap-runtime/lib.rs
+++ b/rust/bootstrap-runtime/lib.rs
@@ -37,10 +37,16 @@ use alloc::vec::Vec;
 
 use zune_inflate::DeflateDecoder;
 
+const HEAP_SIZE: usize = if cfg!(debug_assertions) {
+    512_000_000
+} else {
+    64_000_000
+};
+
 #[allow(unused_unsafe)]
 #[global_allocator]
 static ALLOCATOR: talc::Talck<talc::locking::AssumeUnlockable, talc::ClaimOnOom> = {
-    static mut MEMORY: [u8; 64000000] = [0; 64000000];
+    static mut MEMORY: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
     let span = unsafe { talc::Span::from_const_array(core::ptr::addr_of!(MEMORY)) };
     talc::Talc::new(unsafe { talc::ClaimOnOom::new(span) }).lock()
 };

--- a/rust/perspective-js/test/js/filters.spec.js
+++ b/rust/perspective-js/test/js/filters.spec.js
@@ -314,6 +314,29 @@ const datetime_data_local = [
                 table.delete();
             });
 
+            test("y == 'abcdefghijklmnopqrstuvwxyz' (interned)", async function () {
+                const data = [
+                    { x: 1, y: "a", z: true },
+                    { x: 2, y: "b", z: false },
+                    { x: 3, y: "c", z: true },
+                    {
+                        x: 4,
+                        y: "abcdefghijklmnopqrstuvwxyz",
+                        z: false,
+                    },
+                ];
+
+                const table = await perspective.table(data);
+                const view = await table.view({
+                    filter: [["y", "==", "abcdefghijklmnopqrstuvwxyz"]],
+                });
+
+                const json = await view.to_json();
+                expect(json).toEqual([data[3]]);
+                view.delete();
+                table.delete();
+            });
+
             test("z == true", async function () {
                 var table = await perspective.table(data);
                 var view = await table.view({

--- a/rust/perspective-js/test/js/view_config.spec.js
+++ b/rust/perspective-js/test/js/view_config.spec.js
@@ -1,0 +1,44 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test, expect } from "@finos/perspective-test";
+import perspective from "./perspective_client";
+
+((perspective) => {
+    test.describe("View config", function () {
+        test("Non-interned filter strings do not create corrupted view configs", async function () {
+            const data = [
+                { x: 1, y: "a", z: true },
+                { x: 2, y: "b", z: false },
+                { x: 3, y: "c", z: true },
+                {
+                    x: 4,
+                    y: "abcdefghijklmnopqrstuvwxyz",
+                    z: false,
+                },
+            ];
+
+            const table = await perspective.table(data);
+            const view = await table.view({
+                filter: [["y", "==", "abcdefghijklmnopqrstuvwxyz"]],
+            });
+
+            const config = await view.get_config();
+            expect(config.filter).toEqual([
+                ["y", "==", "abcdefghijklmnopqrstuvwxyz"],
+            ]);
+
+            view.delete();
+            table.delete();
+        });
+    });
+})(perspective);


### PR DESCRIPTION
Fixes a bug introduced In `3.0.0` and introduces two tests (one of which fails pre-fix).

In this version, the translation layer between a domain-language `ViewConfig` (Python `dict` or JavaScript `Object`) was rewritten and ported to C++, in which we neglected to accommodate for `t_tscalar`'s SSO optimization which inlines string under 13 characters. As this type is used for a filter parameter's term component, this leads to a dangling pointer error when the `get_view_config()` public method was invoked with a filter value above this limit. 

Fixes #2781 