### PR TITLE
Fix support for browsers lacking the `SharedWorker` API

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -213,6 +213,7 @@ jobs:
 
         steps:
             - name: Free up disk space
+              if: ${{ runner.os == 'Linux' }}
               run: |
                   rm -rf /__t/*
 

--- a/rust/perspective-js/src/rust/utils/console_logger.rs
+++ b/rust/perspective-js/src/rust/utils/console_logger.rs
@@ -90,7 +90,11 @@ impl tracing::Level {
 static IS_CHROME: OnceLock<bool> = OnceLock::new();
 
 fn detect_chrome() -> bool {
-    web_sys::window().and_then(|w| w.get("chrome")).is_some()
+    if let Some(window) = web_sys::window() {
+        window.get("chrome").is_some()
+    } else {
+        true
+    }
 }
 
 #[extend::ext]
@@ -124,7 +128,7 @@ struct WasmLogger {
 impl Default for WasmLogger {
     fn default() -> Self {
         Self {
-            max_level: tracing::Level::TRACE,
+            max_level: tracing::Level::WARN,
         }
     }
 }

--- a/rust/perspective-js/src/ts/wasm/browser.ts
+++ b/rust/perspective-js/src/ts/wasm/browser.ts
@@ -71,9 +71,13 @@ export async function worker(
 
     const { Client } = await module;
     let port: MessagePort;
-    if (webworker instanceof SharedWorker) {
+    if (
+        typeof SharedWorker !== "undefined" &&
+        webworker instanceof SharedWorker
+    ) {
         port = webworker.port;
     } else {
+        webworker = webworker as ServiceWorker | Worker | MessagePort;
         const messageChannel = new MessageChannel();
         webworker.postMessage(null, [messageChannel.port2]);
         port = messageChannel.port1;

--- a/tools/perspective-bench/cross_platform_suite.mjs
+++ b/tools/perspective-bench/cross_platform_suite.mjs
@@ -198,7 +198,7 @@ export async function table_suite(perspective, metadata) {
         }
     }
 
-    if (!check_version_gte(metadata.version, "2.3.0")) {
+    if (check_version_gte(metadata.version, "2.3.0")) {
         await benchmark({
             name: `.table(arrow, {limit: 1000})`,
             before_all,
@@ -228,15 +228,16 @@ export async function table_suite(perspective, metadata) {
         },
     });
 
-
-    if (!check_version_gte(metadata.version, "3.0.0")) {
+    if (check_version_gte(metadata.version, "3.0.0")) {
         await benchmark({
             name: `table.update(arrow)`,
             before_all,
             metadata,
             async before({ arrow }) {
-                let table2 = await perspective.table(arrow.slice(), { limit: 1000 });
-                return table2
+                let table2 = await perspective.table(arrow.slice(), {
+                    limit: 1000,
+                });
+                return table2;
             },
             async after(_, table) {
                 if (!check_version_gte(metadata.version, "3.4.3")) {


### PR DESCRIPTION
#2936 added support for `SharedWorker` and `ServiceWorker`, in theory without introducing any dependence on these APIs (as for these runtime modes, the worker is constructed externally and passed in as an argument). However, in practice a single `instanceof` check within this initialization is a runtime "Missing Symbol" error in _some_ browsers which lack this API entirely. This PR fixes this issue and adds a test which deletes the `ServiceWorker` and `SharedWorker` symbols from Chrome before initializing the engine.

It should be noted that Perspective _only supports the browsers we run CI tests for_, which it currently only Desktop Chrome and Node.js. As a general rule, we also don't accept PRs for fixes to unsupported browsers as they are virtually impossible to maintain beyond a few versions. This issue was reported on Android Chrome, which unfortunately we cannot support directly for OSS Perspective, but due to the perspicuity of the bug I've made an exception for this case. 