### PR TITLE
Fix failed color range update

### DIFF
--- a/rust/perspective-viewer/src/rust/components/form/color_range_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/form/color_range_selector.rs
@@ -44,6 +44,22 @@ pub fn color_chooser_component(props: &ColorRangeProps) -> Html {
             false,
         )
     });
+
+    {
+        let gradient = gradient.clone();
+
+        use_effect_with(
+            (props.neg_color.clone(), props.pos_color.clone()),
+            move |(neg_color, pos_color)| {
+                let current_gradient = gradient.clone();
+                if &current_gradient.0 != pos_color || &current_gradient.1 != neg_color {
+                    gradient.set((pos_color.clone(), neg_color.clone(), true));
+                }
+                || ()
+            },
+        );
+    }
+
     let on_pos_color = use_callback(
         (gradient.clone(), props.on_pos_color.clone()),
         |event: InputEvent, (gradient, on_pos_color)| {

--- a/rust/perspective-viewer/src/rust/components/number_column_style.rs
+++ b/rust/perspective-viewer/src/rust/components/number_column_style.rs
@@ -203,7 +203,7 @@ impl Component for NumberColumnStyle {
                 }
 
                 self.dispatch_config(ctx);
-                false
+                true
             },
             NumberColumnStyleMsg::NegColorChanged(side, val) => {
                 if side == Fg {
@@ -215,7 +215,7 @@ impl Component for NumberColumnStyle {
                 }
 
                 self.dispatch_config(ctx);
-                false
+                true
             },
             NumberColumnStyleMsg::NumberForeModeChanged(val) => {
                 self.fg_mode = val;

--- a/rust/perspective-viewer/test/js/column_settings.spec.ts
+++ b/rust/perspective-viewer/test/js/column_settings.spec.ts
@@ -245,7 +245,9 @@ test.describe("Plugin Styles", () => {
 
         // expect -ve color input on color range is present and has valid default value
         const getFgColorNeg = async () => {
-            return view.columnSettingsSidebar.styleTab.container.locator("#fg-color-neg");
+            return view.columnSettingsSidebar.styleTab.container.locator(
+                "#fg-color-neg"
+            );
         };
         let fgColorNeg = await getFgColorNeg();
 
@@ -264,7 +266,7 @@ test.describe("Plugin Styles", () => {
         await secondCol.editBtn.waitFor();
         await secondCol.editBtn.click();
 
-        // expect -ve color input on color range is present 
+        // expect -ve color input on color range is present
         fgColorNeg = await getFgColorNeg();
 
         expect(fgColorNeg).toBeVisible();
@@ -277,7 +279,7 @@ test.describe("Plugin Styles", () => {
         await firstCol.editBtn.waitFor();
         await firstCol.editBtn.click();
 
-        // expect -ve color input on color range is present 
+        // expect -ve color input on color range is present
         fgColorNeg = await getFgColorNeg();
 
         expect(fgColorNeg).toBeVisible();


### PR DESCRIPTION
This PR fixes the bug reported in #2568. Previously, when editing a number column on the Datagrid, a changed color in the color range component seems to transfer over, without reflecting on the column, to another editable number column if the sidebar is not closed.

This bug occurred due to the component failing to re-render when the props change upon switching from editing one number column to another. The fix ensures this missing re-render occurs now and a test has been implemented to confirm this.