### PR TITLE
Fix duplicate columns

### DIFF
--- a/examples/python-tornado-streaming/server.py
+++ b/examples/python-tornado-streaming/server.py
@@ -17,6 +17,7 @@ import tornado.web
 import tornado.ioloop
 from datetime import date, datetime
 import perspective
+import perspective.handlers.tornado
 import json
 
 old = json.JSONEncoder.default

--- a/packages/perspective-workspace/src/less/menu.less
+++ b/packages/perspective-workspace/src/less/menu.less
@@ -12,10 +12,6 @@
 
 @import "@lumino/widgets/style/menu.css";
 
-:host {
-    position: absolute;
-}
-
 .lm-Menu {
     font-size: 12px;
     padding: 8px;

--- a/packages/perspective-workspace/src/ts/workspace/workspace.ts
+++ b/packages/perspective-workspace/src/ts/workspace/workspace.ts
@@ -91,7 +91,7 @@ export class PerspectiveWorkspace extends SplitPanel {
         this.commands = createCommands(this, this.indicator);
         this.menu_elem = document.createElement("perspective-workspace-menu");
         this.menu_elem.attachShadow({ mode: "open" });
-        this.menu_elem.shadowRoot!.innerHTML = `<style>${injectedStyles}</style>`;
+        this.menu_elem.shadowRoot!.innerHTML = `<style>:host{position:absolute;}${injectedStyles}</style>`;
 
         this.element.shadowRoot!.insertBefore(
             this.menu_elem,

--- a/rust/perspective-js/test/js/constructors.spec.js
+++ b/rust/perspective-js/test/js/constructors.spec.js
@@ -804,6 +804,26 @@ function validate_typed_array(typed_array, column_data) {
             table.delete();
         });
 
+        test("Handles duplicate column names with different types", async function () {
+            const csv = "A,A\ntest,1";
+            let table = await perspective.table(csv);
+            let view = await table.view();
+            let csv2 = await view.to_json();
+            expect(csv2).toEqual([{ A: "test", "A*": 1 }]);
+            view.delete();
+            table.delete();
+        });
+
+        test("Handles duplicate column names with rename collisions", async function () {
+            const csv = "A,A,A*\ntest,1,2";
+            let table = await perspective.table(csv);
+            let view = await table.view();
+            let csv2 = await view.to_json();
+            expect(csv2).toEqual([{ A: "test", "A*": 1, "A**": 2 }]);
+            view.delete();
+            table.delete();
+        });
+
         test("Handles strings with quotation characters and commas", async function () {
             let table = await perspective.table({ x: "string", y: "integer" });
             table.update([


### PR DESCRIPTION
Fixes #1911, supersedes #1910

Duplicate column support has _not_ been added to Perspective itself, rather duplicates will now be automatically renamed to a unique derivative (suffixed by `*`).

Only CSV and Arrow types support this. While we may be able to implement similar feature for JSON string types, there _shouldn't_ be any libraries which support this output. We'd also need to rely on non-standard convention of key order, potentially leading to some cryptic error messages if keys come out-of-order.