### PR TITLE
AsyncTable support in widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@finos/perspective-workspace": "workspace:^",
         "@fontsource/roboto-mono": "4.5.10",
         "@playwright/test": "^1.49.1",
-        "@types/ws": "^7.4.7",
+        "@types/ws": "^8.18.1",
         "@zip.js/zip.js": "^2.7.54",
         "auto-changelog": "^2.5.0",
         "chalk": "^2.4.2",

--- a/packages/perspective-jupyterlab/DEVELOPMENT.md
+++ b/packages/perspective-jupyterlab/DEVELOPMENT.md
@@ -1,0 +1,16 @@
+## Build
+
+As of March 2025, the build process is a little different from the jupyterlab
+extension cookiecutter template. The build works as follows:
+
+### labextension
+
+1. esbuild produces a bundle in `dist/esm` with `src/index.js` as its entrypoint
+2. `jupyter labextension build` packages that bundle, which is read from the
+   `main` field in `package.json`, into `dist/cjs`
+3. the `dist/cjs` output is copied to the perspective-python package's `.data`
+   directory.
+
+This means running `jupyter labextension build` or `watch` out-of-band from the
+build script won't rebuild the labextension on its own; the `labextension` step
+runs on the output of the esbuild step.

--- a/packages/perspective-jupyterlab/README.md
+++ b/packages/perspective-jupyterlab/README.md
@@ -1,6 +1,7 @@
 # Perspective JupyterLab Extension
 
-This extension allows in-lining perspective based charts in jupyterlab notebooks.
+This extension allows in-lining perspective based charts in jupyterlab
+notebooks.
 
 [Examples](https://github.com/finos/perspective/tree/master/examples/jupyter-notebooks)
 

--- a/packages/perspective-jupyterlab/build.mjs
+++ b/packages/perspective-jupyterlab/build.mjs
@@ -131,7 +131,9 @@ async function build_all() {
 
     await Promise.all(BUILD.map(build)).catch(() => process.exit(1));
     cpy(["src/less/*"], "dist/less");
-    execSync("jupyter labextension build .", { stdio: "inherit" });
+    execSync("jupyter labextension build .", {
+        stdio: "inherit",
+    });
 
     const pkg = JSON.parse(fs.readFileSync("../../package.json").toString());
     const version = pkg.version.replace(/-(rc|alpha|beta)\.\d+/, (x) =>

--- a/packages/perspective-jupyterlab/src/js/view.js
+++ b/packages/perspective-jupyterlab/src/js/view.js
@@ -180,7 +180,6 @@ export class PerspectiveView extends DOMWidgetView {
     }
 
     get psp_client_id() {
-        // XXX(tom): why can't we just use the GUID already used to uniquely identify the view in comms ?
         return this.#psp_client_id;
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^1.49.1
         version: 1.49.1
       '@types/ws':
-        specifier: ^7.4.7
-        version: 7.4.7
+        specifier: ^8.18.1
+        version: 8.18.1
       '@zip.js/zip.js':
         specifier: ^2.7.54
         version: 2.7.54
@@ -405,7 +405,7 @@ importers:
         version: 0.28.11
       html-webpack-plugin:
         specifier: ^5.1.0
-        version: 5.6.0(webpack@5.97.1)
+        version: 5.6.0(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
       style-loader:
         specifier: ^0.18.2
         version: 0.18.2
@@ -682,8 +682,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.3
       '@types/ws':
-        specifier: ^8.5.10
-        version: 8.5.12
+        specifier: ^8.18.1
+        version: 8.18.1
       apache-arrow:
         specifier: 18.1.0
         version: 18.1.0
@@ -4095,11 +4095,8 @@ packages:
   '@types/webpack-sources@0.1.12':
     resolution: {integrity: sha512-+vRVqE3LzMLLVPgZHUeI8k1YmvgEky+MOir5fQhKvFxpB8uZ0CFnGqxkRAmf8jvNhUBQzhuGZpIMNWZDeEyDIA==}
 
-  '@types/ws@7.4.7':
-    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
-
-  '@types/ws@8.5.12':
-    resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -14918,11 +14915,7 @@ snapshots:
       '@types/source-list-map': 0.1.6
       source-map: 0.6.1
 
-  '@types/ws@7.4.7':
-    dependencies:
-      '@types/node': 22.10.5
-
-  '@types/ws@8.5.12':
+  '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.10.5
 
@@ -15020,7 +15013,7 @@ snapshots:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1(esbuild@0.14.54))
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1)
@@ -15030,7 +15023,7 @@ snapshots:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1(esbuild@0.14.54))
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1)
@@ -15040,7 +15033,7 @@ snapshots:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1(esbuild@0.14.54))
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.97.1)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1)
@@ -15997,7 +15990,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.97.1(esbuild@0.14.54)
+      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.14.54)(webpack@5.97.1(esbuild@0.14.54)):
     dependencies:
@@ -17727,6 +17720,16 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  html-webpack-plugin@5.6.0(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.17.21
+      pretty-error: 4.0.0
+      tapable: 2.2.1
+    optionalDependencies:
+      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
+
   html-webpack-plugin@5.6.0(webpack@5.97.1(esbuild@0.14.54)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -17736,16 +17739,6 @@ snapshots:
       tapable: 2.2.1
     optionalDependencies:
       webpack: 5.97.1(esbuild@0.14.54)
-
-  html-webpack-plugin@5.6.0(webpack@5.97.1):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.21
-      pretty-error: 4.0.0
-      tapable: 2.2.1
-    optionalDependencies:
-      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -19057,7 +19050,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.2.1
-      webpack: 5.97.1(esbuild@0.14.54)
+      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
 
   mini-svg-data-uri@1.4.4: {}
 
@@ -21328,6 +21321,17 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
+  terser-webpack-plugin@5.3.11(esbuild@0.14.54)(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 4.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.37.0
+      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
+    optionalDependencies:
+      esbuild: 0.14.54
+
   terser-webpack-plugin@5.3.11(esbuild@0.14.54)(webpack@5.97.1(esbuild@0.14.54)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -21336,17 +21340,6 @@ snapshots:
       serialize-javascript: 6.0.2
       terser: 5.37.0
       webpack: 5.97.1(esbuild@0.14.54)
-    optionalDependencies:
-      esbuild: 0.14.54
-
-  terser-webpack-plugin@5.3.11(esbuild@0.14.54)(webpack@5.97.1):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 4.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.37.0
-      webpack: 5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.14.54
 
@@ -21774,9 +21767,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.97.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.97.1)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -21805,7 +21798,7 @@ snapshots:
       '@types/serve-index': 1.9.4
       '@types/serve-static': 1.15.7
       '@types/sockjs': 0.3.36
-      '@types/ws': 8.5.12
+      '@types/ws': 8.18.1
       ansi-html-community: 0.0.8
       bonjour-service: 1.2.1
       chokidar: 3.6.0
@@ -21908,7 +21901,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(esbuild@0.14.54)(webpack@5.97.1)
+      terser-webpack-plugin: 5.3.11(esbuild@0.14.54)(webpack@5.97.1(esbuild@0.14.54)(webpack-cli@5.1.4))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/rust/perspective-client/src/rust/client.rs
+++ b/rust/perspective-client/src/rust/client.rs
@@ -330,13 +330,13 @@ impl Client {
 
     /// Send a `ClientReq` and await both the successful completion of the
     /// `send`, _and_ the `ClientResp` which is returned.
-    pub(crate) async fn oneshot(&self, msg: &Request) -> ClientResult<ClientResp> {
+    pub(crate) async fn oneshot(&self, req: &Request) -> ClientResult<ClientResp> {
         let (sender, receiver) = futures::channel::oneshot::channel::<ClientResp>();
-        let on_update = Box::new(move |msg: Response| {
-            sender.send(msg.client_resp.unwrap()).map_err(|x| x.into())
+        let on_update = Box::new(move |res: Response| {
+            sender.send(res.client_resp.unwrap()).map_err(|x| x.into())
         });
 
-        self.subscribe_once(msg, on_update).await?;
+        self.subscribe_once(req, on_update).await?;
         receiver
             .await
             .map_err(|_| ClientError::Unknown("Internal error".to_owned()))

--- a/rust/perspective-js/package.json
+++ b/rust/perspective-js/package.json
@@ -52,7 +52,7 @@
         "@finos/perspective-test": "workspace:^",
         "@finos/perspective-metadata": "workspace:^",
         "@types/stoppable": "^1.1.0",
-        "@types/ws": "^8.5.10",
+        "@types/ws": "^8.18.1",
         "apache-arrow": "18.1.0",
         "cpy": "^9.0.1",
         "lodash": "^4.17.21",

--- a/rust/perspective-python/src/client/mod.rs
+++ b/rust/perspective-python/src/client/mod.rs
@@ -14,6 +14,7 @@ pub mod client_async;
 pub mod client_sync;
 mod pandas;
 mod polars;
+pub mod proxy_session;
 mod pyarrow;
 pub mod table_data;
 pub mod update_data;

--- a/rust/perspective-python/src/client/proxy_session.rs
+++ b/rust/perspective-python/src/client/proxy_session.rs
@@ -1,0 +1,78 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+use perspective_client::Session;
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+use pyo3::types::*;
+
+use super::client_async::AsyncClient;
+use super::client_sync::{Client as SyncClient, PyFutureExt};
+use crate::py_err::ResultTClientErrorExt;
+
+#[pyclass(module = "perspective")]
+#[derive(Clone)]
+pub struct ProxySession(perspective_client::ProxySession);
+
+#[pymethods]
+impl ProxySession {
+    #[new]
+    /// Construct a proxy session from an AsyncClient or Client object and a
+    /// `handle_request`` callback.  The callback should ultimately invoke
+    /// `handle_request` on another client, passing along the argument
+    /// passed to it.
+    fn new(py: Python<'_>, client: Py<PyAny>, handle_request: Py<PyAny>) -> PyResult<Self> {
+        let client = if let Ok(py_client) = client.downcast_bound::<AsyncClient>(py) {
+            py_client.borrow().client.clone()
+        } else if let Ok(py_client) = client.downcast_bound::<SyncClient>(py) {
+            py_client.borrow().0.client.clone()
+        } else {
+            return Err(PyTypeError::new_err(
+                "ProxySession::new() not passed a Perspective client",
+            ));
+        };
+        let callback = {
+            move |msg: &[u8]| {
+                let msg = msg.to_vec();
+                Python::with_gil(|py| {
+                    let bytes = PyBytes::new(py, &msg);
+                    handle_request.call1(py, (bytes,))?;
+                    Ok(())
+                })
+            }
+        };
+
+        Ok(ProxySession(perspective_client::ProxySession::new(
+            client, callback,
+        )))
+    }
+
+    pub fn handle_request(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
+        self.0.handle_request(&data).py_block_on(py).into_pyerr()?;
+        Ok(())
+    }
+
+    pub async fn handle_request_async(&self, data: Vec<u8>) -> PyResult<()> {
+        self.0.handle_request(&data).await.into_pyerr()?;
+        Ok(())
+    }
+
+    pub fn poll(&self, py: Python<'_>) -> PyResult<()> {
+        self.0.poll().py_block_on(py).into_pyerr()?;
+        Ok(())
+    }
+
+    pub fn close(&self, py: Python<'_>) -> PyResult<()> {
+        self.0.clone().close().py_block_on(py);
+        Ok(())
+    }
+}

--- a/rust/perspective-python/src/lib.rs
+++ b/rust/perspective-python/src/lib.rs
@@ -17,12 +17,13 @@ mod client;
 mod py_err;
 mod server;
 
-pub use client::client_sync::{Client, ProxySession, Table, View};
+pub use client::client_sync::{Client, Table, View};
+pub use client::proxy_session::ProxySession;
 use py_err::PyPerspectiveError;
 use pyo3::prelude::*;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt};
 
 macro_rules! inherit_doc {
     (#[inherit_doc = $y:literal] $x:item) => {
@@ -58,10 +59,10 @@ fn perspective(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<server::PySyncSession>()?;
     m.add_class::<client::client_sync::Table>()?;
     m.add_class::<client::client_sync::View>()?;
-    m.add_class::<client::client_sync::ProxySession>()?;
     m.add_class::<client::client_async::AsyncClient>()?;
     m.add_class::<client::client_async::AsyncTable>()?;
     m.add_class::<client::client_async::AsyncView>()?;
+    m.add_class::<client::proxy_session::ProxySession>()?;
 
     m.add("PerspectiveError", py.get_type::<PyPerspectiveError>())?;
 

--- a/rust/perspective-python/test.mjs
+++ b/rust/perspective-python/test.mjs
@@ -16,7 +16,9 @@ import { getPyodideDistDir } from "@finos/perspective-scripts/pyodide.mjs";
 import { getEmscriptenWheelPath } from "@finos/perspective-scripts/workspace.mjs";
 
 // avoid executing this script directly, instead run `pnpm run test` from the workspace root
-
+// to pass extra arguments to pytest, run (with perspective-python focused):
+//
+// pnpm run test -k "my_cool_test"
 const execOpts = { stdio: "inherit" };
 if (process.env.PSP_PYODIDE) {
     const pyodideDistDir = getPyodideDistDir();
@@ -51,5 +53,14 @@ if (process.env.PSP_PYODIDE) {
         execOpts
     );
 } else {
-    execFileSync("pytest", ["perspective/tests", "-W error", "--timeout=300", ...process.argv.slice(2)], execOpts);
+    execFileSync(
+        "pytest",
+        [
+            "perspective/tests",
+            "-W error",
+            "--timeout=300",
+            ...process.argv.slice(2),
+        ],
+        execOpts
+    );
 }

--- a/tools/perspective-scripts/sh.mjs
+++ b/tools/perspective-scripts/sh.mjs
@@ -323,7 +323,7 @@ function parse_bind_args(fragments, ...args) {
     for (let i = 0; i < fragments.length - 1; i++) {
         const arg = args[i];
         const start = terms.length === 0 ? fragments[i] : terms.pop();
-        if (arg === undefined || arg !== arg || arg === false) {
+        if (arg === undefined || Number.isNaN(arg) || arg === false) {
             terms.push(start.split(" ").slice(0, -1).join(" "));
             terms.push(" ");
             terms.push(fragments[i + 1].split(" ").slice(1).join(" "));

--- a/tools/perspective-scripts/test_js.mjs
+++ b/tools/perspective-scripts/test_js.mjs
@@ -17,7 +17,7 @@ import minimatch from "minimatch";
 // Unfortunately we have to handle parts of the Jupyter test case here,
 // as the Jupyter server needs to be run outside of the main Jest process.
 const IS_JUPYTER =
-    getarg("--jupyter") &&
+    !!getarg("--jupyter") &&
     process.env.PACKAGE.indexOf("perspective-jupyterlab") > -1;
 
 if (getarg("--debug")) {
@@ -104,7 +104,9 @@ if (process.env.PACKAGE) {
         process.env.PACKAGE.indexOf("perspective-python") >= 0 &&
         process.env.PACKAGE.indexOf("!perspective-python") === -1
     ) {
-        sh`pnpm run --recursive --filter @finos/perspective-python test`.runSync();
+        // Support `pnpm test -- --my_cool --test_arguments`
+        const args = process.argv.slice(2);
+        sh`pnpm run --recursive --filter @finos/perspective-python test ${args}`.runSync();
     }
 
     if (IS_RUST) {
@@ -137,7 +139,7 @@ if (process.env.PACKAGE) {
             target = "--target=aarch64-unknown-linux-gnu";
         }
 
-        sh`cargo test ${flags} ${target} -p perspective`.runSync();
+        sh`cargo test ${flags} ${target} -p perspective -p perspective-client`.runSync();
     }
 } else {
     console.log("-- Running all tests");

--- a/tools/perspective-test/playwright.config.ts
+++ b/tools/perspective-test/playwright.config.ts
@@ -227,7 +227,7 @@ export default defineConfig({
     snapshotPathTemplate:
         "dist/snapshots/{projectName}/{testFilePath}/{arg}{ext}",
     webServer: {
-        command: "node --loader ts-node/esm src/js/start_test_server.ts",
+        command: "tsx src/js/start_test_server.ts",
         port: TEST_SERVER_PORT,
         reuseExistingServer: true,
         stdout: "pipe",


### PR DESCRIPTION
AsyncTable support for PerspectiveWidget

When a `PerspectiveWidget()` is constructed with an `AsyncTable` data
argument, its interface becomes async and methods which operate on the
table return coroutines.

- Add async version of ProxySession.handle_request() with unit test
- Reënable perspective-client unit tests
- New jupyter playwright tests for widget + AsyncTable
