### PR TITLE
fix treemap rendering issue in firefox

### DIFF
--- a/packages/perspective-viewer-d3fc/src/ts/series/treemap/treemapSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/treemap/treemapSeries.ts
@@ -70,8 +70,8 @@ export function treemapSeries() {
         const rects = nodesMerge
             .select("rect")
             .attr("class", (d) => `treerect ${nodeLevelHelper(maxDepth, d)}`)
-            .style("x", (d) => d.x0)
-            .style("y", (d) => d.y0)
+            .style("x", (d) => `${d.x0}px`)
+            .style("y", (d) => `${d.y0}px`)
             .style("width", (d) => calcWidth(d))
             .style("height", (d) => calcHeight(d));
 

--- a/packages/perspective-viewer-d3fc/src/ts/series/treemap/treemapSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/treemap/treemapSeries.ts
@@ -72,8 +72,8 @@ export function treemapSeries() {
             .attr("class", (d) => `treerect ${nodeLevelHelper(maxDepth, d)}`)
             .style("x", (d) => `${d.x0}px`)
             .style("y", (d) => `${d.y0}px`)
-            .style("width", (d) => calcWidth(d))
-            .style("height", (d) => calcHeight(d));
+            .style("width", (d) => `${calcWidth(d)}px`)
+            .style("height", (d) => `${calcHeight(d)}px`);
 
         rects.style("fill", (d) => {
             if (nodeLevelHelper(maxDepth, d) === nodeLevel.leaf) {


### PR DESCRIPTION
This pull request fixes one of the Firefox issues in #2693, specifically issue #1983
I used string interpolation for the style on the rect element (for x and y) to introduce layout consistency by adding px to the `d.x0` and `d.y0` values. I realized that without this, Firefox ignored some of the values, hence the issue.


### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [ ] Include new tests that fail without this PR but passes with it.
-   [ ] Include any relevant Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
