### PR TITLE
sdist licensing follow ups

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,6 +110,7 @@ jobs:
                       rust/perspective-client/docs/
                       rust/perspective-js/src/ts/
                       rust/perspective-viewer/src/ts/
+                      rust/perspective-python/LICENSE_THIRDPARTY_cargo.yml
 
     # ,-,---.       .    .   ,-_/              .---.               .
     #  '|___/ . . . |  ,-|   '  | ,-. .  , ,-. \___  ,-. ,-. . ,-. |-
@@ -487,6 +488,11 @@ jobs:
 
             - uses: actions/download-artifact@v4
               with:
+                  name: perspective-metadata
+                  path: rust/
+
+            - uses: actions/download-artifact@v4
+              with:
                   name: perspective-python-dist-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python-version }}
                   path: .
 
@@ -706,6 +712,13 @@ jobs:
             - name: Install perspective-python sdist
               shell: bash
               run: python -m pip install -vv ./perspective*.tar.gz
+
+            - name: Verify licenses are installed
+              shell: bash
+              run: |
+                  pip show -f perspective-python > wheel_installed_files.txt
+                  grep licenses/LICENSE.md wheel_installed_files.txt
+                  grep licenses/LICENSE_THIRDPARTY_cargo.yml wheel_installed_files.txt
 
             - name: Verify labextension
               shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -247,7 +247,7 @@ rust/perspective-server/cmake
 .pyodide-*/
 rust/perspective-python/*.data
 rust/perspective-python/PKG-INFO
-# rust/perspective-python/perspective.data/data/share/jupyter/labextensions/@finos/perspective-jupyterlab/package.json
+rust/perspective-python/LICENSE.md
 rust/perspective-viewer/docs/exprtk.md
 rust/perspective-server/docs/lib_gen.md
 rust/perspective-client/docs/expression_gen.md

--- a/.gitignore
+++ b/.gitignore
@@ -248,6 +248,7 @@ rust/perspective-server/cmake
 rust/perspective-python/*.data
 rust/perspective-python/PKG-INFO
 rust/perspective-python/LICENSE.md
+rust/perspective-python/LICENSE_*
 rust/perspective-viewer/docs/exprtk.md
 rust/perspective-server/docs/lib_gen.md
 rust/perspective-client/docs/expression_gen.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +136,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -245,6 +265,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
@@ -283,6 +309,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-bundle-licenses"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84985cc23a92e4b3f0b3e496d7588f3ffee433b8a4711c60cc4ce2f92eacbba2"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "env_logger",
+ "git-version",
+ "home",
+ "itertools 0.10.5",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "slug",
+ "spdx",
+ "structopt",
+ "strum 0.24.1",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +399,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
@@ -333,7 +431,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -487,7 +585,7 @@ dependencies = [
  "ident_case",
  "proc-macro2 1.0.83",
  "quote 1.0.36",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.66",
 ]
 
@@ -528,6 +626,12 @@ dependencies = [
  "quote 1.0.36",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
 name = "difflib"
@@ -586,6 +690,19 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "equivalent"
@@ -806,6 +923,26 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2 1.0.83",
+ "quote 1.0.36",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "glob"
@@ -1214,15 +1351,39 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -1286,6 +1447,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1416,6 +1583,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,7 +1697,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "libc",
 ]
 
@@ -1715,7 +1893,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -1798,7 +1976,7 @@ dependencies = [
 name = "perspective-bootstrap"
 version = "0.0.0"
 dependencies = [
- "clap",
+ "clap 4.5.4",
  "flate2",
  "wasm-opt",
 ]
@@ -1816,7 +1994,7 @@ dependencies = [
 name = "perspective-bundle"
 version = "0.0.0"
 dependencies = [
- "clap",
+ "clap 4.5.4",
  "wasm-bindgen-cli-support",
  "wasm-opt",
 ]
@@ -1884,6 +2062,7 @@ dependencies = [
 name = "perspective-metadata"
 version = "0.0.0"
 dependencies = [
+ "cargo-bundle-licenses",
  "perspective-client",
  "perspective-js",
  "perspective-server",
@@ -2309,7 +2488,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24336969a51336e6d27256c81456d25f6b533952c60ef495b33e3288461b9484"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2376,7 +2555,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -2481,7 +2660,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2525,6 +2704,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2617,6 +2805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,6 +2853,19 @@ dependencies = [
  "proc-macro2 1.0.83",
  "quote 1.0.36",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2709,6 +2919,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,10 +2945,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -2737,10 +2972,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2 1.0.83",
+ "quote 1.0.36",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros 0.24.3",
+]
 
 [[package]]
 name = "strum"
@@ -2857,6 +3119,15 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -3001,10 +3272,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3013,6 +3299,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -3039,7 +3327,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "bytes",
  "futures-util",
  "http 1.1.0",
@@ -3245,6 +3533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,6 +3566,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -3768,7 +4068,7 @@ dependencies = [
  "anyhow",
  "basic-toml",
  "bumpalo",
- "clap",
+ "clap 4.5.4",
  "codespan-reporting",
  "diffy",
  "dirs",

--- a/rust/generate-metadata/Cargo.toml
+++ b/rust/generate-metadata/Cargo.toml
@@ -21,6 +21,10 @@ name = "perspective_metadata"
 path = "main.rs"
 bench = false
 
+[dependencies.cargo-bundle-licenses]
+version = "2.0.0"
+artifact = ["bin"]
+
 [dependencies.ts-rs]
 version = "10.0.0"
 features = ["serde-json-impl", "no-serde-warnings"]

--- a/rust/generate-metadata/main.rs
+++ b/rust/generate-metadata/main.rs
@@ -72,9 +72,26 @@ pub fn generate_type_bindings_js() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[doc(hidden)]
+pub fn generate_python_cargo_licenses() -> Result<(), Box<dyn Error>> {
+    use std::fs::File;
+    use std::process::{Command, Stdio};
+    let python_dir = std::env::current_dir()?.join("../perspective-python");
+    let bundler = env!("CARGO_BIN_FILE_CARGO_BUNDLE_LICENSES_cargo-bundle-licenses");
+    let license_file = File::create(python_dir.join("LICENSE_THIRDPARTY_cargo.yml"))?;
+    Command::new(bundler)
+        .arg("--format=yaml")
+        .current_dir(python_dir)
+        .stdout(Stdio::from(license_file))
+        .spawn()?
+        .wait()?;
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     generate_type_bindings_js()?;
     generate_type_bindings_viewer()?;
     generate_exprtk_docs()?;
+    generate_python_cargo_licenses()?;
     Ok(())
 }

--- a/rust/perspective-python/Cargo.toml
+++ b/rust/perspective-python/Cargo.toml
@@ -25,6 +25,8 @@ include = [
     "bench/**/*.py",
     "build.rs",
     "./Cargo.toml",
+    "LICENSE.md",
+    "LICENSE_*",
     "README.md",
     "./package.json",
     "perspective/**/*.py",

--- a/rust/perspective-python/build.mjs
+++ b/rust/perspective-python/build.mjs
@@ -134,10 +134,12 @@ if (build_sdist) {
         );
     }
     const readme_md = fs.readFileSync("./README.md");
+    fs.copyFileSync("../../LICENSE.md", "./LICENSE.md");
     const pkg_info = generatePkgInfo(pyproject, cargo, readme_md);
     fs.writeFileSync("./PKG-INFO", pkg_info);
     const include_paths = Array.from(cargo["package"]["include"]).concat([
         data_dir,
+        "./LICENSE.md",
         "./PKG-INFO",
     ]);
     const files = glob.globSync(include_paths);

--- a/rust/perspective-python/build.mjs
+++ b/rust/perspective-python/build.mjs
@@ -37,6 +37,7 @@ const version = pkg.version.replace(/-(rc|alpha|beta)\.\d+/, (x) =>
 );
 
 fs.mkdirSync(`./perspective_python-${version}.data`, { recursive: true });
+fs.copyFileSync("../../LICENSE.md", "./LICENSE.md");
 
 const cwd = process.cwd();
 const cmd = sh();
@@ -134,15 +135,14 @@ if (build_sdist) {
         );
     }
     const readme_md = fs.readFileSync("./README.md");
-    fs.copyFileSync("../../LICENSE.md", "./LICENSE.md");
     const pkg_info = generatePkgInfo(pyproject, cargo, readme_md);
     fs.writeFileSync("./PKG-INFO", pkg_info);
-    const include_paths = Array.from(cargo["package"]["include"]).concat([
-        data_dir,
-        "./LICENSE.md",
-        "./PKG-INFO",
-    ]);
-    const files = glob.globSync(include_paths);
+    // Maturin finds extra license files in the root of the source directory,
+    // then packages them into .dist-info in the wheel.  As of Nov 2024,
+    // Maturin does not yet support explicitly declaring `license-files` in
+    // pyproject.toml.  See https://github.com/PyO3/maturin/pull/862
+    // https://github.com/PyO3/maturin/issues/861
+    const crate_files = glob.globSync(Array.from(cargo["package"]["include"]));
     const wheel_dir = `../target/wheels`;
     fs.mkdirSync(wheel_dir, { recursive: true });
     await tar.create(
@@ -150,8 +150,9 @@ if (build_sdist) {
             gzip: true,
             file: path.join(wheel_dir, `perspective_python-${version}.tar.gz`),
             prefix: `perspective_python-${version}`,
+            strict: true,
         },
-        files
+        crate_files.concat(["PKG-INFO"])
     );
 }
 

--- a/rust/perspective-python/pyproject.toml
+++ b/rust/perspective-python/pyproject.toml
@@ -19,6 +19,7 @@ name = "perspective-python"
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = []
+license = { file = "LICENSE.md" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Rust",

--- a/rust/perspective-server/build/psp.rs
+++ b/rust/perspective-server/build/psp.rs
@@ -84,7 +84,7 @@ pub fn cmake_build() -> Result<Option<PathBuf>, std::io::Error> {
     // but our conda recipe doesn't directly invoke cmake
     if let Ok(cmake_args) = std::env::var("CMAKE_ARGS") {
         println!(
-            "cargo:warning=MESSAGE Setting CMAKE_ARGS from enviornment {:?}",
+            "cargo:warning=Setting CMAKE_ARGS from environment {:?}",
             cmake_args
         );
         for arg in Shlex::new(&cmake_args) {
@@ -92,7 +92,7 @@ pub fn cmake_build() -> Result<Option<PathBuf>, std::io::Error> {
         }
     }
 
-    println!("cargo:warning=MESSAGE Building cmake {}", profile);
+    println!("cargo:warning=Building cmake {}", profile);
     if std::env::var("PSP_BUILD_VERBOSE").unwrap_or_default() != "" {
         // checks non-empty env var
         dst.very_verbose(true);
@@ -138,7 +138,7 @@ pub fn link_cmake_static_archives(dir: &Path) -> Result<(), std::io::Error> {
                         stem.expect("bad")[3..].to_string()
                     };
 
-                    // println!("cargo:warning=MESSAGE static link {} {}", a, dir.display());
+                    // println!("cargo:warning=static link {} {}", a, dir.display());
                     println!("cargo:rustc-link-search=native={}", dir.display());
                     println!("cargo:rustc-link-lib=static={}", a);
                 }


### PR DESCRIPTION
This adds LICENSE.md from perspective to the sdist, and uses `cargo-bundle-licenses` to bundle perspective-python's dependency licenses into LICENSE_THIRDPARTY_cargo.yml, which is also added to the sdist.

When Maturin builds a wheel, it searches the source for files named `LICENSE*` (among others) and includes them in dist-info. C++ license packaging can use this same framework: we'll generate a file in the perspective-python source tree which aggregates licenses from arrow and other bundled C++ dependencies.

Adds a basic test of the license packaging to the sdist test. Note that this doesn't test the wheels we distribute, which takes a different build path in CI.