### PR TITLE
Fix em++ flag typo for debug Pyodide build

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -232,7 +232,7 @@ if(PSP_WASM_BUILD)
             -g3 \
             -Wcast-align \
             -Wover-aligned \
-            -emit-tsd=perspective-server.d.ts \
+            --emit-tsd=perspective-server.d.ts \
             ")
         if (PSP_WASM_EXCEPTIONS)
             set(OPT_FLAGS "${OPT_FLAGS} -fwasm-exceptions ")


### PR DESCRIPTION
Fix a typo in the OPT_FLAGS for the Pyodide debug build which caused em++ to fail.