### PR TITLE
Add vscode settings to enable prettier

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -7,9 +7,7 @@
     },
     "python.formatting.provider": "black",
     "python.testing.pytestEnabled": true,
-    "python.testing.pytestArgs": [
-        "rust/perspective-python/perspective/tests/"
-    ],
+    "python.testing.pytestArgs": ["rust/perspective-python/perspective/tests/"],
     "rust-analyzer.server.extraEnv": {
         "PSP_ROOT_DIR": "../..",
         "PSP_DISABLE_CPP": "1",
@@ -46,5 +44,15 @@
     "playwright.env": {
         "TZ": "UTC"
     },
-    "clangd.arguments": ["--enable-config"]
+    "clangd.arguments": ["--enable-config"],
+    "[javascript][typescript][typescriptreact]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[markdown][less][html]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "prettier.proseWrap": "always"
 }

--- a/rust/perspective-viewer/README.md
+++ b/rust/perspective-viewer/README.md
@@ -1,4 +1,4 @@
 # `perspective-viewer`
 
 This crate provides the `<perspective-viewer>` Web Component, via JavaScript
-bindings generate from `wasm_bindgen`.
+bindings generated from `wasm_bindgen`.


### PR DESCRIPTION
These settings ensure the correct formatting (as per `pnpm run lint`) is applied when vscode formats a Javascript, Typescript, TSX, Markdown, LESS, HTML, or JSON file.
