### PR TITLE
Python AsyncClient and JS ProxySession

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/universal
+{
+	"name": "Ubuntu: pnpm, rust, cmake, for JS dev",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rust-lang.rust-analyzer",
+				"ms-playwright.playwright"
+			]
+		}
+	},
+
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {},
+		"ghcr.io/devcontainers-extra/features/pnpm:2": {}
+	},
+
+	"postCreateCommand": "./.devcontainer/postcreate.sh"
+}

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+sudo apt-get update
+
+# Install cmake
+test -f /usr/share/doc/kitware-archive-keyring/copyright ||
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+
+echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+sudo apt-get update
+sudo apt-get install -y kitware-archive-keyring
+sudo apt-get install -y cmake
+
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Repo setup
+pnpm install

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ Vagrantfile
 vcpkg
 venv/
 rust/perspective-python/perspective_python-*.data
+.pytest-cache/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["rust-lang.rust", "ms-vscode.cpptools-extension-pack"]
+    "recommendations": ["rust-lang.rust-analyzer", "ms-vscode.cpptools-extension-pack"]
 }

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -6,6 +6,10 @@
         "PSP_ENABLE_WASM": "1"
     },
     "python.formatting.provider": "black",
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        "rust/perspective-python/perspective/tests/"
+    ],
     "rust-analyzer.server.extraEnv": {
         "PSP_ROOT_DIR": "../..",
         "PSP_DISABLE_CPP": "1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,9 +1687,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
@@ -1811,13 +1811,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2100,9 +2100,11 @@ dependencies = [
  "perspective-server",
  "pollster",
  "pyo3",
- "pyo3-build-config 0.20.3",
+ "pyo3-async-runtimes",
+ "pyo3-build-config 0.22.6",
  "python-config-rs",
  "pythonize",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2425,17 +2427,17 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.21.2",
+ "pyo3-build-config 0.23.4",
  "pyo3-ffi",
  "pyo3-macros",
  "serde",
@@ -2443,10 +2445,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3-build-config"
-version = "0.20.3"
+name = "pyo3-async-runtimes"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
+dependencies = [
+ "futures",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "pyo3-async-runtimes-macros",
+ "tokio",
+]
+
+[[package]]
+name = "pyo3-async-runtimes-macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2df2884957d2476731f987673befac5d521dff10abb0a7cbe12015bc7702fe9"
+dependencies = [
+ "proc-macro2 1.0.83",
+ "quote 1.0.36",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2454,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2464,19 +2491,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
 dependencies = [
  "libc",
- "pyo3-build-config 0.21.2",
+ "pyo3-build-config 0.23.4",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
 dependencies = [
  "proc-macro2 1.0.83",
  "pyo3-macros-backend",
@@ -2486,13 +2513,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2 1.0.83",
- "pyo3-build-config 0.21.2",
+ "pyo3-build-config 0.23.4",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -2508,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "pythonize"
-version = "0.21.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0664248812c38cc55a4ed07f88e4df516ce82604b93b1ffdc041aa77a6cb3c"
+checksum = "91a6ee7a084f913f98d70cdc3ebec07e852b735ae3059a1500db2661265da9ff"
 dependencies = [
  "pyo3",
  "serde",
@@ -3221,28 +3248,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2 1.0.83",
  "quote 1.0.36",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "llvm": "17.0.6",
     "pyodide": "0.27.1",
     "engines": {
-        "node": ">=16"
+        "node": ">=16 <23"
     },
     "workspaces": [
         "tools/perspective-test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,15 +705,15 @@ importers:
       '@finos/perspective-scripts':
         specifier: workspace:*
         version: link:../../tools/perspective-scripts
-      '@iarna/toml':
-        specifier: ^1.0.0-rc.1
-        version: 1.7.1
       cpy:
         specifier: ^9.0.1
         version: 9.0.1
       glob:
         specifier: ^11
         version: 11.0.0
+      smol-toml:
+        specifier: ^1.3.1
+        version: 1.3.1
       tar:
         specifier: ^7.4.3
         version: 7.4.3
@@ -3137,9 +3137,6 @@ packages:
   '@humanwhocodes/retry@0.4.1':
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
-
-  '@iarna/toml@1.7.1':
-    resolution: {integrity: sha512-X55PCmaErh7Tk4tg6F0xDxG7wHuomyFTZIeUyTtvZqIGnxF/qLZf5Gvvzp8SL3F/37gb3sZ4z4PVFWQxBOM26w==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -9112,6 +9109,10 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
+  smol-toml@1.3.1:
+    resolution: {integrity: sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==}
+    engines: {node: '>= 18'}
+
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
@@ -13389,8 +13390,6 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.1':
     optional: true
-
-  '@iarna/toml@1.7.1': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -21007,6 +21006,8 @@ snapshots:
   slash@5.1.0: {}
 
   smart-buffer@4.2.0: {}
+
+  smol-toml@1.3.1: {}
 
   snake-case@3.0.4:
     dependencies:

--- a/rust/perspective-js/src/rust/client.rs
+++ b/rust/perspective-js/src/rust/client.rs
@@ -14,7 +14,7 @@ use js_sys::{Function, Uint8Array};
 use macro_rules_attribute::apply;
 #[cfg(doc)]
 use perspective_client::SystemInfo;
-use perspective_client::{TableData, TableInitOptions};
+use perspective_client::{Session, TableData, TableInitOptions};
 use wasm_bindgen::prelude::*;
 
 pub use crate::table::*;
@@ -30,6 +30,52 @@ extern "C" {
     #[derive(Clone)]
     #[wasm_bindgen(typescript_type = "TableInitOptions")]
     pub type JsTableInitOptions;
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct ProxySession(perspective_client::ProxySession);
+
+#[wasm_bindgen]
+impl ProxySession {
+    #[wasm_bindgen(constructor)]
+    pub fn new(client: &Client, on_response: &Function) -> Self {
+        let poll_loop = LocalPollLoop::new({
+            let on_response = on_response.clone();
+            move |msg: Vec<u8>| {
+                let msg = Uint8Array::from(&msg[..]);
+                on_response.call1(&JsValue::UNDEFINED, &JsValue::from(msg))?;
+                Ok(JsValue::null())
+            }
+        });
+        // NB: This swallows any errors raised by the inner callback
+        let on_response = Box::new(move |msg: &[u8]| {
+            wasm_bindgen_futures::spawn_local(poll_loop.poll(msg.to_vec()));
+            Ok(())
+        });
+        Self(perspective_client::ProxySession::new(
+            client.client.clone(),
+            on_response,
+        ))
+    }
+
+    #[wasm_bindgen]
+    pub async fn handle_request(&self, value: JsValue) -> ApiResult<()> {
+        let uint8array = Uint8Array::new(&value);
+        let slice = uint8array.to_vec();
+        self.0.handle_request(&slice).await?;
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub async fn poll(&self) -> ApiResult<()> {
+        self.0.poll().await?;
+        Ok(())
+    }
+
+    pub async fn close(self) {
+        self.0.close().await;
+    }
 }
 
 #[apply(inherit_docs)]
@@ -59,6 +105,11 @@ impl Client {
         });
 
         Client { close, client }
+    }
+
+    #[wasm_bindgen]
+    pub fn new_proxy_session(&self, on_response: &Function) -> ProxySession {
+        ProxySession::new(self, on_response)
     }
 
     #[wasm_bindgen]

--- a/rust/perspective-js/test/js/proxy_session.spec.js
+++ b/rust/perspective-js/test/js/proxy_session.spec.js
@@ -1,0 +1,101 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test, expect } from "@finos/perspective-test";
+import { make_client, make_server } from "@finos/perspective";
+
+test("Proxy session tunnels requests through client", async () => {
+    // test.setTimeout(2000);
+    const { client, server } = connectClientToServer();
+    const { proxyClient } = connectProxyClient(client);
+
+    // Verify that main client + proxy client observe the same server
+    const clientTables1 = await client.get_hosted_table_names();
+    const proxyTables1 = await proxyClient.get_hosted_table_names();
+    expect(proxyTables1).toStrictEqual([]);
+    expect(proxyTables1).toStrictEqual(clientTables1);
+    const name = "abc-" + Math.random();
+    const _table = await client.table({ abc: [123] }, { name });
+    const clientTables2 = await client.get_hosted_table_names();
+    const proxyTables2 = await proxyClient.get_hosted_table_names();
+    expect(proxyTables2).toStrictEqual([name]);
+    expect(proxyTables2).toStrictEqual(clientTables2);
+});
+
+test("Proxy session tunnels on_update callbacks through client", async () => {
+    // test.setTimeout(2000);
+    const { client } = connectClientToServer();
+    const { proxyClient } = connectProxyClient(client);
+    const name = "abc-" + Math.random();
+    const clientTable = await client.table({ abc: [123] }, { name });
+
+    // Add an on_update callback to the proxy client's view of the table
+    const proxyTable = await proxyClient.open_table(name);
+    const proxyView = await proxyTable.view();
+    let resolveUpdate;
+    const onUpdateResp = new Promise((r) => (resolveUpdate = r));
+    await proxyView.on_update(
+        (x) => {
+            resolveUpdate(x);
+        },
+        { mode: "row" }
+    );
+
+    // Enact table update through client's table handle, and assert that proxy
+    // client's on_update callback is called
+    await clientTable.update({ abc: [999] });
+    const expectUpdate = expect.poll(
+        async () => {
+            const data = await onUpdateResp;
+            // TODO: construct table out of onUpdateResp, assert contents?
+            console.log("onUpdateResp, with data", data);
+            return data;
+        },
+        {
+            message: "Ensure proxy view updates with table",
+            timeout: 10000,
+        }
+    );
+
+    expect(await proxyView.to_columns()).toStrictEqual({ abc: [123, 999] });
+
+    await expectUpdate.toHaveProperty("delta");
+    await expectUpdate.toHaveProperty("port_id");
+});
+
+function connectClientToServer() {
+    const server = make_server();
+    const session = server.make_session((msg) => {
+        client.handle_response(msg);
+    });
+    const client = make_client((msg) => {
+        session.handle_request(msg);
+    });
+    return {
+        client,
+        server,
+    };
+}
+
+function connectProxyClient(client) {
+    const sess = client.new_proxy_session((res) => {
+        proxyClient.handle_response(res);
+    });
+    const proxyClient = make_client(async (msg) => {
+        // Have to copy msg with slice() because the memory backing it will be
+        // deallocated before handle_request() is scheduled and executes
+        await sess.handle_request(msg.slice());
+    });
+    return {
+        proxyClient,
+    };
+}

--- a/rust/perspective-python/Cargo.toml
+++ b/rust/perspective-python/Cargo.toml
@@ -56,7 +56,7 @@ crate-type = ["cdylib"]
 [build-dependencies]
 cmake = "0.1.50"
 num_cpus = "^1.16.0"
-pyo3-build-config = "0.20.2"
+pyo3-build-config = "0.22.6"
 python-config-rs = "0.1.2"
 
 [dependencies]
@@ -67,7 +67,22 @@ async-lock = "2.5.0"
 pollster = "0.3.0"
 extend = "1.1.2"
 futures = "0.3.28"
-pyo3 = { version = "0.21.2", features = ["extension-module", "serde"] }
-pythonize = "0.21.1"
+pyo3 = { version = "0.23.4", features = [
+    "experimental-async",
+    "extension-module",
+    "serde",
+    "py-clone",
+] }
+pythonize = "0.23.0"
 tracing = { version = ">=0.1.36" }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
+
+[target.'cfg(target_os="emscripten")'.dependencies]
+pyo3-async-runtimes = { version = "0.23", features = ["attributes"] }
+
+[target.'cfg(not(target_os="emscripten"))'.dependencies]
+pyo3-async-runtimes = { version = "0.23", features = [
+    "attributes",
+    "tokio-runtime",
+] }
+tokio = { version = "1.43.0", features = ["full"] }

--- a/rust/perspective-python/package.json
+++ b/rust/perspective-python/package.json
@@ -16,7 +16,7 @@
     },
     "devDependencies": {
         "@finos/perspective-scripts": "workspace:*",
-        "@iarna/toml": "^1.0.0-rc.1",
+        "smol-toml": "^1.3.1",
         "glob": "^11",
         "cpy": "^9.0.1",
         "tar": "^7.4.3"

--- a/rust/perspective-python/perspective/__init__.py
+++ b/rust/perspective-python/perspective/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "Client",
     "PerspectiveError",
     "ProxySession",
+    "AsyncClient",
 ]
 
 import functools
@@ -26,6 +27,7 @@ from .perspective import (
     PerspectiveError,
     ProxySession,
     PySyncServer as Server,
+    AsyncClient,
     # NOTE: these are classes without constructors,
     # so we import them just for type hinting
     Table,  # noqa: F401

--- a/rust/perspective-python/perspective/tests/async/test_async_client.py
+++ b/rust/perspective-python/perspective/tests/async/test_async_client.py
@@ -1,0 +1,86 @@
+#  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+#  ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+#  ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+#  ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+#  ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+#  ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+#  ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+#  ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+#  ┃ This file is part of the Perspective library, distributed under the terms ┃
+#  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+#  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+from perspective import (
+    AsyncClient,
+    Server,
+    PerspectiveError,
+)
+
+import asyncio
+import pytest
+from unittest.mock import Mock
+
+
+@pytest.fixture
+def server():
+    return Server()
+
+
+@pytest.fixture
+def client(server):
+    async def send_request(msg):
+        sess.handle_request(msg)
+
+    def send_response(msg):
+        async def poke_client():
+            await client.handle_response(msg)
+
+        asyncio.get_running_loop().create_task(poke_client())
+
+    sess = server.new_session(send_response)
+    client = AsyncClient(send_request)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_send_request_callback_awaited(client):
+    table_names = await client.get_hosted_table_names()
+    assert table_names == []
+
+
+# This test also exists in the pyodide-tests/ pytest suite, with the same name.
+# Unfortunately code sharing between the two test suites is currently not easy.
+@pytest.mark.asyncio
+async def test_async_client_kitchen_sink(client):
+    """run various things on the async client"""
+    table = await client.table({"a": [0]}, name="my-cool-data", limit=100)
+    view = await table.view()
+    # synchronous methods
+    assert table.get_index() is None
+    assert table.get_name() == "my-cool-data"
+    limit = table.get_limit()
+    assert limit == 100
+
+    # view update callbacks
+    view_updated = Mock()
+    await view.on_update(view_updated)
+    for i in range(1, limit):
+        await table.update([{"a": i}])
+        await table.size()  # force update to process
+    assert (await table.size()) == limit
+    assert view_updated.call_count == limit - 1
+    rex = await view.to_records()
+    assert rex == [{"a": i} for i in range(limit)]
+
+    # view/table delete callbacks
+    view_deleted = Mock()
+    table_deleted = Mock()
+    await table.on_delete(table_deleted)
+    await view.on_delete(view_deleted)
+    with pytest.raises(PerspectiveError) as excinfo:
+        await table.delete()
+    assert excinfo.match(r"Cannot delete table with views")
+    await view.delete()
+    view_deleted.assert_called_once()
+    await table.delete()
+    table_deleted.assert_called_once()

--- a/rust/perspective-python/perspective/tests/core/test_async.py
+++ b/rust/perspective-python/perspective/tests/core/test_async.py
@@ -14,8 +14,8 @@ import queue
 import random
 import threading
 from functools import partial
+import tornado
 
-import tornado.ioloop
 from perspective import (
     Server,
     Client,
@@ -49,6 +49,14 @@ class TestAsync(object):
     def setup_class(cls):
         import asyncio
 
+        # Storing the current loop, which was set up by the pytest-asyncio
+        # tests running in tests/async, delays its cleanup, which foregoes a
+        # pytest exception about an unclosed socket.  A cleaner way to fix this
+        # probably exists (use an event loop fixture? convert these tests to
+        # pytest-asyncio?)
+        cls.save_old_loop_to_prevent_unclosed_socket_exception = (
+            asyncio.get_event_loop()
+        )
         asyncio.set_event_loop(asyncio.new_event_loop())
         cls.loop = tornado.ioloop.IOLoop.current()
         cls.thread = threading.Thread(target=cls.loop.start)

--- a/rust/perspective-python/pyodide-tests/README.md
+++ b/rust/perspective-python/pyodide-tests/README.md
@@ -24,6 +24,12 @@ Run setup, select `perspective-pyodide` target:
 pnpm -w run setup
 ```
 
+Build the pyodide wheel:
+
+```
+PSP_BUILD_WHEEL=1 pnpm -w run build
+```
+
 Then run tests:
 
 ```

--- a/rust/perspective-python/pyodide-tests/tests/conftest.py
+++ b/rust/perspective-python/pyodide-tests/tests/conftest.py
@@ -11,6 +11,10 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 
+# This is where to change pytest_pyodide's config if necessary.
+# See: https://github.com/pyodide/pyodide/blob/4b1c22ba27f62fba8ae2e13fbaf0e23a32b580ad/conftest.py#L44-L48
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--perspective-emscripten-wheel",

--- a/rust/perspective-python/pyproject.toml
+++ b/rust/perspective-python/pyproject.toml
@@ -56,3 +56,4 @@ python_classes = ["Test", "Describe"]
 python_functions = ["test_", "it_", "and_", "but_", "they_"]
 python_files = ["test_*.py"]
 testpaths = ["tests"]
+asyncio_default_fixture_loop_scope = "function"

--- a/rust/perspective-python/requirements-pyodide.txt
+++ b/rust/perspective-python/requirements-pyodide.txt
@@ -1,5 +1,5 @@
 # Requirements for testing pyodide
 pytest==8.2.2
 pytest-playwright==0.5.2
-pytest-pyodide==0.58.3
+pytest-pyodide==0.58.4
 pytest-timeout==2.3.1

--- a/rust/perspective-python/requirements.txt
+++ b/rust/perspective-python/requirements.txt
@@ -12,6 +12,7 @@ polars==1.13.1
 pyarrow==16.1.0
 psutil==6.0.0
 pytest==8.2.2
+pytest-asyncio==0.25.3
 pytest-sugar==1.0.0
 ruff==0.5.0
 tornado==6.4.1

--- a/rust/perspective-python/src/client/client_async.rs
+++ b/rust/perspective-python/src/client/client_async.rs
@@ -17,14 +17,14 @@ use std::sync::Arc;
 use async_lock::RwLock;
 use futures::FutureExt;
 use perspective_client::{
-    assert_table_api, assert_view_api, clone, Client, OnUpdateMode, OnUpdateOptions, Table,
-    TableData, TableInitOptions, TableReadFormat, UpdateData, UpdateOptions, View,
-    ViewOnUpdateResp, ViewWindow,
+    assert_table_api, assert_view_api, Client, OnUpdateMode, OnUpdateOptions, Table, TableData,
+    TableInitOptions, TableReadFormat, UpdateData, UpdateOptions, View, ViewOnUpdateResp,
+    ViewWindow,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyBytes, PyDict, PyString};
-use pythonize::depythonize_bound;
+use pythonize::depythonize;
 
 use super::pandas::arrow_to_pandas;
 use super::polars::arrow_to_polars;
@@ -33,40 +33,54 @@ use super::update_data::UpdateDataExt;
 use super::{pandas, polars, pyarrow};
 use crate::py_err::{PyPerspectiveError, ResultTClientErrorExt};
 
+#[pyclass(module = "perspective")]
 #[derive(Clone)]
-pub struct PyClient {
+pub struct AsyncClient {
     pub(crate) client: Client,
     loop_cb: Arc<RwLock<Option<Py<PyAny>>>>,
     close_cb: Option<Py<PyAny>>,
 }
 
-impl PyClient {
+impl AsyncClient {
+    pub fn new_from_client(client: Client) -> Self {
+        AsyncClient {
+            client,
+            loop_cb: Arc::default(),
+            close_cb: None,
+        }
+    }
+}
+
+#[pymethods]
+impl AsyncClient {
+    #[new]
+    #[pyo3(signature=(handle_request, handle_close=None))]
     pub fn new(handle_request: Py<PyAny>, handle_close: Option<Py<PyAny>>) -> Self {
+        let handle_request = Arc::new(handle_request);
         let client = Client::new_with_callback({
             move |msg| {
-                clone!(handle_request);
+                let handle_request = handle_request.clone();
                 Box::pin(async move {
-                    Python::with_gil(move |py| {
-                        handle_request.call1(py, (PyBytes::new_bound(py, msg),))
-                    })?;
+                    if let Some(fut) = Python::with_gil(move |py| -> PyResult<_> {
+                        let ret = handle_request.call1(py, (PyBytes::new(py, msg),))?;
+                        if isawaitable(ret.bind(py)).unwrap_or(false) {
+                            Ok(Some(py_async::py_into_future(ret.into_bound(py))?))
+                        } else {
+                            Ok(None)
+                        }
+                    })? {
+                        fut.await?;
+                    }
 
                     Ok(())
                 })
             }
         });
 
-        PyClient {
+        AsyncClient {
             client,
             loop_cb: Arc::default(),
             close_cb: handle_close,
-        }
-    }
-
-    pub fn new_from_client(client: Client) -> Self {
-        PyClient {
-            client,
-            loop_cb: Arc::default(),
-            close_cb: None,
         }
     }
 
@@ -77,6 +91,7 @@ impl PyClient {
             .into_pyerr()
     }
 
+    #[pyo3(signature=(input, limit=None, index=None, name=None, format=None))]
     pub async fn table(
         &self,
         input: Py<PyAny>,
@@ -84,9 +99,9 @@ impl PyClient {
         index: Option<Py<PyString>>,
         name: Option<Py<PyString>>,
         format: Option<Py<PyString>>,
-    ) -> PyResult<PyTable> {
+    ) -> PyResult<AsyncTable> {
         let client = self.client.clone();
-        let py_client = self.clone();
+        let py_client = Python::with_gil(|_| self.clone());
         let table = Python::with_gil(|py| {
             let mut options = TableInitOptions {
                 name: name.map(|x| x.extract::<String>(py)).transpose()?,
@@ -107,35 +122,34 @@ impl PyClient {
                 },
             };
 
-            let input_data = if pyarrow::is_arrow_table(py, input.bind(py))? {
-                pyarrow::to_arrow_bytes(py, input.bind(py))?.to_object(py)
-            } else if pandas::is_pandas_df(py, input.bind(py))? {
-                pandas::pandas_to_arrow_bytes(py, input.bind(py))?.to_object(py)
-            } else if polars::is_polars_df(py, input.bind(py))?
-                || polars::is_polars_lf(py, input.bind(py))?
-            {
-                polars::polars_to_arrow_bytes(py, input.bind(py))?.to_object(py)
+            let input = input.into_bound(py);
+            let input_data = if pyarrow::is_arrow_table(py, &input)? {
+                pyarrow::to_arrow_bytes(py, &input)?.into_any()
+            } else if pandas::is_pandas_df(py, &input)? {
+                pandas::pandas_to_arrow_bytes(py, &input)?.into_any()
+            } else if polars::is_polars_df(py, &input)? || polars::is_polars_lf(py, &input)? {
+                polars::polars_to_arrow_bytes(py, &input)?.into_any()
             } else {
                 input
             };
 
-            let table_data = TableData::from_py(py, input_data, format)?;
+            let table_data = TableData::from_py(input_data, format)?;
             let table = client.table(table_data, options);
             Ok::<_, PyErr>(table)
         })?;
 
         let table = table.await.into_pyerr()?;
-        Ok(PyTable {
+        Ok(AsyncTable {
             table: Arc::new(table),
             client: py_client,
         })
     }
 
-    pub async fn open_table(&self, name: String) -> PyResult<PyTable> {
+    pub async fn open_table(&self, name: String) -> PyResult<AsyncTable> {
         let client = self.client.clone();
         let py_client = self.clone();
         let table = client.open_table(name).await.into_pyerr()?;
-        Ok(PyTable {
+        Ok(AsyncTable {
             table: Arc::new(table),
             client: py_client,
         })
@@ -145,12 +159,12 @@ impl PyClient {
         self.client.get_hosted_table_names().await.into_pyerr()
     }
 
-    pub async fn set_loop_cb(&self, loop_cb: Py<PyAny>) -> PyResult<()> {
+    pub async fn set_loop_callback(&self, loop_cb: Py<PyAny>) -> PyResult<()> {
         *self.loop_cb.write().await = Some(loop_cb);
         Ok(())
     }
 
-    pub async fn terminate(&self, py: Python<'_>) -> PyResult<()> {
+    pub fn terminate(&self, py: Python<'_>) -> PyResult<()> {
         if let Some(cb) = &self.close_cb {
             cb.call0(py)?;
         }
@@ -159,32 +173,34 @@ impl PyClient {
     }
 }
 
+#[pyclass]
 #[derive(Clone)]
-pub struct PyTable {
+pub struct AsyncTable {
     table: Arc<Table>,
-    client: PyClient,
+    client: AsyncClient,
 }
 
-assert_table_api!(PyTable);
+assert_table_api!(AsyncTable);
 
-impl PyTable {
-    pub async fn get_index(&self) -> Option<String> {
+#[pymethods]
+impl AsyncTable {
+    pub fn get_index(&self) -> Option<String> {
         self.table.get_index()
     }
 
-    pub async fn get_client(&self) -> PyClient {
-        PyClient {
+    pub async fn get_client(&self) -> AsyncClient {
+        AsyncClient {
             client: self.table.get_client(),
             loop_cb: self.client.loop_cb.clone(),
             close_cb: self.client.close_cb.clone(),
         }
     }
 
-    pub async fn get_limit(&self) -> Option<u32> {
+    pub fn get_limit(&self) -> Option<u32> {
         self.table.get_limit()
     }
 
-    pub async fn get_name(&self) -> String {
+    pub fn get_name(&self) -> String {
         self.table.get_name().into()
     }
 
@@ -211,7 +227,7 @@ impl PyTable {
     pub async fn on_delete(&self, callback_py: Py<PyAny>) -> PyResult<u32> {
         let loop_cb = self.client.loop_cb.read().await.clone();
         let callback = {
-            let callback_py = callback_py.clone();
+            let callback_py = Python::with_gil(|py| Py::clone_ref(&callback_py, py));
             Box::new(move || {
                 Python::with_gil(|py| {
                     if let Some(loop_cb) = &loop_cb {
@@ -233,20 +249,23 @@ impl PyTable {
         self.table.remove_delete(callback_id).await.into_pyerr()
     }
 
+    #[pyo3(signature=(input, format=None))]
     pub async fn remove(&self, input: Py<PyAny>, format: Option<String>) -> PyResult<()> {
         let table = &self.table;
         let format = TableReadFormat::parse(format).map_err(PyPerspectiveError::new_err)?;
-        let table_data = Python::with_gil(|py| UpdateData::from_py(py, &input, format))?;
+        let table_data = Python::with_gil(|py| UpdateData::from_py(input.into_bound(py), format))?;
         table.remove(table_data).await.into_pyerr()
     }
 
+    #[pyo3(signature=(input, format=None))]
     pub async fn replace(&self, input: Py<PyAny>, format: Option<String>) -> PyResult<()> {
         let table = &self.table;
         let format = TableReadFormat::parse(format).map_err(PyPerspectiveError::new_err)?;
-        let table_data = Python::with_gil(|py| UpdateData::from_py(py, &input, format))?;
+        let table_data = Python::with_gil(|py| UpdateData::from_py(input.into_bound(py), format))?;
         table.replace(table_data).await.into_pyerr()
     }
 
+    #[pyo3(signature=(input, port_id=None, format=None))]
     pub async fn update(
         &self,
         input: Py<PyAny>,
@@ -254,38 +273,37 @@ impl PyTable {
         format: Option<String>,
     ) -> PyResult<()> {
         let input_data: Py<PyAny> = Python::with_gil(|py| {
-            let data = if pyarrow::is_arrow_table(py, input.bind(py))? {
-                pyarrow::to_arrow_bytes(py, input.bind(py))?.to_object(py)
-            } else if pandas::is_pandas_df(py, input.bind(py))? {
-                pandas::pandas_to_arrow_bytes(py, input.bind(py))?.to_object(py)
-            } else if polars::is_polars_df(py, input.bind(py))?
-                || polars::is_polars_lf(py, input.bind(py))?
-            {
-                polars::polars_to_arrow_bytes(py, input.bind(py))?.to_object(py)
+            let input = input.into_bound(py);
+            let data = if pyarrow::is_arrow_table(py, &input)? {
+                pyarrow::to_arrow_bytes(py, &input)?.into_any()
+            } else if pandas::is_pandas_df(py, &input)? {
+                pandas::pandas_to_arrow_bytes(py, &input)?.into_any()
+            } else if polars::is_polars_df(py, &input)? || polars::is_polars_lf(py, &input)? {
+                polars::polars_to_arrow_bytes(py, &input)?.into_any()
             } else {
                 input
             };
-            Ok(data) as PyResult<Py<PyAny>>
+            Ok(data.unbind()) as PyResult<Py<PyAny>>
         })?;
 
         let table = &self.table;
         let format = TableReadFormat::parse(format).map_err(PyPerspectiveError::new_err)?;
-        let table_data = Python::with_gil(|py| UpdateData::from_py(py, &input_data, format))?;
+        let table_data =
+            Python::with_gil(|py| UpdateData::from_py(input_data.into_bound(py), format))?;
         let options = UpdateOptions { port_id, format };
         table.update(table_data, options).await.into_pyerr()?;
         Ok(())
     }
 
     pub async fn validate_expressions(&self, expressions: Py<PyAny>) -> PyResult<Py<PyAny>> {
-        let expressions =
-            Python::with_gil(|py| depythonize_bound(expressions.into_bound(py).into_any()))?;
+        let expressions = Python::with_gil(|py| depythonize(expressions.bind(py)))?;
         let records = self
             .table
             .validate_expressions(expressions)
             .await
             .into_pyerr()?;
 
-        Python::with_gil(|py| Ok(pythonize::pythonize(py, &records)?))
+        Python::with_gil(|py| Ok(pythonize::pythonize(py, &records)?.unbind()))
     }
 
     pub async fn schema(&self) -> PyResult<HashMap<String, String>> {
@@ -296,30 +314,31 @@ impl PyTable {
             .collect())
     }
 
-    pub async fn view(&self, kwargs: Option<Py<PyDict>>) -> PyResult<PyView> {
+    #[pyo3(signature = (**kwargs))]
+    pub async fn view(&self, kwargs: Option<Py<PyDict>>) -> PyResult<AsyncView> {
         let config = kwargs
-            .map(|config| {
-                Python::with_gil(|py| depythonize_bound(config.into_bound(py).into_any()))
-            })
+            .map(|config| Python::with_gil(|py| depythonize(config.bind(py))))
             .transpose()?;
 
         let view = self.table.view(config).await.into_pyerr()?;
-        Ok(PyView {
+        Ok(AsyncView {
             view: Arc::new(view),
             client: self.client.clone(),
         })
     }
 }
 
+#[pyclass]
 #[derive(Clone)]
-pub struct PyView {
+pub struct AsyncView {
     view: Arc<View>,
-    client: PyClient,
+    client: AsyncClient,
 }
 
-assert_view_api!(PyView);
+assert_view_api!(AsyncView);
 
-impl PyView {
+#[pymethods]
+impl AsyncView {
     pub async fn column_paths(&self) -> PyResult<Vec<String>> {
         self.view.column_paths().await.into_pyerr()
     }
@@ -330,7 +349,7 @@ impl PyView {
 
     pub async fn dimensions(&self) -> PyResult<Py<PyAny>> {
         let dim = self.view.dimensions().await.into_pyerr()?;
-        Ok(Python::with_gil(|py| pythonize::pythonize(py, &dim))?)
+        Python::with_gil(|py| Ok(pythonize::pythonize(py, &dim)?.unbind()))
     }
 
     pub async fn expand(&self, index: u32) -> PyResult<u32> {
@@ -354,7 +373,7 @@ impl PyView {
 
     pub async fn get_config(&self) -> PyResult<Py<PyAny>> {
         let config = self.view.get_config().await.into_pyerr()?;
-        Ok(Python::with_gil(|py| pythonize::pythonize(py, &config))?)
+        Python::with_gil(|py| Ok(pythonize::pythonize(py, &config)?.unbind()))
     }
 
     pub async fn get_min_max(&self, name: String) -> PyResult<(String, String)> {
@@ -378,13 +397,13 @@ impl PyView {
 
     pub async fn on_delete(&self, callback_py: Py<PyAny>) -> PyResult<u32> {
         let callback = {
-            let callback_py = callback_py.clone();
+            let callback_py = Arc::new(callback_py);
             let loop_cb = self.client.loop_cb.read().await.clone();
             Box::new(move || {
                 let loop_cb = loop_cb.clone();
                 Python::with_gil(|py| {
                     if let Some(loop_cb) = &loop_cb {
-                        loop_cb.call1(py, (&callback_py,))?;
+                        loop_cb.call1(py, (&*callback_py,))?;
                     } else {
                         callback_py.call0(py)?;
                     }
@@ -403,23 +422,26 @@ impl PyView {
         self.view.remove_delete(callback_id).await.into_pyerr()
     }
 
+    #[pyo3(signature=(callback, mode=None))]
     pub async fn on_update(&self, callback: Py<PyAny>, mode: Option<String>) -> PyResult<u32> {
-        let loop_cb = self.client.loop_cb.read().await.clone();
+        let locked_val = self.client.loop_cb.read().await;
+        let loop_cb = Python::with_gil(|py| locked_val.as_ref().map(|v| Py::clone_ref(v, py)));
         let callback = move |x: ViewOnUpdateResp| {
-            let loop_cb = loop_cb.clone();
-            let callback = callback.clone();
+            let loop_cb = Python::with_gil(|py| loop_cb.as_ref().map(|v| Py::clone_ref(v, py)));
+            let callback = Python::with_gil(|py| Py::clone_ref(&callback, py));
             async move {
                 let aggregate_errors: PyResult<()> = {
-                    let callback = callback.clone();
+                    let callback = Python::with_gil(|py| Py::clone_ref(&callback, py));
                     Python::with_gil(|py| {
                         match (&x.delta, &loop_cb) {
                             (None, None) => callback.call1(py, (x.port_id,))?,
                             (None, Some(loop_cb)) => loop_cb.call1(py, (&callback, x.port_id))?,
                             (Some(delta), None) => {
-                                callback.call1(py, (x.port_id, PyBytes::new_bound(py, delta)))?
+                                callback.call1(py, (x.port_id, PyBytes::new(py, delta)))?
                             },
-                            (Some(delta), Some(loop_cb)) => loop_cb
-                                .call1(py, (callback, x.port_id, PyBytes::new_bound(py, delta)))?,
+                            (Some(delta), Some(loop_cb)) => {
+                                loop_cb.call1(py, (callback, x.port_id, PyBytes::new(py, delta)))?
+                            },
                         };
 
                         Ok(())
@@ -448,66 +470,164 @@ impl PyView {
         self.view.remove_update(callback_id).await.into_pyerr()
     }
 
+    #[pyo3(signature=(window=None))]
     pub async fn to_dataframe(&self, window: Option<Py<PyDict>>) -> PyResult<Py<PyAny>> {
-        let window: ViewWindow =
-            Python::with_gil(|py| window.map(|x| depythonize_bound(x.into_bound(py).into_any())))
-                .transpose()?
-                .unwrap_or_default();
+        let window: ViewWindow = Python::with_gil(|py| window.map(|x| depythonize(x.bind(py))))
+            .transpose()?
+            .unwrap_or_default();
         let arrow = self.view.to_arrow(window).await.into_pyerr()?;
         Python::with_gil(|py| arrow_to_pandas(py, &arrow))
     }
 
+    #[pyo3(signature=(window=None))]
     pub async fn to_polars(&self, window: Option<Py<PyDict>>) -> PyResult<Py<PyAny>> {
-        let window: ViewWindow =
-            Python::with_gil(|py| window.map(|x| depythonize_bound(x.into_bound(py).into_any())))
-                .transpose()?
-                .unwrap_or_default();
+        let window: ViewWindow = Python::with_gil(|py| window.map(|x| depythonize(x.bind(py))))
+            .transpose()?
+            .unwrap_or_default();
         let arrow = self.view.to_arrow(window).await.into_pyerr()?;
         Python::with_gil(|py| arrow_to_polars(py, &arrow))
     }
 
+    #[pyo3(signature=(window=None))]
     pub async fn to_arrow(&self, window: Option<Py<PyDict>>) -> PyResult<Py<PyBytes>> {
-        let window: ViewWindow =
-            Python::with_gil(|py| window.map(|x| depythonize_bound(x.into_bound(py).into_any())))
-                .transpose()?
-                .unwrap_or_default();
+        let window: ViewWindow = Python::with_gil(|py| window.map(|x| depythonize(x.bind(py))))
+            .transpose()?
+            .unwrap_or_default();
         let arrow = self.view.to_arrow(window).await.into_pyerr()?;
-        Ok(Python::with_gil(|py| PyBytes::new_bound(py, &arrow).into()))
+        Ok(Python::with_gil(|py| PyBytes::new(py, &arrow).into()))
     }
 
+    #[pyo3(signature=(window=None))]
     pub async fn to_csv(&self, window: Option<Py<PyDict>>) -> PyResult<String> {
-        let window: ViewWindow =
-            Python::with_gil(|py| window.map(|x| depythonize_bound(x.into_bound(py).into_any())))
-                .transpose()?
-                .unwrap_or_default();
+        let window: ViewWindow = Python::with_gil(|py| window.map(|x| depythonize(x.bind(py))))
+            .transpose()?
+            .unwrap_or_default();
 
         self.view.to_csv(window).await.into_pyerr()
     }
 
+    #[pyo3(signature=(window=None))]
     pub async fn to_columns_string(&self, window: Option<Py<PyDict>>) -> PyResult<String> {
-        let window: ViewWindow =
-            Python::with_gil(|py| window.map(|x| depythonize_bound(x.into_bound(py).into_any())))
-                .transpose()?
-                .unwrap_or_default();
+        let window: ViewWindow = Python::with_gil(|py| window.map(|x| depythonize(x.bind(py))))
+            .transpose()?
+            .unwrap_or_default();
 
         self.view.to_columns_string(window).await.into_pyerr()
     }
 
+    #[pyo3(signature=(window=None))]
     pub async fn to_json_string(&self, window: Option<Py<PyDict>>) -> PyResult<String> {
-        let window: ViewWindow =
-            Python::with_gil(|py| window.map(|x| depythonize_bound(x.into_bound(py).into_any())))
-                .transpose()?
-                .unwrap_or_default();
+        let window: ViewWindow = Python::with_gil(|py| window.map(|x| depythonize(x.bind(py))))
+            .transpose()?
+            .unwrap_or_default();
 
         self.view.to_json_string(window).await.into_pyerr()
     }
 
+    #[pyo3(signature=(window=None))]
     pub async fn to_ndjson(&self, window: Option<Py<PyDict>>) -> PyResult<String> {
-        let window: ViewWindow =
-            Python::with_gil(|py| window.map(|x| depythonize_bound(x.into_bound(py).into_any())))
-                .transpose()?
-                .unwrap_or_default();
+        let window: ViewWindow = Python::with_gil(|py| window.map(|x| depythonize(x.bind(py))))
+            .transpose()?
+            .unwrap_or_default();
 
         self.view.to_ndjson(window).await.into_pyerr()
+    }
+
+    #[pyo3(signature = (**window))]
+    pub async fn to_records<'a>(&self, window: Option<Py<PyDict>>) -> PyResult<Py<PyAny>> {
+        let json = self.to_json_string(window).await?;
+        Python::with_gil(|py| {
+            let json_module = PyModule::import(py, "json")?;
+            let records = json_module.call_method1("loads", (json,))?;
+            Ok(records.unbind())
+        })
+    }
+
+    #[pyo3(signature = (**window))]
+    pub async fn to_json<'a>(&self, window: Option<Py<PyDict>>) -> PyResult<Py<PyAny>> {
+        self.to_records(window).await
+    }
+}
+
+fn isawaitable(object: &Bound<'_, PyAny>) -> PyResult<bool> {
+    let py = object.py();
+    py.import("inspect")?
+        .call_method1("isawaitable", (object,))?
+        .extract()
+}
+
+mod py_async {
+    #[cfg(not(target_os = "emscripten"))]
+    pub use pyo3_async_runtimes::tokio::into_future as py_into_future;
+
+    #[cfg(target_os = "emscripten")]
+    pub use self::trivial::into_future as py_into_future;
+
+    /// This do-nothing, panic all the time runtime is sufficient in emscripten
+    /// for the primitive test suite in test_smoke.py to pass
+    mod trivial {
+        use std::future::Future;
+
+        use pyo3::prelude::*;
+        use pyo3_async_runtimes::generic::{ContextExt, JoinError, Runtime};
+
+        struct TrivialJoinError {}
+        impl JoinError for TrivialJoinError {
+            fn is_panic(&self) -> bool {
+                unimplemented!("TrivialJoinError::is_panic")
+            }
+
+            fn into_panic(self) -> Box<dyn std::any::Any + Send + 'static> {
+                unimplemented!("TrivialJoinError::into_panic")
+            }
+        }
+        struct TrivialJoinHandle {}
+        impl Future for TrivialJoinHandle {
+            type Output = Result<(), TrivialJoinError>;
+
+            fn poll(
+                self: std::pin::Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Self::Output> {
+                unimplemented!("TrivialJoinHandle::poll")
+            }
+        }
+
+        struct TrivialRuntime {}
+
+        impl Runtime for TrivialRuntime {
+            type JoinError = TrivialJoinError;
+            type JoinHandle = TrivialJoinHandle;
+
+            fn spawn<F>(_fut: F) -> Self::JoinHandle
+            where
+                F: std::future::Future<Output = ()> + Send + 'static,
+            {
+                unimplemented!("TrivialRuntime::spawn")
+            }
+        }
+
+        impl ContextExt for TrivialRuntime {
+            fn get_task_locals() -> Option<pyo3_async_runtimes::TaskLocals> {
+                None
+            }
+
+            fn scope<F, R>(
+                _locals: pyo3_async_runtimes::TaskLocals,
+                _fut: F,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = R> + Send>>
+            where
+                F: std::future::Future<Output = R> + Send + 'static,
+            {
+                unimplemented!("TrivialRuntime::scope")
+            }
+        }
+
+        #[allow(unused)]
+        pub fn into_future(
+            awaitable: Bound<PyAny>,
+        ) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {
+            pyo3_async_runtimes::generic::into_future::<TrivialRuntime>(awaitable)
+        }
     }
 }

--- a/rust/perspective-python/src/client/mod.rs
+++ b/rust/perspective-python/src/client/mod.rs
@@ -10,10 +10,10 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
+pub mod client_async;
 pub mod client_sync;
 mod pandas;
 mod polars;
 mod pyarrow;
-pub mod python;
 pub mod table_data;
 pub mod update_data;

--- a/rust/perspective-python/src/client/pyarrow.rs
+++ b/rust/perspective-python/src/client/pyarrow.rs
@@ -15,10 +15,10 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyBytes};
 
 fn get_pyarrow_table_cls(py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
-    let sys = PyModule::import_bound(py, "sys")?;
+    let sys = PyModule::import(py, "sys")?;
     if sys.getattr("modules")?.contains("pyarrow")? {
-        let pandas = PyModule::import_bound(py, "pyarrow")?;
-        Ok(Some(pandas.getattr("Table")?.to_object(py)))
+        let pandas = PyModule::import(py, "pyarrow")?;
+        Ok(Some(pandas.getattr("Table")?.unbind()))
     } else {
         Ok(None)
     }
@@ -36,7 +36,7 @@ pub fn to_arrow_bytes<'py>(
     py: Python<'py>,
     table: &Bound<'py, PyAny>,
 ) -> PyResult<Bound<'py, PyBytes>> {
-    let pyarrow = PyModule::import_bound(py, "pyarrow")?;
+    let pyarrow = PyModule::import(py, "pyarrow")?;
     let table_class = get_pyarrow_table_cls(py)?
         .ok_or_else(|| PyValueError::new_err("Failed to import pyarrow.Table"))?;
 

--- a/rust/perspective-python/src/lib.rs
+++ b/rust/perspective-python/src/lib.rs
@@ -59,10 +59,11 @@ fn perspective(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<client::client_sync::Table>()?;
     m.add_class::<client::client_sync::View>()?;
     m.add_class::<client::client_sync::ProxySession>()?;
-    m.add(
-        "PerspectiveError",
-        py.get_type_bound::<PyPerspectiveError>(),
-    )?;
+    m.add_class::<client::client_async::AsyncClient>()?;
+    m.add_class::<client::client_async::AsyncTable>()?;
+    m.add_class::<client::client_async::AsyncView>()?;
+
+    m.add("PerspectiveError", py.get_type::<PyPerspectiveError>())?;
 
     Ok(())
 }

--- a/rust/perspective-python/src/server/server_sync.rs
+++ b/rust/perspective-python/src/server/server_sync.rs
@@ -20,7 +20,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyBytes};
 
-use crate::client::python::PyClient;
+use crate::client::client_async::AsyncClient;
 
 #[pyclass(module = "perspective")]
 #[derive(Clone)]
@@ -42,7 +42,7 @@ impl SessionHandler for PyConnection {
         &'a mut self,
         msg: &'a [u8],
     ) -> Result<(), perspective_server::ServerError> {
-        Python::with_gil(|py| self.0.call1(py, (PyBytes::new_bound(py, msg),)))?;
+        Python::with_gil(|py| self.0.call1(py, (PyBytes::new(py, msg),)))?;
         Ok(())
     }
 }
@@ -64,12 +64,13 @@ impl PySyncServer {
         PySyncSession { session }
     }
 
+    #[pyo3(signature = (loop_callback=None))]
     pub fn new_local_client(
         &self,
         py: Python<'_>,
         loop_callback: Option<Py<PyAny>>,
     ) -> PyResult<crate::client::client_sync::Client> {
-        let client = crate::client::client_sync::Client(PyClient::new_from_client(
+        let client = crate::client::client_sync::Client(AsyncClient::new_from_client(
             self.server
                 .new_local_client()
                 .take()

--- a/rust/perspective-python/test.mjs
+++ b/rust/perspective-python/test.mjs
@@ -51,5 +51,5 @@ if (process.env.PSP_PYODIDE) {
         execOpts
     );
 } else {
-    execFileSync("pytest", ["perspective/tests", "-W error"], execOpts);
+    execFileSync("pytest", ["perspective/tests", "-W error", ...process.argv.slice(2)], execOpts);
 }


### PR DESCRIPTION
### Pull Request Checklist

* Add support in perspective-js for creating proxy sessions from a
  connected client.
* Support for running maturin commands with uv
  * set `PSP_UV=1` in environment
  * use `uv venv` to create venv, then activate it
  * `uv pip install -r **/requirements.txt` to install requirements
* Update pyo3 from 0.21 to 0.23
  * this was to support use of the `pyo3-async-runtimes` crate
* Build `abi3` .so when building with `maturin develop`
  * **Caveat**: after this change, old non-abi3 .so's still lingering in
    the rust/perspective-python directory may be loaded preferentially
    by Python when using an editable install.  It is best to delete
    those old .so's.
* Repurpose PyClient as AsyncClient and export bindings to Python
* Add async client pytests for both cpython and pyodide
  * Uses `pytest-asyncio` plugin
* Add python and pytest vscode settings
  * Supports running cpython pytest suite from vscode's Test Explorer
* Return an error when `ProxySession::handle_request()` fails to decode
  protobuf, instead of unwrap + panic
 
-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [x] Include new tests that fail without this PR but passes with it.
-   [x] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
