### PR TITLE
Allow for passthrough of event loop in psp webserver handlers

### DIFF
--- a/examples/python-starlette/server.py
+++ b/examples/python-starlette/server.py
@@ -18,7 +18,6 @@ import threading
 import uvicorn
 
 from fastapi import FastAPI, WebSocket
-from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import FileResponse
 from starlette.staticfiles import StaticFiles
 
@@ -64,21 +63,12 @@ def make_app():
         )
         await handler.run()
 
-    # static_html_files = StaticFiles(directory="../python-tornado", html=True)
     static_html_files = StaticFiles(directory="../python-tornado", html=True)
 
     app = FastAPI()
     app.add_api_websocket_route("/websocket", websocket_handler)
     app.get("/node_modules/{rest_of_path:path}")(static_node_modules_handler)
     app.mount("/", static_html_files)
-
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
     return app
 
 

--- a/rust/perspective-python/perspective/handlers/aiohttp.py
+++ b/rust/perspective-python/perspective/handlers/aiohttp.py
@@ -37,11 +37,12 @@ class PerspectiveAIOHTTPHandler(object):
     def __init__(self, **kwargs):
         self.server = kwargs.pop("perspective_server", perspective.GLOBAL_SERVER)
         self._request = kwargs.pop("request")
+        self._loop = kwargs.pop("loop", asyncio.get_event_loop())
         super().__init__(**kwargs)
 
     async def run(self) -> web.WebSocketResponse:
         def inner(msg):
-            asyncio.get_running_loop().create_task(self._ws.send_bytes(msg))
+            self._loop.create_task(self._ws.send_bytes(msg))
 
         self.session = self.server.new_session(inner)
         try:

--- a/rust/perspective-python/perspective/handlers/starlette.py
+++ b/rust/perspective-python/perspective/handlers/starlette.py
@@ -34,11 +34,12 @@ class PerspectiveStarletteHandler(object):
     def __init__(self, **kwargs):
         self._server = kwargs.pop("perspective_server", perspective.GLOBAL_SERVER)
         self._websocket = kwargs.pop("websocket")
+        self._loop = kwargs.pop("loop", asyncio.get_event_loop())
         super().__init__(**kwargs)
 
     async def run(self) -> None:
         def inner(msg):
-            asyncio.get_running_loop().create_task(self._websocket.send_bytes(msg))
+            self._loop.create_task(self._websocket.send_bytes(msg))
 
         self.session = self._server.new_session(inner)
 

--- a/rust/perspective-python/perspective/handlers/tornado.py
+++ b/rust/perspective-python/perspective/handlers/tornado.py
@@ -45,8 +45,9 @@ class PerspectiveTornadoHandler(WebSocketHandler):
     def check_origin(self, origin):
         return True
 
-    def initialize(self, perspective_server=perspective.GLOBAL_SERVER):
+    def initialize(self, perspective_server=perspective.GLOBAL_SERVER, loop=None):
         self.server = perspective_server
+        self.loop = loop or IOLoop.current()
 
     def open(self):
         def inner(msg):
@@ -63,4 +64,4 @@ class PerspectiveTornadoHandler(WebSocketHandler):
             return
 
         self.session.handle_request(msg)
-        IOLoop.current().call_later(0, self.session.poll)
+        self.loop.call_later(0, self.session.poll)


### PR DESCRIPTION
### TODO
More details discussed separately, not done in this PR so don't merge yet

### Repro
Expectation:
![tmp](https://github.com/user-attachments/assets/6628bc50-2127-4ec5-ba05-90702017e1b6)

Reality:
Only first value is used, no updating is propagated through the web server (wrong loop at time of callback)
<img width="134" alt="Screenshot 2024-11-06 at 17 13 04" src="https://github.com/user-attachments/assets/a5876024-6ce4-478d-a7e4-bb32af5e4376">



`index.html`

```html
<html>
  <head>
    <script type="module" src="https://cdn.jsdelivr.net/npm/@finos/perspective/dist/cdn/perspective.js"></script>
    <script type="module" src="https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"></script>
    <script type="module" src="https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js"></script>
    <script type="module" src="https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js"></script>
    <link rel="stylesheet" crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/css/pro.css"/>
    <style>
      perspective-viewer {
        position: absolute;
        top: 0;
        bottom: 0;
        left: 0;
        right: 0;
        display: flex;
        flex-direction: column;
      }
    </style>
  </head>


  <body>
    <perspective-viewer id="viewer"></perspective-viewer>
  </body>


  <script type="module">
    import perspective from "https://cdn.jsdelivr.net/npm/@finos/perspective/dist/cdn/perspective.js";

    window.addEventListener("DOMContentLoaded", async function () {
        const websocket = await perspective.websocket("ws://localhost:8080/websocket");
        const worker = perspective.worker();
        await document.getElementById("viewer").load(websocket.open_table("test"));
    });
</script>
</html>
```

`server.py`
```python
import asyncio
import logging
import random
import threading
import uvicorn

from fastapi import FastAPI, WebSocket
from perspective import Server
from perspective.perspective import Table
from perspective.handlers.starlette import PerspectiveStarletteHandler
from starlette.staticfiles import StaticFiles


def make_perspective_app(server: Server):
    async def websocket_handler(websocket: WebSocket): await PerspectiveStarletteHandler(perspective_server=server, websocket=websocket).run()
    app = FastAPI()
    app.add_api_websocket_route("/websocket", websocket_handler)
    app.mount("/", StaticFiles(directory=".", html=True), name="static")
    return app

def feed(table: Table):
    while True:
        table.update([{"a": random.randint(0, 10), "index": 1}])

def main():
    perspective_server = Server()
    app = make_perspective_app(perspective_server)

    loop = asyncio.get_event_loop()
    threading.Thread(target=loop.run_forever, daemon=True).start()
    client = perspective_server.new_local_client(loop_callback=loop.call_soon_threadsafe)
    table = client.table({"a": "integer", "index": "integer"}, index="index", name="test")
    threading.Thread(target=feed, args=(table,), daemon=True).start()

    logging.critical("Listening on http://localhost:8080")
    uvicorn.run(app, host="0.0.0.0", port=8080)

if __name__ == "__main__":
    main()
```

Happy to write tests but unclear the best way to do so.

### Alternative

Here is an alternative implementation that lets `uvicorn` reuse the event loop created earlier in the code so that they share:

```python
import asyncio
import logging
import random
import threading
import uvicorn
from uvicorn import Config, Server

from fastapi import FastAPI, WebSocket
from perspective import Server as PerspectiveServer
from perspective.perspective import Table
from perspective.handlers.starlette import PerspectiveStarletteHandler
from starlette.staticfiles import StaticFiles


def make_perspective_app(server: PerspectiveServer):
    async def websocket_handler(websocket: WebSocket): await PerspectiveStarletteHandler(perspective_server=server, websocket=websocket).run()
    app = FastAPI()
    app.add_api_websocket_route("/websocket", websocket_handler)
    app.mount("/", StaticFiles(directory=".", html=True), name="static")
    return app

def feed(table: Table):
    while True:
        table.update([{"a": random.randint(0, 10), "index": 1}])

def main():
    perspective_server = PerspectiveServer()
    app = make_perspective_app(perspective_server)

    loop = asyncio.get_event_loop()
    client = perspective_server.new_local_client(loop_callback=loop.call_soon_threadsafe)
    
    logging.critical("Listening on http://localhost:8080")
    config = Config(app=app, loop=loop, host="0.0.0.0", port=8080)
    server = Server(config)
    threading.Thread(target=loop.run_until_complete, args=(server.serve(),)).start()

    table = client.table({"a": "integer", "index": "integer"}, index="index", name="test")
    feed(table)


if __name__ == "__main__":
    main()
```

`aiohttp` would suffer from the same issues, and `web.run_app` accepts a `loop` argument too. 

### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [ ] Include new tests that fail without this PR but passes with it.
-   [ ] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [ ] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
