### PR TITLE
Add aarch64 Mac runners to test_python, restore PSP_ARCH dev behavior

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -592,20 +592,32 @@ jobs:
                 os:
                     - ubuntu-22.04
                     - macos-13
+                    - macos-14
                     - windows-2022
+                arch:
+                    - x86_64
+                    - aarch64
                 python-version:
                     - 3.9
                     # - 3.12
                 node-version: [20.x]
                 is-release:
                     - ${{ startsWith(github.ref, 'refs/tags/v') }}
-                arch:
-                    - x86_64
                 exclude:
                     - os: macos-13
                       is-release: false
+                    - os: macos-14
+                      is-release: false
                     - os: windows-2022
                       is-release: false
+                    - os: macos-13
+                      arch: aarch64
+                    - os: macos-14
+                      arch: x86_64
+                    - os: windows-2022
+                      arch: aarch64
+                    - os: ubuntu-22.04
+                      arch: aarch64
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -623,7 +635,8 @@ jobs:
 
             - uses: actions/download-artifact@v4
               with:
-                  name: perspective-python-dist-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python-version }}
+                  # the macos-14 runner tests artifacts built on macos-13
+                  name: perspective-python-dist-${{ matrix.arch }}-${{ matrix.os == 'macos-14' && 'macos-13' || matrix.os }}-${{ matrix.python-version }}
 
             - uses: ./.github/actions/install-wheel
 


### PR DESCRIPTION
This PR follows up #2798. We weren't previously testing the aarch64 wheel in CI. This adds a macos-14 runner, which is aarch64 native.

I also restored the previous dev environment behavior when PSP_ARCH is not set: instead of a fatal build error, the build just doesn't set `CMAKE_OSX_ARCHITECTURES` (et al).

### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent Discussions, this PR applies to.
-   [x] Include new tests that fail without this PR but passes with it.
  - the new tests (new test runner, really) would have failed before #2798
-   [x] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
