### PR TITLE
Do not wait to call workspace update events

### DIFF
--- a/packages/perspective-workspace/src/ts/workspace/workspace.ts
+++ b/packages/perspective-workspace/src/ts/workspace/workspace.ts
@@ -71,7 +71,7 @@ export class PerspectiveWorkspace extends SplitPanel {
     private _minimizedLayoutSlots?: DockPanel.ILayoutConfig;
     private _minimizedLayout?: DockPanel.ILayoutConfig;
     private _maximizedWidget?: PerspectiveViewerWidget;
-    private _save?: DebouncedFunc<() => false | Promise<void>>;
+    private _save?: () => false | Promise<void>;
     private _context_menu?: Menu & { init_overlay?: () => void };
 
     constructor(element: HTMLElement, options = {}) {
@@ -1028,12 +1028,9 @@ export class PerspectiveWorkspace extends SplitPanel {
 
     async workspaceUpdated() {
         if (!this._save) {
-            this._save = debounce(
-                () =>
-                    this.dockpanel.mode !== "single-document" &&
-                    this._fireUpdateEvent(),
-                500
-            );
+            this._save = () =>
+                this.dockpanel.mode !== "single-document" &&
+                this._fireUpdateEvent();
         }
 
         this._save();


### PR DESCRIPTION
Currently there is a pause in the workspace before update events are fired, which can be quite user-unfriendly. This PR removes the debounce underlying this. 

I am getting some test failures locally (same tests failing on `master`) so I wanted to put this up to run on CI here and see it go green. It seems that instead of firing one update cleanly on changes, the event is called at least 5 times per change.

Going to close this as the event being spammed per change is quite annoying and will adversely affect subscribers of this event.