### PR TITLE
arrow: Fix cross-compiling errors on macos

### DIFF
--- a/cmake/toolchains/darwin-arm64.cmake
+++ b/cmake/toolchains/darwin-arm64.cmake
@@ -1,0 +1,24 @@
+#  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+#  ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+#  ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+#  ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+#  ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+#  ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+#  ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+#  ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+#  ┃ This file is part of the Perspective library, distributed under the terms ┃
+#  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+#  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+# Minimal toolchain file to ensure that Arrow's bundled dependency builds use
+# the correct architecture for Mac builds.
+
+# (Arrow does not as of Oct 2024 pass on CMAKE_OSX_ARCHITECTURES to its
+# dependencies if it is set, but does pass on a toolchain file)
+
+set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Target architecture for Mac builds")
+# Arrow uses this to choose a `-march` flag
+set(CMAKE_SYSTEM_PROCESSOR "arm64")
+# Prevent cmake from overwriting CMAKE_SYSTEM_PROCESSOR
+# https://github.com/apache/arrow/issues/44448#issuecomment-2418649378
+set(CMAKE_SYSTEM_NAME "Darwin")

--- a/cmake/toolchains/darwin-x86_64.cmake
+++ b/cmake/toolchains/darwin-x86_64.cmake
@@ -1,0 +1,24 @@
+#  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+#  ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+#  ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+#  ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+#  ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+#  ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+#  ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+#  ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+#  ┃ This file is part of the Perspective library, distributed under the terms ┃
+#  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+#  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+# Minimal toolchain file to ensure that Arrow's bundled dependency builds use
+# the correct architecture for Mac builds.
+
+# (Arrow does not as of Oct 2024 pass on CMAKE_OSX_ARCHITECTURES to its
+# dependencies if it is set, but does pass on a toolchain file)
+
+set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "Target architecture for Mac builds")
+# Arrow uses this to choose a `-march` flag
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+# Prevent cmake from overwriting CMAKE_SYSTEM_PROCESSOR
+# https://github.com/apache/arrow/issues/44448#issuecomment-2418649378
+set(CMAKE_SYSTEM_NAME "Darwin")


### PR DESCRIPTION
This fixes the issue with missing LZ4 symbols in the arm64 wheel first introduced in v3.1.1.

The crux of the issue is that Arrow was building lz4 (and zstd) in a separate cmake build, and it does not specially pass on the `CMAKE_OSX_ARCHITECTURES` flag that was set when perspective-server's build script invokes cmake.

Arrow's build does forward on the value of CMAKE_TOOLCHAIN_FILE to its external dependencies, if it's set, so this commit creates two minimal toolchain files and uses them in the Mac build to set `CMAKE_OSX_ARCHITECTURES` (and a couple other variables) correctly when cross-compiling.

a good follow-up would be to see if we can enable Python tests on arm64 using a macos-14 runner, which is available for public repos: <https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories>

### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [ ] Include new tests that fail without this PR but passes with it.
  - I am planning to follow up with a CI job which tests the arm64 Python wheel
-   [x] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
