### PR TITLE
Fix `integer` cast expression function

### DIFF
--- a/cpp/perspective/src/cpp/scalar.cpp
+++ b/cpp/perspective/src/cpp/scalar.cpp
@@ -1165,6 +1165,10 @@ t_tscalar::to_double() const {
 
 t_tscalar
 t_tscalar::coerce_numeric_dtype(t_dtype dtype) const {
+    if (dtype == m_type) {
+        return *this;
+    }
+
     switch (dtype) {
         case DTYPE_INT64: {
             return coerce_numeric<std::int64_t>();

--- a/packages/perspective-workspace/package.json
+++ b/packages/perspective-workspace/package.json
@@ -32,6 +32,7 @@
     "author": "",
     "license": "Apache-2.0",
     "dependencies": {
+        "@finos/perspective": "workspace:^",
         "@finos/perspective-viewer": "workspace:^",
         "@lumino/algorithm": ">=2 <3",
         "@lumino/commands": ">=2 <3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -735,6 +735,9 @@ importers:
 
   packages/perspective-workspace:
     dependencies:
+      '@finos/perspective':
+        specifier: workspace:^
+        version: link:../../rust/perspective-js
       '@finos/perspective-viewer':
         specifier: workspace:^
         version: link:../../rust/perspective-viewer

--- a/rust/perspective-js/test/js/expressions/numeric.spec.js
+++ b/rust/perspective-js/test/js/expressions/numeric.spec.js
@@ -706,6 +706,44 @@ function validate_binary_operations(output, expressions, operator) {
             });
         });
 
+        test.describe("Integers", function () {
+            test("Integer outputs with negative values dont overflow", async function () {
+                var data = [
+                    { x: -1, y: "a", z: true },
+                    { x: -2, y: "b", z: false },
+                    { x: -3, y: "c", z: true },
+                    { x: -4, y: "d", z: false },
+                ];
+
+                var table = await perspective.table({
+                    x: "integer",
+                    y: "string",
+                    z: "boolean",
+                });
+
+                await table.update(data);
+
+                var view = await table.view({
+                    group_by: ["z"],
+                    columns: ["x", "w"],
+                    expressions: {
+                        w: 'integer("x")',
+                    },
+                });
+
+                var answer = [
+                    { __ROW_PATH__: [], x: -10, w: -10 },
+                    { __ROW_PATH__: [false], x: -6, w: -6 },
+                    { __ROW_PATH__: [true], x: -4, w: -4 },
+                ];
+
+                let result = await view.to_json();
+                expect(result).toEqual(answer);
+                view.delete();
+                table.delete();
+            });
+        });
+
         test.describe("Functions", function () {
             test("min", async function () {
                 const table = await perspective.table({


### PR DESCRIPTION
This PR fixes an integer-underflow bug encountered when calculating `sum` aggregates over `integer` columns which had been generated by an expression. See the included test for an example using the Perspective ExprTK `integer()` cast function.