### PR TITLE
Show appropriate date when date is part of grouped data on chart.

### DIFF
--- a/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
@@ -17,7 +17,7 @@ function refineDateData(
     settings: Settings,
     data: any[] | undefined = undefined
 ) {
-    let dataToRefine = data !== undefined ? data : settings.data;
+    let dataToRefine = data ?? settings.data;
 
     settings.crossValues.forEach((value, index) => {
         if (

--- a/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
@@ -18,7 +18,7 @@ function refineDateData(settings: Settings) {
     const { crossValues } = settings;
 
     crossValues.forEach(({ type }, index) => {
-        console.log("Type:", type)
+        console.log("Type:", type);
         const formatType =
             type === "date" || type === "datetime"
                 ? (value: any) => new Date(value).toLocaleString()

--- a/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
@@ -22,14 +22,15 @@ function refineDateData(
 
     crossValues.forEach(({ type }, index) => {
         const formatType =
-            (type === "date" || type === "timestamp" || type === "datetime")
-             ? (value: any) => new Date(value).toLocaleDateString()
-            : ((type === "time") ? (value: any) => new Date(value).toLocaleTimeString()
-            : null);
+            type === "date" || type === "timestamp" || type === "datetime"
+                ? (value: any) => new Date(value).toLocaleDateString()
+                : type === "time"
+                ? (value: any) => new Date(value).toLocaleTimeString()
+                : null;
 
         if (formatType) {
             dataToRefine.forEach((row: { __ROW_PATH__: any[] }) => {
-                row.__ROW_PATH__[index] = formatType(row.__ROW_PATH__[index])
+                row.__ROW_PATH__[index] = formatType(row.__ROW_PATH__[index]);
             });
         }
     });

--- a/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
@@ -13,11 +13,41 @@
 import { groupFromKey } from "../series/seriesKey";
 import { DataRowsWithKey, Settings } from "../types";
 
+function refineDateData(
+    settings: Settings,
+    data: any[] | undefined = undefined
+) {
+    let dataToRefine = data !== undefined ? data : settings.data;
+
+    settings.crossValues.forEach((value, index) => {
+        if (
+            value.type === "date" ||
+            value.type === "timestamp" ||
+            value.type === "datetime"
+        ) {
+            dataToRefine.forEach((row: { __ROW_PATH__: any[] }) => {
+                row.__ROW_PATH__[index] = new Date(
+                    row.__ROW_PATH__[index]
+                ).toLocaleDateString();
+            });
+        }
+        if (value.type === "time") {
+            dataToRefine.forEach((row: { __ROW_PATH__: any[] }) => {
+                row.__ROW_PATH__[index] = new Date(
+                    row.__ROW_PATH__[index]
+                ).toLocaleTimeString();
+            });
+        }
+    });
+
+    return dataToRefine;
+}
+
 export function filterData(
     settings: Settings,
     data: any[] | undefined = undefined
 ) {
-    const useData = data || settings.data;
+    const useData = data || refineDateData(settings, settings.data);
     const len = settings.hideKeys?.length ?? 0;
     return len > 0
         ? useData.map((col) => {
@@ -31,7 +61,7 @@ export function filterData(
 }
 
 export function filterDataByGroup(settings: Settings): DataRowsWithKey {
-    const newData = settings.data;
+    const newData = refineDateData(settings);
     const hideKeysLen = settings.hideKeys?.length ?? 0;
     const splitValsLen = settings.splitValues.length;
     return hideKeysLen > 0

--- a/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
@@ -13,19 +13,15 @@
 import { groupFromKey } from "../series/seriesKey";
 import { DataRowsWithKey, Settings } from "../types";
 
-function refineDateData(
-    settings: Settings,
-    data: any[] | undefined = undefined
-) {
-    let dataToRefine = data ?? settings.data;
+function refineDateData(settings: Settings) {
+    let dataToRefine = settings.data;
     const { crossValues } = settings;
 
     crossValues.forEach(({ type }, index) => {
+        console.log("Type:", type)
         const formatType =
-            type === "date" || type === "timestamp" || type === "datetime"
-                ? (value: any) => new Date(value).toLocaleDateString()
-                : type === "time"
-                ? (value: any) => new Date(value).toLocaleTimeString()
+            type === "date" || type === "datetime"
+                ? (value: any) => new Date(value).toLocaleString()
                 : null;
 
         if (formatType) {
@@ -42,7 +38,7 @@ export function filterData(
     settings: Settings,
     data: any[] | undefined = undefined
 ) {
-    const useData = data || refineDateData(settings, settings.data);
+    const useData = data || refineDateData(settings);
     const len = settings.hideKeys?.length ?? 0;
     return len > 0
         ? useData.map((col) => {

--- a/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/legend/filter.ts
@@ -18,24 +18,18 @@ function refineDateData(
     data: any[] | undefined = undefined
 ) {
     let dataToRefine = data ?? settings.data;
+    const { crossValues } = settings;
 
-    settings.crossValues.forEach((value, index) => {
-        if (
-            value.type === "date" ||
-            value.type === "timestamp" ||
-            value.type === "datetime"
-        ) {
+    crossValues.forEach(({ type }, index) => {
+        const formatType =
+            (type === "date" || type === "timestamp" || type === "datetime")
+             ? (value: any) => new Date(value).toLocaleDateString()
+            : ((type === "time") ? (value: any) => new Date(value).toLocaleTimeString()
+            : null);
+
+        if (formatType) {
             dataToRefine.forEach((row: { __ROW_PATH__: any[] }) => {
-                row.__ROW_PATH__[index] = new Date(
-                    row.__ROW_PATH__[index]
-                ).toLocaleDateString();
-            });
-        }
-        if (value.type === "time") {
-            dataToRefine.forEach((row: { __ROW_PATH__: any[] }) => {
-                row.__ROW_PATH__[index] = new Date(
-                    row.__ROW_PATH__[index]
-                ).toLocaleTimeString();
+                row.__ROW_PATH__[index] = formatType(row.__ROW_PATH__[index])
             });
         }
     });

--- a/packages/perspective-viewer-d3fc/test/js/axisLabel.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/axisLabel.spec.ts
@@ -1,0 +1,335 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { expect, test } from "@finos/perspective-test";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/tools/perspective-test/src/html/basic-test.html");
+    await page.evaluate(async () => {
+        while (!window["__TEST_PERSPECTIVE_READY__"]) {
+            await new Promise((x) => setTimeout(x, 10));
+        }
+    });
+
+    await page.evaluate(async () => {
+        let viewer = document.querySelector("perspective-viewer");
+        await viewer!.restore({
+            plugin: "Datagrid",
+            group_by: ["Order Date", "Profit"],
+            x_axis: ["Row ID"],
+        });
+
+        return await viewer.save();
+    });
+
+    await page.click("#settings_button");
+    await page.click(".plugin-select-item");
+});
+
+function confirmDateData(dateValues: any[]) {
+    // expect the first to be a date.
+    expect(!isNaN(Date.parse(dateValues[0]))).toEqual(true);
+
+    // expect any random index of axisLabels to also be a date.
+    let len = dateValues.length;
+    const index = Math.floor(Math.random() * len);
+
+    expect(!isNaN(Date.parse(dateValues[index]))).toEqual(true);
+
+    // expect the last value to be a date.
+
+    expect(!isNaN(Date.parse(dateValues[len - 1]))).toEqual(true);
+
+    /**
+     * To confirm that the date string is not in epoch format.
+     * check if the entire string is numeric.
+     * if it is, confirm that the length is not 10 or 13.
+     * if it is not, return true.
+     */
+    let isNumericOnly = /^\d+$/.test(dateValues[index]);
+
+    expect(isNumericOnly).toEqual(false);
+}
+
+test.describe("Axis Values With Grouped Data With A Date Field In The Group", () => {
+    test("X Bar y-axis label with grouped data", async ({ page }) => {
+        await page.click('div[data-plugin="X Bar"]');
+        await page.waitForSelector("perspective-viewer");
+
+        const dateValues = await page.evaluate(async () => {
+            let viewer = document.querySelector("perspective-viewer");
+
+            if (!viewer) return [];
+
+            const plugin_element = viewer.querySelector(
+                `perspective-viewer-d3fc-xbar`
+            );
+
+            if (!plugin_element) return [];
+
+            const shadowRoot = plugin_element.shadowRoot;
+            const elements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.y-axis.left-axis svg, g.group"
+            );
+
+            // By how the data is grouped, the date values are the last in the array.
+            const lastGroup = elements[elements.length - 1];
+
+            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
+
+            // collect and return the actual date data to be used.
+            return Array.from(dateTextElements).map((el) =>
+                el.textContent?.trim()
+            );
+        });
+
+        confirmDateData(dateValues);
+    });
+
+    test("Y Bar x-axis label with grouped data", async ({ page }) => {
+        await page.click('div[data-plugin="Y Bar"]');
+        await page.waitForSelector("perspective-viewer");
+
+        const dateValues = await page.evaluate(async () => {
+            let viewer = document.querySelector("perspective-viewer");
+
+            if (!viewer) return [];
+
+            const plugin_element = viewer.querySelector(
+                `perspective-viewer-d3fc-ybar`
+            );
+
+            if (!plugin_element) return [];
+
+            const shadowRoot = plugin_element.shadowRoot;
+            const elements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            );
+
+            // By how the data is grouped, the date values are the last in the array.
+            const lastGroup = elements[elements.length - 1];
+
+            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
+
+            // collect and return the actual date data to be used.
+            return Array.from(dateTextElements).map((el) =>
+                el.textContent?.trim()
+            );
+        });
+
+        confirmDateData(dateValues);
+    });
+
+    test("OHLC x-axis label with grouped data", async ({ page }) => {
+        await page.click('div[data-plugin="OHLC"]');
+        await page.waitForSelector("perspective-viewer");
+
+        const dateValues = await page.evaluate(async () => {
+            let viewer = document.querySelector("perspective-viewer");
+
+            if (!viewer) return [];
+
+            const plugin_element = viewer.querySelector(
+                `perspective-viewer-d3fc-ohlc`
+            );
+
+            if (!plugin_element) return [];
+
+            const shadowRoot = plugin_element.shadowRoot;
+            const elements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            );
+
+            // By how the data is grouped, the date values are the last in the array.
+            const lastGroup = elements[elements.length - 1];
+
+            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
+
+            // collect and return the actual date data to be used.
+            return Array.from(dateTextElements).map((el) =>
+                el.textContent?.trim()
+            );
+        });
+
+        confirmDateData(dateValues);
+    });
+
+    test("Heatmap x-axis label with grouped data", async ({ page }) => {
+        await page.click('div[data-plugin="Heatmap"]');
+        await page.waitForSelector("perspective-viewer");
+
+        const dateValues = await page.evaluate(async () => {
+            let viewer = document.querySelector("perspective-viewer");
+
+            if (!viewer) return [];
+
+            const plugin_element = viewer.querySelector(
+                `perspective-viewer-d3fc-heatmap`
+            );
+
+            if (!plugin_element) return [];
+
+            const shadowRoot = plugin_element.shadowRoot;
+            const elements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            );
+
+            // By how the data is grouped, the date values are the last in the array.
+            const lastGroup = elements[elements.length - 1];
+
+            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
+
+            // collect and return the actual date data to be used.
+            return Array.from(dateTextElements).map((el) =>
+                el.textContent?.trim()
+            );
+        });
+
+        confirmDateData(dateValues);
+    });
+
+    test("Y Line x-axis label with grouped data", async ({ page }) => {
+        await page.click('div[data-plugin="Y Line"]');
+        await page.waitForSelector("perspective-viewer");
+
+        const dateValues = await page.evaluate(async () => {
+            let viewer = document.querySelector("perspective-viewer");
+
+            if (!viewer) return [];
+
+            const plugin_element = viewer.querySelector(
+                `perspective-viewer-d3fc-yline`
+            );
+
+            if (!plugin_element) return [];
+
+            const shadowRoot = plugin_element.shadowRoot;
+            const elements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            );
+
+            // By how the data is grouped, the date values are the last in the array.
+            const lastGroup = elements[elements.length - 1];
+
+            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
+
+            // collect and return the actual date data to be used.
+            return Array.from(dateTextElements).map((el) =>
+                el.textContent?.trim()
+            );
+        });
+
+        confirmDateData(dateValues);
+    });
+
+    test("Y Area x-axis label with grouped data", async ({ page }) => {
+        await page.click('div[data-plugin="Y Area"]');
+        await page.waitForSelector("perspective-viewer");
+
+        const dateValues = await page.evaluate(async () => {
+            let viewer = document.querySelector("perspective-viewer");
+
+            if (!viewer) return [];
+
+            const plugin_element = viewer.querySelector(
+                `perspective-viewer-d3fc-yarea`
+            );
+
+            if (!plugin_element) return [];
+
+            const shadowRoot = plugin_element.shadowRoot;
+            const elements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            );
+
+            // By how the data is grouped, the date values are the last in the array.
+            const lastGroup = elements[elements.length - 1];
+
+            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
+
+            // collect and return the actual date data to be used.
+            return Array.from(dateTextElements).map((el) =>
+                el.textContent?.trim()
+            );
+        });
+
+        confirmDateData(dateValues);
+    });
+
+    test("Y Scatter x-axis label with grouped data", async ({ page }) => {
+        await page.click('div[data-plugin="Y Scatter"]');
+        await page.waitForSelector("perspective-viewer");
+
+        const dateValues = await page.evaluate(async () => {
+            let viewer = document.querySelector("perspective-viewer");
+
+            if (!viewer) return [];
+
+            const plugin_element = viewer.querySelector(
+                `perspective-viewer-d3fc-yscatter`
+            );
+
+            if (!plugin_element) return [];
+
+            const shadowRoot = plugin_element.shadowRoot;
+            const elements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            );
+
+            // By how the data is grouped, the date values are the last in the array.
+            const lastGroup = elements[elements.length - 1];
+
+            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
+
+            // collect and return the actual date data to be used.
+            return Array.from(dateTextElements).map((el) =>
+                el.textContent?.trim()
+            );
+        });
+
+        confirmDateData(dateValues);
+    });
+
+    test("CandleStick x-axis label with grouped data", async ({ page }) => {
+        await page.click('div[data-plugin="Candlestick"]');
+        await page.waitForSelector("perspective-viewer");
+
+        const dateValues = await page.evaluate(async () => {
+            let viewer = document.querySelector("perspective-viewer");
+
+            if (!viewer) return [];
+
+            const plugin_element = viewer.querySelector(
+                `perspective-viewer-d3fc-candlestick`
+            );
+
+            if (!plugin_element) return [];
+
+            const shadowRoot = plugin_element.shadowRoot;
+            const elements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            );
+
+            // By how the data is grouped, the date values are the last in the array.
+            const lastGroup = elements[elements.length - 1];
+
+            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
+
+            // collect and return the actual date data to be used.
+            return Array.from(dateTextElements).map((el) =>
+                el.textContent?.trim()
+            );
+        });
+
+        confirmDateData(dateValues);
+    });
+});

--- a/packages/perspective-viewer-d3fc/test/js/axisLabel.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/axisLabel.spec.ts
@@ -36,79 +36,78 @@ test.beforeEach(async ({ page }) => {
 });
 
 function confirmDataIsDate(dateValues: any[]) {
-    if (dateValues.length === 0){
-        throw Error("No date values recorded")
+    if (dateValues.length === 0) {
+        throw Error("No date values recorded");
     }
 
-    const filtered_dates = dateValues.filter(_ => isNaN(Date.parse(_)));
+    const filtered_dates = dateValues.filter((_) => isNaN(Date.parse(_)));
 
-    expect(filtered_dates.length).toEqual(0)
+    expect(filtered_dates.length).toEqual(0);
 }
 
 function confirmDataIsNotEpochForm(dateValues: any[]) {
-    confirmDataIsDate(dateValues)
+    confirmDataIsDate(dateValues);
 
     const isEpoch = (date: any): boolean => {
-        return !isNaN(date) && (date.length === 10 || date.length === 13)
-    }
+        return !isNaN(date) && (date.length === 10 || date.length === 13);
+    };
 
-    const filtered_dates = dateValues.filter(_ => isEpoch(_));
+    const filtered_dates = dateValues.filter((_) => isEpoch(_));
 
-    expect(filtered_dates.length).toEqual(0)
-
+    expect(filtered_dates.length).toEqual(0);
 }
 
 test.describe("Axis Values With Grouped Data With A Date Field In The Group", () => {
     test("X Bar y-axis label with grouped data", async ({ page }) => {
         await page.click('div[data-plugin="X Bar"]');
-        await page.waitForSelector("perspective-viewer")
+        await page.waitForSelector("perspective-viewer");
 
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
             if (!viewer) {
-                return Error("Invalid Viewer")
-            };
+                return Error("Invalid Viewer");
+            }
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-xbar`
             );
 
             if (!plugin_element) {
-                throw Error("Invalid Plugin Element")
+                throw Error("Invalid Plugin Element");
             }
 
             const shadowRoot = plugin_element.shadowRoot;
             const dateTextElements = shadowRoot.querySelectorAll(
                 "div d3fc-group d3fc-svg.y-axis.left-axis svg g.group:last-child g.tick text"
             );
-            
+
             // collect and return the actual date data to be used.
             return Array.from(dateTextElements).map((el) =>
                 el.textContent?.trim()
             );
         });
 
-        confirmDataIsNotEpochForm(dateValues)
+        confirmDataIsNotEpochForm(dateValues);
     });
 
     test("Y Bar x-axis label with grouped data", async ({ page }) => {
         await page.click('div[data-plugin="Y Bar"]');
-        await page.waitForSelector("perspective-viewer")
+        await page.waitForSelector("perspective-viewer");
 
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
             if (!viewer) {
-                return Error("Invalid Viewer")
-            };
+                return Error("Invalid Viewer");
+            }
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-ybar`
             );
 
             if (!plugin_element) {
-                throw Error("Invalid Plugin Element")
+                throw Error("Invalid Plugin Element");
             }
 
             const shadowRoot = plugin_element.shadowRoot;
@@ -133,15 +132,15 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             let viewer = document.querySelector("perspective-viewer");
 
             if (!viewer) {
-                return Error("Invalid Viewer")
-            };
+                return Error("Invalid Viewer");
+            }
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-ohlc`
             );
 
             if (!plugin_element) {
-                throw Error("Invalid Plugin Element")
+                throw Error("Invalid Plugin Element");
             }
 
             const shadowRoot = plugin_element.shadowRoot;
@@ -155,7 +154,7 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             );
         });
 
-       confirmDataIsNotEpochForm(dateValues);
+        confirmDataIsNotEpochForm(dateValues);
     });
 
     test("Heatmap x-axis label with grouped data", async ({ page }) => {
@@ -166,15 +165,15 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             let viewer = document.querySelector("perspective-viewer");
 
             if (!viewer) {
-                return Error("Invalid Viewer")
-            };
+                return Error("Invalid Viewer");
+            }
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-heatmap`
             );
 
             if (!plugin_element) {
-                throw Error("Invalid Plugin Element")
+                throw Error("Invalid Plugin Element");
             }
 
             const shadowRoot = plugin_element.shadowRoot;
@@ -199,15 +198,15 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             let viewer = document.querySelector("perspective-viewer");
 
             if (!viewer) {
-                return Error("Invalid Viewer")
-            };
+                return Error("Invalid Viewer");
+            }
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-yline`
             );
 
             if (!plugin_element) {
-                throw Error("Invalid Plugin Element")
+                throw Error("Invalid Plugin Element");
             }
 
             const shadowRoot = plugin_element.shadowRoot;
@@ -232,15 +231,15 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             let viewer = document.querySelector("perspective-viewer");
 
             if (!viewer) {
-                return Error("Invalid Viewer")
-            };
+                return Error("Invalid Viewer");
+            }
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-yarea`
             );
 
             if (!plugin_element) {
-                throw Error("Invalid Plugin Element")
+                throw Error("Invalid Plugin Element");
             }
 
             const shadowRoot = plugin_element.shadowRoot;
@@ -265,15 +264,15 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             let viewer = document.querySelector("perspective-viewer");
 
             if (!viewer) {
-                return Error("Invalid Viewer")
-            };
+                return Error("Invalid Viewer");
+            }
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-yscatter`
             );
 
             if (!plugin_element) {
-                throw Error("Invalid Plugin Element")
+                throw Error("Invalid Plugin Element");
             }
 
             const shadowRoot = plugin_element.shadowRoot;
@@ -298,15 +297,15 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             let viewer = document.querySelector("perspective-viewer");
 
             if (!viewer) {
-                return Error("Invalid Viewer")
-            };
+                return Error("Invalid Viewer");
+            }
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-candlestick`
             );
 
             if (!plugin_element) {
-                throw Error("Invalid Plugin Element")
+                throw Error("Invalid Plugin Element");
             }
 
             const shadowRoot = plugin_element.shadowRoot;

--- a/packages/perspective-viewer-d3fc/test/js/axisLabel.spec.ts
+++ b/packages/perspective-viewer-d3fc/test/js/axisLabel.spec.ts
@@ -35,90 +35,86 @@ test.beforeEach(async ({ page }) => {
     await page.click(".plugin-select-item");
 });
 
-function confirmDateData(dateValues: any[]) {
-    // expect the first to be a date.
-    expect(!isNaN(Date.parse(dateValues[0]))).toEqual(true);
+function confirmDataIsDate(dateValues: any[]) {
+    if (dateValues.length === 0){
+        throw Error("No date values recorded")
+    }
 
-    // expect any random index of axisLabels to also be a date.
-    let len = dateValues.length;
-    const index = Math.floor(Math.random() * len);
+    const filtered_dates = dateValues.filter(_ => isNaN(Date.parse(_)));
 
-    expect(!isNaN(Date.parse(dateValues[index]))).toEqual(true);
+    expect(filtered_dates.length).toEqual(0)
+}
 
-    // expect the last value to be a date.
+function confirmDataIsNotEpochForm(dateValues: any[]) {
+    confirmDataIsDate(dateValues)
 
-    expect(!isNaN(Date.parse(dateValues[len - 1]))).toEqual(true);
+    const isEpoch = (date: any): boolean => {
+        return !isNaN(date) && (date.length === 10 || date.length === 13)
+    }
 
-    /**
-     * To confirm that the date string is not in epoch format.
-     * check if the entire string is numeric.
-     * if it is, confirm that the length is not 10 or 13.
-     * if it is not, return true.
-     */
-    let isNumericOnly = /^\d+$/.test(dateValues[index]);
+    const filtered_dates = dateValues.filter(_ => isEpoch(_));
 
-    expect(isNumericOnly).toEqual(false);
+    expect(filtered_dates.length).toEqual(0)
+
 }
 
 test.describe("Axis Values With Grouped Data With A Date Field In The Group", () => {
     test("X Bar y-axis label with grouped data", async ({ page }) => {
         await page.click('div[data-plugin="X Bar"]');
-        await page.waitForSelector("perspective-viewer");
+        await page.waitForSelector("perspective-viewer")
 
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
-            if (!viewer) return [];
+            if (!viewer) {
+                return Error("Invalid Viewer")
+            };
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-xbar`
             );
 
-            if (!plugin_element) return [];
+            if (!plugin_element) {
+                throw Error("Invalid Plugin Element")
+            }
 
             const shadowRoot = plugin_element.shadowRoot;
-            const elements = shadowRoot.querySelectorAll(
-                "div d3fc-group d3fc-svg.y-axis.left-axis svg, g.group"
+            const dateTextElements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.y-axis.left-axis svg g.group:last-child g.tick text"
             );
-
-            // By how the data is grouped, the date values are the last in the array.
-            const lastGroup = elements[elements.length - 1];
-
-            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
-
+            
             // collect and return the actual date data to be used.
             return Array.from(dateTextElements).map((el) =>
                 el.textContent?.trim()
             );
         });
 
-        confirmDateData(dateValues);
+        confirmDataIsNotEpochForm(dateValues)
     });
 
     test("Y Bar x-axis label with grouped data", async ({ page }) => {
         await page.click('div[data-plugin="Y Bar"]');
-        await page.waitForSelector("perspective-viewer");
+        await page.waitForSelector("perspective-viewer")
 
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
-            if (!viewer) return [];
+            if (!viewer) {
+                return Error("Invalid Viewer")
+            };
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-ybar`
             );
 
-            if (!plugin_element) return [];
+            if (!plugin_element) {
+                throw Error("Invalid Plugin Element")
+            }
 
             const shadowRoot = plugin_element.shadowRoot;
-            const elements = shadowRoot.querySelectorAll(
-                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            const dateTextElements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg g.group:last-child g.tick text"
             );
-
-            // By how the data is grouped, the date values are the last in the array.
-            const lastGroup = elements[elements.length - 1];
-
-            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
 
             // collect and return the actual date data to be used.
             return Array.from(dateTextElements).map((el) =>
@@ -126,7 +122,7 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             );
         });
 
-        confirmDateData(dateValues);
+        confirmDataIsNotEpochForm(dateValues);
     });
 
     test("OHLC x-axis label with grouped data", async ({ page }) => {
@@ -136,23 +132,22 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
-            if (!viewer) return [];
+            if (!viewer) {
+                return Error("Invalid Viewer")
+            };
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-ohlc`
             );
 
-            if (!plugin_element) return [];
+            if (!plugin_element) {
+                throw Error("Invalid Plugin Element")
+            }
 
             const shadowRoot = plugin_element.shadowRoot;
-            const elements = shadowRoot.querySelectorAll(
-                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            const dateTextElements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg g.group:last-child g.tick text"
             );
-
-            // By how the data is grouped, the date values are the last in the array.
-            const lastGroup = elements[elements.length - 1];
-
-            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
 
             // collect and return the actual date data to be used.
             return Array.from(dateTextElements).map((el) =>
@@ -160,7 +155,7 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             );
         });
 
-        confirmDateData(dateValues);
+       confirmDataIsNotEpochForm(dateValues);
     });
 
     test("Heatmap x-axis label with grouped data", async ({ page }) => {
@@ -170,23 +165,22 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
-            if (!viewer) return [];
+            if (!viewer) {
+                return Error("Invalid Viewer")
+            };
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-heatmap`
             );
 
-            if (!plugin_element) return [];
+            if (!plugin_element) {
+                throw Error("Invalid Plugin Element")
+            }
 
             const shadowRoot = plugin_element.shadowRoot;
-            const elements = shadowRoot.querySelectorAll(
-                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            const dateTextElements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg g.group:last-child g.tick text"
             );
-
-            // By how the data is grouped, the date values are the last in the array.
-            const lastGroup = elements[elements.length - 1];
-
-            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
 
             // collect and return the actual date data to be used.
             return Array.from(dateTextElements).map((el) =>
@@ -194,7 +188,7 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             );
         });
 
-        confirmDateData(dateValues);
+        confirmDataIsNotEpochForm(dateValues);
     });
 
     test("Y Line x-axis label with grouped data", async ({ page }) => {
@@ -204,23 +198,22 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
-            if (!viewer) return [];
+            if (!viewer) {
+                return Error("Invalid Viewer")
+            };
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-yline`
             );
 
-            if (!plugin_element) return [];
+            if (!plugin_element) {
+                throw Error("Invalid Plugin Element")
+            }
 
             const shadowRoot = plugin_element.shadowRoot;
-            const elements = shadowRoot.querySelectorAll(
-                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            const dateTextElements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg g.group:last-child g.tick text"
             );
-
-            // By how the data is grouped, the date values are the last in the array.
-            const lastGroup = elements[elements.length - 1];
-
-            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
 
             // collect and return the actual date data to be used.
             return Array.from(dateTextElements).map((el) =>
@@ -228,7 +221,7 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             );
         });
 
-        confirmDateData(dateValues);
+        confirmDataIsNotEpochForm(dateValues);
     });
 
     test("Y Area x-axis label with grouped data", async ({ page }) => {
@@ -238,23 +231,22 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
-            if (!viewer) return [];
+            if (!viewer) {
+                return Error("Invalid Viewer")
+            };
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-yarea`
             );
 
-            if (!plugin_element) return [];
+            if (!plugin_element) {
+                throw Error("Invalid Plugin Element")
+            }
 
             const shadowRoot = plugin_element.shadowRoot;
-            const elements = shadowRoot.querySelectorAll(
-                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            const dateTextElements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg g.group:last-child g.tick text"
             );
-
-            // By how the data is grouped, the date values are the last in the array.
-            const lastGroup = elements[elements.length - 1];
-
-            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
 
             // collect and return the actual date data to be used.
             return Array.from(dateTextElements).map((el) =>
@@ -262,7 +254,7 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             );
         });
 
-        confirmDateData(dateValues);
+        confirmDataIsNotEpochForm(dateValues);
     });
 
     test("Y Scatter x-axis label with grouped data", async ({ page }) => {
@@ -272,23 +264,22 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
-            if (!viewer) return [];
+            if (!viewer) {
+                return Error("Invalid Viewer")
+            };
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-yscatter`
             );
 
-            if (!plugin_element) return [];
+            if (!plugin_element) {
+                throw Error("Invalid Plugin Element")
+            }
 
             const shadowRoot = plugin_element.shadowRoot;
-            const elements = shadowRoot.querySelectorAll(
-                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            const dateTextElements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg g.group:last-child g.tick text"
             );
-
-            // By how the data is grouped, the date values are the last in the array.
-            const lastGroup = elements[elements.length - 1];
-
-            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
 
             // collect and return the actual date data to be used.
             return Array.from(dateTextElements).map((el) =>
@@ -296,7 +287,7 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             );
         });
 
-        confirmDateData(dateValues);
+        confirmDataIsNotEpochForm(dateValues);
     });
 
     test("CandleStick x-axis label with grouped data", async ({ page }) => {
@@ -306,23 +297,22 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
         const dateValues = await page.evaluate(async () => {
             let viewer = document.querySelector("perspective-viewer");
 
-            if (!viewer) return [];
+            if (!viewer) {
+                return Error("Invalid Viewer")
+            };
 
             const plugin_element = viewer.querySelector(
                 `perspective-viewer-d3fc-candlestick`
             );
 
-            if (!plugin_element) return [];
+            if (!plugin_element) {
+                throw Error("Invalid Plugin Element")
+            }
 
             const shadowRoot = plugin_element.shadowRoot;
-            const elements = shadowRoot.querySelectorAll(
-                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg, g.group"
+            const dateTextElements = shadowRoot.querySelectorAll(
+                "div d3fc-group d3fc-svg.x-axis.bottom-axis svg g.group:last-child g.tick text"
             );
-
-            // By how the data is grouped, the date values are the last in the array.
-            const lastGroup = elements[elements.length - 1];
-
-            const dateTextElements = lastGroup.querySelectorAll("g.tick text");
 
             // collect and return the actual date data to be used.
             return Array.from(dateTextElements).map((el) =>
@@ -330,6 +320,6 @@ test.describe("Axis Values With Grouped Data With A Date Field In The Group", ()
             );
         });
 
-        confirmDateData(dateValues);
+        confirmDataIsNotEpochForm(dateValues);
     });
 });


### PR DESCRIPTION
This PR addresses issue #2566. When the data is grouped and a date is part of the grouped data, the date values are then represented in epoch format. I couldn't figure out the exact source of the problem, and this solution addresses the problem. I included a function in the filter.ts file since all the plugins affected by this issue import the functions in filter.ts. I refine the date type values before the functions in filter.ts run. The tests included confirm this solution too.

### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [x] Include new tests that fail without this PR but passes with it.
-   [ ] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
