### PR TITLE
Fix `plugin` switch 

### DIFF
--- a/packages/perspective-jupyterlab/test/jupyter/widget.spec.mts
+++ b/packages/perspective-jupyterlab/test/jupyter/widget.spec.mts
@@ -442,6 +442,52 @@ perpsective.PerspectiveWidget(df, **config)
             expect(errored).toBe(false);
         });
 
+        test_jupyter(
+            "Toggles to datagrid and back regression",
+            [
+                "w = perspective.widget.PerspectiveWidget(arrow_data, columns=['f64', 'str', 'datetime'])",
+                "w",
+            ],
+            async ({ page }) => {
+                await default_body(page);
+                const num_columns = await page
+                    .locator("regular-table thead tr")
+                    .first()
+                    .evaluate((tr) => tr.childElementCount);
+
+                async function toggle(plugin) {
+                    await page.locator(".plugin-select-item").click();
+                    await page
+                        .locator("#plugin_selector_container.open")
+                        .waitFor();
+
+                    await page
+                        .locator(`[data-plugin=${plugin}].plugin-select-item`)
+                        .click();
+
+                    await page
+                        .locator("#plugin_selector_container:not(.open)")
+                        .waitFor();
+
+                    await page.evaluate(async () => {
+                        await document
+                            .querySelector("perspective-viewer")!
+                            .flush();
+                    });
+                }
+
+                await toggle('"X/Y Line"');
+                await toggle("Datagrid");
+                await toggle('"X/Y Line"');
+                await toggle("Datagrid");
+
+                // expect(num_columns).toEqual(3);
+                await expect(
+                    page.locator("regular-table tbody tr")
+                ).toHaveCount(5);
+            }
+        );
+
         // *************************
         // UTILS
         // *************************

--- a/packages/perspective-viewer-datagrid/src/js/model/toolbar.js
+++ b/packages/perspective-viewer-datagrid/src/js/model/toolbar.js
@@ -27,7 +27,7 @@ export function toggle_edit_mode(mode = undefined) {
     }
 
     this.model._edit_mode = mode;
-    this.parentElement.setSelection();
+    this.parentElement?.setSelection();
     this.model._selection_state = {
         selected_areas: [],
         dirty: true,


### PR DESCRIPTION
This PR fixes a regression in the `PerspectiveWidget` Python extension. In `3.0.0`, selection modes were added to Perspective's datagrid component; however, we neglected to test this feature when the settings are updated for a detached (hidden) viewer. This is not a common feature typically, but is coincidentally a state of the default `PerspectiveWidget` loading workflow due to the lack of a working end-to-end async model for `perspective` and `perspective-viewer` remote calls. As a result, switching _to_ the Datagrid plugin in Jupyter will throw a runtime exception.

This PR fixes patches this behavior and adds a test for JupyterLab. However, it _does not_ resolve the underlying inconsistency which is async ordering issues imposed by the current `PerspectiveWidget` architecture. We will need to figure out why the current widget detaches during this call, as it is likely a sign of a deeper performance-sapping bug.

Fixes #2827 