### PR TITLE
Add timeouts to pytest, fix jupyterlab error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -776,7 +776,7 @@ jobs:
               run: python -c 'import perspective'
 
             - name: Run pytests
-              run: pytest -v --pyargs 'perspective.tests'
+              run: pytest -v --pyargs 'perspective.tests' --timeout=300
 
     # ,-,---.             .                 .
     #  '|___/ ,-. ,-. ,-. |-. ,-,-. ,-. ,-. | ,

--- a/packages/perspective-jupyterlab/src/js/view.js
+++ b/packages/perspective-jupyterlab/src/js/view.js
@@ -71,7 +71,7 @@ export class PerspectiveView extends DOMWidgetView {
             const { Client } = wasm_module;
             // Responses are fed to the client in the widget's msg:custom handler
             this.perspective_client = new Client(
-                (binary_msg) => {
+                async (binary_msg) => {
                     const buffer = binary_msg.slice().buffer;
                     this.send(
                         { type: "binary_msg", client_id: this.psp_client_id },

--- a/rust/perspective-python/requirements.txt
+++ b/rust/perspective-python/requirements.txt
@@ -14,6 +14,7 @@ psutil==6.0.0
 pytest==8.2.2
 pytest-asyncio==0.25.3
 pytest-sugar==1.0.0
+pytest-timeout==2.3.1
 ruff==0.5.0
 tornado==6.4.1
 traitlets==5.14.3

--- a/rust/perspective-python/test.mjs
+++ b/rust/perspective-python/test.mjs
@@ -51,5 +51,5 @@ if (process.env.PSP_PYODIDE) {
         execOpts
     );
 } else {
-    execFileSync("pytest", ["perspective/tests", "-W error", ...process.argv.slice(2)], execOpts);
+    execFileSync("pytest", ["perspective/tests", "-W error", "--timeout=300", ...process.argv.slice(2)], execOpts);
 }


### PR DESCRIPTION
We had a pytest which deadlocked in the CI sdist tests. Exception spew from errors which
caused the deadlock was also somehow being swallowed and didn't make it to the log
output in Github Actions.

Add a timeout with pytest-timeout when running the non-pyodide pytest suite, including
for the CI sdist tests. When a test deadlocks, the timeout will fire and pytest-timeout then
prints the deadlocked test's output.

This is a run on a test tag, which shows the error output which was previously being lost in CI:
https://github.com/tomjakubowski/perspective/actions/runs/13820587424/job/38668499105
