### PR TITLE
Nightly artifacts

### DIFF
--- a/.github/actions/config/action.yaml
+++ b/.github/actions/config/action.yaml
@@ -20,6 +20,8 @@ outputs:
         value: ${{ steps.setuppush.outputs.SKIP_CACHE || steps.setuppr.outputs.SKIP_CACHE || steps.setupmanual.outputs.SKIP_CACHE }}
     FULL_RUN:
         value: ${{ steps.setuppush.outputs.FULL_RUN || steps.setuppr.outputs.FULL_RUN || steps.setupmanual.outputs.FULL_RUN }}
+    PUBLISH_RELEASE:
+        value: ${{ steps.setuppush.outputs.PUBLISH_RELEASE || steps.setuppr.outputs.PUBLISH_RELEASE || steps.setupmanual.outputs.PUBLISH_RELEASE }}
     SKIP_PYTHON:
         value: ${{ steps.setuppush.outputs.SKIP_PYTHON || steps.setuppr.outputs.SKIP_PYTHON || steps.setupmanual.outputs.SKIP_PYTHON }}
     INCLUDE_WINDOWS:
@@ -46,18 +48,21 @@ runs:
               echo "Skip CI: $SKIP_CI"
               echo "Skip Cache: $SKIP_CACHE"
               echo "Full Run: $FULL_RUN"
+              echo "Publish Release: $PUBLISH_RELEASE"
               echo "Skip Python: $SKIP_PYTHON"
               echo "Include Windows: $INCLUDE_WINDOWS"
               echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
               echo "SKIP_CI=$SKIP_CI" >> $GITHUB_OUTPUT
               echo "SKIP_CACHE=$SKIP_CACHE" >> $GITHUB_OUTPUT
               echo "FULL_RUN=$FULL_RUN" >> $GITHUB_OUTPUT
+              echo "PUBLISH_RELEASE=$PUBLISH_RELEASE" >> $GITHUB_OUTPUT
               echo "SKIP_PYTHON=$SKIP_PYTHON" >> $GITHUB_OUTPUT
               echo "INCLUDE_WINDOWS=$INCLUDE_WINDOWS" >> $GITHUB_OUTPUT
           env:
               SKIP_CI: ${{ contains(github.event.head_commit.message, '[ci-skip]') }}
               SKIP_CACHE: ${{ contains(github.event.head_commit.message, '[ci-skip-cache]') }}
-              FULL_RUN: ${{ startsWith(github.ref_name, 'v') || contains(github.event.head_commit.message, '[ci-full]') }}
+              FULL_RUN: ${{ startsWith(github.ref_name, 'v') || contains(github.event.head_commit.message, '[ci-full]') || github.ref_name == 'master' }}
+              PUBLISH_RELEASE: ${{ startsWith(github.ref_name, 'v') }}
               SKIP_PYTHON: ${{ contains(github.event.head_commit.message, '[ci-skip-python]') }}
               INCLUDE_WINDOWS: ${{ contains(github.event.head_commit.message, '[ci-include-windows]') }}
           if: ${{ github.event_name == 'push' }}
@@ -70,18 +75,21 @@ runs:
               echo "Skip CI: $SKIP_CI"
               echo "Skip Cache: $SKIP_CACHE"
               echo "Full Run: $FULL_RUN"
+              echo "Publish Release: $PUBLISH_RELEASE"
               echo "Skip Python: $SKIP_PYTHON"
               echo "Include Windows: $INCLUDE_WINDOWS"
               echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
               echo "SKIP_CI=$SKIP_CI" >> $GITHUB_OUTPUT
               echo "SKIP_CACHE=$SKIP_CACHE" >> $GITHUB_OUTPUT
               echo "FULL_RUN=$FULL_RUN" >> $GITHUB_OUTPUT
+              echo "PUBLISH_RELEASE=$PUBLISH_RELEASE" >> $GITHUB_OUTPUT
               echo "SKIP_PYTHON=$SKIP_PYTHON" >> $GITHUB_OUTPUT
               echo "INCLUDE_WINDOWS=$INCLUDE_WINDOWS" >> $GITHUB_OUTPUT
           env:
               SKIP_CI: ${{ contains(github.event.pull_request.title, '[ci-skip]') || contains(github.event.head_commit.message, '[ci-skip]') }}
               SKIP_CACHE: ${{ contains(github.event.pull_request.title, '[ci-skip-cache]') || contains(github.event.head_commit.message, '[ci-skip-cache]') }}
               FULL_RUN: ${{ contains(github.event.pull_request.title, '[ci-full]') || contains(github.event.head_commit.message, '[ci-full]') }}
+              PUBLISH_RELEASE: ${{ startsWith(github.ref_name, 'v') }}
               SKIP_PYTHON: ${{ contains(github.event.pull_request.title, '[ci-skip-python]') || contains(github.event.head_commit.message, '[ci-skip-python]') }}
               INCLUDE_WINDOWS: ${{ contains(github.event.pull_request.title, '[ci-include-windows]') || contains(github.event.head_commit.message, '[ci-include-windows]') }}
           if: ${{ github.event_name == 'pull_request' }}
@@ -94,18 +102,21 @@ runs:
               echo "Skip CI: $SKIP_CI"
               echo "Skip Cache: $SKIP_CACHE"
               echo "Full Run: $FULL_RUN"
+              echo "Publish Release: $PUBLISH_RELEASE"
               echo "Skip Python: $SKIP_PYTHON"
               echo "Include Windows: $INCLUDE_WINDOWS"
               echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
               echo "SKIP_CI=$SKIP_CI" >> $GITHUB_OUTPUT
               echo "SKIP_CACHE=$SKIP_CACHE" >> $GITHUB_OUTPUT
               echo "FULL_RUN=$FULL_RUN" >> $GITHUB_OUTPUT
+              echo "PUBLISH_RELEASE=$PUBLISH_RELEASE" >> $GITHUB_OUTPUT
               echo "SKIP_PYTHON=$SKIP_PYTHON" >> $GITHUB_OUTPUT
               echo "INCLUDE_WINDOWS=$INCLUDE_WINDOWS" >> $GITHUB_OUTPUT
           env:
               SKIP_CI: false
               SKIP_CACHE: ${{ github.event.inputs.ci-skip-cache }}
               FULL_RUN: ${{ github.event.inputs.ci-full }}
+              PUBLISH_RELEASE: ${{ startsWith(github.ref_name, 'v') }}
               SKIP_PYTHON: ${{ github.event.inputs.ci-skip-python }}
               INCLUDE_WINDOWS: ${{ github.event.inputs.ci-include-windows }}
           if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -200,7 +200,7 @@ jobs:
                       python-version: 3.9
                       container: pagmo2/manylinux228_x86_64_with_deps
                 is-release:
-                    - ${{ startsWith(github.ref, 'refs/tags/v') }}
+                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
                 exclude:
                     - os: windows-2022
                       arch: aarch64
@@ -296,7 +296,7 @@ jobs:
                     - x86_64
                 node-version: [20.x]
                 is-release:
-                    - ${{ startsWith(github.ref, 'refs/tags/v') }}
+                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
                 exclude:
                     - os: windows-2022
                       is-release: false
@@ -357,11 +357,11 @@ jobs:
                   PACKAGE: "perspective-rs"
 
             - name: Package
-              if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(matrix.os, 'windows') }}
+              if: ${{ !contains(matrix.os, 'windows') }}
               run: cargo package --allow-dirty -p perspective -p perspective-viewer -p perspective-js -p perspective-client -p perspective-server -p perspective-python
 
             - uses: actions/upload-artifact@v4
-              if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(matrix.os, 'windows') }}
+              if: ${{ !contains(matrix.os, 'windows') }}
               with:
                   name: perspective-rust
                   path: rust/target/package/*.crate
@@ -502,7 +502,7 @@ jobs:
                     - 3.9
                 node-version: [20.x]
                 is-release:
-                    - ${{ startsWith(github.ref, 'refs/tags/v') }}
+                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
                 exclude:
                     - os: windows-2022
                       arch: aarch64
@@ -656,7 +656,7 @@ jobs:
                     # - 3.12
                 node-version: [20.x]
                 is-release:
-                    - ${{ startsWith(github.ref, 'refs/tags/v') }}
+                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
                 exclude:
                     - os: macos-13
                       is-release: false
@@ -701,9 +701,8 @@ jobs:
                   # PSP_USE_CCACHE: 1
 
     test_python_sdist:
-        needs: [build_and_test_jupyterlab]
+        needs: [build_and_test_jupyterlab, build_and_test_rust]
         runs-on: ${{ matrix.os }}
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
         strategy:
             fail-fast: false
@@ -796,7 +795,6 @@ jobs:
     #        `-'
     benchmark_python:
         needs: [build_python, build_js]
-        if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
@@ -856,7 +854,6 @@ jobs:
     # `--'                              '
     benchmark_js:
         needs: [build_js]
-        if: startsWith(github.ref, 'refs/tags/v')
         strategy:
             matrix:
                 os: [ubuntu-22.04]
@@ -913,7 +910,7 @@ jobs:
                 build_and_test_rust,
                 lint_and_docs,
             ]
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master'
         strategy:
             matrix:
                 os: [ubuntu-22.04]
@@ -999,8 +996,21 @@ jobs:
             - run: pnpm pack --pack-destination=../..
               working-directory: ./packages/perspective-jupyterlab
 
+            - name: Upload nightly artifacts
+              uses: actions/upload-artifact@v4
+              if: ${{ steps.config-step.outputs.PUBLISH_RELEASE == 'false' }}
+              with:
+                  name: nightly
+                  path: |
+                      *.whl
+                      *.tar.gz
+                      *.tgz
+                      *.arrow
+                      *.crate
+
             - name: Publish assets
               uses: softprops/action-gh-release@v2
+              if: ${{ steps.config-step.outputs.PUBLISH_RELEASE == 'true' }}
               with:
                   draft: true
                   generate_release_notes: true


### PR DESCRIPTION
This modifies the CI to build production releases on the `master` branch whenever a PR is merged. Previously, the same _dev_ CI workflow was run on `master` branch merges, and only release tags built the full production workflow, which includes MacOS & Windows python wheels and benchmarks among other tweaks.

As a result, we'll now have apples-to-apples intermediate builds between releases, which will halpe keep regressions out of released perspective wheels/crates/packages.