### PR TITLE
Add dedicated `Worker`, `SharedWorker` and `ServiceWorker` support

### DIFF
--- a/docs/md/SUMMARY.md
+++ b/docs/md/SUMMARY.md
@@ -40,6 +40,7 @@
         -   [Serializing data](./how_to/javascript/serializing.md)
         -   [Cleaning up resources](./how_to/javascript/deleting.md)
         -   [Hosting a `WebSocketServer` in Node.js](./how_to/javascript/nodejs_server.md)
+        -   [Using a dedicated `Worker`, `SharedWorker`, or `ServiceWorker`](./how_to/javascript/custom_worker.md)
     -   [`perspective-viewer` Custom Element library](./how_to/javascript/viewer.md)
         -   [Theming](./how_to/javascript/theming.md)
         -   [Custom Themes](./how_to/javascript/custom_themes.md)

--- a/docs/md/how_to/javascript/custom_worker.md
+++ b/docs/md/how_to/javascript/custom_worker.md
@@ -1,0 +1,33 @@
+# Using a custom WebWorker
+
+The `Client.worker` constructor by default creates a dedicated `Worker` bound to
+the page context. Alternatively, `Client.worker` can take a `Worker`,
+`SharedWorker` or `ServiceWorker` instance as a first argument, which load the
+worker script disted at
+`"@finos/perspective/dist/cdn/perspective-server.worker.js"`.
+
+<span class="warning">`SharedWorker` and `ServiceWorker` have more complicated
+behavior compared to a dedicated `Worker`, and will need special consideration
+to integrate (or debug).</span>
+
+## Dedicated `Worker`
+
+```javascript
+const worker = await perspective.worker(new Worker(url));
+```
+
+## `SharedWorker`
+
+```javascript
+const worker = await perspective.worker(new SharedWorker(url));
+```
+
+## `ServiceWorker`
+
+```javascript
+const registration = await navigator.serviceWorker.register(url, {
+    scope: "", // Your scope here
+});
+
+const worker = await perspective.worker(registration.active);
+```

--- a/examples/blocks/src/editable/README.md
+++ b/examples/blocks/src/editable/README.md
@@ -1,4 +1,7 @@
-A simple example of [Perspective](https://github.com/finos/perspective) with superstore
-data, and editability enabled (not default but easy to toggle at runtime). This
-example has no server component, and the edits occur only within the browser session;
-refreshing the page will forget any edits and revert to the original dataset.
+A simple example of [Perspective](https://github.com/finos/perspective) with
+superstore data, and editability enabled (not default but easy to toggle at
+runtime).
+
+An explcit `SharedWorker` is used to create the Perspective engine, allowing
+edits to be shared live when this example is opened across multiple browser
+tabs.

--- a/examples/blocks/src/editable/index.html
+++ b/examples/blocks/src/editable/index.html
@@ -13,13 +13,23 @@
 
             import perspective from "/node_modules/@finos/perspective/dist/cdn/perspective.js";
 
-            const worker = await perspective.worker();
-            const resp = await fetch("/node_modules/superstore-arrow/superstore.lz4.arrow");
-            const arrow = await resp.arrayBuffer();
             const viewer = document.getElementsByTagName("perspective-viewer")[0];
-            const table = worker.table(arrow);
-            viewer.load(table);
-            viewer.restore({ settings: true, plugin_config: { edit_mode: "EDIT" } });
+
+            const worker = new SharedWorker("/node_modules/@finos/perspective/dist/cdn/perspective-server.worker.js");
+            const client = await perspective.worker(worker);
+            const tables = await client.get_hosted_table_names();
+
+            if (tables.length > 0) {
+                const table = client.open_table(tables[0]);
+                viewer.load(table);
+            } else {
+                const resp = await fetch("/node_modules/superstore-arrow/superstore.lz4.arrow");
+                const arrow = await resp.arrayBuffer();
+                const table = client.table(arrow);
+                viewer.load(table);
+            }
+
+            viewer.restore({ plugin_config: { edit_mode: "EDIT" } });
         </script>
         <style>
             perspective-viewer {

--- a/rust/perspective-js/src/ts/perspective.browser.ts
+++ b/rust/perspective-js/src/ts/perspective.browser.ts
@@ -127,7 +127,7 @@ let GLOBAL_WORKER: undefined | (() => Promise<Worker>) = undefined;
 // @ts-ignore
 import perspective_wasm_worker from "../../src/ts/perspective-server.worker.js";
 
-function get_worker() {
+function get_worker(): Promise<Worker> {
     if (GLOBAL_WORKER === undefined) {
         return perspective_wasm_worker();
     }
@@ -139,8 +139,14 @@ export async function websocket(url: string | URL) {
     return await api.websocket(get_client(), url);
 }
 
-export async function worker() {
-    return await api.worker(get_client(), get_server(), get_worker());
+export async function worker(
+    worker?: Promise<SharedWorker | ServiceWorker | Worker>
+) {
+    if (typeof worker === "undefined") {
+        worker = get_worker();
+    }
+
+    return await api.worker(get_client(), get_server(), worker);
 }
 
 export default { websocket, worker, init_client, init_server };

--- a/rust/perspective-js/src/ts/wasm/browser.ts
+++ b/rust/perspective-js/src/ts/wasm/browser.ts
@@ -21,17 +21,24 @@ function invert_promise<T>(): [(t: T) => void, Promise<T>] {
     return [sender as unknown as (t: T) => void, receiver];
 }
 
-async function _init(ws: Worker, wasm: WebAssembly.Module) {
+async function _init(ws: MessagePort | Worker, wasm: WebAssembly.Module) {
     const [sender, receiver] = invert_promise();
     ws.addEventListener("message", function listener(resp) {
         ws.removeEventListener("message", listener);
         sender(null);
     });
 
+    ws.onmessage = function listener(resp) {
+        ws.onmessage = function () {};
+        sender(null);
+    };
+
+    ws.onmessageerror = console.error;
     ws.postMessage(
         { cmd: "init", args: [wasm] },
         { transfer: wasm instanceof WebAssembly.Module ? [] : [wasm] }
     );
+
     await receiver;
 }
 
@@ -44,27 +51,36 @@ async function _init(ws: Worker, wasm: WebAssembly.Module) {
 export async function worker(
     module: Promise<typeof psp>,
     server_wasm: Promise<WebAssembly.Module>,
-    perspective_wasm_worker: Promise<Worker>
+    perspective_wasm_worker: Promise<SharedWorker | ServiceWorker | Worker>
 ) {
-    const [wasm, webworker]: [WebAssembly.Module, Worker] = await Promise.all([
-        server_wasm,
-        perspective_wasm_worker,
-    ]);
+    let [wasm, webworker]: [
+        WebAssembly.Module,
+        SharedWorker | ServiceWorker | Worker | MessagePort
+    ] = await Promise.all([server_wasm, perspective_wasm_worker]);
 
     const { Client } = await module;
+    let port: MessagePort;
+    if (webworker instanceof SharedWorker) {
+        port = webworker.port;
+    } else {
+        const messageChannel = new MessageChannel();
+        webworker.postMessage(null, [messageChannel.port2]);
+        port = messageChannel.port1;
+    }
+
     const client = new Client(
         (proto: Uint8Array) => {
             const f = proto.slice().buffer;
-            webworker.postMessage(f, { transfer: [f] });
+            port.postMessage(f, { transfer: [f] });
         },
         () => {
             console.debug("Closing WebWorker");
-            webworker.terminate();
+            port.close();
         }
     );
 
-    await _init(webworker, wasm);
-    webworker.addEventListener("message", (json: MessageEvent<Uint8Array>) => {
+    await _init(port, wasm);
+    port.addEventListener("message", (json: MessageEvent<Uint8Array>) => {
         client.handle_response(json.data);
     });
 

--- a/rust/perspective-js/src/ts/wasm/engine.ts
+++ b/rust/perspective-js/src/ts/wasm/engine.ts
@@ -20,12 +20,10 @@ export type ApiResponse = {
 
 export class PerspectiveServer {
     clients: Map<number, (buffer: Uint8Array) => Promise<void>>;
-    id_gen: number;
     server: EmscriptenServer;
     module: MainModule;
     constructor(module: MainModule) {
         this.clients = new Map();
-        this.id_gen = 0;
         this.module = module;
         this.server = module._psp_new_server() as EmscriptenServer;
     }

--- a/rust/perspective-js/test/html/service_worker.html
+++ b/rust/perspective-js/test/html/service_worker.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="module">
+            import perspective from "/node_modules/@finos/perspective/dist/esm/perspective.js";
+            let resp = await fetch("/node_modules/@finos/perspective-test/assets/superstore.csv");
+            let csv = await resp.text();
+            const wasm = fetch("/node_modules/@finos/perspective/dist/wasm/perspective-js.wasm");
+            const wasm2 = fetch("/node_modules/@finos/perspective/dist/wasm/perspective-server.wasm");
+            perspective.init_client(wasm);
+            perspective.init_server(wasm2);
+            const registration = await navigator.serviceWorker.register("/node_modules/@finos/perspective/dist/cdn/perspective-server.worker.js", {
+                scope: "/node_modules/@finos/perspective/dist/cdn/",
+            });
+
+            const worker = await perspective.worker(registration.active);
+            window.table = worker.table(csv, { index: "Row ID" });
+            window.__TEST_WORKER__ = worker;
+            window.__TEST_PERSPECTIVE_READY__ = true;
+        </script>
+    </head>
+</html>

--- a/rust/perspective-js/test/html/shared_worker.html
+++ b/rust/perspective-js/test/html/shared_worker.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="module">
+            import perspective from "/node_modules/@finos/perspective/dist/esm/perspective.js";
+            let resp = await fetch("/node_modules/@finos/perspective-test/assets/superstore.csv");
+            let csv = await resp.text();
+            const wasm = fetch("/node_modules/@finos/perspective/dist/wasm/perspective-js.wasm");
+            const wasm2 = fetch("/node_modules/@finos/perspective/dist/wasm/perspective-server.wasm");
+            perspective.init_client(wasm);
+            perspective.init_server(wasm2);
+            const worker = await perspective.worker(new SharedWorker("/node_modules/@finos/perspective/dist/cdn/perspective-server.worker.js"));
+            window.table = worker.table(csv, { index: "Row ID" });
+            window.__TEST_WORKER__ = worker;
+            window.__TEST_PERSPECTIVE_READY__ = true;
+        </script>
+    </head>
+</html>

--- a/rust/perspective-js/test/html/worker.html
+++ b/rust/perspective-js/test/html/worker.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="module">
+            import perspective from "/node_modules/@finos/perspective/dist/esm/perspective.js";
+            let resp = await fetch("/node_modules/@finos/perspective-test/assets/superstore.csv");
+            let csv = await resp.text();
+            const wasm = fetch("/node_modules/@finos/perspective/dist/wasm/perspective-js.wasm");
+            const wasm2 = fetch("/node_modules/@finos/perspective/dist/wasm/perspective-server.wasm");
+            perspective.init_client(wasm);
+            perspective.init_server(wasm2);
+            const worker = await perspective.worker(new Worker("/node_modules/@finos/perspective/dist/cdn/perspective-server.worker.js"));
+            window.table = worker.table(csv, { index: "Row ID" });
+            window.__TEST_WORKER__ = worker;
+            window.__TEST_PERSPECTIVE_READY__ = true;
+        </script>
+    </head>
+</html>


### PR DESCRIPTION
This PR adds support for `SharedWorker` and `ServiceWorker` architectures to `@finos/perspective`'s web worker runtime, as well as overriding the default dedicated `Worker` instance.


```javascript
// Dedicated Worker
const worker = await perspective.worker(new Worker(url));

// SharedWorker
const worker = await perspective.worker(new SharedWorker(url));

// ServiceWorker
const registration = await navigator.serviceWorker.register(url, {
    scope: "", // Your scope here
});

const worker = await perspective.worker(registration.active);
```

The `editable` example has been updated to use a `SharedWorker`, which means opening this example in multiple browser tabs will use the same `Table` state and receive eachother's updates.

https://github.com/user-attachments/assets/9b38c209-95c9-4e43-8950-ed7d705156c0

