### PR TITLE
Fix empty Arrow `Table` constructor

### DIFF
--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -77,10 +77,10 @@ load_file(
     } else {
         std::shared_ptr<arrow::ipc::RecordBatchFileReader> batch_reader =
             *status;
+
         std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
         auto num_batches = batch_reader->num_record_batches();
         for (int i = 0; i < num_batches; ++i) {
-
             auto status2 = batch_reader->ReadRecordBatch(i);
             if (!status2.ok()) {
                 PSP_COMPLAIN_AND_ABORT(
@@ -91,7 +91,10 @@ load_file(
             std::shared_ptr<arrow::RecordBatch> chunk = *status2;
             batches.push_back(chunk);
         }
-        auto status3 = arrow::Table::FromRecordBatches(batches);
+
+        auto status3 =
+            arrow::Table::FromRecordBatches(batch_reader->schema(), batches);
+
         if (!status3.ok()) {
             std::stringstream ss;
             ss << "Failed to create Table from RecordBatches: "

--- a/docs/src/components/DocItem/browser.js
+++ b/docs/src/components/DocItem/browser.js
@@ -10,11 +10,12 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import "@finos/perspective-viewer";
-import "@finos/perspective-viewer-datagrid";
 import { SUPERSTORE_TABLE } from "@site/src/data/superstore.js";
 
 export async function main(colorMode) {
+    await import("@finos/perspective-viewer", { type: "module" });
+    await import("@finos/perspective-viewer-datagrid");
+
     await customElements.whenDefined("perspective-viewer");
     const viewers = document.querySelectorAll(
         "perspective-viewer:not(.nosuperstore)"

--- a/examples/blocks/src/raycasting/index.js
+++ b/examples/blocks/src/raycasting/index.js
@@ -55,7 +55,7 @@ for (var j := 0; j <= radialSegments; j += 1) {
         vs[i0] := vs[i0] * bcos - vs[i0 + 2] * bsin;
         vs[i0 + 2] := b * bsin + vs[i0 + 2] * bcos;
     }
-}
+};
 
 // Render scene
 var scale := resolution / (tan(fov / 2) * 400);

--- a/packages/perspective-esbuild-plugin/index.js
+++ b/packages/perspective-esbuild-plugin/index.js
@@ -16,7 +16,11 @@ const { WorkerPlugin } = require("./worker.js");
 exports.PerspectiveEsbuildPlugin = function PerspectiveEsbuildPlugin(
     options = {}
 ) {
-    const wasm_plugin = WasmPlugin(!!options.wasm?.inline);
+    const wasm_plugin = WasmPlugin(
+        !!options.wasm?.inline,
+        !options.wasm?.webpack_hack
+    );
+
     const worker_plugin = WorkerPlugin({
         targetdir: options.worker?.targetdir,
     });

--- a/packages/perspective-esbuild-plugin/worker.js
+++ b/packages/perspective-esbuild-plugin/worker.js
@@ -154,29 +154,6 @@ exports.WorkerPlugin = function WorkerPlugin(options = {}) {
                 loader: "text",
             };
         });
-
-        build.onEnd(({ metafile }) => {
-            for (const file of Object.keys(metafile.outputs)) {
-                if (file.endsWith(".js")) {
-                    let contents = fs.readFileSync(file).toString();
-                    const symbol = contents.match(
-                        /__PSP_INLINE_WORKER__\(([a-zA-Z0-9_\$]+?)\)/
-                    );
-                    if (symbol?.[1]) {
-                        const filename = contents.match(
-                            new RegExp(`${symbol[1]}\\s*?=\\s*?\\"(.+?)\\"`)
-                        );
-
-                        contents = contents.replace(
-                            /__PSP_INLINE_WORKER__\([a-zA-Z0-9_\$]+?\)/,
-                            `"${filename[1]}"`
-                        );
-
-                        fs.writeFileSync(file, contents);
-                    }
-                }
-            }
-        });
     }
 
     return {

--- a/rust/perspective-python/perspective/tests/table/test_table_arrow.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_arrow.py
@@ -117,6 +117,27 @@ class TestTableArrow(object):
             "d": data[3],
         }
 
+    def test_empty_arrow(self, util):
+        table = pa.table(
+            {
+                "col1": [1, 2, 3],
+                "col2": ["abc", "foo", "bar"],
+            }
+        )
+
+        empty_table = table.schema.empty_table()
+        assert client.table(table, name="table").size() == 3
+        assert client.table(empty_table, name="table_empty_bad").size() == 0
+        assert client.table(table, name="table").schema() == {
+            "col1": "integer",
+            "col2": "string",
+        }
+
+        assert client.table(empty_table, name="table").schema() == {
+            "col1": "integer",
+            "col2": "string",
+        }
+
     def test_table_arrow_loads_float_stream(self, util):
         data = [[i for i in range(10)], [i * 1.5 for i in range(10)]]
         arrow_data = util.make_arrow(["a", "b"], data)

--- a/rust/perspective-python/src/client/client_sync.rs
+++ b/rust/perspective-python/src/client/client_sync.rs
@@ -26,7 +26,7 @@ use super::python::*;
 use crate::py_err::ResultTClientErrorExt;
 use crate::server::PySyncServer;
 
-#[pyclass]
+#[pyclass(module = "perspective")]
 #[derive(Clone)]
 pub struct ProxySession(perspective_client::ProxySession);
 
@@ -81,7 +81,7 @@ trait PyFutureExt: Future {
 impl<F: Future> PyFutureExt for F {}
 
 #[doc = crate::inherit_docs!("client.md")]
-#[pyclass(subclass)]
+#[pyclass(subclass, module = "perspective")]
 pub struct Client(pub(crate) PyClient);
 
 #[pymethods]
@@ -147,7 +147,7 @@ impl Client {
 }
 
 #[doc = crate::inherit_docs!("table.md")]
-#[pyclass(subclass, name = "Table")]
+#[pyclass(subclass, name = "Table", module = "perspective")]
 pub struct Table(PyTable);
 
 assert_table_api!(Table);
@@ -272,7 +272,7 @@ impl Table {
 }
 
 #[doc = crate::inherit_docs!("view.md")]
-#[pyclass(subclass, name = "View")]
+#[pyclass(subclass, name = "View", module = "perspective")]
 pub struct View(PyView);
 
 assert_view_api!(View);

--- a/rust/perspective-python/src/server/server_sync.rs
+++ b/rust/perspective-python/src/server/server_sync.rs
@@ -22,13 +22,13 @@ use pyo3::types::{PyAny, PyBytes};
 
 use crate::client::python::PyClient;
 
-#[pyclass]
+#[pyclass(module = "perspective")]
 #[derive(Clone)]
 pub struct PySyncSession {
     session: Arc<RwLock<Option<LocalSession>>>,
 }
 
-#[pyclass(subclass)]
+#[pyclass(subclass, module = "perspective")]
 #[derive(Clone, Default)]
 pub struct PySyncServer {
     pub server: Server,


### PR DESCRIPTION
* Fixed empty Arrow `Table` constructor bug #2844
* Fixed `perspective-python` objects repr to read e.g. `<class 'perspective.PySyncServer'>` instead of `<class 'builtins.PySyncServer'>`
* Fixed minification bug with `perspective-esbuild-plugin`, and added an option `webpack_hack` which can be used to disable this problematic regex next time it decides to act up.
