### PR TITLE
Maintain `@finos/perspective` TypeScript Compatibility for Clientside Environments

### DIFF
--- a/rust/perspective-js/package.json
+++ b/rust/perspective-js/package.json
@@ -29,6 +29,7 @@
         "./package.json": "./package.json",
         "./tsconfig.json": "./tsconfig.json"
     },
+    "types": "./dist/esm/perspective.browser.d.ts",
     "files": [
         "dist/**/*",
         "src/**/*",


### PR DESCRIPTION
This PR restores the `types` field that was removed from this package's `package.json` in 7c134b3, directing to the "browser" typedef. Removing this field causes compatibility issues with projects that use the "node" algorithm for tsconfig's `moduleResolution`, which includes all NextJS projects.

**Heads up:** one outstanding issue in the current release version of perspective-js (i.e. _unrelated to this PR_) is that [the referenced typedef for Node](https://github.com/finos/perspective/blob/master/rust/perspective-js/package.json#L23) isn't actually created, and attempting to import from `@finos/perspective/node` indeed does not work for me.