### PR TITLE
Fix `limit` overflow bug

### DIFF
--- a/cpp/perspective/src/cpp/arrow_loader.cpp
+++ b/cpp/perspective/src/cpp/arrow_loader.cpp
@@ -236,7 +236,6 @@ ArrowLoader::fill_table(
     const t_schema& input_schema,
     const std::string& index,
     std::uint32_t offset,
-    std::uint32_t limit,
     bool is_update
 ) {
     bool implicit_index = false;
@@ -280,8 +279,8 @@ ArrowLoader::fill_table(
             auto* okey_col = tbl.add_column("psp_okey", DTYPE_INT32, true);
 
             for (std::uint32_t ridx = 0; ridx < tbl.size(); ++ridx) {
-                key_col->set_nth<std::uint32_t>(ridx, (ridx + offset) % limit);
-                okey_col->set_nth<std::uint32_t>(ridx, (ridx + offset) % limit);
+                key_col->set_nth<std::uint32_t>(ridx, (ridx + offset));
+                okey_col->set_nth<std::uint32_t>(ridx, (ridx + offset));
             }
         } else {
             if (!input_schema.has_column(index)) {

--- a/cpp/perspective/src/cpp/base.cpp
+++ b/cpp/perspective/src/cpp/base.cpp
@@ -799,19 +799,6 @@ type_to_dtype<void*>() {
     return DTYPE_OBJECT;
 }
 
-std::ostream&
-operator<<(std::ostream& os, const t_op& op) {
-#define X(NAME)                                                                \
-    case NAME:                                                                 \
-        os << #NAME;                                                           \
-        break;
-
-    switch (op) { FOREACH_T_OP(X) }
-#undef X
-
-    return os;
-}
-
 } // end namespace perspective
 
 namespace std {

--- a/cpp/perspective/src/cpp/binding_api.cpp
+++ b/cpp/perspective/src/cpp/binding_api.cpp
@@ -96,8 +96,8 @@ psp_handle_request(
 
 PERSPECTIVE_EXPORT
 EncodedApiEntries*
-psp_poll(ProtoServer* server) {
-    auto responses = server->poll();
+psp_poll(ProtoServer* server, std::uint32_t client_id) {
+    auto responses = server->poll(client_id);
     return encode_api_responses(responses);
 }
 

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -10,8 +10,6 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-#include "perspective/base.h"
-#include "perspective/raw_types.h"
 #include <perspective/first.h>
 #include <perspective/context_base.h>
 #include <perspective/get_data_extents.h>
@@ -103,7 +101,6 @@ t_ctx0::notify(
         flattened.get_const_column("psp_pkey");
     std::shared_ptr<const t_column> op_sptr =
         flattened.get_const_column("psp_op");
-    auto old_pkey_col = flattened.get_column("psp_old_pkey");
     const t_column* pkey_col = pkey_sptr.get();
     const t_column* op_col = op_sptr.get();
 
@@ -176,20 +173,11 @@ t_ctx0::notify(
             m_symtable.get_interned_tscalar(pkey_col->get_scalar(idx));
         std::uint8_t op_ = *(op_col->get_nth<std::uint8_t>(idx));
         t_op op = static_cast<t_op>(op_);
-        const auto existed = *(existed_col->get_nth<bool>(idx));
-        const auto old_pkey = old_pkey_col->get_scalar(idx);
+        bool existed = *(existed_col->get_nth<bool>(idx));
 
         switch (op) {
             case OP_INSERT: {
-                if (old_pkey.is_valid()) {
-                    m_traversal->move_row(
-                        *m_gstate,
-                        *(m_expression_tables->m_master),
-                        m_config,
-                        old_pkey,
-                        pkey
-                    );
-                } else if (existed) {
+                if (existed) {
                     m_traversal->update_row(
                         *m_gstate,
                         *(m_expression_tables->m_master),

--- a/cpp/perspective/src/cpp/data_table.cpp
+++ b/cpp/perspective/src/cpp/data_table.cpp
@@ -23,12 +23,6 @@
 #include <sstream>
 #include <utility>
 namespace perspective {
-std::ostream&
-operator<<(std::ostream& os, const t_flatten_record& fr) {
-    os << "store_idx: " << fr.m_store_idx << ", bidx: " << fr.m_begin_idx
-       << ", eidx: " << fr.m_edge_idx;
-    return os;
-}
 
 void
 t_data_table::set_capacity(t_uindex idx) {
@@ -325,7 +319,7 @@ t_data_table::get_schema() const {
 }
 
 std::shared_ptr<t_data_table>
-t_data_table::flatten(t_uindex limit) const {
+t_data_table::flatten() const {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     PSP_VERBOSE_ASSERT(is_pkey_table(), "Not a pkeyed table");
@@ -333,7 +327,7 @@ t_data_table::flatten(t_uindex limit) const {
         "", "", m_schema, DEFAULT_EMPTY_CAPACITY, BACKING_STORE_MEMORY
     );
     flattened->init();
-    flatten_body<std::shared_ptr<t_data_table>>(flattened, limit);
+    flatten_body<std::shared_ptr<t_data_table>>(flattened);
     return flattened;
 }
 
@@ -641,13 +635,6 @@ t_data_table::join(const std::shared_ptr<t_data_table>& other_table) const {
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
 
     if (size() != other_table->size()) {
-#if PSP_DEBUG
-        LOG_DEBUG("Joining current table:");
-        pprint();
-        LOG_DEBUG("on this this table:");
-        other_table->pprint();
-#endif
-
         std::stringstream ss;
         ss << "[t_data_table::join] Cannot join two tables of unequal sizes! "
               "Current size: "

--- a/cpp/perspective/src/cpp/flat_traversal.cpp
+++ b/cpp/perspective/src/cpp/flat_traversal.cpp
@@ -388,28 +388,6 @@ t_ftrav::delete_row(t_tscalar pkey) {
     ++m_step_deletes;
 }
 
-void
-t_ftrav::move_row(
-    const t_gstate& gstate,
-    const t_data_table& expression_master_table,
-    const t_config& config,
-    t_tscalar old_pkey,
-    t_tscalar new_pkey
-) {
-    auto old_pkiter = m_pkeyidx.find(old_pkey);
-    bool old_pkey_existed = old_pkiter != m_pkeyidx.end();
-    if (!old_pkey_existed) {
-        LOG_DEBUG("Tried to move pkey that doesn't exist: " << old_pkey);
-        return;
-    }
-    LOG_DEBUG("Moving pkey from: " << old_pkey << " to: " << new_pkey);
-
-    (*m_index)[old_pkiter->second].m_deleted = true;
-    t_mselem mselem;
-    fill_sort_elem(gstate, expression_master_table, config, new_pkey, mselem);
-    m_new_elems[new_pkey] = mselem;
-}
-
 std::vector<t_sortspec>
 t_ftrav::get_sort_by() const {
     return m_sortby;

--- a/cpp/perspective/src/cpp/gnode.cpp
+++ b/cpp/perspective/src/cpp/gnode.cpp
@@ -1202,10 +1202,10 @@ t_gnode::_compute_expressions(
                     expression_regex_mapping
                 );
                 ctx->get_expression_tables()->set_flattened(
-                    m_gstate->get_pkeyed_table(
-                        ctx->get_expression_tables()->m_master->get_schema(),
-                        ctx->get_expression_tables()->m_master
-                    )
+                    // m_gstate->get_pkeyed_table(
+                    //     ctx->get_expression_tables()->m_master->get_schema(),
+                    ctx->get_expression_tables()->m_master
+                    // )
                 );
             } break;
             case ONE_SIDED_CONTEXT: {
@@ -1217,10 +1217,10 @@ t_gnode::_compute_expressions(
                     expression_regex_mapping
                 );
                 ctx->get_expression_tables()->set_flattened(
-                    m_gstate->get_pkeyed_table(
-                        ctx->get_expression_tables()->m_master->get_schema(),
-                        ctx->get_expression_tables()->m_master
-                    )
+                    // m_gstate->get_pkeyed_table(
+                    //     ctx->get_expression_tables()->m_master->get_schema(),
+                    ctx->get_expression_tables()->m_master
+                    // )
                 );
             } break;
             case ZERO_SIDED_CONTEXT: {
@@ -1232,10 +1232,10 @@ t_gnode::_compute_expressions(
                     expression_regex_mapping
                 );
                 ctx->get_expression_tables()->set_flattened(
-                    m_gstate->get_pkeyed_table(
-                        ctx->get_expression_tables()->m_master->get_schema(),
-                        ctx->get_expression_tables()->m_master
-                    )
+                    // m_gstate->get_pkeyed_table(
+                    //     ctx->get_expression_tables()->m_master->get_schema(),
+                    ctx->get_expression_tables()->m_master
+                    // )
                 );
             } break;
             case GROUPED_PKEY_CONTEXT: {
@@ -1247,10 +1247,10 @@ t_gnode::_compute_expressions(
                     expression_regex_mapping
                 );
                 ctx->get_expression_tables()->set_flattened(
-                    m_gstate->get_pkeyed_table(
-                        ctx->get_expression_tables()->m_master->get_schema(),
-                        ctx->get_expression_tables()->m_master
-                    )
+                    // m_gstate->get_pkeyed_table(
+                    //     ctx->get_expression_tables()->m_master->get_schema(),
+                    ctx->get_expression_tables()->m_master
+                    // )
                 );
             } break;
             case UNIT_CONTEXT:

--- a/cpp/perspective/src/cpp/server.cpp
+++ b/cpp/perspective/src/cpp/server.cpp
@@ -2141,11 +2141,11 @@ ProtoServer::_handle_request(std::uint32_t client_id, Request&& req) {
                             auto tm = scalar.get<t_date>();
                             std::stringstream ss;
                             ss << std::setfill('0') << std::setw(4) << tm.year()
+                               << "-" << std::setfill('0') << std::setw(2)
+                               // Increment month by 1, as date::month is [1-12] but
+                               // t_date::month() is [0-11]
+                               << tm.month() + 1
                                << "-" << std::setfill('0')
-                               << std::setw(2)
-                               // Increment month by 1, as date::month is [1-12]
-                               // but t_date::month() is [0-11]
-                               << tm.month() + 1 << "-" << std::setfill('0')
                                << std::setw(2) << tm.day();
                             s->set_string(ss.str());
                             break;

--- a/cpp/perspective/src/cpp/server.cpp
+++ b/cpp/perspective/src/cpp/server.cpp
@@ -799,13 +799,52 @@ ProtoServer::handle_request(
 }
 
 std::vector<ProtoServerResp<std::string>>
-ProtoServer::poll() {
+ProtoServer::poll(std::uint32_t client_id) {
     std::vector<ProtoServerResp<std::string>> out;
-    for (auto& resp : _poll()) {
+    try {
+        const auto& responses = _poll();
+        for (const auto& resp : responses) {
+            ProtoServerResp<std::string> str_resp;
+            str_resp.data = resp.data.SerializeAsString();
+            str_resp.client_id = resp.client_id;
+            out.emplace_back(str_resp);
+        }
+
+    } catch (const PerspectiveException& e) {
+        proto::Response resp;
+        auto* err = resp.mutable_server_error()->mutable_message();
+        *err = std::string(e.what());
         ProtoServerResp<std::string> str_resp;
-        str_resp.data = resp.data.SerializeAsString();
-        str_resp.client_id = resp.client_id;
-        out.emplace_back(str_resp);
+        str_resp.data = resp.SerializeAsString();
+        str_resp.client_id = client_id;
+        out.emplace_back(std::move(str_resp));
+    } catch (const PerspectiveViewNotFoundException& e) {
+        proto::Response resp;
+        auto* err = resp.mutable_server_error();
+        err->set_status_code(proto::StatusCode::VIEW_NOT_FOUND);
+        auto* msg = err->mutable_message();
+        *msg = std::string(e.what());
+        ProtoServerResp<std::string> str_resp;
+        str_resp.data = resp.SerializeAsString();
+        str_resp.client_id = client_id;
+        out.emplace_back(std::move(str_resp));
+    } catch (const std::exception& e) {
+        proto::Response resp;
+        auto* err = resp.mutable_server_error()->mutable_message();
+        *err = std::string(e.what());
+        ProtoServerResp<std::string> str_resp;
+        str_resp.data = resp.SerializeAsString();
+        str_resp.client_id = client_id;
+        out.emplace_back(std::move(str_resp));
+    } catch (...) {
+        proto::Response resp;
+        auto* err = resp.mutable_server_error()->mutable_message();
+        std::exception_ptr p = std::current_exception();
+        *err = "Unknown exception";
+        ProtoServerResp<std::string> str_resp;
+        str_resp.data = resp.SerializeAsString();
+        str_resp.client_id = client_id;
+        out.emplace_back(std::move(str_resp));
     }
 
     return out;
@@ -2141,11 +2180,11 @@ ProtoServer::_handle_request(std::uint32_t client_id, Request&& req) {
                             auto tm = scalar.get<t_date>();
                             std::stringstream ss;
                             ss << std::setfill('0') << std::setw(4) << tm.year()
-                               << "-" << std::setfill('0') << std::setw(2)
-                               // Increment month by 1, as date::month is [1-12] but
-                               // t_date::month() is [0-11]
-                               << tm.month() + 1
                                << "-" << std::setfill('0')
+                               << std::setw(2)
+                               // Increment month by 1, as date::month is [1-12]
+                               // but t_date::month() is [0-11]
+                               << tm.month() + 1 << "-" << std::setfill('0')
                                << std::setw(2) << tm.day();
                             s->set_string(ss.str());
                             break;

--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -182,7 +182,7 @@ Table::validate_expressions(
 std::shared_ptr<t_gnode>
 Table::make_gnode(const t_schema& in_schema) {
     t_schema out_schema = in_schema.drop({"psp_pkey", "psp_op"});
-    auto gnode = std::make_shared<t_gnode>(in_schema, out_schema, m_limit);
+    auto gnode = std::make_shared<t_gnode>(in_schema, out_schema);
     gnode->init();
     return gnode;
 }
@@ -226,7 +226,7 @@ Table::remove_port(t_uindex port_id) const {
 
 void
 Table::calculate_offset(std::uint32_t row_count) {
-    m_offset = m_offset + row_count;
+    m_offset = (m_offset + row_count) % m_limit;
 }
 
 t_uindex
@@ -948,7 +948,7 @@ Table::update_cols(const std::string_view& data, std::uint32_t port_id) {
 
     if (is_implicit && !document.GetObj().HasMember("__INDEX__")) {
         for (std::uint32_t ii = 0; ii < nrows; ii++) {
-            psp_pkey_col->set_nth<std::uint32_t>(ii, m_offset + ii);
+            psp_pkey_col->set_nth<std::uint32_t>(ii, (m_offset + ii) % m_limit);
         }
     }
 
@@ -1088,8 +1088,8 @@ Table::from_cols(
 
     if (is_implicit) {
         for (t_uindex ii = 0; ii < nrows; ii++) {
-            psp_pkey_col->set_nth<std::int32_t>(ii, ii);
-            psp_okey_col->set_nth<std::int32_t>(ii, ii);
+            psp_pkey_col->set_nth<std::int32_t>(ii, ii % limit);
+            psp_okey_col->set_nth<std::int32_t>(ii, ii % limit);
         }
     }
 
@@ -1158,7 +1158,7 @@ Table::update_rows(const std::string_view& data, std::uint32_t port_id) {
     // 3.) Fill table
     for (const auto& row : document.GetArray()) {
         if (is_implicit) {
-            psp_pkey_col->set_nth<std::uint32_t>(ii, ii + m_offset);
+            psp_pkey_col->set_nth<std::uint32_t>(ii, (ii + m_offset) % m_limit);
         }
 
         // col_count = m_column_names.size();
@@ -1336,8 +1336,8 @@ Table::from_rows(
         }
 
         if (is_implicit) {
-            psp_pkey_col->set_nth<std::int32_t>(ii, ii);
-            psp_okey_col->set_nth<std::int32_t>(ii, ii);
+            psp_pkey_col->set_nth<std::int32_t>(ii, ii % limit);
+            psp_okey_col->set_nth<std::int32_t>(ii, ii % limit);
         }
 
         ii++;
@@ -1408,7 +1408,7 @@ Table::update_ndjson(const std::string_view& data, std::uint32_t port_id) {
     bool is_finished = false;
     while (!is_finished) {
         if (is_implicit) {
-            psp_pkey_col->set_nth<std::uint32_t>(ii, ii + m_offset);
+            psp_pkey_col->set_nth<std::uint32_t>(ii, (ii + m_offset) % m_limit);
         }
 
         for (const auto& it : document.GetObj()) {
@@ -1588,8 +1588,8 @@ Table::from_ndjson(
         }
 
         if (is_implicit) {
-            psp_pkey_col->set_nth<std::int32_t>(ii, ii);
-            psp_okey_col->set_nth<std::int32_t>(ii, ii);
+            psp_pkey_col->set_nth<std::int32_t>(ii, ii % limit);
+            psp_okey_col->set_nth<std::int32_t>(ii, ii % limit);
         }
 
         ii++;

--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -226,7 +226,7 @@ Table::remove_port(t_uindex port_id) const {
 
 void
 Table::calculate_offset(std::uint32_t row_count) {
-    m_offset = (m_offset + row_count) % m_limit;
+    m_offset = m_offset + row_count;
 }
 
 t_uindex
@@ -350,9 +350,7 @@ Table::update_csv(const std::string_view& data, std::uint32_t port_id) {
     t_data_table data_table(get_schema());
     data_table.init();
     data_table.extend(row_count);
-    arrow_loader.fill_table(
-        data_table, get_schema(), m_index, m_offset, m_limit, true
-    );
+    arrow_loader.fill_table(data_table, get_schema(), m_index, m_offset, true);
     process_op_column(data_table, t_op::OP_INSERT);
     calculate_offset(row_count);
     m_pool->send(get_gnode()->get_id(), port_id, data_table);
@@ -395,7 +393,7 @@ Table::from_csv(
         auto _ = std::move(data);
         auto loader = std::move(arrow_loader);
         data_table->extend(row_count);
-        loader.fill_table(*data_table, input_schema, index, 0, limit, false);
+        loader.fill_table(*data_table, input_schema, index, 0, false);
     }
     auto pool = std::make_shared<t_pool>();
     pool->init();
@@ -948,7 +946,7 @@ Table::update_cols(const std::string_view& data, std::uint32_t port_id) {
 
     if (is_implicit && !document.GetObj().HasMember("__INDEX__")) {
         for (std::uint32_t ii = 0; ii < nrows; ii++) {
-            psp_pkey_col->set_nth<std::uint32_t>(ii, (m_offset + ii) % m_limit);
+            psp_pkey_col->set_nth<std::uint32_t>(ii, (m_offset + ii));
         }
     }
 
@@ -1088,8 +1086,8 @@ Table::from_cols(
 
     if (is_implicit) {
         for (t_uindex ii = 0; ii < nrows; ii++) {
-            psp_pkey_col->set_nth<std::int32_t>(ii, ii % limit);
-            psp_okey_col->set_nth<std::int32_t>(ii, ii % limit);
+            psp_pkey_col->set_nth<std::int32_t>(ii, ii);
+            psp_okey_col->set_nth<std::int32_t>(ii, ii);
         }
     }
 
@@ -1158,7 +1156,7 @@ Table::update_rows(const std::string_view& data, std::uint32_t port_id) {
     // 3.) Fill table
     for (const auto& row : document.GetArray()) {
         if (is_implicit) {
-            psp_pkey_col->set_nth<std::uint32_t>(ii, (ii + m_offset) % m_limit);
+            psp_pkey_col->set_nth<std::uint32_t>(ii, (ii + m_offset));
         }
 
         // col_count = m_column_names.size();
@@ -1199,23 +1197,7 @@ Table::update_rows(const std::string_view& data, std::uint32_t port_id) {
             }
         }
 
-        // // Check if this row "overflows", wrapping around due to a `m_limit`
-        // // value, as partial updates are not allowed in this case.
-        // if (!supports_partial && col_count != 0) {
-        //     std::cout << col_count << std::endl;
-        //     PSP_COMPLAIN_AND_ABORT(
-        //         "Inconsistent row count in update - `Table` partial updates "
-        //         "require an `index`"
-        //     );
-        // }
-
         is_first_row = false;
-        if (ii + m_offset >= m_limit) {
-            for (auto& col_name : missing_columns) {
-                data_table.get_column(col_name)->unset(ii);
-            }
-        }
-
         ii++;
     }
 
@@ -1336,8 +1318,8 @@ Table::from_rows(
         }
 
         if (is_implicit) {
-            psp_pkey_col->set_nth<std::int32_t>(ii, ii % limit);
-            psp_okey_col->set_nth<std::int32_t>(ii, ii % limit);
+            psp_pkey_col->set_nth<std::int32_t>(ii, ii);
+            psp_okey_col->set_nth<std::int32_t>(ii, ii);
         }
 
         ii++;
@@ -1408,7 +1390,7 @@ Table::update_ndjson(const std::string_view& data, std::uint32_t port_id) {
     bool is_finished = false;
     while (!is_finished) {
         if (is_implicit) {
-            psp_pkey_col->set_nth<std::uint32_t>(ii, (ii + m_offset) % m_limit);
+            psp_pkey_col->set_nth<std::uint32_t>(ii, (ii + m_offset));
         }
 
         for (const auto& it : document.GetObj()) {
@@ -1449,11 +1431,6 @@ Table::update_ndjson(const std::string_view& data, std::uint32_t port_id) {
         }
 
         is_first_row = false;
-        if (ii + m_offset >= m_limit) {
-            for (auto& col_name : missing_columns) {
-                data_table.get_column(col_name)->unset(ii);
-            }
-        }
 
         ii++;
 
@@ -1588,8 +1565,8 @@ Table::from_ndjson(
         }
 
         if (is_implicit) {
-            psp_pkey_col->set_nth<std::int32_t>(ii, ii % limit);
-            psp_okey_col->set_nth<std::int32_t>(ii, ii % limit);
+            psp_pkey_col->set_nth<std::int32_t>(ii, ii);
+            psp_okey_col->set_nth<std::int32_t>(ii, ii);
         }
 
         ii++;
@@ -1676,9 +1653,7 @@ Table::update_arrow(const std::string_view& data, std::uint32_t port_id) {
         }
     }
 
-    arrow_loader.fill_table(
-        data_table, input_schema, m_index, m_offset, m_limit, true
-    );
+    arrow_loader.fill_table(data_table, input_schema, m_index, m_offset, true);
 
     process_op_column(data_table, t_op::OP_INSERT);
     calculate_offset(row_count);
@@ -1722,7 +1697,7 @@ Table::from_arrow(
         auto loader = std::move(arrow_loader);
         auto row_count = loader.row_count();
         data_table->extend(row_count);
-        loader.fill_table(*data_table, input_schema, index, 0, limit, false);
+        loader.fill_table(*data_table, input_schema, index, 0, false);
     }
 
     // Make Table
@@ -1795,6 +1770,21 @@ Table::process_op_column(t_data_table& data_table, const t_op op) {
         } break;
         default: {
             op_col->raw_fill<std::uint8_t>(OP_INSERT);
+            const auto size = data_table.size();
+            if (m_offset + size >= m_limit) {
+                const auto& psp_pkey_col = data_table.get_column("psp_pkey");
+                const auto d_rows =
+                    size - std::max<t_index>(0, m_limit - m_offset);
+                data_table.extend(size + d_rows);
+                auto* op_col =
+                    data_table.add_column("psp_op", DTYPE_UINT8, false);
+                auto old_key = std::max<t_index>(0, m_offset - m_limit);
+                for (auto i = 0; i < d_rows; i++) {
+                    psp_pkey_col->set_nth<std::uint32_t>(size + i, old_key);
+                    op_col->set_nth<std::uint8_t>(size + i, OP_DELETE);
+                    old_key += 1;
+                }
+            }
         }
     }
 }

--- a/cpp/perspective/src/include/perspective/arrow_loader.h
+++ b/cpp/perspective/src/include/perspective/arrow_loader.h
@@ -62,7 +62,6 @@ namespace apachearrow {
          * @param input_schema
          * @param index
          * @param offset
-         * @param limit
          * @param is_update
          */
         void fill_table(
@@ -70,7 +69,6 @@ namespace apachearrow {
             const t_schema& input_schema,
             const std::string& index,
             std::uint32_t offset,
-            std::uint32_t limit,
             bool is_update
         );
 

--- a/cpp/perspective/src/include/perspective/base.h
+++ b/cpp/perspective/src/include/perspective/base.h
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <ostream>
 #ifdef WIN32
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -311,16 +310,7 @@ enum t_ctx_type {
     GROUPED_COLUMNS_CONTEXT
 };
 
-#define FOREACH_T_OP(X)                                                        \
-    X(OP_INSERT)                                                               \
-    X(OP_DELETE)                                                               \
-    X(OP_CLEAR)
-
-#define X(NAME) NAME,
-enum t_op { FOREACH_T_OP(X) };
-#undef X
-
-std::ostream& operator<<(std::ostream& os, const t_op& op);
+enum t_op { OP_INSERT, OP_DELETE, OP_CLEAR };
 
 enum t_value_transition {
     VALUE_TRANSITION_EQ_FF, // Value did not change, and row remains invalid
@@ -465,7 +455,7 @@ struct PERSPECTIVE_EXPORT t_cmp_charptr {
     bool
     operator()(const char* a, const char* b) const {
         return std::strcmp(a, b) < 0;
-    } // namespace perspective
+    }
 };
 
 template <class Arg1, class Arg2, class Result>

--- a/cpp/perspective/src/include/perspective/data_table.h
+++ b/cpp/perspective/src/include/perspective/data_table.h
@@ -11,7 +11,6 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 #pragma once
-#include "perspective/raw_types.h"
 #include <perspective/first.h>
 #include <perspective/base.h>
 #include <perspective/column.h>
@@ -34,22 +33,11 @@ struct t_rowpack {
     t_op m_op;
 };
 
-template <typename DATA_T>
-std::ostream&
-operator<<(std::ostream& os, const t_rowpack<DATA_T>& fr) {
-    os << "t_rowpack { m_pkey: " << fr.m_pkey
-       << ", m_pkey_is_valid: " << fr.m_pkey_is_valid << ", m_idx: " << fr.m_idx
-       << ", m_op: " << fr.m_op << "}";
-    return os;
-}
-
 struct t_flatten_record {
     t_uindex m_store_idx;
-    t_uindex m_begin_idx;
-    t_uindex m_edge_idx;
+    t_uindex m_bidx;
+    t_uindex m_eidx;
 };
-
-std::ostream& operator<<(std::ostream& os, const t_flatten_record& fr);
 
 class t_data_table;
 
@@ -139,7 +127,7 @@ public:
 
     t_column* _get_column(std::string_view colname);
 
-    std::shared_ptr<t_data_table> flatten(t_uindex limit) const;
+    std::shared_ptr<t_data_table> flatten() const;
 
     bool is_pkey_table() const;
     bool is_same_shape(t_data_table& tbl) const;
@@ -243,10 +231,10 @@ public:
 
 protected:
     template <typename FLATTENED_T>
-    void flatten_body(FLATTENED_T flattened, t_uindex limit) const;
+    void flatten_body(FLATTENED_T flattened) const;
 
     template <typename FLATTENED_T, typename PKEY_T>
-    void flatten_helper_1(FLATTENED_T flattened, t_uindex limit) const;
+    void flatten_helper_1(FLATTENED_T flattened) const;
 
     template <typename DATA_T, typename ROWPACK_VEC_T>
     void flatten_helper_2(
@@ -273,7 +261,7 @@ operator==(const t_data_table& lhs, const t_data_table& rhs);
 
 template <typename FLATTENED_T>
 void
-t_data_table::flatten_body(FLATTENED_T flattened, t_uindex limit) const {
+t_data_table::flatten_body(FLATTENED_T flattened) const {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
     PSP_VERBOSE_ASSERT(is_pkey_table(), "Not a pkeyed table");
@@ -281,43 +269,43 @@ t_data_table::flatten_body(FLATTENED_T flattened, t_uindex limit) const {
     t_dtype pkey_dtype = get_const_column("psp_pkey")->get_dtype();
     switch (pkey_dtype) {
         case DTYPE_INT64: {
-            flatten_helper_1<FLATTENED_T, std::int64_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::int64_t>(flattened);
         } break;
         case DTYPE_INT32: {
-            flatten_helper_1<FLATTENED_T, std::int32_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::int32_t>(flattened);
         } break;
         case DTYPE_INT16: {
-            flatten_helper_1<FLATTENED_T, std::int16_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::int16_t>(flattened);
         } break;
         case DTYPE_INT8: {
-            flatten_helper_1<FLATTENED_T, std::int8_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::int8_t>(flattened);
         } break;
         case DTYPE_UINT64: {
-            flatten_helper_1<FLATTENED_T, std::uint64_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::uint64_t>(flattened);
         } break;
         case DTYPE_UINT32: {
-            flatten_helper_1<FLATTENED_T, std::uint32_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::uint32_t>(flattened);
         } break;
         case DTYPE_UINT16: {
-            flatten_helper_1<FLATTENED_T, std::uint16_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::uint16_t>(flattened);
         } break;
         case DTYPE_UINT8: {
-            flatten_helper_1<FLATTENED_T, std::uint8_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::uint8_t>(flattened);
         } break;
         case DTYPE_TIME: {
-            flatten_helper_1<FLATTENED_T, std::int64_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::int64_t>(flattened);
         } break;
         case DTYPE_DATE: {
-            flatten_helper_1<FLATTENED_T, std::uint32_t>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, std::uint32_t>(flattened);
         } break;
         case DTYPE_STR: {
-            flatten_helper_1<FLATTENED_T, t_uindex>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, t_uindex>(flattened);
         } break;
         case DTYPE_FLOAT64: {
-            flatten_helper_1<FLATTENED_T, double>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, double>(flattened);
         } break;
         case DTYPE_FLOAT32: {
-            flatten_helper_1<FLATTENED_T, float>(flattened, limit);
+            flatten_helper_1<FLATTENED_T, float>(flattened);
         } break;
         default: {
             std::stringstream ss;
@@ -336,28 +324,27 @@ void
 t_data_table::flatten_helper_2(
     ROWPACK_VEC_T& sorted,
     std::vector<t_flatten_record>& fltrecs,
-    const t_column* source_col,
-    t_column* dest_col
+    const t_column* scol,
+    t_column* dcol
 ) const {
     for (const auto& rec : fltrecs) {
-        bool should_write = false;
+        bool added = false;
         t_index fragidx = 0;
         t_status status = STATUS_INVALID;
-        for (t_index spanidx = rec.m_edge_idx - 1;
-             spanidx >= t_index(rec.m_begin_idx);
+        for (t_index spanidx = rec.m_eidx - 1; spanidx >= t_index(rec.m_bidx);
              --spanidx) {
             const auto& sort_rec = sorted[spanidx];
             fragidx = sort_rec.m_idx;
-            status = *(source_col->get_nth_status(fragidx));
+            status = *(scol->get_nth_status(fragidx));
             if (status != STATUS_INVALID) {
-                should_write = true;
+                added = true;
                 break;
             }
         }
 
-        if (should_write) {
-            dest_col->set_nth<DATA_T>(
-                rec.m_store_idx, *(source_col->get_nth<DATA_T>(fragidx)), status
+        if (added) {
+            dcol->set_nth<DATA_T>(
+                rec.m_store_idx, *(scol->get_nth<DATA_T>(fragidx)), status
             );
         }
     }
@@ -365,9 +352,8 @@ t_data_table::flatten_helper_2(
 
 template <typename FLATTENED_T, typename PKEY_T>
 void
-t_data_table::flatten_helper_1(FLATTENED_T flattened, t_uindex limit) const {
+t_data_table::flatten_helper_1(FLATTENED_T flattened) const {
 
-    // t_uindex frags_size = std::min(size(), limit);
     t_uindex frags_size = size();
 
     PSP_VERBOSE_ASSERT(is_same_shape(*flattened), "Misaligned shaped found");
@@ -376,13 +362,13 @@ t_data_table::flatten_helper_1(FLATTENED_T flattened, t_uindex limit) const {
         return;
     }
 
-    std::vector<const t_column*> source_columns;
-    std::vector<t_column*> dest_columns;
+    std::vector<const t_column*> s_columns;
+    std::vector<t_column*> d_columns;
 
     for (const auto& colname : m_schema.m_columns) {
         if (colname != "psp_pkey" && colname != "psp_op") {
-            source_columns.push_back(get_const_column(colname).get());
-            dest_columns.push_back(flattened->get_column(colname).get());
+            s_columns.push_back(get_const_column(colname).get());
+            d_columns.push_back(flattened->get_column(colname).get());
         }
     }
 
@@ -408,7 +394,7 @@ t_data_table::flatten_helper_1(FLATTENED_T flattened, t_uindex limit) const {
         operator()(const t_rowpack<PKEY_T>& a, const t_rowpack<PKEY_T>& b)
             const {
             return a.m_pkey < b.m_pkey
-                || (a.m_pkey == b.m_pkey && a.m_idx < b.m_idx);
+                || (!(b.m_pkey < a.m_pkey) && a.m_idx < b.m_idx);
         }
     };
 
@@ -418,9 +404,6 @@ t_data_table::flatten_helper_1(FLATTENED_T flattened, t_uindex limit) const {
     std::vector<t_index> edges;
     edges.push_back(0);
 
-    // | pkey-1 | pkey-1 | pkey-2 | pkey-2
-    //                   ^ Is this an edge? I think so.
-    // |-----------------| <- This is a span between those edges.
     for (t_index idx = 1, loop_end = sorted.size(); idx < loop_end; ++idx) {
         if ((sorted[idx].m_pkey_is_valid != sorted[idx - 1].m_pkey_is_valid)
             || (sorted[idx].m_pkey != sorted[idx - 1].m_pkey)) {
@@ -434,147 +417,129 @@ t_data_table::flatten_helper_1(FLATTENED_T flattened, t_uindex limit) const {
 
     t_uindex store_idx = 0;
 
-    for (t_index frag_index = 0; frag_index < edges.size(); ++frag_index) {
-        t_index begin_edge_idx = edges[frag_index];
-        bool edge_bool = frag_index == static_cast<t_index>(edges.size() - 1);
-        t_index next_edge_idx =
-            edge_bool ? sorted.size() : edges[frag_index + 1];
+    for (t_index fidx = 0, loop_end = edges.size(); fidx < loop_end; ++fidx) {
+        t_index bidx = edges[fidx];
+        bool edge_bool = fidx == static_cast<t_index>(edges.size() - 1);
+        t_index eidx = edge_bool ? sorted.size() : edges[fidx + 1];
 
         bool delete_encountered = false;
 
-        for (t_index spanidx = begin_edge_idx; spanidx < next_edge_idx;
-             ++spanidx) {
+        for (t_index spanidx = bidx; spanidx < eidx; ++spanidx) {
             if (sorted[spanidx].m_op == OP_DELETE) {
-                begin_edge_idx = spanidx;
+                bidx = spanidx;
                 delete_encountered = true;
             }
         }
 
-        const auto& sort_rec = sorted[begin_edge_idx];
+        const auto& sort_rec = sorted[bidx];
         if (delete_encountered) {
-            d_pkey_col->set_nth(
-                store_idx % limit,
+            d_pkey_col->push_back(
                 sort_rec.m_pkey,
                 sort_rec.m_pkey_is_valid ? t_status::STATUS_VALID
                                          : t_status::STATUS_INVALID
             );
             std::uint8_t op8 = OP_DELETE;
-            d_op_col->set_nth(store_idx % limit, op8);
+            d_op_col->push_back(op8);
             ++store_idx;
         }
 
-        const auto single_element_span = (begin_edge_idx + 1 == next_edge_idx);
-        // if there are no deletes in the span, flatten.
-        // if there are deletes but the span is larger than 1 op, flatten.
-        if (!delete_encountered || !single_element_span) {
+        if (!delete_encountered || (bidx + 1 != eidx)) {
             t_flatten_record rec;
-            rec.m_store_idx = store_idx % limit;
-            rec.m_begin_idx = begin_edge_idx;
-            rec.m_edge_idx = next_edge_idx;
+            rec.m_store_idx = store_idx;
+            rec.m_bidx = bidx;
+            rec.m_eidx = eidx;
             fltrecs.push_back(rec);
 
-            d_pkey_col->set_nth(
-                store_idx % limit,
+            d_pkey_col->push_back(
                 sort_rec.m_pkey,
                 sort_rec.m_pkey_is_valid ? t_status::STATUS_VALID
                                          : t_status::STATUS_INVALID
             );
 
             std::uint8_t op8 = OP_INSERT;
-            d_op_col->set_nth(store_idx % limit, op8);
+            d_op_col->push_back(op8);
             ++store_idx;
         }
     }
 
-    flattened->set_size(std::min(store_idx, limit));
-    t_uindex ndata_cols = dest_columns.size();
-
-#if PSP_DEBUG
-    LOG_DEBUG("sorted: ");
-    for (const auto& sort : sorted) {
-        LOG_DEBUG(sort);
-    }
-    LOG_DEBUG("fltrecs: ");
-    for (const auto& fltrec : fltrecs) {
-        LOG_DEBUG(fltrec);
-    }
-#endif
+    flattened->set_size(store_idx);
+    t_uindex ndata_cols = d_columns.size();
 
     parallel_for(
         int(ndata_cols),
-        [&source_columns, &sorted, &dest_columns, &fltrecs, this](int colidx) {
-            const auto* source_col = source_columns[colidx];
-            auto* dest_col = dest_columns[colidx];
+        [&s_columns, &sorted, &d_columns, &fltrecs, this](int colidx) {
+            auto scol = s_columns[colidx];
+            auto dcol = d_columns[colidx];
 
-            switch (source_col->get_dtype()) {
+            switch (scol->get_dtype()) {
                 case DTYPE_INT64: {
                     this->flatten_helper_2<std::int64_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_INT32: {
                     this->flatten_helper_2<std::int32_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_INT16: {
                     this->flatten_helper_2<std::int16_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_INT8: {
                     this->flatten_helper_2<std::int8_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_UINT64: {
                     this->flatten_helper_2<std::uint64_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_UINT32: {
                     this->flatten_helper_2<std::uint32_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_UINT16: {
                     this->flatten_helper_2<std::uint16_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_UINT8: {
                     this->flatten_helper_2<std::uint8_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_FLOAT64: {
                     this->flatten_helper_2<double, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_FLOAT32: {
                     this->flatten_helper_2<float, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_BOOL: {
                     this->flatten_helper_2<std::uint8_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_TIME: {
                     this->flatten_helper_2<std::int64_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_DATE: {
                     this->flatten_helper_2<std::uint32_t, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_STR: {
                     this->flatten_helper_2<t_uindex, t_rpvec>(
-                        sorted, fltrecs, source_col, dest_col
+                        sorted, fltrecs, scol, dcol
                     );
                 } break;
                 case DTYPE_OBJECT:

--- a/cpp/perspective/src/include/perspective/flat_traversal.h
+++ b/cpp/perspective/src/include/perspective/flat_traversal.h
@@ -117,16 +117,6 @@ public:
 
     void delete_row(t_tscalar pkey);
 
-    // Moves a row under a new primary key and deletes references to old primary
-    // key.
-    void move_row(
-        const t_gstate& gstate,
-        const t_data_table& expression_master_table,
-        const t_config& config,
-        t_tscalar old_pkey,
-        t_tscalar new_pkey
-    );
-
     std::vector<t_sortspec> get_sort_by() const;
     bool empty_sort_by() const;
 

--- a/cpp/perspective/src/include/perspective/gnode.h
+++ b/cpp/perspective/src/include/perspective/gnode.h
@@ -11,7 +11,6 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 #pragma once
-#include "perspective/raw_types.h"
 #include <perspective/first.h>
 #include <perspective/base.h>
 #include <perspective/port.h>
@@ -94,11 +93,7 @@ public:
      * @param input_schema
      * @param output_schema
      */
-    t_gnode(
-        t_schema input_schema,
-        t_schema output_schema,
-        t_uindex limit = std::numeric_limits<t_uindex>::max()
-    );
+    t_gnode(t_schema input_schema, t_schema output_schema);
     ~t_gnode();
 
     void init();
@@ -386,7 +381,6 @@ private:
 
     bool m_init;
     t_uindex m_id;
-    t_uindex m_limit;
 
     // Input ports mapped by integer id
     tsl::ordered_map<t_uindex, std::shared_ptr<t_port>> m_input_ports;
@@ -517,18 +511,8 @@ t_gnode::update_context_from_state(
         // together and pass it to the context.
         std::shared_ptr<t_expression_tables> ctx_expression_tables =
             ctx->get_expression_tables();
-#if PSP_DEBUG
-        LOG_DEBUG("FLATTENED");
-        flattened->pprint();
-        LOG_DEBUG("EXPRESSION_TABLE");
-        ctx_expression_tables->m_flattened->pprint();
-#endif
         std::shared_ptr<t_data_table> joined_flattened =
             flattened->join(ctx_expression_tables->m_flattened);
-#if PSP_DEBUG
-        LOG_DEBUG("JOINED");
-        joined_flattened->pprint();
-#endif
         ctx->notify(*joined_flattened);
     } else {
         // Just use the table from the gnode

--- a/cpp/perspective/src/include/perspective/gnode_state.h
+++ b/cpp/perspective/src/include/perspective/gnode_state.h
@@ -31,8 +31,9 @@ public:
     /**
      * @brief A mapping of `t_tscalar` primary keys to `t_uindex` row indices.
      */
-    using t_mapping = tsl::hopscotch_map<t_tscalar, t_uindex>;
-    using t_free_items = tsl::hopscotch_set<t_uindex>;
+    typedef tsl::hopscotch_map<t_tscalar, t_uindex> t_mapping;
+
+    typedef tsl::hopscotch_set<t_uindex> t_free_items;
 
     /**
      * @brief Construct a new `t_gstate`, which manages the canonical state of
@@ -46,11 +47,7 @@ public:
      * @param input_schema
      * @param output_schema
      */
-    t_gstate(
-        t_schema input_schema,
-        t_schema output_schema,
-        t_uindex limit = std::numeric_limits<t_uindex>::max()
-    );
+    t_gstate(t_schema input_schema, t_schema output_schema);
 
     ~t_gstate();
 
@@ -292,7 +289,6 @@ private:
     t_schema m_output_schema; // tblschema
 
     bool m_init;
-    t_uindex m_limit;
     std::shared_ptr<t_data_table> m_table;
     t_mapping m_mapping;
     t_free_items m_free;

--- a/cpp/perspective/src/include/perspective/scalar.h
+++ b/cpp/perspective/src/include/perspective/scalar.h
@@ -40,7 +40,7 @@ struct PERSPECTIVE_EXPORT t_const_char_comparator {
         COMPARER_T<t_index> cmp;
         int cmpval = std::strcmp(s1, s2);
         return cmp(cmpval, 0);
-    } // namespace perspective
+    }
 };
 
 #ifdef PSP_SSO_SCALAR
@@ -202,7 +202,7 @@ struct PERSPECTIVE_EXPORT t_tscalar {
     t_tscalar coerce_numeric_dtype(t_dtype dtype) const;
 
     t_scalar_u m_data;
-    t_dtype m_type;
+    unsigned char m_type;
     t_status m_status;
 #ifdef PSP_SSO_SCALAR
     bool m_inplace;

--- a/cpp/perspective/src/include/perspective/server.h
+++ b/cpp/perspective/src/include/perspective/server.h
@@ -625,7 +625,7 @@ namespace server {
         void close_session(std::uint32_t);
         std::vector<ProtoServerResp<std::string>>
         handle_request(std::uint32_t client_id, const std::string_view& data);
-        std::vector<ProtoServerResp<std::string>> poll();
+        std::vector<ProtoServerResp<std::string>> poll(std::uint32_t client_id);
 
     private:
         void handle_process_table(

--- a/rust/perspective-js/src/ts/wasm/engine.ts
+++ b/rust/perspective-js/src/ts/wasm/engine.ts
@@ -79,7 +79,7 @@ export class PerspectiveSession {
     }
 
     poll() {
-        const polled = this.mod._psp_poll(this.server as any);
+        const polled = this.mod._psp_poll(this.server as any, this.client_id);
         decode_api_responses(this.mod, polled, async (msg: ApiResponse) => {
             await this.client_map.get(msg.client_id)!(msg.data);
         });

--- a/rust/perspective-js/test/js/updates.spec.js
+++ b/rust/perspective-js/test/js/updates.spec.js
@@ -3381,7 +3381,7 @@ async function match_delta(perspective, delta, expected) {
             );
 
             for (let i = 0; i < 3; i++) {
-                await tbl.update({
+                tbl.update({
                     index: ["a", "d", "b"],
                     x: ["abc", "def", "acc"],
                 });

--- a/rust/perspective-python/perspective/tests/table/test_table_limit.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_limit.py
@@ -17,6 +17,18 @@ Table = client.table
 
 
 class TestTableInfer(object):
+    def test_table_limit_wraparound_does_not_respect_partial_none(self):
+        t = Table({"a": "float", "b": "float"}, limit=3)
+        t.update([{"a": 10}, {"b": 1}, {"a": 20}, {"a": None, "b": 2}])
+        d1 = t.view().to_json()
+
+        t2 = Table({"a": "float", "b": "float"}, limit=3)
+        t2.update([{"a": 10}, {"b": 1}, {"a": 20}, {"b": 2}])
+        d2 = t2.view().to_json()
+
+        assert d1[0] == d2[0]
+        assert d1[1:] == d2[1:]
+
     def test_table_limit_wraparound_does_not_respect_partial(self):
         t = Table({"a": "float", "b": "float"}, limit=3)
         t.update([{"a": 10}, {"b": 1}, {"a": 20}, {"a": 10, "b": 2}])
@@ -26,7 +38,7 @@ class TestTableInfer(object):
         t2.update([{"a": 10}, {"b": 1}, {"a": 20}, {"b": 2}])
         d2 = t2.view().to_columns()
 
-        assert d1 == d2
+        assert d1 != d2
 
     def test_table_limit_with_json(self):
         t = Table({"a": [1, 2, 3]}, limit=1)

--- a/rust/perspective-server/src/ffi.rs
+++ b/rust/perspective-server/src/ffi.rs
@@ -35,7 +35,7 @@ unsafe extern "C" {
         buffer_ptr: *const u8,
         buffer_len: usize,
     ) -> ResponseBatch;
-    fn psp_poll(server: *const u8) -> ResponseBatch;
+    fn psp_poll(server: *const u8, client_id: u32) -> ResponseBatch;
     fn psp_close_session(server: *const u8, client_id: u32);
 }
 
@@ -122,8 +122,8 @@ impl Server {
         unsafe { psp_handle_request(self.0, client_id, request.0, request.1) }
     }
 
-    pub fn poll(&self) -> ResponseBatch {
-        unsafe { psp_poll(self.0) }
+    pub fn poll(&self, client_id: u32) -> ResponseBatch {
+        unsafe { psp_poll(self.0, client_id) }
     }
 
     pub fn close_session(&self, session_id: u32) {

--- a/rust/perspective-server/src/local_session.rs
+++ b/rust/perspective-server/src/local_session.rs
@@ -57,7 +57,7 @@ impl Session<ServerError> for LocalSession {
     }
 
     async fn poll(&self) -> Result<(), ServerError> {
-        let responses = self.server.server.poll();
+        let responses = self.server.server.poll(self.id);
         for response in responses.iter_responses() {
             let cb = self
                 .server


### PR DESCRIPTION
This PR addresses a resource leak introduced in #2964, which causes unbound resource growth (recoverable) in the processing of a `View` with some `group_by` and `split_by` configs attached to a `Table` with a `limit`, causing increased memory usage, over-time performance degradation of streaming `View` data, as well as data accumulation errors with a `limit` and `split_by` (but no `group_by`).

#2964 sought to address a primary key implicit ordering feature by tracking the limit property and allocation impact within the engine itself, where previously we'd simply applied `id % limit` to the auto-incrementing primary key generator. However, the implementation failed to account for bounded tracking of these values over time, leading to some cases which never reclaimed primary keys (just the keys, not the rows they reference) which had been evicted due to `limit`. This did not show up in our memory sanitization tests because it is not an allocator leak, as the over-allocation is reclaimed when the `View` is deleted; and it did not show up in our leak test suite (which tests overall allocation), because the base heap size in our WASM builds (16mb) was too large to cause an overflow in a single iteration loop (as only keys leak, which are `u32`), and because we lack `limit` leak tests specifically.

This PR:

* Partially reverts #2964 and its follow-up #2972, minus the valgrind fixes, `m_dirty_tables` fix, and tests.
* Implements a new method to address these PRs, derived from a discussion with @timbess which re-uses the existing `OP_DELETE` mechanism to order incrementing keys. While in theory this should be slower - it does not show up in our benchmarks and it is _much_ easier to implement. It also passes the tests added in #2964 as well as new tests to address the accumulation issue.
* Adds error handling to the `poll()` session API. While not strictly related to this change, my attempt to revert the previous PRs led me to accidentally revert the _valid_ drive-by fixes (specifically, the `m_dirty_tables` fix), but the lack of `poll()` error handling meant this error was swallowed in some environments but not others - Chrome has no visible errors, Python interpreter or loop threads will error but not kill the interpreter, but native threads would `abort` following an unhandled C++ exception. Semantically, this is a _breaking_ change, in that in previous versions, calls to e.g. `Table::update()` may have _silently_ failed due to failures in their bound `View` or associated listeners, whereas this PR makes these throw exceptions (but otherwise still fail internally in the same way). As this PR is already addressing a resource leak, this change felt appropriate to include.
* Adds leaks tests for `limit` tables specifically.