### PR TITLE
Escape esbuild plugin's symbol replacement.

### DIFF
--- a/packages/perspective-esbuild-plugin/wasm.js
+++ b/packages/perspective-esbuild-plugin/wasm.js
@@ -95,8 +95,14 @@ exports.WasmPlugin = function WasmPlugin(inline) {
 
                         if (symbol?.[1]) {
                             updated = true;
+                            const escapedSymbol = symbol[1].replace(
+                                /\$/g,
+                                "\\$"
+                            );
                             const filename = contents.match(
-                                new RegExp(`${symbol[1]}\\s*?=\\s*?\\"(.+?)\\"`)
+                                new RegExp(
+                                    `${escapedSymbol}\\s*?=\\s*?\\"(.+?)\\"`
+                                )
                             );
 
                             contents = contents.replace(


### PR DESCRIPTION
Minification sometimes adds `$` to variable names causing it to be interpreted as regex rather than literally.