### PR TITLE
fix aiohttp disconnect error on websockets

### DIFF
--- a/rust/perspective-python/perspective/handlers/aiohttp.py
+++ b/rust/perspective-python/perspective/handlers/aiohttp.py
@@ -39,7 +39,7 @@ class PerspectiveAIOHTTPHandler(object):
         self._request = kwargs.pop("request")
         super().__init__(**kwargs)
 
-    async def run(self) -> None:
+    async def run(self) -> web.WebSocketResponse:
         def inner(msg):
             asyncio.get_running_loop().create_task(self._ws.send_bytes(msg))
 
@@ -53,3 +53,4 @@ class PerspectiveAIOHTTPHandler(object):
 
         finally:
             self.session.close()
+        return self._ws


### PR DESCRIPTION
aiohttp will throw if the handler doesn't return anything.

```python
14:11:35 aiohttp ERRO Missing return statement on request handler
Traceback (most recent call last):
  File "/Users/steve/conda/envs/port/lib/python3.12/site-packages/aiohttp/web_protocol.py", line 653, in finish_response
    prepare_meth = resp.prepare
                   ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'prepare'
```

Fixes #2805

https://docs.aiohttp.org/en/stable/web_quickstart.html#websockets

### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [ ] Include new tests that fail without this PR but passes with it.
-   [x] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
