### PR TITLE
Fix last row label state after collapse and expand

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/style_handlers/table_cell/row_header.js
+++ b/packages/perspective-viewer-datagrid/src/js/style_handlers/table_cell/row_header.js
@@ -20,7 +20,11 @@ export function cell_style_row_header(regularTable, td, metadata) {
         dx: 0,
         dy: metadata.y - metadata.y0 + 1,
     });
+
+    const is_last_item = !next || next.row_header === undefined;
+
     const is_collapse =
+        !is_last_item &&
         next &&
         next.row_header &&
         typeof next.row_header[metadata.row_header_x + 1] !== "undefined";

--- a/packages/perspective-viewer-datagrid/test/js/row_header.spec.js
+++ b/packages/perspective-viewer-datagrid/test/js/row_header.spec.js
@@ -1,5 +1,16 @@
-import { test, expect } from "@finos/perspective-test";
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
+import { test, expect } from "@finos/perspective-test";
 
 test.describe("Datagrid Test for row header", () => {
     test.beforeEach(async ({ page }) => {
@@ -9,10 +20,11 @@ test.describe("Datagrid Test for row header", () => {
                 await new Promise((x) => setTimeout(x, 10));
             }
         });
+    });
 
-    })
-
-    test("verify last row tree label state after total collapse/expand", async ({ page }) => {
+    test("verify last row tree label state after total collapse/expand", async ({
+        page,
+    }) => {
         await page.evaluate(async () => {
             await document.querySelector("perspective-viewer").restore({
                 plugin: "Datagrid",
@@ -30,5 +42,5 @@ test.describe("Datagrid Test for row header", () => {
 
         await expect(westHeader).toHaveClass(/psp-tree-label-expand/);
         await expect(westHeader).not.toHaveClass(/psp-tree-label-collapse/);
-    })
-})
+    });
+});

--- a/packages/perspective-viewer-datagrid/test/js/row_header.spec.js
+++ b/packages/perspective-viewer-datagrid/test/js/row_header.spec.js
@@ -1,0 +1,34 @@
+import { test, expect } from "@finos/perspective-test";
+
+
+test.describe("Datagrid Test for row header", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/tools/perspective-test/src/html/basic-test.html");
+        await page.evaluate(async () => {
+            while (!window["__TEST_PERSPECTIVE_READY__"]) {
+                await new Promise((x) => setTimeout(x, 10));
+            }
+        });
+
+    })
+
+    test("verify last row tree label state after total collapse/expand", async ({ page }) => {
+        await page.evaluate(async () => {
+            await document.querySelector("perspective-viewer").restore({
+                plugin: "Datagrid",
+                group_by: ["Region", "Category"],
+                columns: ["Sales", "Quantity", "Discount", "Profit"],
+            });
+        });
+
+        const totalHeader = await page.locator('th:has-text("TOTAL")').first();
+
+        await totalHeader.click();
+        await totalHeader.click();
+
+        const westHeader = await page.locator('th:has-text("West")').first();
+
+        await expect(westHeader).toHaveClass(/psp-tree-label-expand/);
+        await expect(westHeader).not.toHaveClass(/psp-tree-label-collapse/);
+    })
+})


### PR DESCRIPTION
This fixes the issue found in #2368 where in a grouped state (within Datagrid), the last grouped row header seemed as if it had been already unfolded showing the (-) sign instead of the (+) sign.
Now the last grouped row rightly shows the (+) sign.

### Pull Request Checklist

-   [ ] Description which clearly states what problems the PR solves.
-   [ ] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [ ] Include new tests that fail without this PR but passes with it.
-   [ ] Include any relevent Documentation changes related to this change.
-   [ ] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [ ] Reviewed PR commit history to remove unnecessary changes.
-   [ ] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
