### PR TITLE
Fix datagrid scroll drift on resize

### DIFF
--- a/packages/perspective-viewer-datagrid/package.json
+++ b/packages/perspective-viewer-datagrid/package.json
@@ -35,7 +35,7 @@
         "@finos/perspective": "workspace:^",
         "@finos/perspective-viewer": "workspace:^",
         "chroma-js": "^1.3.4",
-        "regular-table": "=0.6.5"
+        "regular-table": "=0.6.6"
     },
     "devDependencies": {
         "@prospective.co/procss": "^0.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,13 +120,13 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: ^3.7.0
-        version: 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+        version: 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/preset-classic':
         specifier: ^3.7.0
-        version: 3.7.0(@algolia/client-search@5.18.0)(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.2.2)
+        version: 3.7.0(@algolia/client-search@5.18.0)(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.2.2)
       '@docusaurus/theme-common':
         specifier: ^3.7.0
-        version: 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@finos/perspective':
         specifier: workspace:^
         version: link:../rust/perspective-js
@@ -405,7 +405,7 @@ importers:
         version: 0.28.11
       html-webpack-plugin:
         specifier: ^5.1.0
-        version: 5.6.0(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
+        version: 5.6.0(webpack@5.97.1)
       style-loader:
         specifier: ^0.18.2
         version: 0.18.2
@@ -550,8 +550,8 @@ importers:
         specifier: ^1.3.4
         version: 1.4.1
       regular-table:
-        specifier: '=0.6.5'
-        version: 0.6.5
+        specifier: '=0.6.6'
+        version: 0.6.6
     devDependencies:
       '@finos/perspective-esbuild-plugin':
         specifier: workspace:^
@@ -8756,8 +8756,8 @@ packages:
     resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
     hasBin: true
 
-  regular-table@0.6.5:
-    resolution: {integrity: sha512-KbQ07NMZGHpY8KuLirfn60HWfOsrZCVwrXBfVYTi/EE97zlfTOsc1A5UhR0QodPzO+ZR5BPKDLACuFT7mIG8hA==}
+  regular-table@0.6.6:
+    resolution: {integrity: sha512-v2JieNm/fhUICKA4PZ6mcGqKpjKVvYF/3p2X0tmuFzxrLA+wvDySiDtEkN82AGrjIz57ThWjxjpkJbkbNMA95g==}
     engines: {node: '>=16'}
 
   rehype-raw@7.0.0:
@@ -12201,7 +12201,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.7.0(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/bundler@3.7.0(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
       '@babel/core': 7.26.0
       '@docusaurus/babel': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12222,7 +12222,7 @@ snapshots:
       postcss: 8.4.49
       postcss-loader: 7.3.4(postcss@8.4.49)(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54))
       postcss-preset-env: 10.1.3(postcss@8.4.49)
-      react-dev-utils: 12.0.1(eslint@9.17.0)(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54))
+      react-dev-utils: 12.0.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54))
       terser-webpack-plugin: 5.3.11(esbuild@0.14.54)(webpack@5.97.1(esbuild@0.14.54))
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1(esbuild@0.14.54)))(webpack@5.97.1(esbuild@0.14.54))
@@ -12245,10 +12245,10 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/core@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/core@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
       '@docusaurus/babel': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/bundler': 3.7.0(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/bundler': 3.7.0(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12275,7 +12275,7 @@ snapshots:
       p-map: 4.0.0
       prompts: 2.4.2
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@9.17.0)(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54))
+      react-dev-utils: 12.0.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54))
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
@@ -12376,13 +12376,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12419,13 +12419,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12460,9 +12460,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/mdx-loader': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12492,9 +12492,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.2.0
@@ -12522,9 +12522,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -12550,9 +12550,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/gtag.js': 0.0.12
@@ -12579,9 +12579,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -12607,9 +12607,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12640,9 +12640,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12672,21 +12672,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.18.0)(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.2.2)':
+  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.18.0)(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-classic': 3.7.0(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.18.0)(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-classic': 3.7.0(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.18.0)(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.2.2)
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -12718,16 +12718,16 @@ snapshots:
       '@types/react': 18.3.8
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.7.0(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/theme-classic@3.7.0(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.7.0
       '@docusaurus/types': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12768,11 +12768,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@docusaurus/mdx-loader': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
@@ -12792,13 +12792,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.18.0)(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.2.2)':
+  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.18.0)(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(@types/react@18.3.8)(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.2.2)':
     dependencies:
       '@docsearch/react': 3.8.2(@algolia/client-search@5.18.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.0.1(@types/react@18.3.8)(react@18.3.1))(esbuild@0.14.54)(eslint@9.17.0(jiti@1.21.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.7.0
       '@docusaurus/utils': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(esbuild@0.14.54)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -13075,9 +13075,9 @@ snapshots:
   '@esbuild/win32-x64@0.24.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.1(eslint@9.17.0)':
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.17.0(jiti@1.21.6))':
     dependencies:
-      eslint: 9.17.0
+      eslint: 9.17.0(jiti@1.21.6)
       eslint-visitor-keys: 3.4.3
     optional: true
 
@@ -15014,7 +15014,7 @@ snapshots:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1(esbuild@0.14.54))
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1)
@@ -15024,7 +15024,7 @@ snapshots:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1(esbuild@0.14.54))
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1)
@@ -15034,7 +15034,7 @@ snapshots:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1(esbuild@0.14.54))
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1)
@@ -15991,7 +15991,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
+      webpack: 5.97.1(esbuild@0.14.54)
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.14.54)(webpack@5.97.1(esbuild@0.14.54)):
     dependencies:
@@ -16911,9 +16911,9 @@ snapshots:
   eslint-visitor-keys@4.2.0:
     optional: true
 
-  eslint@9.17.0:
+  eslint@9.17.0(jiti@1.21.6):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0)
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@1.21.6))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.19.1
       '@eslint/core': 0.9.1
@@ -16947,6 +16947,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.6
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -17243,7 +17245,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.17.0)(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54)):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.17.0(jiti@1.21.6))(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54)):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@types/json-schema': 7.0.15
@@ -17261,7 +17263,7 @@ snapshots:
       typescript: 5.2.2
       webpack: 5.97.1(esbuild@0.14.54)
     optionalDependencies:
-      eslint: 9.17.0
+      eslint: 9.17.0(jiti@1.21.6)
 
   form-data-encoder@2.1.4: {}
 
@@ -17719,16 +17721,6 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.21
-      pretty-error: 4.0.0
-      tapable: 2.2.1
-    optionalDependencies:
-      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
-
   html-webpack-plugin@5.6.0(webpack@5.97.1(esbuild@0.14.54)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -17738,6 +17730,16 @@ snapshots:
       tapable: 2.2.1
     optionalDependencies:
       webpack: 5.97.1(esbuild@0.14.54)
+
+  html-webpack-plugin@5.6.0(webpack@5.97.1):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.17.21
+      pretty-error: 4.0.0
+      tapable: 2.2.1
+    optionalDependencies:
+      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -19049,7 +19051,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.2.1
-      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
+      webpack: 5.97.1(esbuild@0.14.54)
 
   mini-svg-data-uri@1.4.4: {}
 
@@ -20323,7 +20325,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dev-utils@12.0.1(eslint@9.17.0)(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54)):
+  react-dev-utils@12.0.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54)):
     dependencies:
       '@babel/code-frame': 7.26.2
       address: 1.2.2
@@ -20334,7 +20336,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.17.0)(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54))
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.17.0(jiti@1.21.6))(typescript@5.2.2)(webpack@5.97.1(esbuild@0.14.54))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -20551,7 +20553,7 @@ snapshots:
     dependencies:
       jsesc: 0.5.0
 
-  regular-table@0.6.5: {}
+  regular-table@0.6.6: {}
 
   rehype-raw@7.0.0:
     dependencies:
@@ -21318,17 +21320,6 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
-  terser-webpack-plugin@5.3.11(esbuild@0.14.54)(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 4.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.37.0
-      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
-    optionalDependencies:
-      esbuild: 0.14.54
-
   terser-webpack-plugin@5.3.11(esbuild@0.14.54)(webpack@5.97.1(esbuild@0.14.54)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -21337,6 +21328,17 @@ snapshots:
       serialize-javascript: 6.0.2
       terser: 5.37.0
       webpack: 5.97.1(esbuild@0.14.54)
+    optionalDependencies:
+      esbuild: 0.14.54
+
+  terser-webpack-plugin@5.3.11(esbuild@0.14.54)(webpack@5.97.1):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 4.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.37.0
+      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.14.54
 
@@ -21764,9 +21766,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.97.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.97.1)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -21898,7 +21900,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(esbuild@0.14.54)(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.11(esbuild@0.14.54)(webpack@5.97.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
@@ -12,6 +12,7 @@
 
 use itertools::Itertools;
 use perspective_client::config::*;
+use perspective_client::ColumnType;
 use web_sys::*;
 use yew::prelude::*;
 
@@ -147,7 +148,7 @@ impl Component for InactiveColumn {
             .session
             .metadata()
             .get_column_table_type(&ctx.props().name)
-            .expect("Unknown column");
+            .unwrap_or(ColumnType::String);
 
         let add_column = ctx
             .link()

--- a/rust/perspective-viewer/src/rust/components/viewer.rs
+++ b/rust/perspective-viewer/src/rust/components/viewer.rs
@@ -559,7 +559,7 @@ impl Component for PerspectiveViewer {
                                 initial_size={self.settings_panel_width_override}
                                 on_reset={ctx.link().callback(|_| PerspectiveViewerMsg::SettingsPanelSizeUpdate(None))}
                                 on_resize={on_split_panel_resize}
-                                on_resize_finished={ctx.props().render_callback()}
+                                on_resize_finished={ctx.props().resize_callback()}
                             >
                                 { settings_panel }
                                 { main_panel }

--- a/rust/perspective-viewer/src/rust/model/update_and_render.rs
+++ b/rust/perspective-viewer/src/rust/model/update_and_render.rs
@@ -39,6 +39,18 @@ pub trait UpdateAndRender: HasRenderer + HasSession {
         })
     }
 
+    /// Create a `Callback` that resizes from the current `View` and `Plugin`.
+    fn resize_callback(&self) -> Callback<()> {
+        clone!(self.renderer());
+        Callback::from(move |_| {
+            clone!(renderer);
+            ApiFuture::spawn(async move {
+                renderer.resize().await?;
+                Ok(())
+            })
+        })
+    }
+
     /// Apply a `ViewConfigUpdate` to the current `View` and render.
     fn update_and_render(&self, update: ViewConfigUpdate) -> ApiFuture<()> {
         self.session().update_view_config(update);


### PR DESCRIPTION
This PR fixes an issue with `perspective-viewer-datagrid` which caused scroll position to drift when the component dimensions change.