### PR TITLE
Support ndjson

### DIFF
--- a/cpp/perspective/src/include/perspective/server.h
+++ b/cpp/perspective/src/include/perspective/server.h
@@ -180,6 +180,24 @@ namespace server {
         ) const = 0;
 
         [[nodiscard]]
+        virtual std::string to_ndjson(
+            t_uindex start_row,
+            t_uindex end_row,
+            t_uindex start_col,
+            t_uindex end_col,
+            t_uindex hidden,
+            bool is_formatted,
+            bool get_pkeys,
+            bool get_ids,
+            bool leaves_only,
+            t_uindex num_sides,
+            bool has_row_path,
+            std::string nidx,
+            t_uindex columns_length,
+            t_uindex group_by_length
+        ) const = 0;
+
+        [[nodiscard]]
         virtual std::string to_columns(
             t_uindex start_row,
             t_uindex end_row,
@@ -297,6 +315,42 @@ namespace server {
             t_uindex group_by_length
         ) const override {
             return m_view->to_rows(
+                start_row,
+                end_row,
+                start_col,
+                end_col,
+                hidden,
+                is_formatted,
+                get_pkeys,
+                get_ids,
+                leaves_only,
+                num_sides,
+                has_row_path,
+                nidx,
+                columns_length,
+                group_by_length
+            );
+        }
+
+        [[nodiscard]]
+        std::string
+        to_ndjson(
+            t_uindex start_row,
+            t_uindex end_row,
+            t_uindex start_col,
+            t_uindex end_col,
+            t_uindex hidden,
+            bool is_formatted,
+            bool get_pkeys,
+            bool get_ids,
+            bool leaves_only,
+            t_uindex num_sides,
+            bool has_row_path,
+            std::string nidx,
+            t_uindex columns_length,
+            t_uindex group_by_length
+        ) const override {
+            return m_view->to_ndjson(
                 start_row,
                 end_row,
                 start_col,

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -198,6 +198,7 @@ public:
     void update_csv(const std::string_view& data, std::uint32_t port_id);
     void update_rows(const std::string_view& data, std::uint32_t port_id);
     void update_cols(const std::string_view& data, std::uint32_t port_id);
+    void update_ndjson(const std::string_view& data, std::uint32_t port_id);
     // void update_cols(const std::string_view& data) const;
 
     static std::shared_ptr<Table> from_csv(
@@ -213,6 +214,12 @@ public:
     );
 
     static std::shared_ptr<Table> from_rows(
+        const std::string& index,
+        const std::string_view& data,
+        std::uint32_t limit = std::numeric_limits<std::uint32_t>::max()
+    );
+
+    static std::shared_ptr<Table> from_ndjson(
         const std::string& index,
         const std::string_view& data,
         std::uint32_t limit = std::numeric_limits<std::uint32_t>::max()

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -222,6 +222,23 @@ public:
         t_uindex group_by_length
     ) const;
 
+    std::string to_ndjson(
+        t_uindex start_row,
+        t_uindex end_row,
+        t_uindex start_col,
+        t_uindex end_col,
+        t_uindex hidden,
+        bool is_formatted,
+        bool get_pkeys,
+        bool get_ids,
+        bool leaves_only,
+        t_uindex num_sides,
+        bool has_row_path,
+        const std::string& nidx,
+        t_uindex columns_length,
+        t_uindex group_by_length
+    ) const;
+
     std::string to_columns(
         t_uindex start_row,
         t_uindex end_row,

--- a/cpp/protos/perspective.proto
+++ b/cpp/protos/perspective.proto
@@ -50,6 +50,7 @@ message MakeTableData {
         string from_rows = 4;
         string from_cols = 5;
         string from_view = 6;
+        string from_ndjson = 7;
     };
 }
 
@@ -142,6 +143,7 @@ message Request {
         ViewToColumnsStringReq view_to_columns_string_req = 24;
         ViewToCSVReq view_to_csv_req = 25;
         ViewToRowsStringReq view_to_rows_string_req = 26;
+        ViewToNdjsonStringReq view_to_ndjson_string_req = 36;
 
         // External (we don't need these for viewer, but the developer may).
         MakeTableReq make_table_req = 27;
@@ -184,6 +186,7 @@ message Response {
         ViewToColumnsStringResp view_to_columns_string_resp = 24;
         ViewToCSVResp view_to_csv_resp = 25;
         ViewToRowsStringResp view_to_rows_string_resp = 26;
+        ViewToNdjsonStringResp view_to_ndjson_string_resp = 36;
         MakeTableResp make_table_resp = 27;
         TableDeleteResp table_delete_resp = 28;
         TableOnDeleteResp table_on_delete_resp = 29;
@@ -371,7 +374,6 @@ message ViewToColumnsStringResp {
     string json_string = 1;
 }
 
-
 message ViewToRowsStringReq {
     ViewPort viewport = 1;
     optional bool id = 2;
@@ -382,6 +384,18 @@ message ViewToRowsStringReq {
 
 message ViewToRowsStringResp {
     string json_string = 1;
+}
+
+message ViewToNdjsonStringReq {
+    ViewPort viewport = 1;
+    optional bool id = 2;
+    optional bool index = 3;
+    optional bool formatted = 4;
+    optional bool leaves_only = 5;
+}
+
+message ViewToNdjsonStringResp {
+    string ndjson_string = 1;
 }
 
 message ViewToArrowReq {

--- a/rust/perspective-client/docs/table.md
+++ b/rust/perspective-client/docs/table.md
@@ -114,6 +114,41 @@ reader may _coerce_ a `date` or `datetime` from these native JSON types:
 For CSV input types, Perspective relies on Apache Arrow's CSV parser, and as
 such uses the same column-type inference logic as Arrow itself.
 
+### Row Oriented JSON
+
+Row-oriented JSON is in the form of a list of objects. Each object in the list
+corresponds to a row in the table. For example:
+
+```json
+[
+    { "a": 86, "b": false, "c": "words" },
+    { "a": 0, "b": true, "c": "" },
+    { "a": 12345, "b": false, "c": "here" }
+]
+```
+
+### Column Oriented JSON
+
+Column-Oriented JSON comes in the form of an object of lists. Each key of the
+object is a column name, and each element of the list is the corresponding value
+in the row.
+
+```json
+{
+    "a": [86, 0, 12345],
+    "b": [false, true, false],
+    "c": ["words", "", "here"]
+}
+```
+
+### [NDJSON](https://github.com/ndjson/ndjson-spec)
+
+```json
+{ "a": 86, "b": false, "c": "words" }
+{ "a": 0, "b": true, "c": "" }
+{ "a": 12345, "b": false, "c": "here" }
+```
+
 ## Index and Limit
 
 Initializing a [`Table`] with an `index` tells Perspective to treat a column as
@@ -279,35 +314,3 @@ table.replace(df)
 </div>
 
 <div class="warning">`limit` cannot be used in conjunction with `index`.</div>
-
-# JSON Input Data
-
-Perspective supports many kinds of input data, including two formats of JSON
-data: row-oriented and column-oriented data.
-
-## Row Oriented JSON
-
-Row-oriented JSON is in the form of a list of objects. Each object in the list
-corresponds to a row in the table. For example:
-
-```json
-[
-    { "a": 86, "b": false, "c": "words" },
-    { "a": 0, "b": true, "c": "" },
-    { "a": 12345, "b": false, "c": "here" }
-]
-```
-
-## Column Oriented JSON
-
-Column-Oriented JSON comes in the form of an object of lists. Each key of the
-object is a column name, and each element of the list is the corresponding value
-in the row.
-
-```json
-{
-    "a": [86, 0, 12345],
-    "b": [false, true, false],
-    "c": ["words", "", "here"]
-}
-```

--- a/rust/perspective-client/docs/view/to_ndjson.md
+++ b/rust/perspective-client/docs/view/to_ndjson.md
@@ -1,0 +1,2 @@
+Renders this `View` as an [NDJSON](https://github.com/ndjson/ndjson-spec)
+formatted `String`.

--- a/rust/perspective-client/src/rust/table.rs
+++ b/rust/perspective-client/src/rust/table.rs
@@ -44,6 +44,9 @@ pub enum TableReadFormat {
 
     #[serde(rename = "arrow")]
     Arrow,
+
+    #[serde(rename = "ndjson")]
+    Ndjson,
 }
 
 impl TableReadFormat {
@@ -53,6 +56,7 @@ impl TableReadFormat {
             Some("json") => Some(TableReadFormat::JsonString),
             Some("columns") => Some(TableReadFormat::ColumnsString),
             Some("arrow") => Some(TableReadFormat::Arrow),
+            Some("ndjson") => Some(TableReadFormat::Ndjson),
             None => None,
             Some(x) => return Err(format!("Unknown format \"{}\"", x)),
         })

--- a/rust/perspective-client/src/rust/table_data.rs
+++ b/rust/perspective-client/src/rust/table_data.rs
@@ -35,6 +35,7 @@ pub enum UpdateData {
     Arrow(Bytes),
     JsonRows(String),
     JsonColumns(String),
+    Ndjson(String),
 }
 
 impl From<UpdateData> for TableData {
@@ -70,6 +71,7 @@ impl From<UpdateData> for proto::MakeTableData {
             UpdateData::Arrow(x) => make_table_data::Data::FromArrow(x.into()),
             UpdateData::JsonRows(x) => make_table_data::Data::FromRows(x),
             UpdateData::JsonColumns(x) => make_table_data::Data::FromCols(x),
+            UpdateData::Ndjson(x) => make_table_data::Data::FromNdjson(x),
         };
 
         MakeTableData { data: Some(data) }

--- a/rust/perspective-client/src/rust/view.rs
+++ b/rust/perspective-client/src/rust/view.rs
@@ -243,6 +243,31 @@ impl View {
         }
     }
 
+    #[doc = include_str!("../../docs/view/to_ndjson.md")]
+    pub async fn to_ndjson(&self, window: ViewWindow) -> ClientResult<String> {
+        let viewport = ViewPort {
+            start_row: window.start_row.map(|x| x.floor() as u32),
+            start_col: window.start_col.map(|x| x.floor() as u32),
+            end_row: window.end_row.map(|x| x.ceil() as u32),
+            end_col: window.end_col.map(|x| x.ceil() as u32),
+        };
+
+        let msg = self.client_message(ClientReq::ViewToNdjsonStringReq(ViewToNdjsonStringReq {
+            viewport: Some(viewport),
+            id: window.id,
+            index: window.index,
+            formatted: window.formatted,
+            leaves_only: window.leaves_only,
+        }));
+
+        match self.client.oneshot(&msg).await? {
+            ClientResp::ViewToNdjsonStringResp(ViewToNdjsonStringResp { ndjson_string }) => {
+                Ok(ndjson_string)
+            },
+            resp => Err(resp.into()),
+        }
+    }
+
     #[doc = include_str!("../../docs/view/to_csv.md")]
     pub async fn to_csv(&self, window: ViewWindow) -> ClientResult<String> {
         let msg = self.client_message(ClientReq::ViewToCsvReq(ViewToCsvReq {

--- a/rust/perspective-js/src/rust/table.rs
+++ b/rust/perspective-js/src/rust/table.rs
@@ -109,6 +109,9 @@ pub(crate) impl UpdateData {
                 Some(TableReadFormat::Arrow) => Ok(Some(UpdateData::Arrow(
                     value.as_string().into_apierror()?.into_bytes().into(),
                 ))),
+                Some(TableReadFormat::Ndjson) => {
+                    Ok(Some(UpdateData::Ndjson(value.as_string().into_apierror()?)))
+                },
             }
         } else if value.is_instance_of::<ArrayBuffer>() {
             let uint8array = Uint8Array::new(value);
@@ -121,6 +124,9 @@ pub(crate) impl UpdateData {
                 Some(TableReadFormat::ColumnsString) => {
                     Ok(Some(UpdateData::JsonColumns(String::from_utf8(slice)?)))
                 },
+                Some(TableReadFormat::Ndjson) => {
+                    Ok(Some(UpdateData::Ndjson(String::from_utf8(slice)?)))
+                },
                 None | Some(TableReadFormat::Arrow) => Ok(Some(UpdateData::Arrow(slice.into()))),
             }
         } else if let Some(uint8array) = value.dyn_ref::<Uint8Array>() {
@@ -132,6 +138,9 @@ pub(crate) impl UpdateData {
                 },
                 Some(TableReadFormat::ColumnsString) => {
                     Ok(Some(UpdateData::JsonColumns(String::from_utf8(slice)?)))
+                },
+                Some(TableReadFormat::Ndjson) => {
+                    Ok(Some(UpdateData::Ndjson(String::from_utf8(slice)?)))
                 },
                 None | Some(TableReadFormat::Arrow) => Ok(Some(UpdateData::Arrow(slice.into()))),
             }

--- a/rust/perspective-js/src/rust/view.rs
+++ b/rust/perspective-js/src/rust/view.rs
@@ -165,6 +165,14 @@ impl View {
         Ok(js_sys::JSON::parse(&json)?.unchecked_into())
     }
 
+    #[doc = inherit_docs!("view/to_ndjson.md")]
+    #[wasm_bindgen]
+    pub async fn to_ndjson(&self, window: Option<JsViewWindow>) -> ApiResult<String> {
+        let window = window.into_serde_ext::<Option<ViewWindow>>()?;
+        let ndjson = self.0.to_ndjson(window.unwrap_or_default()).await?;
+        Ok(ndjson)
+    }
+
     #[doc = inherit_docs!("view/to_csv.md")]
     #[wasm_bindgen]
     pub async fn to_csv(&self, window: Option<JsViewWindow>) -> ApiResult<String> {

--- a/rust/perspective-js/test/js/constructors.spec.js
+++ b/rust/perspective-js/test/js/constructors.spec.js
@@ -856,6 +856,50 @@ function validate_typed_array(typed_array, column_data) {
         });
     });
 
+    test.describe("ndjson", function () {
+        test("basic constructor", async function () {
+            var table = await perspective.table(`{"x":1}\n{"x":2}`, {
+                format: "ndjson",
+            });
+            var view = await table.view();
+            let result = await view.to_json();
+            expect(result).toEqual([{ x: 1 }, { x: 2 }]);
+            view.delete();
+            table.delete();
+        });
+
+        test("date types", async function () {
+            const ndjson = [];
+            for (const row of data_4) {
+                ndjson.push(row);
+            }
+            var table = await perspective.table(
+                ndjson.map(JSON.stringify).join("\n"),
+                {
+                    format: "ndjson",
+                }
+            );
+            var view = await table.view();
+            let result = await view.to_json();
+            expect(result).toEqual([{ v: +data_4[0]["v"] }]);
+            view.delete();
+            table.delete();
+        });
+
+        test("Handles dates when provided a schema", async function () {
+            var table = await perspective.table(meta_4);
+            await table.update(data_4.map(JSON.stringify).join("\n"), {
+                format: "ndjson",
+            });
+
+            let view = await table.view();
+            let result = await view.to_json();
+            expect(result).toEqual([{ v: +data_4[0]["v"] }]);
+            view.delete();
+            table.delete();
+        });
+    });
+
     test.describe("Constructors", function () {
         test("JSON constructor", async function () {
             var table = await perspective.table(data);

--- a/rust/perspective-js/test/js/to_format.spec.js
+++ b/rust/perspective-js/test/js/to_format.spec.js
@@ -13,11 +13,13 @@
 import { test, expect } from "@finos/perspective-test";
 import perspective from "./perspective_client";
 
+const STD_DATE = new Date();
+
 const int_float_string_data = [
-    { int: 1, float: 2.25, string: "a", datetime: new Date() },
-    { int: 2, float: 3.5, string: "b", datetime: new Date() },
-    { int: 3, float: 4.75, string: "c", datetime: new Date() },
-    { int: 4, float: 5.25, string: "d", datetime: new Date() },
+    { int: 1, float: 2.25, string: "a", datetime: STD_DATE },
+    { int: 2, float: 3.5, string: "b", datetime: STD_DATE },
+    { int: 3, float: 4.75, string: "c", datetime: STD_DATE },
+    { int: 4, float: 5.25, string: "d", datetime: STD_DATE },
 ];
 
 const pivoted_output = [
@@ -386,6 +388,52 @@ const pivoted_output = [
             for (let d of json) {
                 expect(d.__ROW_PATH__).toBeDefined();
             }
+            view.delete();
+            table.delete();
+        });
+    });
+
+    test.describe("to_ndjson", function () {
+        test("should work with context 0", async function () {
+            let table = await perspective.table(int_float_string_data);
+            let view = await table.view({});
+            let json = await view.to_ndjson();
+            expect(json)
+                .toEqual(`{"int":1,"float":2.25,"string":"a","datetime":${+STD_DATE}}
+{"int":2,"float":3.5,"string":"b","datetime":${+STD_DATE}}
+{"int":3,"float":4.75,"string":"c","datetime":${+STD_DATE}}
+{"int":4,"float":5.25,"string":"d","datetime":${+STD_DATE}}`);
+            view.delete();
+            table.delete();
+        });
+
+        test("should work with context 1", async function () {
+            let table = await perspective.table(int_float_string_data);
+            let view = await table.view({ group_by: ["string"] });
+            let json = await view.to_ndjson();
+            expect(json)
+                .toEqual(`{"__ROW_PATH__":[],"int":10,"float":15.75,"string":4,"datetime":4}
+{"__ROW_PATH__":["a"],"int":1,"float":2.25,"string":1,"datetime":1}
+{"__ROW_PATH__":["b"],"int":2,"float":3.5,"string":1,"datetime":1}
+{"__ROW_PATH__":["c"],"int":3,"float":4.75,"string":1,"datetime":1}
+{"__ROW_PATH__":["d"],"int":4,"float":5.25,"string":1,"datetime":1}`);
+            view.delete();
+            table.delete();
+        });
+
+        test("should work with context 2", async function () {
+            let table = await perspective.table(int_float_string_data);
+            let view = await table.view({
+                group_by: ["string"],
+                split_by: ["int"],
+            });
+            let json = await view.to_ndjson();
+            expect(json)
+                .toEqual(`{"__ROW_PATH__":[],"1|int":1,"1|float":2.25,"1|string":1,"1|datetime":1,"2|int":2,"2|float":3.5,"2|string":1,"2|datetime":1,"3|int":3,"3|float":4.75,"3|string":1,"3|datetime":1,"4|int":4,"4|float":5.25,"4|string":1,"4|datetime":1}
+{"__ROW_PATH__":["a"],"1|int":1,"1|float":2.25,"1|string":1,"1|datetime":1,"2|int":null,"2|float":null,"2|string":null,"2|datetime":null,"3|int":null,"3|float":null,"3|string":null,"3|datetime":null,"4|int":null,"4|float":null,"4|string":null,"4|datetime":null}
+{"__ROW_PATH__":["b"],"1|int":null,"1|float":null,"1|string":null,"1|datetime":null,"2|int":2,"2|float":3.5,"2|string":1,"2|datetime":1,"3|int":null,"3|float":null,"3|string":null,"3|datetime":null,"4|int":null,"4|float":null,"4|string":null,"4|datetime":null}
+{"__ROW_PATH__":["c"],"1|int":null,"1|float":null,"1|string":null,"1|datetime":null,"2|int":null,"2|float":null,"2|string":null,"2|datetime":null,"3|int":3,"3|float":4.75,"3|string":1,"3|datetime":1,"4|int":null,"4|float":null,"4|string":null,"4|datetime":null}
+{"__ROW_PATH__":["d"],"1|int":null,"1|float":null,"1|string":null,"1|datetime":null,"2|int":null,"2|float":null,"2|string":null,"2|datetime":null,"3|int":null,"3|float":null,"3|string":null,"3|datetime":null,"4|int":4,"4|float":5.25,"4|string":1,"4|datetime":1}`);
             view.delete();
             table.delete();
         });

--- a/rust/perspective-python/src/client/client_sync.rs
+++ b/rust/perspective-python/src/client/client_sync.rs
@@ -307,6 +307,12 @@ impl View {
         self.0.to_json_string(window).py_block_on(py)
     }
 
+    #[doc = crate::inherit_docs!("view/to_ndjson.md")]
+    #[pyo3(signature = (**window))]
+    pub fn to_ndjson(&self, py: Python<'_>, window: Option<Py<PyDict>>) -> PyResult<String> {
+        self.0.to_ndjson(window).py_block_on(py)
+    }
+
     #[pyo3(signature = (**window))]
     pub fn to_records<'a>(
         &self,

--- a/rust/perspective-python/src/client/python.rs
+++ b/rust/perspective-python/src/client/python.rs
@@ -501,4 +501,13 @@ impl PyView {
 
         self.view.to_json_string(window).await.into_pyerr()
     }
+
+    pub async fn to_ndjson(&self, window: Option<Py<PyDict>>) -> PyResult<String> {
+        let window: ViewWindow =
+            Python::with_gil(|py| window.map(|x| depythonize_bound(x.into_bound(py).into_any())))
+                .transpose()?
+                .unwrap_or_default();
+
+        self.view.to_ndjson(window).await.into_pyerr()
+    }
 }

--- a/rust/perspective-python/src/client/update_data.rs
+++ b/rust/perspective-python/src/client/update_data.rs
@@ -30,6 +30,7 @@ fn from_arrow(
         Some(TableReadFormat::JsonString) => {
             Ok(Some(UpdateData::JsonRows(String::from_utf8(vec)?)))
         },
+        Some(TableReadFormat::Ndjson) => Ok(Some(UpdateData::Ndjson(String::from_utf8(vec)?))),
         Some(TableReadFormat::ColumnsString) => {
             Ok(Some(UpdateData::JsonColumns(String::from_utf8(vec)?)))
         },
@@ -45,6 +46,7 @@ fn from_string(
     match format {
         None | Some(TableReadFormat::Csv) => Ok(Some(UpdateData::Csv(string))),
         Some(TableReadFormat::JsonString) => Ok(Some(UpdateData::JsonRows(string))),
+        Some(TableReadFormat::Ndjson) => Ok(Some(UpdateData::Ndjson(string))),
         Some(TableReadFormat::ColumnsString) => Ok(Some(UpdateData::JsonColumns(string))),
         Some(TableReadFormat::Arrow) => Ok(Some(UpdateData::Arrow(string.into_bytes().into()))),
     }

--- a/rust/perspective-viewer/src/rust/components/copy_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/copy_dropdown.rs
@@ -82,14 +82,20 @@ fn get_menu_items(has_render: bool, has_selection: bool) -> Vec<CopyDropDownMenu
         CopyDropDownMenuItem::OptGroup(
             "Current View".into(),
             if has_render {
-                vec![ExportMethod::Csv, ExportMethod::Json, ExportMethod::Png]
+                vec![
+                    ExportMethod::Csv,
+                    ExportMethod::Json,
+                    ExportMethod::Ndjson,
+                    ExportMethod::Png,
+                ]
             } else {
-                vec![ExportMethod::Csv, ExportMethod::Json]
+                vec![ExportMethod::Csv, ExportMethod::Json, ExportMethod::Ndjson]
             },
         ),
         CopyDropDownMenuItem::OptGroup("All".into(), vec![
             ExportMethod::CsvAll,
             ExportMethod::JsonAll,
+            ExportMethod::NdjsonAll,
         ]),
         CopyDropDownMenuItem::OptGroup("Config".into(), vec![ExportMethod::JsonConfig]),
     ];
@@ -100,6 +106,7 @@ fn get_menu_items(has_render: bool, has_selection: bool) -> Vec<CopyDropDownMenu
             CopyDropDownMenuItem::OptGroup("Current Selection".into(), vec![
                 ExportMethod::CsvSelected,
                 ExportMethod::JsonSelected,
+                ExportMethod::NdjsonSelected,
             ]),
         )
     }

--- a/rust/perspective-viewer/src/rust/components/export_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/export_dropdown.rs
@@ -61,6 +61,7 @@ fn get_menu_items(name: &str, has_render: bool) -> Vec<ExportDropDownMenuItem> {
                 vec![
                     ExportMethod::Csv.new_file(name),
                     ExportMethod::Json.new_file(name),
+                    ExportMethod::Ndjson.new_file(name),
                     ExportMethod::Arrow.new_file(name),
                     ExportMethod::Html.new_file(name),
                     ExportMethod::Png.new_file(name),
@@ -69,6 +70,7 @@ fn get_menu_items(name: &str, has_render: bool) -> Vec<ExportDropDownMenuItem> {
                 vec![
                     ExportMethod::Csv.new_file(name),
                     ExportMethod::Json.new_file(name),
+                    ExportMethod::Ndjson.new_file(name),
                     ExportMethod::Arrow.new_file(name),
                     ExportMethod::Html.new_file(name),
                 ]
@@ -77,6 +79,7 @@ fn get_menu_items(name: &str, has_render: bool) -> Vec<ExportDropDownMenuItem> {
         ExportDropDownMenuItem::OptGroup("All".into(), vec![
             ExportMethod::CsvAll.new_file(name),
             ExportMethod::JsonAll.new_file(name),
+            ExportMethod::NdjsonAll.new_file(name),
             ExportMethod::ArrowAll.new_file(name),
         ]),
         ExportDropDownMenuItem::OptGroup("Config".into(), vec![

--- a/rust/perspective-viewer/src/rust/model/copy_export.rs
+++ b/rust/perspective-viewer/src/rust/model/copy_export.rs
@@ -119,6 +119,24 @@ pub trait CopyExportModel:
                 let session = self.session().clone();
                 ApiFuture::new(async move { session.json_as_jsvalue(true, None).await?.as_blob() })
             },
+            ExportMethod::Ndjson => {
+                let session = self.session().clone();
+                ApiFuture::new(
+                    async move { session.ndjson_as_jsvalue(false, None).await?.as_blob() },
+                )
+            },
+            ExportMethod::NdjsonSelected => {
+                let session = self.session().clone();
+                ApiFuture::new(async move {
+                    session.ndjson_as_jsvalue(false, viewport).await?.as_blob()
+                })
+            },
+            ExportMethod::NdjsonAll => {
+                let session = self.session().clone();
+                ApiFuture::new(
+                    async move { session.ndjson_as_jsvalue(true, None).await?.as_blob() },
+                )
+            },
             ExportMethod::Arrow => {
                 let session = self.session().clone();
                 ApiFuture::new(

--- a/rust/perspective-viewer/src/rust/model/export_method.rs
+++ b/rust/perspective-viewer/src/rust/model/export_method.rs
@@ -24,6 +24,9 @@ pub enum ExportMethod {
     Json,
     JsonAll,
     JsonSelected,
+    Ndjson,
+    NdjsonAll,
+    NdjsonSelected,
     Html,
     Png,
     Arrow,
@@ -47,6 +50,9 @@ impl ExportMethod {
             Self::CsvSelected => ".selected.csv",
             Self::JsonSelected => ".selected.json",
             Self::ArrowSelected => ".selected.arrow",
+            Self::Ndjson => ".ndjson",
+            Self::NdjsonAll => ".all.ndjson",
+            Self::NdjsonSelected => ".selected.ndjson",
         }
     }
 

--- a/rust/perspective-viewer/src/rust/session.rs
+++ b/rust/perspective-viewer/src/rust/session.rs
@@ -307,6 +307,20 @@ impl Session {
             .unchecked_into())
     }
 
+    pub async fn ndjson_as_jsvalue(
+        self,
+        flat: bool,
+        window: Option<ViewWindow>,
+    ) -> Result<js_sys::JsString, ApiError> {
+        let json: String = self
+            .flat_view(flat)
+            .await?
+            .to_ndjson(window.unwrap_or_default())
+            .await?;
+
+        Ok(json.into())
+    }
+
     pub async fn json_as_jsvalue(
         self,
         flat: bool,


### PR DESCRIPTION
* Adds [NDJSON](https://github.com/ndjson/ndjson-spec) support to the `perspective.table()` constructor, via the `format` option.
* Adds `view.to_ndjson()` serialization method.

```javascript
const table = await perspective.table(`{"x": 1}\n{"x": 2}`, {format: "ndjson"});
const view = await table.view();
const ndjson = await view.to_ndjson();
```