### PR TITLE
Add a stroke-width configuration to lineSeries d3fc charts

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -220,6 +220,7 @@ if(PSP_WASM_BUILD)
             -g3 \
             -Wcast-align \
             -Wover-aligned \
+            --emit-tsd=perspective-server.d.ts \
             ")
         if (PSP_WASM_EXCEPTIONS)
             set(OPT_FLAGS "${OPT_FLAGS} -fwasm-exceptions ")

--- a/packages/perspective-viewer-d3fc/build.js
+++ b/packages/perspective-viewer-d3fc/build.js
@@ -82,7 +82,7 @@ function add(builder, path) {
     );
 }
 
-async function compile_css() {
+function compile_css() {
     fs.mkdirSync("dist/css", { recursive: true });
     const builder = new BuildCss("");
     add(builder, "./series_colors.less");
@@ -94,10 +94,24 @@ async function compile_css() {
     );
 }
 
+function move_html() {
+    fs.mkdirSync("dist/html", { recursive: true });
+
+    const srcDir = "src/html";
+    const destDir = "dist/html";
+
+    fs.readdirSync(srcDir).forEach((file) => {
+        const srcFile = `${srcDir}/${file}`;
+        const destFile = `${destDir}/${file}`;
+        fs.copyFileSync(srcFile, destFile);
+    });
+}
+
 async function build_all() {
     // NOTE: compile_css and other build step must be run before tsc, because
     // (for now) nothing runs after the tsc step.
-    await compile_css();
+    compile_css();
+    move_html();
     await Promise.all(BUILD.map(build)).catch(() => process.exit(1));
 
     // esbuild can handle typescript files, and strips out types from the output,

--- a/packages/perspective-viewer-d3fc/src/ts/series/lineSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/lineSeries.ts
@@ -14,7 +14,11 @@ import * as fc from "d3fc";
 import { withoutOpacity } from "./seriesColors.js";
 import { D3Scale, Settings } from "../types.js";
 
-export function lineSeries(settings: Settings, color: D3Scale) {
+export function lineSeries(
+    settings: Settings,
+    color: D3Scale,
+    stroke_width: number | undefined = undefined
+) {
     let series = fc.seriesSvgLine();
 
     const estimated_size =
@@ -23,15 +27,17 @@ export function lineSeries(settings: Settings, color: D3Scale) {
             ? Object.keys(settings.data[0]).length -
               (settings.crossValues?.length > 0 ? 1 : 0)
             : 0);
-    const stroke_width = Math.max(
-        1,
-        Math.min(3, Math.floor(settings.size.width / estimated_size / 2))
-    );
+    const width =
+        stroke_width ??
+        Math.max(
+            1,
+            Math.min(3, Math.floor(settings.size.width / estimated_size / 2))
+        );
 
     series = series.decorate((selection) => {
         selection
             .style("stroke", (d) => withoutOpacity(color(d[0] && d[0].key)))
-            .style("stroke-width", stroke_width);
+            .style("stroke-width", width);
     });
 
     return series.crossValue((d) => d.crossValue).mainValue((d) => d.mainValue);


### PR DESCRIPTION
Hello, I was working on a custom plugin based on perspective-viewer-d3fc and wanted to add a custom stroke width to a lineSeries. This change keeps the previous default value if not provided, so it is completely backwards compatible. 

This PR also includes some fixes to the build scripts. First, it exports typescript declarations during debug builds, and second it puts HTML into the `perspective-viewer-d3fc/dist` directory for the ESM builds, as the CDN builds had the HTML inlined.