### PR TITLE
Update `limit` behavior to use incrementing `index` (fix `last_by_index` aggregate)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -212,6 +212,10 @@ jobs:
                       is-release: false
 
         steps:
+            - name: Free up disk space
+              run: |
+                  rm -rf /__t/*
+
             - name: Checkout
               uses: actions/checkout@v4
 

--- a/cpp/perspective/build.js
+++ b/cpp/perspective/build.js
@@ -42,7 +42,7 @@ try {
     execSync(`mkdirp ${cwd}`, { stdio });
     process.env.CLICOLOR_FORCE = 1;
     execSync(
-        `emcmake cmake ${__dirname} ${cmake_flags} -DCMAKE_BUILD_TYPE=${env}`,
+        `emcmake cmake ${__dirname} ${cmake_flags} -DCMAKE_BUILD_TYPE=${env} -DRAPIDJSON_BUILD_EXAMPLES=OFF`,
         {
             cwd,
             stdio,

--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -799,6 +799,19 @@ type_to_dtype<void*>() {
     return DTYPE_OBJECT;
 }
 
+std::ostream&
+operator<<(std::ostream& os, const t_op& op) {
+#define X(NAME)                                                                \
+    case NAME:                                                                 \
+        os << #NAME;                                                           \
+        break;
+
+    switch (op) { FOREACH_T_OP(X) }
+#undef X
+
+    return os;
+}
+
 } // end namespace perspective
 
 namespace std {

--- a/cpp/perspective/src/cpp/binding_api.cpp
+++ b/cpp/perspective/src/cpp/binding_api.cpp
@@ -47,7 +47,7 @@ void
 encode_api_response(
     const ProtoServerResp<std::string>& msg, EncodedApiResp* encoded
 ) {
-    auto* data = new char[msg.data.size()];
+    auto* data = static_cast<char*>(UNINSTRUMENTED_MALLOC(msg.data.size()));
     std::copy(msg.data.begin(), msg.data.end(), data);
 
     encoded->data = data;
@@ -57,8 +57,12 @@ encode_api_response(
 
 EncodedApiEntries*
 encode_api_responses(const std::vector<ProtoServerResp<std::string>>& msgs) {
-    auto* encoded = new EncodedApiEntries;
-    encoded->entries = new EncodedApiResp[msgs.size()];
+    auto* encoded = static_cast<EncodedApiEntries*>(
+        UNINSTRUMENTED_MALLOC(sizeof(EncodedApiEntries))
+    );
+    encoded->entries = static_cast<EncodedApiResp*>(
+        UNINSTRUMENTED_MALLOC(sizeof(EncodedApiResp) * msgs.size())
+    );
 
     encoded->size = msgs.size();
     auto* encoded_mem = encoded->entries;

--- a/cpp/perspective/src/cpp/flat_traversal.cpp
+++ b/cpp/perspective/src/cpp/flat_traversal.cpp
@@ -388,6 +388,28 @@ t_ftrav::delete_row(t_tscalar pkey) {
     ++m_step_deletes;
 }
 
+void
+t_ftrav::move_row(
+    const t_gstate& gstate,
+    const t_data_table& expression_master_table,
+    const t_config& config,
+    t_tscalar old_pkey,
+    t_tscalar new_pkey
+) {
+    auto old_pkiter = m_pkeyidx.find(old_pkey);
+    bool old_pkey_existed = old_pkiter != m_pkeyidx.end();
+    if (!old_pkey_existed) {
+        LOG_DEBUG("Tried to move pkey that doesn't exist: " << old_pkey);
+        return;
+    }
+    LOG_DEBUG("Moving pkey from: " << old_pkey << " to: " << new_pkey);
+
+    (*m_index)[old_pkiter->second].m_deleted = true;
+    t_mselem mselem;
+    fill_sort_elem(gstate, expression_master_table, config, new_pkey, mselem);
+    m_new_elems[new_pkey] = mselem;
+}
+
 std::vector<t_sortspec>
 t_ftrav::get_sort_by() const {
     return m_sortby;

--- a/cpp/perspective/src/cpp/gnode_state.cpp
+++ b/cpp/perspective/src/cpp/gnode_state.cpp
@@ -10,6 +10,9 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
+#include "perspective/raw_types.h"
+#include <algorithm>
+#include <limits>
 #include <perspective/first.h>
 #include <perspective/context_unit.h>
 #include <perspective/context_zero.h>
@@ -24,10 +27,15 @@
 
 namespace perspective {
 
-t_gstate::t_gstate(t_schema input_schema, t_schema output_schema) :
+t_gstate::t_gstate(
+    t_schema input_schema, t_schema output_schema, t_uindex limit
+) :
     m_input_schema(std::move(input_schema)),
     m_output_schema(std::move(output_schema)),
-    m_init(false) {
+    m_init(false),
+    m_limit(limit)
+
+{
     LOG_CONSTRUCTOR("t_gstate");
 }
 
@@ -101,21 +109,24 @@ t_gstate::lookup_or_create(const t_tscalar& pkey) {
         return idx;
     }
 
-    t_uindex nrows = m_table->num_rows();
-    if (nrows >= m_table->get_capacity() - 1) {
-        m_table->reserve(std::max(
-            nrows + 1,
-            static_cast<t_uindex>(
-                m_table->get_capacity() * PSP_TABLE_GROW_RATIO
-            )
-        ));
-    }
+    t_uindex next_idx_original = m_table->size();
+    t_uindex next_idx = next_idx_original % m_limit;
 
-    m_table->set_size(nrows + 1);
-    m_opcol->set_nth<std::uint8_t>(nrows, OP_INSERT);
-    m_pkcol->set_scalar(nrows, pkey);
-    m_mapping[pkey_] = nrows;
-    return nrows;
+    if (next_idx + 1 <= m_limit) {
+        if (next_idx >= m_table->get_capacity() - 1) {
+            m_table->reserve(
+                std::max(
+                    (next_idx + 1),
+                    static_cast<t_uindex>(
+                        m_table->get_capacity() * PSP_TABLE_GROW_RATIO
+                    )
+                )
+            );
+        }
+        m_table->set_size(std::max(m_table->size() + 1, next_idx + 1));
+    }
+    m_mapping[pkey_] = next_idx;
+    return next_idx_original;
 }
 
 void
@@ -153,8 +164,10 @@ t_gstate::fill_master_table(const t_data_table* flattened) {
     m_pkcol = master_table->get_column("psp_pkey");
     m_opcol = master_table->get_column("psp_op");
 
-    master_table->set_capacity(flattened->get_capacity());
-    master_table->set_size(flattened->size());
+    master_table->set_capacity(
+        std::min(flattened->get_capacity(), m_limit + 1)
+    );
+    master_table->set_size(std::min(flattened->size(), m_limit + 1));
 
     for (t_uindex idx = 0, loop_end = flattened->num_rows(); idx < loop_end;
          ++idx) {
@@ -165,18 +178,27 @@ t_gstate::fill_master_table(const t_data_table* flattened) {
         switch (op) {
             case OP_INSERT: {
                 // Write new primary keys into `m_mapping`
-                m_mapping[m_symtable.get_interned_tscalar(pkey)] = idx;
-                m_opcol->set_nth<std::uint8_t>(idx, OP_INSERT);
-                m_pkcol->set_scalar(idx, pkey);
+                m_mapping[m_symtable.get_interned_tscalar(pkey)] =
+                    idx % m_limit;
+                m_opcol->set_nth<std::uint8_t>(idx % m_limit, OP_INSERT);
+                m_pkcol->set_scalar(idx % m_limit, pkey);
             } break;
             case OP_DELETE: {
-                _mark_deleted(idx);
+                _mark_deleted(idx % m_limit);
             } break;
             default: {
                 PSP_COMPLAIN_AND_ABORT("Unexpected OP");
             } break;
         }
     }
+
+#if PSP_DEBUG
+    LOG_DEBUG("Flattened");
+    flattened->pprint();
+
+    LOG_DEBUG("Master");
+    m_table->pprint();
+#endif
 
 #ifdef PSP_TABLE_VERIFY
     master_table->verify();
@@ -193,28 +215,44 @@ t_gstate::update_master_table(const t_data_table* flattened) {
     // Update existing `m_table`
     const t_column* flattened_pkey_col =
         flattened->get_const_column("psp_pkey").get();
+    t_column* flattened_old_pkey_col =
+        flattened->get_column("psp_old_pkey").get();
     const t_column* flattened_op_col =
         flattened->get_const_column("psp_op").get();
 
     t_data_table* master_table = m_table.get();
-    std::vector<t_uindex> master_table_indexes(flattened->num_rows());
+    std::vector<t_uindex> master_table_indexes(
+        std::min(flattened->num_rows(), m_limit)
+    );
 
-    for (t_uindex idx = 0, loop_end = flattened->num_rows(); idx < loop_end;
-         ++idx) {
-        t_tscalar pkey = flattened_pkey_col->get_scalar(idx);
-        const auto* op_ptr = flattened_op_col->get_nth<std::uint8_t>(idx);
+    for (t_uindex flattened_idx = 0, loop_end = flattened->num_rows();
+         flattened_idx < loop_end;
+         ++flattened_idx) {
+        t_tscalar pkey = flattened_pkey_col->get_scalar(flattened_idx);
+        const auto* op_ptr =
+            flattened_op_col->get_nth<std::uint8_t>(flattened_idx);
         t_op op = static_cast<t_op>(*op_ptr);
 
         switch (op) {
             case OP_INSERT: {
                 // Lookup/create the row index in `m_table` based on pkey
-                master_table_indexes[idx] = lookup_or_create(pkey);
+                const auto new_idx = lookup_or_create(pkey);
+                master_table_indexes[flattened_idx % m_limit] =
+                    new_idx % m_limit;
+
+                if (new_idx >= m_limit
+                    && m_pkcol->is_valid(new_idx % m_limit)) {
+                    const auto old = m_pkcol->get_scalar(new_idx % m_limit);
+                    m_mapping.erase(old);
+                    flattened_old_pkey_col->set_scalar(flattened_idx, old);
+                    flattened_old_pkey_col->set_valid(flattened_idx, true);
+                    LOG_DEBUG("DELETING OLD PKEY: " << old);
+                    // erase(old);
+                }
 
                 // Write the op and pkey to `m_table`
-                m_opcol->set_nth<std::uint8_t>(
-                    master_table_indexes[idx], OP_INSERT
-                );
-                m_pkcol->set_scalar(master_table_indexes[idx], pkey);
+                m_opcol->set_nth<std::uint8_t>(new_idx % m_limit, OP_INSERT);
+                m_pkcol->set_scalar(new_idx % m_limit, pkey);
             } break;
             case OP_DELETE: {
                 // Erase the pkey from the master table, but this does not
@@ -227,8 +265,12 @@ t_gstate::update_master_table(const t_data_table* flattened) {
         }
     }
 
+    m_table->set_size(std::min(m_table->size(), m_limit));
+
     const t_schema& master_schema = m_table->get_schema();
     t_uindex ncols = master_table->num_columns();
+
+    LOG_DEBUG("Master Table Indices: " << master_table_indexes);
 
     parallel_for(
         int(ncols),
@@ -246,15 +288,24 @@ t_gstate::update_master_table(const t_data_table* flattened) {
             if (!flattened_column) {
                 return;
             }
+
             update_master_column(
                 master_column,
                 flattened_column.get(),
                 flattened_op_col,
                 master_table_indexes,
-                flattened->num_rows()
+                std::min(flattened->num_rows(), m_limit)
             );
         }
     );
+
+#if PSP_DEBUG
+    LOG_DEBUG("Flattened");
+    flattened->pprint();
+
+    LOG_DEBUG("Master");
+    m_table->pprint();
+#endif
 }
 
 void

--- a/cpp/perspective/src/cpp/server.cpp
+++ b/cpp/perspective/src/cpp/server.cpp
@@ -329,10 +329,11 @@ template <typename F>
 static std::vector<ValidatedExpr>
 parse_expression_strings(const F& column_expr) {
     // assert that F has an operator[] that takes a string and returns a string
-    static_assert(std::is_same_v<
-                  decltype(std::declval<F>()[std::declval<const std::string&>()]
-                  ),
-                  std::string&>);
+    static_assert(
+        std::is_same_v<
+            decltype(std::declval<F>()[std::declval<const std::string&>()]),
+            std::string&>
+    );
     std::vector<ValidatedExpr> validated_exprs;
     for (const auto& [colname, expr] : column_expr) {
         // TODO: Remove
@@ -356,9 +357,9 @@ parse_expression_strings(const F& column_expr) {
                 validated_expr
             );
 
-        validated_expr.parse_expression_string =
-            re_intern_strings(std::move(validated_expr.parse_expression_string)
-            );
+        validated_expr.parse_expression_string = re_intern_strings(
+            std::move(validated_expr.parse_expression_string)
+        );
 
         validated_expr.parse_expression_string = re_unintern_some_exprs(
             std::move(validated_expr.parse_expression_string)
@@ -494,6 +495,7 @@ ServerResources::delete_table(const t_id& id) {
     if (m_tables.find(id) != m_tables.end()) {
         if (m_table_to_view.find(id) == m_table_to_view.end()) {
             m_tables.erase(id);
+            m_dirty_tables.erase(id);
         } else {
             PSP_COMPLAIN_AND_ABORT("Cannot delete table with views");
         }
@@ -896,7 +898,7 @@ parse_format_options(
         viewport.has_end_row()
             ? viewport.end_row()
             : (viewport_height != 0 ? out.start_row + viewport_height : max_rows
-            )
+              )
     );
     out.end_col = std::min(
         max_cols,
@@ -1749,13 +1751,15 @@ ProtoServer::_handle_request(std::uint32_t client_id, Request&& req) {
                 auto dtype = computed_expression->get_dtype();
 
                 schema->add_column(expr.expression_alias, dtype);
-                expressions.push_back(std::make_shared<t_computed_expression>(
-                    expr.expression_alias,
-                    expr.expression,
-                    expr.parse_expression_string,
-                    column_id_map,
-                    dtype
-                ));
+                expressions.push_back(
+                    std::make_shared<t_computed_expression>(
+                        expr.expression_alias,
+                        expr.expression,
+                        expr.parse_expression_string,
+                        column_id_map,
+                        dtype
+                    )
+                );
             }
 
             t_vocab vocab;
@@ -2140,11 +2144,11 @@ ProtoServer::_handle_request(std::uint32_t client_id, Request&& req) {
                             auto tm = scalar.get<t_date>();
                             std::stringstream ss;
                             ss << std::setfill('0') << std::setw(4) << tm.year()
-                               << "-" << std::setfill('0') << std::setw(2)
-                               // Increment month by 1, as date::month is [1-12] but
-                               // t_date::month() is [0-11]
-                               << tm.month() + 1
                                << "-" << std::setfill('0')
+                               << std::setw(2)
+                               // Increment month by 1, as date::month is [1-12]
+                               // but t_date::month() is [0-11]
+                               << tm.month() + 1 << "-" << std::setfill('0')
                                << std::setw(2) << tm.day();
                             s->set_string(ss.str());
                             break;

--- a/cpp/perspective/src/include/perspective/base.h
+++ b/cpp/perspective/src/include/perspective/base.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <ostream>
 #ifdef WIN32
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -310,7 +311,16 @@ enum t_ctx_type {
     GROUPED_COLUMNS_CONTEXT
 };
 
-enum t_op { OP_INSERT, OP_DELETE, OP_CLEAR };
+#define FOREACH_T_OP(X)                                                        \
+    X(OP_INSERT)                                                               \
+    X(OP_DELETE)                                                               \
+    X(OP_CLEAR)
+
+#define X(NAME) NAME,
+enum t_op { FOREACH_T_OP(X) };
+#undef X
+
+std::ostream& operator<<(std::ostream& os, const t_op& op);
 
 enum t_value_transition {
     VALUE_TRANSITION_EQ_FF, // Value did not change, and row remains invalid
@@ -451,12 +461,12 @@ void check_init(bool init, const char* file, std::int32_t line);
 
 t_uindex root_pidx();
 
-struct PERSPECTIVE_EXPORT t_cmp_charptr {
-    bool
-    operator()(const char* a, const char* b) const {
-        return std::strcmp(a, b) < 0;
-    }
-};
+struct PERSPECTIVE_EXPORT t_cmp_charptr{
+    bool operator()(const char* a, const char* b)
+        const {return std::strcmp(a, b) < 0;
+} // namespace perspective
+}
+;
 
 template <class Arg1, class Arg2, class Result>
 struct binary_function {

--- a/cpp/perspective/src/include/perspective/flat_traversal.h
+++ b/cpp/perspective/src/include/perspective/flat_traversal.h
@@ -117,6 +117,16 @@ public:
 
     void delete_row(t_tscalar pkey);
 
+    // Moves a row under a new primary key and deletes references to old primary
+    // key.
+    void move_row(
+        const t_gstate& gstate,
+        const t_data_table& expression_master_table,
+        const t_config& config,
+        t_tscalar old_pkey,
+        t_tscalar new_pkey
+    );
+
     std::vector<t_sortspec> get_sort_by() const;
     bool empty_sort_by() const;
 

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -11,6 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 #pragma once
+#include "perspective/raw_types.h"
 #include <perspective/first.h>
 #include <perspective/base.h>
 #include <perspective/port.h>
@@ -93,7 +94,11 @@ public:
      * @param input_schema
      * @param output_schema
      */
-    t_gnode(t_schema input_schema, t_schema output_schema);
+    t_gnode(
+        t_schema input_schema,
+        t_schema output_schema,
+        t_uindex limit = std::numeric_limits<t_uindex>::max()
+    );
     ~t_gnode();
 
     void init();
@@ -381,6 +386,7 @@ private:
 
     bool m_init;
     t_uindex m_id;
+    t_uindex m_limit;
 
     // Input ports mapped by integer id
     tsl::ordered_map<t_uindex, std::shared_ptr<t_port>> m_input_ports;
@@ -511,8 +517,18 @@ t_gnode::update_context_from_state(
         // together and pass it to the context.
         std::shared_ptr<t_expression_tables> ctx_expression_tables =
             ctx->get_expression_tables();
+#if PSP_DEBUG
+        LOG_DEBUG("FLATTENED");
+        flattened->pprint();
+        LOG_DEBUG("EXPRESSION_TABLE");
+        ctx_expression_tables->m_flattened->pprint();
+#endif
         std::shared_ptr<t_data_table> joined_flattened =
             flattened->join(ctx_expression_tables->m_flattened);
+#if PSP_DEBUG
+        LOG_DEBUG("JOINED");
+        joined_flattened->pprint();
+#endif
         ctx->notify(*joined_flattened);
     } else {
         // Just use the table from the gnode

--- a/cpp/perspective/src/include/perspective/gnode_state.h
+++ b/cpp/perspective/src/include/perspective/gnode_state.h
@@ -31,9 +31,8 @@ public:
     /**
      * @brief A mapping of `t_tscalar` primary keys to `t_uindex` row indices.
      */
-    typedef tsl::hopscotch_map<t_tscalar, t_uindex> t_mapping;
-
-    typedef tsl::hopscotch_set<t_uindex> t_free_items;
+    using t_mapping = tsl::hopscotch_map<t_tscalar, t_uindex>;
+    using t_free_items = tsl::hopscotch_set<t_uindex>;
 
     /**
      * @brief Construct a new `t_gstate`, which manages the canonical state of
@@ -47,7 +46,11 @@ public:
      * @param input_schema
      * @param output_schema
      */
-    t_gstate(t_schema input_schema, t_schema output_schema);
+    t_gstate(
+        t_schema input_schema,
+        t_schema output_schema,
+        t_uindex limit = std::numeric_limits<t_uindex>::max()
+    );
 
     ~t_gstate();
 
@@ -289,6 +292,7 @@ private:
     t_schema m_output_schema; // tblschema
 
     bool m_init;
+    t_uindex m_limit;
     std::shared_ptr<t_data_table> m_table;
     t_mapping m_mapping;
     t_free_items m_free;

--- a/cpp/perspective/src/include/perspective/parallel_for.h
+++ b/cpp/perspective/src/include/perspective/parallel_for.h
@@ -26,6 +26,7 @@ namespace perspective {
 template <class FUNCTION>
 void
 parallel_for(int num_tasks, FUNCTION&& func) {
+#undef PSP_PARALLEL_FOR
 #ifdef PSP_PARALLEL_FOR
     std::exception_ptr e;
     std::mutex e_mtx;

--- a/cpp/perspective/src/include/perspective/scalar.h
+++ b/cpp/perspective/src/include/perspective/scalar.h
@@ -34,14 +34,14 @@
 namespace perspective {
 
 template <template <typename COMPARED_T> class COMPARER_T>
-struct PERSPECTIVE_EXPORT t_const_char_comparator {
-    inline bool
-    operator()(const char* s1, const char* s2) const {
-        COMPARER_T<t_index> cmp;
-        int cmpval = std::strcmp(s1, s2);
-        return cmp(cmpval, 0);
-    }
-};
+struct PERSPECTIVE_EXPORT t_const_char_comparator{
+    inline bool operator()(const char* s1, const char* s2)
+        const {COMPARER_T<t_index> cmp;
+int cmpval = std::strcmp(s1, s2);
+return cmp(cmpval, 0);
+} // namespace perspective
+}
+;
 
 #ifdef PSP_SSO_SCALAR
 const int SCALAR_INPLACE_LEN = 13;
@@ -202,7 +202,7 @@ struct PERSPECTIVE_EXPORT t_tscalar {
     t_tscalar coerce_numeric_dtype(t_dtype dtype) const;
 
     t_scalar_u m_data;
-    unsigned char m_type;
+    t_dtype m_type;
     t_status m_status;
 #ifdef PSP_SSO_SCALAR
     bool m_inplace;

--- a/rust/perspective-js/test/js/constructors.spec.js
+++ b/rust/perspective-js/test/js/constructors.spec.js
@@ -1821,9 +1821,9 @@ function validate_typed_array(typed_array, column_data) {
                 await view.delete();
                 await table.delete();
                 expect(records).toEqual([
-                    { a: 40, b: null },
                     { a: 20, b: 2 },
                     { a: 30, b: null },
+                    { a: 40, b: null },
                 ]);
             });
 

--- a/rust/perspective-js/test/js/expressions/multiple_views.spec.js
+++ b/rust/perspective-js/test/js/expressions/multiple_views.spec.js
@@ -397,8 +397,10 @@ import * as expressions_common from "./common.js";
                 result = await v1.to_columns();
                 result2 = await v2.to_columns();
 
-                expect(result["column"]).toEqual([null, 20]);
-                expect(result2["column"]).toEqual(["DEF", "ABC"]);
+                expect(result["column"]).toEqual([20, null]);
+                expect(result2["column"]).toEqual(["ABC", "DEF"]);
+
+                expect(await table.size()).toEqual(2);
 
                 await v2.delete();
                 await v1.delete();
@@ -737,6 +739,7 @@ import * as expressions_common from "./common.js";
 
                 expect(result["column"]).toEqual([6, 8]);
                 expect(result2["column"]).toEqual(["C", "D"]);
+                expect(result["y"]).toEqual(["c", "d"]);
 
                 table.update({
                     x: [2, 4, 3, 10, null],
@@ -746,8 +749,8 @@ import * as expressions_common from "./common.js";
                 result = await v1.to_columns();
                 result2 = await v2.to_columns();
 
-                expect(result["column"]).toEqual([null, 20]);
-                expect(result2["column"]).toEqual(["DEF", "ABC"]);
+                expect(result["column"]).toEqual([20, null]);
+                expect(result2["column"]).toEqual(["ABC", "DEF"]);
 
                 await v2.delete();
                 await v1.delete();

--- a/rust/perspective-js/test/js/limit.spec.js
+++ b/rust/perspective-js/test/js/limit.spec.js
@@ -1,0 +1,102 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { test, expect } from "@finos/perspective-test";
+import perspective from "./perspective_client";
+
+import moment from "moment";
+import * as arrows from "./test_arrows.js";
+
+((perspective) => {
+    async function match_delta(
+        perspective,
+        delta,
+        expected,
+        formatter = "to_json"
+    ) {
+        const table = await perspective.table(delta);
+        const view = await table.view();
+        const result = await view[formatter]();
+        expect(result).toEqual(expected);
+        await view.delete();
+        await table.delete();
+    }
+
+    test.describe("Limits", () => {
+        test("Limiting rows should not limit the index space", async ({
+            page,
+        }) => {
+            const table = await perspective.table(
+                {
+                    x: "integer",
+                    group: "integer",
+                },
+                { limit: 10 }
+            );
+
+            const data = [];
+            for (let i = 0; i < 15; i++) {
+                data.push({ x: i, group: 0 });
+            }
+
+            await table.update(data);
+            const lastByIdx = await (
+                await table.view({
+                    group_by: ["group"],
+                    aggregates: { x: "last by index" },
+                })
+            ).to_json();
+            expect(lastByIdx[0]["x"]).toEqual(14);
+
+            const view = await table.view();
+            let viewData = await view.to_json();
+            expect(viewData.length).toBe(10);
+            expect(viewData).toEqual(data.slice(-10));
+        });
+
+        test("Append in sequence", async () => {
+            const table = await perspective.table(
+                {
+                    x: "integer",
+                    y: "string",
+                    z: "boolean",
+                },
+                { limit: 2 }
+            );
+
+            const v1 = await table.view();
+            const v2 = await table.view();
+
+            await table.update({
+                x: [0],
+                y: ["0"],
+            });
+
+            await v1.to_columns();
+
+            await table.update({
+                x: [1, 2],
+                y: ["1", "2"],
+            });
+
+            let result = await v1.to_columns();
+            let result2 = await v2.to_columns();
+
+            expect(result["x"]).toEqual([1, 2]);
+            expect(result2["y"]).toEqual(["1", "2"]);
+
+            await v2.delete();
+            await v1.delete();
+            await table.delete();
+        });
+    });
+})(perspective);

--- a/rust/perspective-js/test/js/updates.spec.js
+++ b/rust/perspective-js/test/js/updates.spec.js
@@ -1508,12 +1508,11 @@ async function match_delta(perspective, delta, expected) {
 
         test("{limit: 5} with 2 updates of size 4", async function () {
             var table = await perspective.table(data, { limit: 5 });
-            table.update(data);
+            await table.update(data);
             var view = await table.view();
             let result = await view.to_json();
-            expect(result).toEqual(
-                data.slice(1).concat(data.slice(3, 4)).concat(data.slice(0, 1))
-            );
+            let expected = data.concat(data).slice(-5);
+            expect(result).toEqual(expected);
             view.delete();
             table.delete();
         });
@@ -3369,6 +3368,21 @@ async function match_delta(perspective, delta, expected) {
             }
 
             await view2.delete();
+            await tbl.delete();
+        });
+
+        test("Delete a table with pending updates", async () => {
+            const tbl = await perspective.table(
+                {
+                    index: "string",
+                    x: "string",
+                },
+                { index: "index" }
+            );
+
+            for (let i = 0; i < 3; i++) {
+                await tbl.update({ index: ["a", "d", "b"], x: ["abc", "def", "acc"] });
+            }
             await tbl.delete();
         });
     });

--- a/rust/perspective-js/test/js/updates.spec.js
+++ b/rust/perspective-js/test/js/updates.spec.js
@@ -3381,7 +3381,10 @@ async function match_delta(perspective, delta, expected) {
             );
 
             for (let i = 0; i < 3; i++) {
-                await tbl.update({ index: ["a", "d", "b"], x: ["abc", "def", "acc"] });
+                await tbl.update({
+                    index: ["a", "d", "b"],
+                    x: ["abc", "def", "acc"],
+                });
             }
             await tbl.delete();
         });

--- a/rust/perspective-python/perspective/tests/table/test_table_limit.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_limit.py
@@ -17,18 +17,6 @@ Table = client.table
 
 
 class TestTableInfer(object):
-    def test_table_limit_wraparound_does_not_respect_partial_none(self):
-        t = Table({"a": "float", "b": "float"}, limit=3)
-        t.update([{"a": 10}, {"b": 1}, {"a": 20}, {"a": None, "b": 2}])
-        d1 = t.view().to_json()
-
-        t2 = Table({"a": "float", "b": "float"}, limit=3)
-        t2.update([{"a": 10}, {"b": 1}, {"a": 20}, {"b": 2}])
-        d2 = t2.view().to_json()
-
-        assert d1[0] != d2[0]
-        assert d1[1:] == d2[1:]
-
     def test_table_limit_wraparound_does_not_respect_partial(self):
         t = Table({"a": "float", "b": "float"}, limit=3)
         t.update([{"a": 10}, {"b": 1}, {"a": 20}, {"a": 10, "b": 2}])

--- a/rust/perspective-server/build/psp.rs
+++ b/rust/perspective-server/build/psp.rs
@@ -26,6 +26,9 @@ pub fn cmake_build() -> Result<Option<PathBuf>, std::io::Error> {
     let profile = std::env::var("PROFILE").unwrap();
     dst.always_configure(true);
     dst.define("CMAKE_BUILD_TYPE", profile.as_str());
+    dst.define("ARROW_BUILD_EXAMPLES", "OFF");
+    dst.define("RAPIDJSON_BUILD_EXAMPLES", "OFF");
+    dst.define("ARROW_CXX_FLAGS_DEBUG", "-Wno-error");
 
     if cfg!(target_os = "macos") {
         // Set CMAKE_OSX_ARCHITECTURES et al. for Mac builds.  Arrow does not forward on

--- a/tools/perspective-bench/cross_platform_suite.mjs
+++ b/tools/perspective-bench/cross_platform_suite.mjs
@@ -198,20 +198,21 @@ export async function table_suite(perspective, metadata) {
         }
     }
 
-    await benchmark({
-        name: `.table(arrow, {limit: 1000})`,
-        before_all,
-        metadata,
-        async after(_, table) {
-            if (check_version_gte(metadata.version, "3.0.0")) {
-                await table.delete();
-            }
-        },
-        async test({ arrow }) {
-            return await perspective.table(arrow.slice(), { limit: 1000 });
-        },
-    });
-
+    if (!check_version_gte(metadata.version, "2.3.0")) {
+        await benchmark({
+            name: `.table(arrow, {limit: 1000})`,
+            before_all,
+            metadata,
+            async after(_, table) {
+                if (check_version_gte(metadata.version, "3.0.0")) {
+                    await table.delete();
+                }
+            },
+            async test({ arrow }) {
+                return await perspective.table(arrow.slice(), { limit: 1000 });
+            },
+        });
+    }
 
     await benchmark({
         name: `.table(arrow)`,
@@ -228,30 +229,30 @@ export async function table_suite(perspective, metadata) {
     });
 
 
-    await benchmark({
-        name: `table.update(arrow)`,
-        before_all,
-        metadata,
-        async before({ arrow }) {
-            let table2 = await perspective.table(arrow.slice(), { limit: 1000 });
-            return table2
-        },
-        async after(_, table) {
-            if (check_version_gte(metadata.version, "3.0.0")) {
+    if (!check_version_gte(metadata.version, "3.0.0")) {
+        await benchmark({
+            name: `table.update(arrow)`,
+            before_all,
+            metadata,
+            async before({ arrow }) {
+                let table2 = await perspective.table(arrow.slice(), { limit: 1000 });
+                return table2
+            },
+            async after(_, table) {
                 if (!check_version_gte(metadata.version, "3.4.3")) {
                     // Bug with old versions of perspective segfault when you delete
                     // a table with pending updates.
                     await table.size();
                 }
                 await table.delete();
-            }
-        },
-        async test({ arrow }, table2) {
-            for (let i = 0; i < 3; i++) {
-                await table2.update(arrow.slice());
-            }
-        },
-    });
+            },
+            async test({ arrow }, table2) {
+                for (let i = 0; i < 3; i++) {
+                    await table2.update(arrow.slice());
+                }
+            },
+        });
+    }
 
     await benchmark({
         name: `.table(csv)`,


### PR DESCRIPTION
This PR decouples primary keys from the limit functionality of perspective tables, allowing us to handle aggregates like "last by index" a bit better when users have a limit and want to rely on insert order to window their data.

Along the way I also fixed some memory safety issues where we had called `new` to allocate some memory and free'd it with `free` rather than `delete`. This wasn't breaking anything at the moment, but may have been relying on undefined behavior accidentally.

The new benchmarks also triggered a bug in our polling implementation where if a table was dirtied and deleted before the `poll` call, it would segfault the poll call because we hadn't removed it from the dirty map in the server, so I fixed that as well.