### PR TITLE
Add API for keyboard copy from `perspective-viewer-datagrid`

### DIFF
--- a/packages/perspective-viewer-datagrid/src/js/data_listener/format_cell.js
+++ b/packages/perspective-viewer-datagrid/src/js/data_listener/format_cell.js
@@ -15,6 +15,10 @@ import { FormatterCache } from "./formatter_cache";
 const FORMAT_CACHE = new FormatterCache();
 const MAX_BAR_WIDTH_PCT = 1;
 
+export function format_raw(type, value) {
+    return FORMAT_CACHE.get(type, value);
+}
+
 /**
  * Format a single cell's text content as the content of a `<td>` or `<th>`.
  *

--- a/packages/perspective-viewer-datagrid/src/js/event_handlers/click.js
+++ b/packages/perspective-viewer-datagrid/src/js/event_handlers/click.js
@@ -36,7 +36,7 @@ export function keydownListener(table, viewer, selected_position_map, event) {
             event
         );
     } else {
-        console.log(
+        console.debug(
             `Mode ${this._edit_mode} for "keydown" event not yet implemented`
         );
     }
@@ -54,7 +54,7 @@ export function clickListener(table, viewer, event) {
     } else if (this._edit_mode === "SELECT_ROW") {
     } else if (this._edit_mode === "SELECT_REGION") {
     } else {
-        console.log(
+        console.debug(
             `Mode ${this._edit_mode} for "click" event not yet implemented`
         );
     }

--- a/packages/perspective-viewer-datagrid/src/js/event_handlers/select_region.js
+++ b/packages/perspective-viewer-datagrid/src/js/event_handlers/select_region.js
@@ -143,7 +143,7 @@ const getMouseupListener = (datagrid, table, className) => (event) => {
         datagrid.model._edit_mode === "SELECT_COLUMN"
     ) {
         const meta = table.getMeta(event.target);
-        if (datagrid.model._selection_state.old_selected_areas.length > 0) {
+        if (datagrid.model._selection_state.old_selected_areas?.length > 0) {
             const selected =
                 datagrid.model._selection_state.old_selected_areas[0];
             if (

--- a/packages/perspective-viewer-datagrid/src/js/model/create.js
+++ b/packages/perspective-viewer-datagrid/src/js/model/create.js
@@ -125,6 +125,8 @@ export async function createModel(regular, table, view, extend = {}) {
         _is_editable.push(!!table_schema[column]);
     }
 
+    let _edit_mode = this._edit_mode || "READ_ONLY";
+    this._edit_button.dataset.editMode = _edit_mode;
     const model = Object.assign(extend, {
         _edit_port,
         _view: view,
@@ -143,6 +145,7 @@ export async function createModel(regular, table, view, extend = {}) {
         _column_paths,
         _column_types,
         _is_editable,
+        _edit_mode,
         _selection_state: {
             selected_areas: [],
             dirty: false,

--- a/packages/perspective-viewer-datagrid/src/js/model/toolbar.js
+++ b/packages/perspective-viewer-datagrid/src/js/model/toolbar.js
@@ -26,18 +26,18 @@ export function toggle_edit_mode(mode = undefined) {
             ];
     }
 
+    this.parentElement?.setSelection();
+    this._edit_mode = mode;
     if (this.model) {
         this.model._edit_mode = mode;
-        this.parentElement?.setSelection();
         this.model._selection_state = {
             selected_areas: [],
             dirty: true,
         };
+    }
 
-        this._edit_mode = mode;
-        if (this._edit_button !== undefined) {
-            this._edit_button.dataset.editMode = mode;
-        }
+    if (this._edit_button !== undefined) {
+        this._edit_button.dataset.editMode = mode;
     }
 
     this.dataset.editMode = mode;

--- a/rust/perspective-client/src/rust/client.rs
+++ b/rust/perspective-client/src/rust/client.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU32;
 
 use async_lock::{Mutex, RwLock};
+use futures::Future;
 use futures::future::{BoxFuture, LocalBoxFuture, join_all};
-use futures::{Future, FutureExt};
 use nanoid::*;
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -32,6 +32,7 @@ use crate::table::{Table, TableInitOptions, TableOptions};
 use crate::table_data::{TableData, UpdateData};
 use crate::utils::*;
 use crate::view::ViewWindow;
+use crate::{OnUpdateMode, OnUpdateOptions, asyncfn, clone};
 
 /// Metadata about the engine runtime (such as total heap utilization).
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -113,12 +114,10 @@ pub type ReconnectCallback =
 impl Client {
     /// Create a new client instance with a closure that handles message
     /// dispatch. See [`Client::new`] for details.
-    pub fn new_with_callback<T>(send_request: T) -> Self
+    pub fn new_with_callback<T, U>(send_request: T) -> Self
     where
-        T: for<'a> Fn(Vec<u8>) -> BoxFuture<'static, Result<(), Box<dyn Error + Send + Sync>>>
-            + 'static
-            + Sync
-            + Send,
+        T: Fn(Vec<u8>) -> U + 'static + Sync + Send,
+        U: Future<Output = Result<(), Box<dyn Error + Send + Sync>>> + Send + 'static,
     {
         let send_request = Arc::new(send_request);
         let send: SendCallback = Arc::new(move |req| {
@@ -143,10 +142,9 @@ impl Client {
     where
         T: ClientHandler + 'static + Sync + Send,
     {
-        Self::new_with_callback(move |req| {
-            let client_handler = client_handler.clone();
-            Box::pin(async move { client_handler.send_request(req).await })
-        })
+        Self::new_with_callback(asyncfn!(client_handler, async move |req| {
+            client_handler.send_request(req).await
+        }))
     }
 
     /// Handle a message from the external message queue.
@@ -173,23 +171,45 @@ impl Client {
         Ok(false)
     }
 
-    pub async fn handle_error(
+    pub async fn handle_error<T, U>(
         &self,
         message: Option<String>,
-        reconnect: Option<ReconnectCallback>,
-    ) -> ClientResult<()> {
+        reconnect: Option<T>,
+    ) -> ClientResult<()>
+    where
+        T: Fn() -> U + Clone + Send + Sync + 'static,
+        U: Future<Output = Result<(), ClientError>>,
+    {
         let subs = self.subscriptions_errors.read().await;
-        let tasks = join_all(
-            subs.values()
-                .map(|callback| callback(message.clone(), reconnect.clone())),
-        );
+        let tasks = join_all(subs.values().map(|callback| {
+            callback(
+                message.clone(),
+                reconnect.clone().map(move |f| {
+                    Arc::new(move || {
+                        clone!(f);
+                        Box::pin(async move { Ok(f().await?) }) as LocalBoxFuture<'static, _>
+                    }) as ReconnectCallback
+                }),
+            )
+        }));
+
         tasks.await.into_iter().collect::<Result<(), _>>()?;
         Ok(())
     }
 
-    pub async fn on_error(&self, on_error: OnErrorCallback) -> ClientResult<u32> {
+    pub async fn on_error<T, U, V>(&self, on_error: T) -> ClientResult<u32>
+    where
+        T: Fn(Option<String>, Option<ReconnectCallback>) -> U + Clone + Send + Sync + 'static,
+        U: Future<Output = V> + Send + 'static,
+        V: Into<Result<(), ClientError>> + Sync + 'static,
+    {
         let id = self.gen_id();
-        self.subscriptions_errors.write().await.insert(id, on_error);
+        let callback = asyncfn!(on_error, async move |x, y| on_error(x, y).await.into());
+        self.subscriptions_errors
+            .write()
+            .await
+            .insert(id, Box::new(move |x, y| Box::pin(callback(x, y))));
+
         Ok(id)
     }
 
@@ -246,15 +266,34 @@ impl Client {
         }
     }
 
-    pub(crate) async fn subscribe(
-        &self,
-        msg: &Request,
-        on_update: BoxFn<Response, BoxFuture<'static, Result<(), ClientError>>>,
-    ) -> ClientResult<()> {
+    // pub(crate) async fn subscribe(
+    //     &self,
+    //     msg: &Request,
+    //     on_update: BoxFn<Response, BoxFuture<'static, Result<(), ClientError>>>,
+    // ) -> ClientResult<()> {
+    //     self.subscriptions
+    //         .write()
+    //         .await
+    //         .insert(msg.msg_id, on_update);
+    //     tracing::debug!("SEND {}", msg);
+    //     if let Err(e) = (self.send)(msg).await {
+    //         self.subscriptions.write().await.remove(&msg.msg_id);
+    //         Err(ClientError::Unknown(e.to_string()))
+    //     } else {
+    //         Ok(())
+    //     }
+    // }
+
+    pub(crate) async fn subscribe<T, U>(&self, msg: &Request, on_update: T) -> ClientResult<()>
+    where
+        T: Fn(Response) -> U + Send + Sync + 'static,
+        U: Future<Output = Result<(), ClientError>> + Send + 'static,
+    {
         self.subscriptions
             .write()
             .await
-            .insert(msg.msg_id, on_update);
+            .insert(msg.msg_id, Box::new(move |x| Box::pin(on_update(x))));
+
         tracing::debug!("SEND {}", msg);
         if let Err(e) = (self.send)(msg).await {
             self.subscriptions.write().await.remove(&msg.msg_id);
@@ -302,29 +341,22 @@ impl Client {
                 .crate_table_inner(UpdateData::Arrow(arrow).into(), options.into(), entity_id)
                 .await?;
 
-            let callback = {
-                let table = table.clone();
-                move |update: crate::proto::ViewOnUpdateResp| {
-                    let table = table.clone();
-                    let update = update.delta.expect("Missing update");
-                    async move {
-                        table
-                            .update(
-                                UpdateData::Arrow(update.into()),
-                                crate::UpdateOptions::default(),
-                            )
-                            .await
-                            .unwrap_or_log();
-                    }
+            let table_ = table.clone();
+            let callback = asyncfn!(
+                table_,
+                update,
+                async move |update: crate::proto::ViewOnUpdateResp| {
+                    let update = UpdateData::Arrow(update.delta.expect("Malformed message").into());
+                    let options = crate::UpdateOptions::default();
+                    table_.update(update, options).await.unwrap_or_log();
                 }
+            );
+
+            let options = OnUpdateOptions {
+                mode: Some(OnUpdateMode::Row),
             };
 
-            let on_update_token = view
-                .on_update(callback, crate::view::OnUpdateOptions {
-                    mode: Some(crate::view::OnUpdateMode::Row),
-                })
-                .await?;
-
+            let on_update_token = view.on_update(callback, options).await?;
             table.view_update_token = Some(on_update_token);
             Ok(table)
         } else {
@@ -413,19 +445,15 @@ impl Client {
         U: Future<Output = ()> + Send + 'static,
     {
         let on_update = Arc::new(on_update);
-        let callback = move |resp: Response| {
-            let on_update = on_update.clone();
-            async move {
-                match resp.client_resp {
-                    Some(ClientResp::GetHostedTablesResp(_)) | None => {
-                        on_update().await;
-                        Ok(())
-                    },
-                    resp => Err(ClientError::OptionResponseFailed(resp.into())),
-                }
+        let callback = asyncfn!(on_update, async move |resp: Response| {
+            match resp.client_resp {
+                Some(ClientResp::GetHostedTablesResp(_)) | None => {
+                    on_update().await;
+                    Ok(())
+                },
+                resp => Err(ClientError::OptionResponseFailed(resp.into())),
             }
-            .boxed()
-        };
+        });
 
         let msg = Request {
             msg_id: self.gen_id(),
@@ -435,7 +463,7 @@ impl Client {
             })),
         };
 
-        self.subscribe(&msg, Box::new(callback)).await?;
+        self.subscribe(&msg, callback).await?;
         Ok(msg.msg_id)
     }
 

--- a/rust/perspective-client/src/rust/client.rs
+++ b/rust/perspective-client/src/rust/client.rs
@@ -171,6 +171,31 @@ impl Client {
         Ok(false)
     }
 
+    // pub async fn handle_error<T>(
+    //     &self,
+    //     message: Option<String>,
+    //     reconnect: Option<T>,
+    // ) -> ClientResult<()>
+    // where
+    //     T: AsyncFn() -> ClientResult<()> + Clone + Send + Sync + 'static,
+    // {
+    //     let subs = self.subscriptions_errors.read().await;
+    //     let tasks = join_all(subs.values().map(|callback| {
+    //         callback(
+    //             message.clone(),
+    //             reconnect.clone().map(move |f| {
+    //                 Arc::new(move || {
+    //                     clone!(f);
+    //                     Box::pin(async move { Ok(f().await?) }) as
+    // LocalBoxFuture<'static, _>                 }) as ReconnectCallback
+    //             }),
+    //         )
+    //     }));
+
+    //     tasks.await.into_iter().collect::<Result<(), _>>()?;
+    //     Ok(())
+    // }
+
     pub async fn handle_error<T, U>(
         &self,
         message: Option<String>,
@@ -178,7 +203,7 @@ impl Client {
     ) -> ClientResult<()>
     where
         T: Fn() -> U + Clone + Send + Sync + 'static,
-        U: Future<Output = Result<(), ClientError>>,
+        U: Future<Output = ClientResult<()>>,
     {
         let subs = self.subscriptions_errors.read().await;
         let tasks = join_all(subs.values().map(|callback| {

--- a/rust/perspective-client/src/rust/config/view_config.rs
+++ b/rust/perspective-client/src/rust/config/view_config.rs
@@ -32,7 +32,7 @@ pub struct ViewConfig {
     pub split_by: Vec<String>,
 
     #[serde(default)]
-    pub columns: Vec<Option<String>>,
+    pub sort: Vec<Sort>,
 
     #[serde(default)]
     pub filter: Vec<Filter>,
@@ -42,10 +42,10 @@ pub struct ViewConfig {
     pub filter_op: FilterReducer,
 
     #[serde(default)]
-    pub sort: Vec<Sort>,
+    pub expressions: Expressions,
 
     #[serde(default)]
-    pub expressions: Expressions,
+    pub columns: Vec<Option<String>>,
 
     #[serde(default)]
     pub aggregates: HashMap<String, Aggregate>,

--- a/rust/perspective-client/src/rust/utils/clone.rs
+++ b/rust/perspective-client/src/rust/utils/clone.rs
@@ -29,12 +29,26 @@ macro_rules! clone {
         let $i = $($orig)*.clone();
     };
 
+    (impl @bind $i:tt { $($orig:tt)* } { @mut }) => {
+        let mut $i = $($orig)*.clone();
+    };
+
     (impl @bind $i:tt { $($orig:tt)* } { $binder:tt }) => {
         let $binder = $($orig)*.clone();
     };
 
+    (impl @bind $i:tt { $($orig:tt)* } { @mut $binder:tt }) => {
+        let mut $binder = $($orig)*.clone();
+    };
+
+
     (impl @expand { $($orig:tt)* } { $($binder:tt)* } $i:tt) => {
         $crate::clone!(impl @bind $i { $($orig)* $i } { $($binder)* });
+    };
+
+
+    (impl @expand { $($orig:tt)* } { $($binder:tt)* } mut $i:tt) => {
+        $crate::clone!(impl @bind $i { $($orig)* $i } { @mut $($binder)* });
     };
 
     (impl @expand { $($orig:tt)* } { $($binder:tt)* } $i:tt ()) => {
@@ -55,6 +69,10 @@ macro_rules! clone {
 
     (impl @expand { $($orig:tt)* } { $($binder:tt)* } $i:tt . 3) => {
         $crate::clone!(impl @bind $i { $($orig)* $i . 3 } { $($binder)* });
+    };
+
+    (impl @expand { $($orig:tt)* } { $($binder:tt)* } mut $i:tt = $($tail:tt)+) => {
+        $crate::clone!(impl @expand { $($orig)* } { @mut $i } $($tail)+);
     };
 
     (impl @expand { $($orig:tt)* } { $($binder:tt)* } $i:tt = $($tail:tt)+) => {

--- a/rust/perspective-client/src/rust/view.rs
+++ b/rust/perspective-client/src/rust/view.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use futures::{Future, FutureExt};
+use futures::Future;
 use prost::bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
@@ -321,14 +321,13 @@ impl View {
                     resp => Err(ClientError::OptionResponseFailed(resp.into())),
                 }
             }
-            .boxed()
         };
 
         let msg = self.client_message(ClientReq::ViewOnUpdateReq(ViewOnUpdateReq {
             mode: options.mode.map(|OnUpdateMode::Row| Mode::Row as i32),
         }));
 
-        self.client.subscribe(&msg, Box::new(callback)).await?;
+        self.client.subscribe(&msg, callback).await?;
         Ok(msg.msg_id)
     }
 

--- a/rust/perspective-js/src/rust/utils/console_logger.rs
+++ b/rust/perspective-js/src/rust/utils/console_logger.rs
@@ -13,11 +13,11 @@
 use std::fmt::{Debug, Write};
 use std::sync::OnceLock;
 
-use tracing::field::{Field, Visit};
 use tracing::Subscriber;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::Layer;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::Layer;
 use wasm_bindgen::prelude::*;
 
 use crate::utils::*;
@@ -209,6 +209,14 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WasmLogger {
 pub fn set_global_logging() {
     static INIT_LOGGING: OnceLock<()> = OnceLock::new();
     INIT_LOGGING.get_or_init(|| {
+        if !*IS_CHROME.get_or_init(detect_chrome) {
+            web_sys::console::warn_1(
+                &"Unknown browser detected. Some features may not work, and performance may be \
+                  degraded."
+                    .into(),
+            );
+        }
+
         use tracing_subscriber::layer::SubscriberExt;
         let filter = tracing_subscriber::filter::filter_fn(|meta| {
             meta.module_path()

--- a/rust/perspective-js/src/rust/utils/futures.rs
+++ b/rust/perspective-js/src/rust/utils/futures.rs
@@ -20,7 +20,7 @@ use wasm_bindgen::__rt::IntoJsResult;
 use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi};
 use wasm_bindgen::describe::WasmDescribe;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::{future_to_promise, JsFuture};
+use wasm_bindgen_futures::{JsFuture, future_to_promise};
 
 use super::errors::*;
 
@@ -173,6 +173,7 @@ pub impl Result<JsValue, JsValue> {
 #[extend::ext]
 pub impl Result<JsValue, ApiError> {
     fn ignore_view_delete(self) -> Result<JsValue, ApiError> {
+        tracing::error!("B");
         self.or_else(|x| {
             let f: JsValue = x.clone().into();
             match f.dyn_ref::<PerspectiveViewNotFoundError>() {

--- a/rust/perspective-viewer/src/rust/components/export_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/export_dropdown.rs
@@ -53,37 +53,37 @@ pub enum ExportDropDownMenuMsg {
     TitleChange,
 }
 
-fn get_menu_items(name: &str, has_render: bool) -> Vec<ExportDropDownMenuItem> {
+fn get_menu_items(name: &str, is_chart: bool) -> Vec<ExportDropDownMenuItem> {
     vec![
         ExportDropDownMenuItem::OptGroup(
             "Current View".into(),
-            if has_render {
+            if is_chart {
                 vec![
-                    ExportMethod::Csv.new_file(name),
-                    ExportMethod::Json.new_file(name),
-                    ExportMethod::Ndjson.new_file(name),
-                    ExportMethod::Arrow.new_file(name),
-                    ExportMethod::Html.new_file(name),
-                    ExportMethod::Png.new_file(name),
+                    ExportMethod::Csv.new_file(name, is_chart),
+                    ExportMethod::Json.new_file(name, is_chart),
+                    ExportMethod::Ndjson.new_file(name, is_chart),
+                    ExportMethod::Arrow.new_file(name, is_chart),
+                    ExportMethod::Html.new_file(name, is_chart),
+                    ExportMethod::Plugin.new_file(name, is_chart),
                 ]
             } else {
                 vec![
-                    ExportMethod::Csv.new_file(name),
-                    ExportMethod::Json.new_file(name),
-                    ExportMethod::Ndjson.new_file(name),
-                    ExportMethod::Arrow.new_file(name),
-                    ExportMethod::Html.new_file(name),
+                    ExportMethod::Csv.new_file(name, is_chart),
+                    ExportMethod::Json.new_file(name, is_chart),
+                    ExportMethod::Ndjson.new_file(name, is_chart),
+                    ExportMethod::Arrow.new_file(name, is_chart),
+                    ExportMethod::Html.new_file(name, is_chart),
                 ]
             },
         ),
         ExportDropDownMenuItem::OptGroup("All".into(), vec![
-            ExportMethod::CsvAll.new_file(name),
-            ExportMethod::JsonAll.new_file(name),
-            ExportMethod::NdjsonAll.new_file(name),
-            ExportMethod::ArrowAll.new_file(name),
+            ExportMethod::CsvAll.new_file(name, is_chart),
+            ExportMethod::JsonAll.new_file(name, is_chart),
+            ExportMethod::NdjsonAll.new_file(name, is_chart),
+            ExportMethod::ArrowAll.new_file(name, is_chart),
         ]),
         ExportDropDownMenuItem::OptGroup("Config".into(), vec![
-            ExportMethod::JsonConfig.new_file(name),
+            ExportMethod::JsonConfig.new_file(name, is_chart),
         ]),
     ]
 }
@@ -95,7 +95,9 @@ impl Component for ExportDropDownMenu {
     fn view(&self, ctx: &Context<Self>) -> yew::virtual_dom::VNode {
         let callback = ctx.link().callback(|_| ExportDropDownMenuMsg::TitleChange);
         let plugin = ctx.props().renderer.get_active_plugin().unwrap();
-        let has_render = js_sys::Reflect::has(&plugin, js_intern::js_intern!("render")).unwrap();
+        // let has_render = js_sys::Reflect::has(&plugin,
+        // js_intern::js_intern!("render")).unwrap();
+        let is_chart = plugin.name().as_str() != "Datagrid";
         html! {
             <StyleProvider>
                 <span class="dropdown-group-label">{ "Save as" }</span>
@@ -106,7 +108,7 @@ impl Component for ExportDropDownMenu {
                     value={self.title.to_owned()}
                 />
                 <DropDownMenu<ExportFile>
-                    values={Rc::new(get_menu_items(&self.title, has_render))}
+                    values={Rc::new(get_menu_items(&self.title, is_chart))}
                     callback={&ctx.props().callback}
                 />
             </StyleProvider>

--- a/rust/perspective-viewer/src/rust/components/viewer.rs
+++ b/rust/perspective-viewer/src/rust/components/viewer.rs
@@ -324,7 +324,10 @@ impl Component for PerspectiveViewer {
                 if matches!(self.fonts.get_status(), FontLoaderStatus::Finished) =>
             {
                 self.selected_column = None;
-                resolve.send(()).expect("Orphan render");
+                if let Err(e) = resolve.send(()) {
+                    tracing::error!("toggle settings failed {:?}", e);
+                }
+
                 false
             },
             PerspectiveViewerMsg::ToggleSettingsComplete(_, resolve) => {
@@ -414,12 +417,9 @@ impl Component for PerspectiveViewer {
 
         if self.on_rendered.is_some()
             && matches!(self.fonts.get_status(), FontLoaderStatus::Finished)
+            && self.on_rendered.take().unwrap().send(()).is_err()
         {
-            self.on_rendered
-                .take()
-                .unwrap()
-                .send(())
-                .expect("Orphan render");
+            tracing::warn!("Orphan render");
         }
     }
 

--- a/rust/perspective-viewer/src/rust/custom_elements/copy_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/copy_dropdown.rs
@@ -84,12 +84,13 @@ impl CopyDropDownMenuElement {
         let callback = Callback::from({
             let model = model.cloned();
             let modal_rc = self.modal.clone();
-            move |x: ExportMethod| {
-                let js_task = model.export_method_to_jsvalue(x);
-                let copy_task = copy_to_clipboard(js_task, x.mimetype());
+            move |x: ExportFile| {
+                let model = model.clone();
                 let modal = modal_rc.borrow().clone().unwrap();
                 spawn_local(async move {
-                    let result = copy_task.await;
+                    let mime = x.method.mimetype(x.is_chart);
+                    let task = model.export_method_to_jsvalue(x.method);
+                    let result = copy_to_clipboard(task, mime).await;
                     crate::js_log_maybe!({
                         result?;
                         modal.hide()?;

--- a/rust/perspective-viewer/src/rust/custom_elements/export_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/export_dropdown.rs
@@ -89,7 +89,8 @@ impl ExportDropDownMenuElement {
                     clone!(modal_rc, model);
                     spawn_local(async move {
                         let val = model.export_method_to_jsvalue(x.method).await.unwrap();
-                        download(&x.as_filename(), &val).unwrap();
+                        let is_chart = model.renderer().is_chart();
+                        download(&x.as_filename(is_chart), &val).unwrap();
                         modal_rc.borrow().clone().unwrap().hide().unwrap();
                     })
                 }

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -19,6 +19,7 @@
 #![feature(macro_metavar_expr)]
 #![feature(iter_intersperse)]
 #![feature(stmt_expr_attributes)]
+#![allow(async_fn_in_trait)]
 #![warn(
     clippy::all,
     clippy::panic_in_result_fn,

--- a/rust/perspective-viewer/src/rust/model/export_method.rs
+++ b/rust/perspective-viewer/src/rust/model/export_method.rs
@@ -12,38 +12,82 @@
 
 use std::rc::Rc;
 
+use serde::Deserialize;
 use yew::prelude::*;
 
 use crate::js::*;
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Deserialize)]
 pub enum ExportMethod {
+    #[serde(rename = "csv")]
     Csv,
+
+    #[serde(rename = "csv-all")]
     CsvAll,
+
+    #[serde(rename = "csv-selected")]
     CsvSelected,
+
+    #[serde(rename = "json")]
     Json,
+
+    #[serde(rename = "json-all")]
     JsonAll,
+
+    #[serde(rename = "json-selected")]
     JsonSelected,
+
+    // #[serde(rename = "columns")]
+    // JsonColumns,
+
+    // #[serde(rename = "columns-all")]
+    // JsonColumnsAll,
+
+    // #[serde(rename = "columns-selected")]
+    // JsonColumnsSelected,
+    #[serde(rename = "ndjson")]
     Ndjson,
+
+    #[serde(rename = "ndjson-all")]
     NdjsonAll,
+
+    #[serde(rename = "ndjson-selected")]
     NdjsonSelected,
+
+    #[serde(rename = "html")]
     Html,
-    Png,
+
+    #[serde(rename = "plugin")]
+    Plugin,
+
+    #[serde(rename = "arrow")]
     Arrow,
+
+    #[serde(rename = "arrow-selected")]
     ArrowSelected,
+
+    #[serde(rename = "arrow-all")]
     ArrowAll,
+
+    #[serde(rename = "json-config")]
     JsonConfig,
 }
 
 impl ExportMethod {
-    pub const fn as_filename(&self) -> &'static str {
+    pub const fn as_filename(&self, is_chart: bool) -> &'static str {
         match self {
             Self::Csv => ".csv",
             Self::CsvAll => ".all.csv",
             Self::Json => ".json",
             Self::JsonAll => ".all.json",
             Self::Html => ".html",
-            Self::Png => ".png",
+            Self::Plugin => {
+                if is_chart {
+                    ".png"
+                } else {
+                    ".txt"
+                }
+            },
             Self::Arrow => ".arrow",
             Self::ArrowAll => ".all.arrow",
             Self::JsonConfig => ".config.json",
@@ -53,28 +97,30 @@ impl ExportMethod {
             Self::Ndjson => ".ndjson",
             Self::NdjsonAll => ".all.ndjson",
             Self::NdjsonSelected => ".selected.ndjson",
+            // Self::JsonColumns => ".columns.json",
+            // Self::JsonColumnsAll => ".all.columns.json",
+            // Self::JsonColumnsSelected => ".selected.columns.json",
         }
     }
 
-    pub const fn mimetype(&self) -> MimeType {
+    pub const fn mimetype(&self, is_chart: bool) -> MimeType {
         match self {
-            Self::Png => MimeType::ImagePng,
+            Self::Plugin if is_chart => MimeType::ImagePng,
             _ => MimeType::TextPlain,
         }
     }
-}
 
-impl From<ExportMethod> for Html {
-    fn from(x: ExportMethod) -> Self {
-        html! { <code>{ x.as_filename() }</code> }
+    pub fn to_html(&self, is_chart: bool) -> Html {
+        html! { <code>{ self.as_filename(is_chart) }</code> }
     }
 }
 
 impl ExportMethod {
-    pub fn new_file(&self, x: &str) -> ExportFile {
+    pub fn new_file(&self, x: &str, is_chart: bool) -> ExportFile {
         ExportFile {
             name: Rc::new(x.to_owned()),
             method: *self,
+            is_chart,
         }
     }
 }
@@ -83,11 +129,12 @@ impl ExportMethod {
 pub struct ExportFile {
     pub name: Rc<String>,
     pub method: ExportMethod,
+    pub is_chart: bool,
 }
 
 impl ExportFile {
-    pub fn as_filename(&self) -> String {
-        format!("{}{}", self.name, self.method.as_filename())
+    pub fn as_filename(&self, is_chart: bool) -> String {
+        format!("{}{}", self.name, self.method.as_filename(is_chart))
     }
 }
 
@@ -99,6 +146,6 @@ impl From<ExportFile> for Html {
             None
         };
 
-        html! { <code {class}>{ x.name }{ x.method.as_filename() }</code> }
+        html! { <code {class}>{ x.name }{ x.method.as_filename(x.is_chart) }</code> }
     }
 }

--- a/rust/perspective-viewer/src/rust/renderer.rs
+++ b/rust/perspective-viewer/src/rust/renderer.rs
@@ -141,6 +141,11 @@ impl Renderer {
         Ref::map(self.borrow(), |x| &x.metadata)
     }
 
+    pub fn is_chart(&self) -> bool {
+        let plugin = self.get_active_plugin().unwrap();
+        plugin.name().as_str() != "Datagrid"
+    }
+
     /// Return all plugin instances, whether they are active or not.  Useful
     /// for configuring all or specific plugins at application init.
     pub fn get_all_plugins(&self) -> Vec<JsPerspectiveViewerPlugin> {

--- a/rust/perspective-viewer/src/rust/session.rs
+++ b/rust/perspective-viewer/src/rust/session.rs
@@ -168,10 +168,10 @@ impl Session {
                 let _callback_id = client
                     .on_error(Box::new(move |message, reconnect| {
                         let poll_loop = poll_loop.clone();
-                        Box::pin(async move {
+                        async move {
                             poll_loop.poll((message, reconnect)).await;
                             Ok(())
-                        })
+                        }
                     }))
                     .await?;
 
@@ -366,7 +366,7 @@ impl Session {
     }
 
     pub async fn arrow_as_jsvalue(
-        self,
+        &self,
         flat: bool,
         window: Option<ViewWindow>,
     ) -> Result<js_sys::ArrayBuffer, ApiError> {
@@ -381,7 +381,7 @@ impl Session {
     }
 
     pub async fn ndjson_as_jsvalue(
-        self,
+        &self,
         flat: bool,
         window: Option<ViewWindow>,
     ) -> Result<js_sys::JsString, ApiError> {
@@ -395,7 +395,7 @@ impl Session {
     }
 
     pub async fn json_as_jsvalue(
-        self,
+        &self,
         flat: bool,
         window: Option<ViewWindow>,
     ) -> Result<js_sys::Object, ApiError> {


### PR DESCRIPTION
Thsi PR adds a export support for `perspective-viewer-datagrid`, which allows the datagrid contents to be serialized to clipboard or download in the HTML rendered format provided by the plugin itself (rather than the engine). This method was already implemented for charts (which export png).

Additionally, the signature of the `PerspectiveViewer::copy` has been changed to accept a `String` as an argument, signifying the desired export method (previous `bool` to choose between `"csv"` and `"csv-all"` methods).