### PR TITLE
Fix `date` formatting for `perspective-viewer-datagrid` plugin

### DIFF
--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -108,6 +108,7 @@ load_file(
 
         std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
         auto num_batches = batch_reader->num_record_batches();
+        batches.reserve(num_batches);
         for (int i = 0; i < num_batches; ++i) {
             auto status2 = batch_reader->ReadRecordBatch(i);
             if (!status2.ok()) {

--- a/packages/perspective-viewer-datagrid/src/js/data_listener/formatter_cache.js
+++ b/packages/perspective-viewer-datagrid/src/js/data_listener/formatter_cache.js
@@ -55,103 +55,104 @@ export class FormatterCache {
             dateStyle: "short",
             timeStyle: "medium",
         };
-        if (type === "datetime") {
-            if (plugin.date_format?.format !== "custom") {
-                const options = {
-                    ...type_config,
-                    timeZone: plugin.date_format?.timeZone,
-                    dateStyle: plugin.date_format?.dateStyle,
-                    timeStyle: plugin.date_format?.timeStyle,
-                };
-                if (options.dateStyle === "disabled") {
-                    options.dateStyle = undefined;
-                } else if (options.dateStyle === undefined) {
-                    options.dateStyle = "short";
-                }
 
-                if (options.timeStyle === "disabled") {
-                    options.timeStyle = undefined;
-                } else if (options.timeStyle === undefined) {
-                    options.timeStyle = "medium";
-                }
-
-                return new Intl.DateTimeFormat(navigator.languages, options);
-            } else {
-                const options = {
-                    // ...type_config.format,
-                    timeZone: plugin.date_format?.timeZone,
-                    second: plugin.date_format?.second,
-                    minute: plugin.date_format?.minute,
-                    hour: plugin.date_format?.hour,
-                    day: plugin.date_format?.day,
-                    weekday: plugin.date_format?.weekday,
-                    month: plugin.date_format?.month,
-                    year: plugin.date_format?.year,
-                    hour12: plugin.date_format?.hour12,
-                    fractionalSecondDigits:
-                        plugin.date_format?.fractionalSecondDigits,
-                };
-
-                if (options.year === "disabled") {
-                    options.year = undefined;
-                } else if (options.year === undefined) {
-                    options.year = "2-digit";
-                }
-
-                if (options.month === "disabled") {
-                    options.month = undefined;
-                } else if (options.month === undefined) {
-                    options.month = "numeric";
-                }
-
-                if (options.day === "disabled") {
-                    options.day = undefined;
-                } else if (options.day === undefined) {
-                    options.day = "numeric";
-                }
-
-                if (options.weekday === "disabled") {
-                    options.weekday = undefined;
-                }
-
-                if (options.hour === "disabled") {
-                    options.hour = undefined;
-                } else if (options.hour === undefined) {
-                    options.hour = "numeric";
-                }
-
-                if (options.minute === "disabled") {
-                    options.minute = undefined;
-                } else if (options.minute === undefined) {
-                    options.minute = "numeric";
-                }
-
-                if (options.second === "disabled") {
-                    options.second = undefined;
-                } else if (options.second === undefined) {
-                    options.second = "numeric";
-                }
-
-                if (options.hour12 === undefined) {
-                    options.hour12 = true;
-                }
-
-                return new Intl.DateTimeFormat(navigator.languages, options);
-            }
-        } else {
+        if (plugin.date_format?.format !== "custom") {
             const options = {
-                ...type_config.format,
+                ...type_config,
+                timeZone: plugin.date_format?.timeZone,
                 dateStyle: plugin.date_format?.dateStyle,
+                timeStyle: plugin.date_format?.timeStyle,
             };
-
             if (options.dateStyle === "disabled") {
                 options.dateStyle = undefined;
             } else if (options.dateStyle === undefined) {
                 options.dateStyle = "short";
             }
 
+            if (options.timeStyle === "disabled") {
+                options.timeStyle = undefined;
+            } else if (options.timeStyle === undefined) {
+                options.timeStyle = "medium";
+            }
+
+            return new Intl.DateTimeFormat(navigator.languages, options);
+        } else {
+            const options = {
+                // ...type_config.format,
+                timeZone: plugin.date_format?.timeZone,
+                second: plugin.date_format?.second,
+                minute: plugin.date_format?.minute,
+                hour: plugin.date_format?.hour,
+                day: plugin.date_format?.day,
+                weekday: plugin.date_format?.weekday,
+                month: plugin.date_format?.month,
+                year: plugin.date_format?.year,
+                hour12: plugin.date_format?.hour12,
+                fractionalSecondDigits:
+                    plugin.date_format?.fractionalSecondDigits,
+            };
+
+            if (options.year === "disabled") {
+                options.year = undefined;
+            } else if (options.year === undefined) {
+                options.year = "2-digit";
+            }
+
+            if (options.month === "disabled") {
+                options.month = undefined;
+            } else if (options.month === undefined) {
+                options.month = "numeric";
+            }
+
+            if (options.day === "disabled") {
+                options.day = undefined;
+            } else if (options.day === undefined) {
+                options.day = "numeric";
+            }
+
+            if (options.weekday === "disabled") {
+                options.weekday = undefined;
+            }
+
+            if (options.hour === "disabled") {
+                options.hour = undefined;
+            } else if (options.hour === undefined) {
+                options.hour = "numeric";
+            }
+
+            if (options.minute === "disabled") {
+                options.minute = undefined;
+            } else if (options.minute === undefined) {
+                options.minute = "numeric";
+            }
+
+            if (options.second === "disabled") {
+                options.second = undefined;
+            } else if (options.second === undefined) {
+                options.second = "numeric";
+            }
+
+            if (options.hour12 === undefined) {
+                options.hour12 = true;
+            }
+
             return new Intl.DateTimeFormat(navigator.languages, options);
         }
+    }
+
+    create_date_formatter(type, plugin) {
+        const options = {
+            dateStyle: plugin.date_format?.dateStyle,
+            timeZone: "utc",
+        };
+
+        if (options.dateStyle === "disabled") {
+            options.dateStyle = undefined;
+        } else if (options.dateStyle === undefined) {
+            options.dateStyle = "short";
+        }
+
+        return new Intl.DateTimeFormat(navigator.languages, options);
     }
 
     create_number_formatter(type, plugin) {
@@ -175,7 +176,12 @@ export class FormatterCache {
         ].join("-");
 
         if (!this._formatters.has(formatter_key)) {
-            if (type === "date" || type === "datetime") {
+            if (type === "date") {
+                this._formatters.set(
+                    formatter_key,
+                    this.create_date_formatter(type, plugin)
+                );
+            } else if (type === "datetime") {
                 this._formatters.set(
                     formatter_key,
                     this.create_datetime_formatter(type, plugin)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,6 +671,9 @@ importers:
       '@types/ws':
         specifier: ^8.5.10
         version: 8.5.12
+      apache-arrow:
+        specifier: 18.1.0
+        version: 18.1.0
       cpy:
         specifier: ^9.0.1
         version: 9.0.1
@@ -3742,6 +3745,9 @@ packages:
     resolution: {integrity: sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA==}
     engines: {node: '>=14'}
 
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
@@ -3782,6 +3788,12 @@ packages:
 
   '@types/btoa-lite@1.0.2':
     resolution: {integrity: sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==}
+
+  '@types/command-line-args@5.2.3':
+    resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==}
+
+  '@types/command-line-usage@5.0.4':
+    resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
 
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
@@ -3980,6 +3992,9 @@ packages:
 
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
+  '@types/node@20.17.16':
+    resolution: {integrity: sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==}
 
   '@types/node@22.10.5':
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
@@ -4278,6 +4293,10 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apache-arrow@18.1.0:
+    resolution: {integrity: sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==}
+    hasBin: true
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -4289,6 +4308,14 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-back@3.1.0:
+    resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
+    engines: {node: '>=6'}
+
+  array-back@6.2.2:
+    resolution: {integrity: sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==}
+    engines: {node: '>=12.17'}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -4565,6 +4592,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chalk-template@0.4.0:
+    resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
+    engines: {node: '>=12'}
+
   chalk@1.1.3:
     resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
@@ -4732,6 +4763,14 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  command-line-args@5.2.1:
+    resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
+    engines: {node: '>=4.0.0'}
+
+  command-line-usage@7.0.3:
+    resolution: {integrity: sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==}
+    engines: {node: '>=12.20.0'}
 
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -5899,6 +5938,10 @@ packages:
     resolution: {integrity: sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==}
     engines: {node: '>=14.16'}
 
+  find-replace@3.0.0:
+    resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
+    engines: {node: '>=4.0.0'}
+
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
@@ -5928,6 +5971,9 @@ packages:
 
   flatbuffers@1.12.0:
     resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
+
+  flatbuffers@24.12.23:
+    resolution: {integrity: sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==}
 
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
@@ -6831,6 +6877,10 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-bignum@0.0.3:
+    resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
+    engines: {node: '>=0.8'}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -9288,6 +9338,10 @@ packages:
   tabbable@5.3.3:
     resolution: {integrity: sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==}
 
+  table-layout@4.1.1:
+    resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
+    engines: {node: '>=12.17'}
+
   tapable@1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
     engines: {node: '>=6'}
@@ -9464,6 +9518,14 @@ packages:
   typestyle@2.4.0:
     resolution: {integrity: sha512-/d1BL6Qi+YlMLEydnUEB8KL/CAjAN8cyt3/UyGnOyBrWf7bLGcR/6yhmsaUstO2IcYwZfagjE7AIzuI2vUW9mg==}
 
+  typical@4.0.0:
+    resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
+    engines: {node: '>=8'}
+
+  typical@7.3.0:
+    resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
+    engines: {node: '>=12.17'}
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -9478,6 +9540,9 @@ packages:
 
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
@@ -9853,6 +9918,10 @@ packages:
 
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
+  wordwrapjs@5.1.0:
+    resolution: {integrity: sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==}
+    engines: {node: '>=12.17'}
 
   worker-loader@3.0.8:
     resolution: {integrity: sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==}
@@ -14438,6 +14507,10 @@ snapshots:
       - supports-color
       - typescript
 
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
@@ -14475,6 +14548,10 @@ snapshots:
       '@types/node': 22.10.5
 
   '@types/btoa-lite@1.0.2': {}
+
+  '@types/command-line-args@5.2.3': {}
+
+  '@types/command-line-usage@5.0.4': {}
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
@@ -14710,6 +14787,10 @@ snapshots:
       '@types/node': 22.10.5
 
   '@types/node@17.0.45': {}
+
+  '@types/node@20.17.16':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/node@22.10.5':
     dependencies:
@@ -15056,6 +15137,18 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  apache-arrow@18.1.0:
+    dependencies:
+      '@swc/helpers': 0.5.15
+      '@types/command-line-args': 5.2.3
+      '@types/command-line-usage': 5.0.4
+      '@types/node': 20.17.16
+      command-line-args: 5.2.1
+      command-line-usage: 7.0.3
+      flatbuffers: 24.12.23
+      json-bignum: 0.0.3
+      tslib: 2.8.1
+
   arg@4.1.3: {}
 
   arg@5.0.2: {}
@@ -15065,6 +15158,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  array-back@3.1.0: {}
+
+  array-back@6.2.2: {}
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -15443,6 +15540,10 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chalk-template@0.4.0:
+    dependencies:
+      chalk: 4.1.2
+
   chalk@1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -15612,6 +15713,20 @@ snapshots:
   combine-promises@1.2.0: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  command-line-args@5.2.1:
+    dependencies:
+      array-back: 3.1.0
+      find-replace: 3.0.0
+      lodash.camelcase: 4.3.0
+      typical: 4.0.0
+
+  command-line-usage@7.0.3:
+    dependencies:
+      array-back: 6.2.2
+      chalk-template: 0.4.0
+      table-layout: 4.1.1
+      typical: 7.3.0
 
   commander@10.0.1: {}
 
@@ -17046,6 +17161,10 @@ snapshots:
       common-path-prefix: 3.0.0
       pkg-dir: 7.0.0
 
+  find-replace@3.0.0:
+    dependencies:
+      array-back: 3.1.0
+
   find-root@1.1.0: {}
 
   find-up@3.0.0:
@@ -17076,6 +17195,8 @@ snapshots:
   flat@5.0.2: {}
 
   flatbuffers@1.12.0: {}
+
+  flatbuffers@24.12.23: {}
 
   flatted@3.3.2:
     optional: true
@@ -18086,6 +18207,8 @@ snapshots:
   jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
+
+  json-bignum@0.0.3: {}
 
   json-buffer@3.0.1: {}
 
@@ -21125,6 +21248,11 @@ snapshots:
 
   tabbable@5.3.3: {}
 
+  table-layout@4.1.1:
+    dependencies:
+      array-back: 6.2.2
+      wordwrapjs: 5.1.0
+
   tapable@1.1.3: {}
 
   tapable@2.2.1: {}
@@ -21323,6 +21451,10 @@ snapshots:
       csstype: 3.0.10
       free-style: 3.1.0
 
+  typical@4.0.0: {}
+
+  typical@7.3.0: {}
+
   uglify-js@3.19.3:
     optional: true
 
@@ -21339,6 +21471,8 @@ snapshots:
       through: 2.3.8
 
   underscore@1.13.7: {}
+
+  undici-types@6.19.8: {}
 
   undici-types@6.20.0: {}
 
@@ -21842,6 +21976,8 @@ snapshots:
     optional: true
 
   wordwrap@1.0.0: {}
+
+  wordwrapjs@5.1.0: {}
 
   worker-loader@3.0.8(webpack@5.97.1(esbuild@0.14.54)):
     dependencies:

--- a/rust/perspective-js/package.json
+++ b/rust/perspective-js/package.json
@@ -53,6 +53,7 @@
         "@finos/perspective-metadata": "workspace:^",
         "@types/stoppable": "^1.1.0",
         "@types/ws": "^8.5.10",
+        "apache-arrow": "18.1.0",
         "cpy": "^9.0.1",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",

--- a/rust/perspective-js/src/ts/perspective.browser.ts
+++ b/rust/perspective-js/src/ts/perspective.browser.ts
@@ -92,7 +92,6 @@ export function init_client(wasm: PerspectiveWasm, disable_stage_0 = false) {
                     .arrayBuffer()
                     .then((x) => compilerize(x, disable_stage_0));
             } else {
-                // } else if (wasm instanceof Object) {
                 return wasm as typeof psp;
             }
         });
@@ -123,17 +122,6 @@ function get_server() {
 }
 
 let GLOBAL_WORKER: undefined | (() => Promise<Worker>) = undefined;
-
-// function init_worker(worker) {
-//     GLOBAL_WORKER = worker;
-// }
-
-// function perspective_wasm_worker() {
-//     return new Worker(
-//         new URL("./perspective-server.worker.js", import.meta.url),
-//         { type: "module" }
-//     );
-// }
 
 // Inline the worker for now. This code will eventually allow outlining this resource
 // @ts-ignore

--- a/rust/perspective-js/src/ts/wasm/emscripten_api.ts
+++ b/rust/perspective-js/src/ts/wasm/emscripten_api.ts
@@ -10,14 +10,11 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-// import * as perspective_server from "../../../dist/wasm/perspective-server.js";
 import * as perspective_server from "./perspective-server.poly.ts";
-
 export type * from "../../../dist/wasm/perspective-js.js";
 import type * as perspective_server_t from "../../../dist/wasm/perspective-server.js";
 
 export type PspPtr = BigInt | number;
-
 export type EmscriptenServer = bigint | number;
 
 export async function compile_perspective(
@@ -48,7 +45,11 @@ export async function compile_perspective(
                     return ptr;
                 },
                 psp_heap_size() {
-                    return module.HEAPU8.buffer.byteLength;
+                    if (module._psp_is_memory64()) {
+                        return BigInt(module.HEAPU8.buffer.byteLength);
+                    } else {
+                        return module.HEAPU8.buffer.byteLength;
+                    }
                 },
             };
 

--- a/rust/perspective-js/test/js/constructors/arrow.spec.ts
+++ b/rust/perspective-js/test/js/constructors/arrow.spec.ts
@@ -1,0 +1,71 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import * as arrow from "apache-arrow";
+import { test, expect } from "@finos/perspective-test";
+import perspective from "../perspective_client";
+
+test.describe("Arrow", function () {
+    test.describe("Date columns", function () {
+        // https://github.com/finos/perspective/issues/2894
+        // https://github.com/jdangerx/repro-perspective-float-filter/tree/dates
+        test("Date columns are preserved through Arrow in and out", async function () {
+            const tableData = arrow.tableFromArrays({
+                date: arrow.vectorFromArray([20089], new arrow.Date_()),
+            });
+
+            const table = await perspective.table(arrow.tableToIPC(tableData));
+            const view = await table.view();
+            const json = await view.to_json();
+
+            const d = new Date(json[0].date);
+            expect(json[0].date).toEqual(1735689600000);
+
+            // This doesn't test anything except my math
+            expect(d.getUTCFullYear()).toEqual(2025);
+            expect(d.getUTCDate()).toEqual(1);
+            expect(d.getUTCMonth()).toEqual(0);
+            expect(d.getUTCHours()).toEqual(0);
+            expect(d.getUTCMinutes()).toEqual(0);
+            expect(d.getUTCSeconds()).toEqual(0);
+            expect(d.getTimezoneOffset()).toEqual(0);
+            await view.delete();
+            await table.delete();
+        });
+
+        test("Date columns are preserved through Arrow in and out, in a negative timezone", async function () {
+            process.env.TZ = `America/New_York`;
+            const tableData = arrow.tableFromArrays({
+                date: arrow.vectorFromArray([20089], new arrow.Date_()),
+            });
+
+            const table = await perspective.table(arrow.tableToIPC(tableData));
+            const view = await table.view();
+            const json = await view.to_json();
+
+            const d = new Date(json[0].date);
+            expect(json[0].date).toEqual(1735689600000);
+            expect(d.getUTCFullYear()).toEqual(2025);
+            expect(d.getUTCDate()).toEqual(1);
+            expect(d.getUTCMonth()).toEqual(0);
+            expect(d.getUTCHours()).toEqual(0);
+            expect(d.getUTCMinutes()).toEqual(0);
+            expect(d.getUTCSeconds()).toEqual(0);
+
+            // NY now ...
+            expect(d.getTimezoneOffset()).toEqual(300);
+            await view.delete();
+            await table.delete();
+            process.env.TZ = `UTC`;
+        });
+    });
+});


### PR DESCRIPTION
Fixes #2894, an issue with `perspective-viewer-datagrid`'s formatting. Though internally Perspective `date` columns have no timezone offset, we use JavaScript `Date` types to format these values to the locale/ui settings, which by default will format to string in local time, causing `date` columns to appear off-by-one in this plugin.

Added a test based on the [repro](https://github.com/jdangerx/repro-perspective-float-filter/tree/dates) provided, which asserts (_sans UI_) that Perspective's engine encodes and decodes `date` columns types transitively.