### PR TITLE
shows the right tooltip for the correct cell the cursor hovers over

### DIFF
--- a/packages/perspective-viewer-d3fc/src/ts/tooltip/nearbyTip.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/tooltip/nearbyTip.ts
@@ -147,10 +147,16 @@ export default (): NearbyTip => {
                 )
                     return null;
 
-                return Math.sqrt(
-                    Math.pow((xScale(v[xValueName]) as number) - pos.x, 2) +
-                        Math.pow(scale(v[yValueName]) - pos.y, 2)
-                );
+                const xDist = (xScale(v[xValueName]) as number) - pos.x;
+                const yDist = scale(v[yValueName]) - pos.y;
+
+
+                if (xDist <= 0 && yDist <= 0) {
+                    return Math.sqrt(
+                        Math.pow(xDist, 2) +
+                        Math.pow(yDist, 2)
+                    );
+                }
             };
         };
 


### PR DESCRIPTION
This pull request addresses the issue https://github.com/finos/perspective/issues/2340 where the heatmap chart showed tooltips for the wrong cell; specifically, the nearest cell to the right when the cursor moves halfway in the "right" direction, instead of the actual cell currently being highlighted.

