### PR TITLE
Export Table and View with aliasing to discourage instantiation

### DIFF
--- a/rust/perspective-python/perspective/__init__.py
+++ b/rust/perspective-python/perspective/__init__.py
@@ -27,6 +27,10 @@ from .perspective import (
     PerspectiveError,
     ProxySession,
     PySyncServer as Server,
+    # NOTE: these are classes without constructors,
+    # so we import them just for type hinting
+    Table as TableType,  # noqa: F401
+    View as ViewType,  # noqa: F401
 )
 
 


### PR DESCRIPTION
https://github.com/finos/perspective/pull/2754 remove the top level `Table` and `View` as they are not constructible. However, libraries like `pydantic` and `csp` like to have types for type validation, so here we reintroduce them but alias them to types to discourage direct instantiation.

### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [ ] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [ ] Include new tests that fail without this PR but passes with it.
-   [ ] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [ ] Reviewed PR commit history to remove unnecessary changes.
-   [ ] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
