### PR TITLE
Add `min` and `max` aggregates for `date` and `datetime` columns

### DIFF
--- a/cpp/perspective/src/cpp/sparse_tree.cpp
+++ b/cpp/perspective/src/cpp/sparse_tree.cpp
@@ -1544,15 +1544,15 @@ t_stree::update_agg_table(
                 t_tscalar dst_scalar = dst->get_scalar(dst_ridx);
                 old_value.set(dst_scalar);
                 auto pkeys = get_pkeys(nidx);
-                std::vector<double> values;
+                std::vector<t_tscalar> values;
                 read_column_from_gstate(
                     gstate,
                     expression_master_table,
                     spec.get_dependencies()[0].name(),
                     pkeys,
-                    values,
-                    true
+                    values
                 );
+
                 new_value.set(*std::max_element(values.begin(), values.end()));
                 dst->set_scalar(dst_ridx, new_value);
             } break;
@@ -1560,15 +1560,15 @@ t_stree::update_agg_table(
                 t_tscalar dst_scalar = dst->get_scalar(dst_ridx);
                 old_value.set(dst_scalar);
                 auto pkeys = get_pkeys(nidx);
-                std::vector<double> values;
+                std::vector<t_tscalar> values;
                 read_column_from_gstate(
                     gstate,
                     expression_master_table,
                     spec.get_dependencies()[0].name(),
                     pkeys,
-                    values,
-                    true
+                    values
                 );
+
                 new_value.set(*std::min_element(values.begin(), values.end()));
                 dst->set_scalar(dst_ridx, new_value);
             } break;

--- a/rust/perspective-client/src/rust/config/aggregates.rs
+++ b/rust/perspective-client/src/rust/config/aggregates.rs
@@ -272,10 +272,32 @@ const NUMBER_AGGREGATES: &[SingleAggregate] = &[
     SingleAggregate::Var,
 ];
 
+const DATETIME_AGGREGATES: &[SingleAggregate] = &[
+    SingleAggregate::Any,
+    SingleAggregate::Avg,
+    SingleAggregate::Count,
+    SingleAggregate::DistinctCount,
+    SingleAggregate::Dominant,
+    SingleAggregate::First,
+    SingleAggregate::High,
+    SingleAggregate::Low,
+    SingleAggregate::Max,
+    SingleAggregate::Min,
+    SingleAggregate::LastByIndex,
+    SingleAggregate::Last,
+    SingleAggregate::Median,
+    SingleAggregate::Unique,
+];
+
 impl proto::ColumnType {
     pub fn aggregates_iter(&self) -> Box<dyn Iterator<Item = Aggregate>> {
         match self {
-            Self::Boolean | Self::Date | Self::Datetime | Self::String => Box::new(
+            Self::Date | Self::Datetime => Box::new(
+                DATETIME_AGGREGATES
+                    .iter()
+                    .map(|x| Aggregate::SingleAggregate(*x)),
+            ),
+            Self::Boolean | Self::String => Box::new(
                 STRING_AGGREGATES
                     .iter()
                     .map(|x| Aggregate::SingleAggregate(*x)),

--- a/rust/perspective-js/test/js/pivots.spec.js
+++ b/rust/perspective-js/test/js/pivots.spec.js
@@ -524,6 +524,80 @@ const std = (nums) => {
             await table.delete();
         });
 
+        test("min", async () => {
+            const data = {
+                w: [1.5, 2.5, 3.5, 4.5],
+                x: [1, 2, 3, 4],
+                y: ["a", "b", "a", "b"],
+                z: [
+                    new Date(1555126035065),
+                    new Date(1555126035065),
+                    new Date(1555026035065),
+                    new Date(1555026035065),
+                ],
+            };
+
+            const table = await perspective.table(data);
+            const view = await table.view({
+                aggregates: {
+                    w: "min",
+                    x: "min",
+                    y: "min",
+                    z: "min",
+                },
+                group_by: ["y"],
+            });
+
+            const cols = await view.to_columns();
+            expect(cols).toEqual({
+                __ROW_PATH__: [[], ["a"], ["b"]],
+                w: [1.5, 1.5, 2.5],
+                x: [1, 1, 2],
+                y: ["a", "a", "b"],
+                z: [1555026035065, 1555026035065, 1555026035065],
+            });
+
+            await view.delete();
+            await table.delete();
+        });
+
+        test("max", async () => {
+            const data = {
+                w: [1.5, 2.5, 3.5, 4.5],
+                x: [1, 2, 3, 4],
+                y: ["a", "b", "a", "b"],
+                z: [
+                    new Date(1555126035065),
+                    new Date(1555126035065),
+                    new Date(1555026035065),
+                    new Date(1555026035065),
+                ],
+            };
+
+            const table = await perspective.table(data);
+            const view = await table.view({
+                aggregates: {
+                    w: "max",
+                    x: "max",
+                    y: "max",
+                    z: "max",
+                },
+                group_by: ["y"],
+            });
+
+            const cols = await view.to_columns();
+            expect(cols).toEqual({
+                __ROW_PATH__: [[], ["a"], ["b"]],
+                w: [4.5, 3.5, 4.5],
+                x: [4, 3, 4],
+                y: ["b", "a", "b"],
+                z: [1555126035065, 1555126035065, 1555126035065],
+            });
+
+            await view.delete();
+            await table.delete();
+        });
+
         test("high with count and partial update", async () => {
             const table = await perspective.table(
                 {


### PR DESCRIPTION
Fixes #2876