### PR TITLE
Shrink `d3fc` bundle

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -232,6 +232,7 @@ if(PSP_WASM_BUILD)
             -g3 \
             -Wcast-align \
             -Wover-aligned \
+            -emit-tsd=perspective-server.d.ts \
             ")
         if (PSP_WASM_EXCEPTIONS)
             set(OPT_FLAGS "${OPT_FLAGS} -fwasm-exceptions ")

--- a/packages/perspective-cli/package.json
+++ b/packages/perspective-cli/package.json
@@ -33,5 +33,8 @@
         "@finos/perspective-workspace": "workspace:^",
         "commander": "^2.19.0",
         "puppeteer": "^23"
+    },
+    "devDependencies": {
+        "@finos/perspective-test": "workspace:^"
     }
 }

--- a/packages/perspective-viewer-d3fc/build.js
+++ b/packages/perspective-viewer-d3fc/build.js
@@ -66,7 +66,6 @@ const BUILD = [
         },
         plugins: [],
         format: "esm",
-        metafile: false,
         loader: {
             ".css": "text",
             ".html": "text",

--- a/packages/perspective-viewer-d3fc/src/ts/axis/axisFactory.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/axis/axisFactory.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { AxisTypeValues, axisType } from "./axisType";
 import * as none from "./noAxis";
 import * as linear from "./linearAxis";

--- a/packages/perspective-viewer-d3fc/src/ts/axis/axisLabel.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/axis/axisLabel.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { rebindAll } from "d3fc";
+import { rebindAll } from "d3fc/index.js";
 import { axisType } from "./axisType";
 import { labelFunction as noLabel } from "./noAxis";
 import { labelFunction as timeLabel } from "./timeAxis";

--- a/packages/perspective-viewer-d3fc/src/ts/axis/chartFactory.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/axis/chartFactory.ts
@@ -11,7 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import * as d3 from "d3";
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 
 export const chartSvgFactory = (xAxis, yAxis) =>
     chartFactory(xAxis, yAxis, (x, y) => x.svgPlotArea(y), false);

--- a/packages/perspective-viewer-d3fc/src/ts/axis/linearAxis.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/axis/linearAxis.ts
@@ -11,7 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import * as d3 from "d3";
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { flattenArray } from "./flatten";
 import { extentLinear as customExtent } from "../d3fc/extent/extentLinear";
 import { getValueFormatterForRange } from "./valueFormatter";

--- a/packages/perspective-viewer-d3fc/src/ts/axis/minBandwidth.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/axis/minBandwidth.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { rebindAll } from "d3fc";
+import { rebindAll } from "d3fc/index.js";
 
 const MIN_BANDWIDTH = 1;
 

--- a/packages/perspective-viewer-d3fc/src/ts/axis/ordinalAxis.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/axis/ordinalAxis.ts
@@ -11,7 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import * as d3 from "d3";
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import minBandwidth from "./minBandwidth";
 import { flattenArray } from "./flatten";
 import {

--- a/packages/perspective-viewer-d3fc/src/ts/axis/splitterLabels.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/axis/splitterLabels.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { getChartElement } from "../plugin/root";
 import { withoutOpacity } from "../series/seriesColors.js";
 import { HTMLSelection, Settings } from "../types";

--- a/packages/perspective-viewer-d3fc/src/ts/axis/timeAxis.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/axis/timeAxis.ts
@@ -11,7 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import * as d3 from "d3";
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { flattenArray } from "./flatten";
 import { Domain, ValueName } from "../types";
 

--- a/packages/perspective-viewer-d3fc/src/ts/axis/withoutTicks.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/axis/withoutTicks.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { rebindAll } from "d3fc";
+import { rebindAll } from "d3fc/index.js";
 
 export default (adaptee) => {
     const withoutTicks = (arg) => {

--- a/packages/perspective-viewer-d3fc/src/ts/charts/area.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/charts/area.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { AxisFactoryContent, axisFactory } from "../axis/axisFactory";
 import { chartSvgFactory } from "../axis/chartFactory";
 import { axisSplitter } from "../axis/axisSplitter";

--- a/packages/perspective-viewer-d3fc/src/ts/charts/bar.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/charts/bar.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { axisFactory } from "../axis/axisFactory";
 import { chartSvgFactory } from "../axis/chartFactory";
 import { AXIS_TYPES } from "../axis/axisType";

--- a/packages/perspective-viewer-d3fc/src/ts/charts/candlestick.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/charts/candlestick.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { seriesCanvasCandlestick } from "d3fc";
+import { seriesCanvasCandlestick } from "d3fc/index.js";
 import ohlcCandle from "./ohlcCandle";
 
 let candlestick = ohlcCandle(seriesCanvasCandlestick);

--- a/packages/perspective-viewer-d3fc/src/ts/charts/column.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/charts/column.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { axisFactory } from "../axis/axisFactory";
 import { chartSvgFactory } from "../axis/chartFactory";
 import domainMatchOrigins from "../axis/domainMatchOrigins";

--- a/packages/perspective-viewer-d3fc/src/ts/charts/line.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/charts/line.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { AxisFactoryContent, axisFactory } from "../axis/axisFactory";
 import { AXIS_TYPES } from "../axis/axisType";
 import { chartSvgFactory } from "../axis/chartFactory";

--- a/packages/perspective-viewer-d3fc/src/ts/charts/ohlc.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/charts/ohlc.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { seriesCanvasOhlc } from "d3fc";
+import { seriesCanvasOhlc } from "d3fc/index.js";
 import ohlcCandle from "./ohlcCandle";
 
 const ohlc = ohlcCandle(seriesCanvasOhlc);

--- a/packages/perspective-viewer-d3fc/src/ts/charts/ohlcCandle.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/charts/ohlcCandle.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { AxisFactoryContent, axisFactory } from "../axis/axisFactory";
 import { chartCanvasFactory } from "../axis/chartFactory";
 import { ohlcData } from "../data/ohlcData";

--- a/packages/perspective-viewer-d3fc/src/ts/charts/xy-line.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/charts/xy-line.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { transposeData } from "../data/transposeData";
 import { AxisFactoryContent, axisFactory } from "../axis/axisFactory";
 import { chartSvgFactory } from "../axis/chartFactory";

--- a/packages/perspective-viewer-d3fc/src/ts/charts/y-scatter.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/charts/y-scatter.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { AxisFactoryContent, axisFactory } from "../axis/axisFactory";
 import { AXIS_TYPES } from "../axis/axisType";
 import { chartSvgFactory } from "../axis/chartFactory";

--- a/packages/perspective-viewer-d3fc/src/ts/d3fc/axis/multi-axis.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/d3fc/axis/multi-axis.ts
@@ -19,7 +19,7 @@ import {
     dataJoin,
     rebindAll,
     exclude,
-} from "d3fc";
+} from "d3fc/index.js";
 import store from "./store";
 import { Orient } from "../../types";
 

--- a/packages/perspective-viewer-d3fc/src/ts/d3fc/padding/hardLimitZero.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/d3fc/padding/hardLimitZero.ts
@@ -12,7 +12,7 @@
 
 import { Pad, PadUnit, PaddingStrategy } from "../../types";
 import { defaultPadding } from "./default";
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 
 export const hardLimitZeroPadding = (): PaddingStrategy => {
     const _defaultPadding = defaultPadding();

--- a/packages/perspective-viewer-d3fc/src/ts/gridlines/gridlines.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/gridlines/gridlines.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { D3Scale, Orientation } from "../types";
 
 const mainGridSvg = (settings) => (x, xTick) =>

--- a/packages/perspective-viewer-d3fc/src/ts/legend/colorRangeLegend.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/legend/colorRangeLegend.ts
@@ -11,7 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import * as d3 from "d3";
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { getOrCreateElement } from "../utils/utils";
 import { getValueFormatterForRange as getValueFormatter } from "../axis/valueFormatter";
 

--- a/packages/perspective-viewer-d3fc/src/ts/legend/scrollableLegend.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/legend/scrollableLegend.ts
@@ -11,7 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import * as d3Legend from "d3-svg-legend";
-import { rebindAll } from "d3fc";
+import { rebindAll } from "d3fc/index.js";
 import { getOrCreateElement } from "../utils/utils";
 import legendControlsTemplate from "../../html/legend-controls.html";
 import { cropCellContents } from "./styling/cropCellContents";

--- a/packages/perspective-viewer-d3fc/src/ts/series/areaSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/areaSeries.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { D3Scale, Settings } from "../types";
 
 export function areaSeries(_settings: Settings, color: D3Scale) {

--- a/packages/perspective-viewer-d3fc/src/ts/series/barSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/barSeries.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { tooltip } from "../tooltip/tooltip";
 import { ScaleSequential, Settings } from "../types";
 

--- a/packages/perspective-viewer-d3fc/src/ts/series/categoryPointSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/categoryPointSeries.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { withOpacity, withoutOpacity } from "./seriesColors";
 import { fromDomain } from "./seriesSymbols";
 import { D3Scale, Settings } from "../types";

--- a/packages/perspective-viewer-d3fc/src/ts/series/heatmapSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/heatmapSeries.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { tooltip } from "../tooltip/tooltip";
 import { Settings } from "../types";
 

--- a/packages/perspective-viewer-d3fc/src/ts/series/lineSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/lineSeries.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { withoutOpacity } from "./seriesColors.js";
 import { D3Scale, Settings } from "../types.js";
 

--- a/packages/perspective-viewer-d3fc/src/ts/series/ohlcCandleSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/ohlcCandleSeries.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { colorScale, setOpacity } from "./seriesColors";
 import { D3Scale, Settings } from "../types";
 

--- a/packages/perspective-viewer-d3fc/src/ts/series/pointSeriesCanvas.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/pointSeriesCanvas.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import { seriesCanvasPoint } from "d3fc";
+import { seriesCanvasPoint } from "d3fc/index.js";
 import { withOpacity, withoutOpacity } from "./seriesColors";
 import { groupFromKey } from "./seriesKey";
 import { fromDomain } from "./seriesSymbols";

--- a/packages/perspective-viewer-d3fc/src/ts/series/xy-scatter/xyScatterSeries.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/series/xy-scatter/xyScatterSeries.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { axisFactory } from "../../axis/axisFactory";
 import { chartCanvasFactory } from "../../axis/chartFactory";
 import { pointSeriesCanvas, symbolTypeFromColumn } from "../pointSeriesCanvas";

--- a/packages/perspective-viewer-d3fc/src/ts/tooltip/nearbyTip.ts
+++ b/packages/perspective-viewer-d3fc/src/ts/tooltip/nearbyTip.ts
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import * as fc from "d3fc";
+import * as fc from "d3fc/index.js";
 import { tooltip } from "./tooltip";
 import { withOpacity } from "../series/seriesColors.js";
 import { findBestFromData } from "../data/findBest";

--- a/packages/perspective-viewer-openlayers/package.json
+++ b/packages/perspective-viewer-openlayers/package.json
@@ -35,6 +35,7 @@
     },
     "devDependencies": {
         "@finos/perspective-esbuild-plugin": "workspace:^",
+        "@finos/perspective-test": "workspace:^",
         "@prospective.co/procss": "^0.1.16"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,10 @@ importers:
       puppeteer:
         specifier: ^23
         version: 23.11.1(typescript@5.2.2)
+    devDependencies:
+      '@finos/perspective-test':
+        specifier: workspace:^
+        version: link:../../tools/perspective-test
 
   packages/perspective-jupyterlab:
     dependencies:
@@ -590,6 +594,9 @@ importers:
       '@finos/perspective-esbuild-plugin':
         specifier: workspace:^
         version: link:../../tools/perspective-esbuild-plugin
+      '@finos/perspective-test':
+        specifier: workspace:^
+        version: link:../../tools/perspective-test
       '@prospective.co/procss':
         specifier: ^0.1.16
         version: 0.1.16

--- a/rust/perspective-js/src/ts/wasm/emscripten_api.ts
+++ b/rust/perspective-js/src/ts/wasm/emscripten_api.ts
@@ -31,10 +31,7 @@ export async function compile_perspective(
             imports["env"] = {
                 ...imports["env"],
                 psp_stack_trace() {
-                    const old = Error.stackTraceLimit;
-                    Error.stackTraceLimit = 1000;
                     const str = Error().stack || "";
-                    Error.stackTraceLimit = old;
                     const textEncoder = new TextEncoder();
                     const bytes = textEncoder.encode(str);
                     const ptr = module._psp_alloc(

--- a/rust/perspective-js/tsconfig.browser.json
+++ b/rust/perspective-js/tsconfig.browser.json
@@ -8,7 +8,8 @@
         "outDir": "./dist/esm",
         "rootDir": "./src/ts",
         "moduleResolution": "bundler",
-        "allowImportingTsExtensions": true
+        "allowImportingTsExtensions": true,
+        "types": []
     },
     "files": ["./src/ts/perspective.cdn.ts"]
 }

--- a/rust/perspective-viewer/tsconfig.json
+++ b/rust/perspective-viewer/tsconfig.json
@@ -8,7 +8,8 @@
         "outDir": "./dist/esm",
         "rootDir": "./src/ts",
         "moduleResolution": "bundler",
-        "allowImportingTsExtensions": true
+        "allowImportingTsExtensions": true,
+        "typeRoots": ["./node_modules/@types"]
     },
     "files": ["src/ts/perspective-viewer.ts"]
 }


### PR DESCRIPTION
This PR replaces direct imports to `d3fc` with source imports to `d3fc/index.js`, shrinking the footprint of this plugin by 250kb. The former is resolved by `npm` to a bundled artifact from the d3fc monorepo which recursively injects runtime headers for every monorepo member; importing the latter unbundled code allows us to omit this runtime code.