### PR TITLE
Support for pyodide 0.27.1, including pyarrow + pandas

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -197,21 +197,6 @@ runs:
               fi
           if: ${{ runner.os == 'Linux' && inputs.cpp == 'true' && inputs.javascript == 'false' }}
 
-        - name: Install Python Pyodide dependencies
-          shell: bash
-          run: python -m pip install -r rust/perspective-python/requirements-pyodide.txt
-          if: ${{ inputs.pyodide == 'true' }}
-
-        - name: Install Pyodide distribution
-          shell: bash
-          run: pnpm run install_pyodide
-          if: ${{ inputs.pyodide == 'true' }}
-
-        - name: Install Python Playwright browsers
-          shell: bash
-          run: python -m playwright install
-          if: ${{ inputs.pyodide == 'true' }}
-
         # - name: Install CCache
         #   shell: bash
         #   run: sudo apt install -y ccache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -398,7 +398,6 @@ jobs:
               id: init-step
               uses: ./.github/actions/install-deps
               with:
-                  pyodide: "true"
                   javascript: "false"
                   arch: ${{ matrix.arch }}
                   manylinux: "false"
@@ -411,18 +410,64 @@ jobs:
                   PACKAGE: "perspective-python"
                   CI: 1
 
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: perspective-python-dist-wasm32-emscripten-${{ matrix.python-version }}
+                  path: rust/target/wheels/*.whl
+
+    # ~*~ Test pyodide ~*~
+    test_emscripten_wheel:
+        runs-on: ${{ matrix.os }}
+        needs: [build_emscripten_wheel]
+        strategy:
+            fail-fast: false
+            matrix:
+                os:
+                    - ubuntu-22.04
+                arch:
+                    - x86_64
+                python-version:
+                    - 3.9
+                node-version: [20.x]
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Config
+              id: config-step
+              uses: ./.github/actions/config
+
+            - name: Initialize Build
+              uses: ./.github/actions/install-deps
+              with:
+                  javascript: "false"
+                  arch: ${{ matrix.arch }}
+                  manylinux: "false"
+                  skip_cache: ${{ steps.config-step.outputs.SKIP_CACHE }}
+
+            - uses: actions/download-artifact@v4
+              with:
+                  name: perspective-python-dist-wasm32-emscripten-${{ matrix.python-version }}
+                  path: rust/target/wheels/
+
+            - name: Install Python Pyodide dependencies
+              shell: bash
+              run: python -m pip install -r rust/perspective-python/requirements-pyodide.txt
+
+            - name: Install Pyodide distribution
+              shell: bash
+              run: pnpm run install_pyodide
+
+            - name: Install Python Playwright browsers
+              shell: bash
+              run: python -m playwright install
+
             - name: "Test Pyodide"
               run: pnpm run test
               env:
                   PSP_PYODIDE: 1
                   PACKAGE: "perspective-python"
                   CI: 1
-
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: perspective-python-dist-wasm32-emscripten-${{ matrix.python-version }}
-                  path: rust/target/wheels/*.whl
-
     # ,-,---.       .    .             .   ,--,--'      .
     #  '|___/ . . . |  ,-|   ,-. ,-. ,-|   `- | ,-. ,-. |-
     #  ,|   \ | | | |  | |   ,-| | | | |    , | |-' `-. |
@@ -859,6 +904,7 @@ jobs:
                 benchmark_js,
                 benchmark_python,
                 build_emscripten_wheel,
+                test_emscripten_wheel,
                 build_and_test_rust,
                 lint_and_docs,
             ]

--- a/cmake/modules/FindInstallDependency.cmake
+++ b/cmake/modules/FindInstallDependency.cmake
@@ -37,6 +37,7 @@ function(psp_build_dep name cmake_file)
             message(FATAL_ERROR "Build step for ${name} failed: ${result}")
         endif()
     endif()
+
     if(${name} STREQUAL arrow)
         set(ARROW_DEFINE_OPTIONS ON)
         set(ARROW_BUILD_SHARED OFF)

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -338,6 +338,15 @@ if(PSP_PYODIDE)
     string(APPEND CMAKE_CXX_FLAGS "${RELOCATABLE_FLAGS}")
 endif()
 
+if(PSP_PYODIDE)
+    string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden")
+endif()
+
+if (PSP_PYODIDE AND NOT PSP_WASM_EXCEPTIONS)
+    # Emscripten exceptions
+    string(APPEND CMAKE_CXX_FLAGS " -fexceptions")
+endif()
+
 # Build (read: download and extract) header-only dependencies from external sources
 set(all_deps_INCLUDE_DIRS "")
 psp_build_dep("date" "${PSP_CMAKE_MODULE_PATH}/date.txt.in")
@@ -608,11 +617,6 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
             target_include_directories(psp PRIVATE ${psp_INCLUDE_DIRS})
             target_include_directories(psp SYSTEM PRIVATE ${all_deps_INCLUDE_DIRS})
             target_compile_definitions(psp PRIVATE PSP_ENABLE_PYTHON=1 PSP_ENABLE_WASM=1)
-            # support for emscripten exceptions https://emscripten.org/docs/porting/exceptions.html#emscripten-javascript-based-exception-support
-            target_compile_options(psp PUBLIC -fexceptions -fvisibility=hidden)
-            target_compile_options(arrow_static PUBLIC -fexceptions -fvisibility=hidden)
-            target_compile_options(re2 PUBLIC -fexceptions -fvisibility=hidden)
-            target_compile_options(protos PUBLIC -fexceptions -fvisibility=hidden)
         else()
             # Cpython
             add_library(psp STATIC ${PYTHON_SOURCE_FILES})
@@ -631,7 +635,6 @@ elseif(PSP_CPP_BUILD OR PSP_PYTHON_BUILD)
             target_compile_options(psp PRIVATE -fvisibility=hidden)
         endif()
 
-        # Link against arrow static library
         # Linking against arrow_static also links against its bundled dependencies
         target_link_libraries(psp PRIVATE arrow_static re2 protos)
     else()

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "module",
     "emscripten": "3.1.58",
     "llvm": "17.0.6",
-    "pyodide": "0.26.2",
+    "pyodide": "0.27.1",
     "engines": {
         "node": ">=16"
     },

--- a/rust/perspective-python/pyodide-tests/README.md
+++ b/rust/perspective-python/pyodide-tests/README.md
@@ -1,5 +1,37 @@
 # pyodide-tests
 
-Smoke and integration tests for the perspective-python Pyodide wheel.
+Smoke and integration tests for the perspective-python Pyodide wheel. The tests
+are specced in `pytest` and executed with `playwright`, using the
+`pytest-pyodide` package.
 
 These tests require that a Pyodide wheel has been built to rust/target/wheels
+
+## test setup
+
+Create a virtual environment. Install perspective-python requirements and
+special pyodide-only requirements:
+
+```
+pip install -r rust/perspective-python/requirements.txt
+pip install -r rust/perspective-python/requirements-pyodide.txt
+```
+
+## running tests
+
+Run setup, select `perspective-pyodide` target:
+
+```
+pnpm -w run setup
+```
+
+Then run tests:
+
+```
+pnpm -w test
+```
+
+If you are prompted to install playwright browsers, run this in your venv:
+
+```
+python -m playwright install
+```

--- a/rust/perspective-python/requirements-pyodide.txt
+++ b/rust/perspective-python/requirements-pyodide.txt
@@ -2,4 +2,4 @@
 pytest==8.2.2
 pytest-playwright==0.5.2
 pytest-pyodide==0.58.3
-
+pytest-timeout==2.3.1

--- a/rust/perspective-python/test.mjs
+++ b/rust/perspective-python/test.mjs
@@ -42,6 +42,10 @@ if (process.env.PSP_PYODIDE) {
             `--dist-dir=${pyodideDistDir}`,
             `--perspective-emscripten-wheel=${emscriptenWheel}`,
             "--verbose",
+            "--timeout=300",
+            // with --timeout_method=signal, tests hang.  seems like the
+            // pytest-pyodide webserver fixture does not shut down
+            "--timeout_method=thread",
             ...process.argv.slice(2),
         ],
         execOpts

--- a/rust/perspective-python/test.mjs
+++ b/rust/perspective-python/test.mjs
@@ -41,6 +41,8 @@ if (process.env.PSP_PYODIDE) {
             "--runtime=chrome",
             `--dist-dir=${pyodideDistDir}`,
             `--perspective-emscripten-wheel=${emscriptenWheel}`,
+            "--verbose",
+            ...process.argv.slice(2),
         ],
         execOpts
     );

--- a/tools/perspective-scripts/setup.mjs
+++ b/tools/perspective-scripts/setup.mjs
@@ -168,7 +168,14 @@ async function focus_package() {
             message: "Focus NPM package(s)?",
             default: () => {
                 if (CONFIG["PACKAGE"]) {
-                    return CONFIG["PACKAGE"].split(",");
+                    const packages = CONFIG["PACKAGE"].split(",");
+                    if (CONFIG["PSP_PYODIDE"] === "1") {
+                        const py = packages.indexOf("perspective-python");
+                        if (py >= 0) {
+                            packages[py] = "perspective-pyodide";
+                        }
+                    }
+                    return packages;
                 } else {
                     return [""];
                 }


### PR DESCRIPTION
- Switch to using global `CMAKE_CXX_FLAGS` to ensure every target we
  need to link, including all Arrow components, is built with Emscripten
  exceptions support.  The build already does the same thing for wasm
  exceptions so it's at least more consistent now.
- Add two regression tests to the pytest-pyodide suite for pyarrow and
  pandas examples, which were previously crashing due to inconsistent
  Emscripten exceptions support between the object files

Also includes:
- small devex fix for the setup script when using Pyodide
- splits CI job for Pyodide wheel into build/test, uploads the artifact even when test suite fails

### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [ ] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to. (N/A)
-   [x] Include new tests that fail without this PR but passes with it.
-   [x] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
