### PR TITLE
Fix overallocations

### DIFF
--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -138,6 +138,7 @@ using namespace perspective;
 
 ArrowLoader::ArrowLoader() = default;
 ArrowLoader::~ArrowLoader() = default;
+ArrowLoader::ArrowLoader(ArrowLoader&&) noexcept = default;
 
 t_dtype
 convert_type(const std::string& src) {
@@ -483,6 +484,11 @@ copy_array(
 
             t_vocab* vocab = dest->_get_vocab();
             std::string elem;
+
+            vocab->reserve(
+                dict->value_data()->size() + dsize, // vocab len + null bytes
+                dsize
+            );
 
             for (std::uint64_t i = 0; i < dsize; ++i) {
                 std::int32_t bidx = offsets[i];

--- a/cpp/perspective/src/include/perspective/arrow_loader.h
+++ b/cpp/perspective/src/include/perspective/arrow_loader.h
@@ -32,6 +32,7 @@ namespace apachearrow {
     public:
         ArrowLoader();
         ~ArrowLoader();
+        ArrowLoader(ArrowLoader&& other) noexcept;
 
         /**
          * @brief Initialize the arrow loader with a pointer to a binary.

--- a/cpp/perspective/src/include/perspective/server.h
+++ b/cpp/perspective/src/include/perspective/server.h
@@ -625,7 +625,7 @@ namespace server {
         );
 
         std::vector<ProtoServerResp<Response>>
-        _handle_request(std::uint32_t client_id, const Request& req);
+        _handle_request(std::uint32_t client_id, Request&& req);
 
         std::vector<ProtoServerResp<Response>> _poll();
 

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -203,25 +203,25 @@ public:
 
     static std::shared_ptr<Table> from_csv(
         const std::string& index,
-        const std::string_view& data,
+        std::string&& data,
         std::uint32_t limit = std::numeric_limits<std::uint32_t>::max()
     );
 
     static std::shared_ptr<Table> from_cols(
         const std::string& index,
-        const std::string_view& data,
+        std::string&& data,
         std::uint32_t limit = std::numeric_limits<std::uint32_t>::max()
     );
 
     static std::shared_ptr<Table> from_rows(
         const std::string& index,
-        const std::string_view& data,
+        std::string&& data,
         std::uint32_t limit = std::numeric_limits<std::uint32_t>::max()
     );
 
     static std::shared_ptr<Table> from_ndjson(
         const std::string& index,
-        const std::string_view& data,
+        std::string&& data,
         std::uint32_t limit = std::numeric_limits<std::uint32_t>::max()
     );
 
@@ -233,7 +233,7 @@ public:
 
     static std::shared_ptr<Table> from_arrow(
         const std::string& index,
-        const std::string_view& data,
+        std::string&& data,
         std::uint32_t limit = std::numeric_limits<std::uint32_t>::max()
     );
 


### PR DESCRIPTION
This fixes a couple of places where we're overallocating.
1. Reserve vocabs while loading arrows into perspective to prevent overgrowth.
2. Free data tables and protobuf messages before processing the table to minimize the concurrent copies of the data in memory.