### PR TITLE
Fix `View::to_polars` and add `LargeUTF8` Arrow dictionary support

### DIFF
--- a/rust/perspective-python/perspective/tests/table/test_to_polars.py
+++ b/rust/perspective-python/perspective/tests/table/test_to_polars.py
@@ -1,0 +1,26 @@
+#  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+#  ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+#  ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+#  ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+#  ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+#  ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+#  ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+#  ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+#  ┃ This file is part of the Perspective library, distributed under the terms ┃
+#  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+#  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import perspective as psp
+
+client = psp.Server().new_local_client()
+Table = client.table
+
+
+class TestToPolars(object):
+    def test_to_polars(self, superstore):
+        original_tbl = Table(superstore.to_dict(orient="records"))
+        df = original_tbl.view().to_polars()
+        tbl = Table(df)
+        assert tbl.size() == original_tbl.size()
+        df2 = tbl.view().to_polars()
+        assert df.equals(df2)

--- a/rust/perspective-python/src/client/polars.rs
+++ b/rust/perspective-python/src/client/polars.rs
@@ -62,7 +62,6 @@ pub fn arrow_to_polars(py: Python<'_>, arrow: &[u8]) -> PyResult<Py<PyAny>> {
     Ok(polars
         .getattr("read_ipc_stream")?
         .call1((bytes,))?
-        .call0()?
         .as_unbound()
         .clone())
 }

--- a/rust/perspective-python/src/server/server_sync.rs
+++ b/rust/perspective-python/src/server/server_sync.rs
@@ -70,7 +70,10 @@ impl PySyncServer {
         loop_callback: Option<Py<PyAny>>,
     ) -> PyResult<crate::client::client_sync::Client> {
         let client = crate::client::client_sync::Client(PyClient::new_from_client(
-            self.server.new_local_client().clone(),
+            self.server
+                .new_local_client()
+                .take()
+                .map_err(PyValueError::new_err)?,
         ));
 
         if let Some(loop_cb) = loop_callback {


### PR DESCRIPTION
This PR fixes the Python `View::to_polars` function to work and adds a test.

While attempting to implement transitive testing (perspective -> polars -> perspective), I realized [Polars stores dictionary columns in the uncommon `LargeUTF8` dictionary format](https://github.com/pola-rs/polars/issues/320), which caused segfaults in our u32-indexed dictionary reading code. As a result, this PR also adds support for Arrow/PyArrow`LargeUTF8` dictionary columns.