### PR TITLE
Better `datetime`/`date` string parsing performance

### DIFF
--- a/cmake/arrow.txt.in
+++ b/cmake/arrow.txt.in
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0097 NEW)
 include(ExternalProject)
 ExternalProject_Add(apachearrow
   GIT_REPOSITORY    https://github.com/apache/arrow.git
-  GIT_TAG           apache-arrow-17.0.0
+  GIT_TAG           apache-arrow-18.1.0
   GIT_SUBMODULES    ""
   GIT_SHALLOW       TRUE
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/arrow-src"
@@ -20,5 +20,5 @@ ExternalProject_Add(apachearrow
   TEST_COMMAND      ""
   # This patch is to work around https://github.com/apache/arrow/issues/44384
   # It can be removed when a version of Arrow is released with https://github.com/apache/arrow/pull/44385
-  PATCH_COMMAND     "${CMAKE_COMMAND}" -E chdir <SOURCE_DIR> git apply "${CMAKE_SOURCE_DIR}/patches/fix_arrow_libtool.patch"
+  PATCH_COMMAND     "${CMAKE_COMMAND}" -E chdir <SOURCE_DIR> git apply "${CMAKE_SOURCE_DIR}/patches/fix_arrow_libtool.patch" && "${CMAKE_COMMAND}" -E chdir <SOURCE_DIR> git apply "${CMAKE_SOURCE_DIR}/patches/arrow_strptime.patch"
 )

--- a/cpp/perspective/patches/arrow_strptime.patch
+++ b/cpp/perspective/patches/arrow_strptime.patch
@@ -1,0 +1,13 @@
+diff --git a/cpp/src/arrow/util/value_parsing.h b/cpp/src/arrow/util/value_parsing.h
+index 609906052..1e3dfae7c 100644
+--- a/cpp/src/arrow/util/value_parsing.h
++++ b/cpp/src/arrow/util/value_parsing.h
+@@ -804,7 +804,7 @@ static inline bool ParseTimestampStrptime(const char* buf, size_t length,
+   std::string clean_copy(buf, length);
+   struct tm result;
+   memset(&result, 0, sizeof(struct tm));
+-#ifdef _WIN32
++#if defined(_WIN32) || defined(__EMSCRIPTEN__)
+   char* ret = arrow_strptime(clean_copy.c_str(), format, &result);
+ #else
+   char* ret = strptime(clean_copy.c_str(), format, &result);

--- a/tools/perspective-bench/cross_platform_suite.mjs
+++ b/tools/perspective-bench/cross_platform_suite.mjs
@@ -158,8 +158,10 @@ export async function table_suite(perspective, metadata) {
             const table = await perspective.table(
                 new_superstore_table(metadata)
             );
+
             const view = await table.view();
             const csv = await view.to_csv();
+            const arrow = await view.to_arrow();
             const json = await view.to_json();
             const columns = await view.to_columns();
             if (check_version_gte(metadata.version, "2.10.9")) {
@@ -169,7 +171,8 @@ export async function table_suite(perspective, metadata) {
             if (check_version_gte(metadata.version, "3.0.0")) {
                 await table.delete();
             }
-            return { csv, columns, json };
+
+            return { csv, arrow, table, json, columns };
         } catch (e) {
             console.error(e);
         }
@@ -184,8 +187,8 @@ export async function table_suite(perspective, metadata) {
                 await table.delete();
             }
         },
-        async test() {
-            return await perspective.table(new_superstore_table(metadata));
+        async test({ table, arrow }) {
+            return await perspective.table(arrow.slice());
         },
     });
 
@@ -198,7 +201,7 @@ export async function table_suite(perspective, metadata) {
                 await table.delete();
             }
         },
-        async test({ table, csv }) {
+        async test({ csv }) {
             return await perspective.table(csv);
         },
     });

--- a/tools/perspective-bench/src/js/superstore.mjs
+++ b/tools/perspective-bench/src/js/superstore.mjs
@@ -10,8 +10,6 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fs from "node:fs";
-import { createRequire } from "node:module";
 
 /**
  * Load a file as an `ArrayBuffer`, which is useful for loading Apache Arrow
@@ -19,13 +17,25 @@ import { createRequire } from "node:module";
  * @param {*} path
  * @returns
  */
-function get_buffer(path) {
-    const _require = createRequire(import.meta.url);
-    return fs.readFileSync(_require.resolve(path)).buffer;
+async function get_buffer(path) {
+    if (typeof window !== "undefined") {
+        const resp = await fetch(
+            "http://localhost:8080/node_modules/superstore-arrow/superstore.lz4.arrow"
+        );
+
+        return await resp.arrayBuffer();
+    } else {
+        const fs = await import("node:fs");
+        const { createRequire } = await import("node:module");
+        const _require = createRequire(import.meta.url);
+        return fs.readFileSync(_require.resolve(path)).buffer;
+    }
 }
 
-const SUPERSTORE_ARROW = get_buffer("superstore-arrow/superstore.arrow");
-const SUPERSTORE_FEATHER = get_buffer("superstore-arrow/superstore.lz4.arrow");
+const SUPERSTORE_ARROW = await get_buffer("superstore-arrow/superstore.arrow");
+const SUPERSTORE_FEATHER = await get_buffer(
+    "superstore-arrow/superstore.lz4.arrow"
+);
 
 /**
  * Load the Superstore example data set as either a Feather (LZ4) or


### PR DESCRIPTION
Tl;DR 7x performance improvement parsing non-ISO-8601 datetime strings in CSV or JSON formats.

I've been analyzing Perspective performance using this [NYC Open Data 500k row CSV file](https://data.cityofnewyork.us/City-Government/Case-Related-Information-About-Civil-Litigation/pjgc-h7uv/about_data), which loads fine but takes ~22 seconds on my computer to parse:

<img width="998" alt="Screenshot 2024-12-22 at 4 50 23 PM" src="https://github.com/user-attachments/assets/7f72b98b-2d68-469f-81ad-b7b655a5487c" />


Looking into the profile analysis shows a lot of long calls _out_ from WASM into JS to call `strptime`, which Perspective uses for anything _not_ [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) formatted date or datetime strings. In Emscripten, [`strptime` is implemented as a JavaScript foreign call](https://github.com/emscripten-core/emscripten/blob/b94d6e6ced33576a1ad96c7f6e701788c6f49211/src/library_time.js#L261) which turns out to be quite expensive, as well as requiring unnecessary string copying.

<img width="677" alt="Screenshot 2024-12-22 at 4 54 59 PM" src="https://github.com/user-attachments/assets/e2c222f6-97c8-40fd-b0f5-870b37b87c3e" />


[Perspective ultimately calls`strptime` through Arrow](https://github.com/finos/perspective/blob/master/cpp/perspective/src/cpp/arrow_csv.cpp#L561), which is used internally for CSV and any other string-to-datetime parsing (including in JSON formats). It turns out though, Arrow itself has a vendored C++ implementation of `strptime` which it [uses for Windows builds](https://github.com/apache/arrow/blob/main/cpp/src/arrow/util/value_parsing.h#L807). Patching Arrow to use its own vendored `strptime` implementation for Emscripten as well reduces the original runtime to ~3s:

<img width="966" alt="Screenshot 2024-12-22 at 5 12 25 PM" src="https://github.com/user-attachments/assets/7ab21521-90f8-452d-b68e-ffee56384b41" />

This PR only applies this fix for Emscripten (WebAssembly) builds. I haven't yet tested Python, but I don't expect this fix to be applicable for Python as these implementations are likely identical in this context.