### PR TITLE
delete jupyter examples (they don't exist)

### DIFF
--- a/packages/perspective-jupyterlab/README.md
+++ b/packages/perspective-jupyterlab/README.md
@@ -2,8 +2,6 @@
 
 This extension allows in-lining perspective based charts in jupyterlab notebooks.
 
-[Examples](https://github.com/finos/perspective/tree/master/examples/jupyter-notebooks)
-
 ## Installation
 
 ### From npm


### PR DESCRIPTION
Readme contained a link to examples, but those give 404.