### PR TITLE
Fix `ProxySession` message routing bug with Jupyter widget

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,8 +6,8 @@ rustflags = ["--cfg=web_sys_unstable_apis"]
 target-dir = "rust/target"
 
 [target.wasm32-unknown-unknown]
-runner = 'wasm-bindgen-test-runner'
 rustflags = [
+    "--cfg=getrandom_backend=\"wasm_js\"",
     "--cfg=web_sys_unstable_apis",
     "-Ctarget-feature=+bulk-memory,+simd128,+relaxed-simd,+reference-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1137,7 +1151,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903f432be5ba34427eac5e16048ef65604a82061fe93789f2212afc73d8617d6"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "gloo-events 0.2.0",
  "gloo-utils 0.2.0",
  "serde",
@@ -1710,10 +1724,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1860,7 +1875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2064,6 +2079,7 @@ version = "3.6.1"
 dependencies = [
  "async-lock",
  "futures",
+ "getrandom 0.3.2",
  "itertools 0.10.5",
  "nanoid",
  "paste",
@@ -2071,6 +2087,8 @@ dependencies = [
  "prost-build",
  "prost-types",
  "protobuf-src",
+ "rand",
+ "rand-unique",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -2090,7 +2108,7 @@ dependencies = [
  "derivative",
  "extend",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "js-intern",
  "js-sys",
  "macro_rules_attribute",
@@ -2608,6 +2626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2640,16 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+]
+
+[[package]]
+name = "rand-unique"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a83e1f91c1c954a1ade65d6402d5e6c8172586b888355cee1835ef1340368dfd"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -2634,7 +2668,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2672,7 +2706,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -3712,6 +3746,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,9 +4018,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4169,6 +4212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,6 +870,15 @@ importers:
       perspective-3-3-0:
         specifier: npm:@finos/perspective@3.3.0
         version: '@finos/perspective@3.3.0'
+      perspective-3-4-0:
+        specifier: npm:@finos/perspective@3.4.0
+        version: '@finos/perspective@3.4.0'
+      perspective-3-5-0:
+        specifier: npm:@finos/perspective@3.5.0
+        version: '@finos/perspective@3.5.0'
+      perspective-3-6-0:
+        specifier: npm:@finos/perspective@3.6.0
+        version: '@finos/perspective@3.6.0'
     devDependencies:
       '@finos/perspective':
         specifier: workspace:^
@@ -3350,6 +3359,15 @@ packages:
 
   '@finos/perspective@3.3.0':
     resolution: {integrity: sha512-GYzXPqHnhrWQz930f9OejVvsBs5I6jjJLvbK/xfUK2AUijMhzAUsPI70uEKUFwsy5VMA6sxWPl/UQB9W9IBGDw==}
+
+  '@finos/perspective@3.4.0':
+    resolution: {integrity: sha512-7FlOdnotYkJOc5/+yerpcSv9VH+1e2fs53ZiOAm0/id2cke9RySbm30NpHICGq13SQW5J3ezByZElx3V72A8mQ==}
+
+  '@finos/perspective@3.5.0':
+    resolution: {integrity: sha512-J4Q6aGq541iFeNeCrnW6tuq1ELfg0hhILH8qYoI9oJUSx1O/kwackunHOkxcPxW6zeaT0vUfHZaJjS7u1dYTuA==}
+
+  '@finos/perspective@3.6.0':
+    resolution: {integrity: sha512-MOXifjSsPNO39Bc0LiXp1OvV6ujNes4EoFxJ58edzCutbeSWf0yknXyEBmwR0PB/QWNHx1Czl3cnnJHXgRPn3Q==}
 
   '@fontsource/roboto-mono@4.5.10':
     resolution: {integrity: sha512-KrJdmkqz6DszT2wV/bbhXef4r0hV3B0vw2mAqei8A2kRnvq+gcJLmmIeQ94vu9VEXrUQzos5M9lH1TAAXpRphw==}
@@ -13972,6 +13990,30 @@ snapshots:
       - utf-8-validate
 
   '@finos/perspective@3.3.0':
+    dependencies:
+      stoppable: 1.1.0
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@finos/perspective@3.4.0':
+    dependencies:
+      stoppable: 1.1.0
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@finos/perspective@3.5.0':
+    dependencies:
+      stoppable: 1.1.0
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@finos/perspective@3.6.0':
     dependencies:
       stoppable: 1.1.0
       ws: 8.18.0

--- a/rust/perspective-client/Cargo.toml
+++ b/rust/perspective-client/Cargo.toml
@@ -59,6 +59,9 @@ itertools = { version = "0.10.1" }
 nanoid = { version = "0.4.0" }
 paste = { version = "1.0.12" }
 prost-types = { version = "0.12.3" }
+getrandom = { version = "0.3", features = ["wasm_js"] }
+rand = { version = "*" }
+rand-unique = { version = "0.2.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = { version = "0.11" }
 serde_json = { version = "1.0.107", features = ["raw_value"] }

--- a/rust/perspective-js/Cargo.toml
+++ b/rust/perspective-js/Cargo.toml
@@ -55,7 +55,7 @@ futures = "0.3.28"
 derivative = "2.2.0"
 getrandom = { version = "0.2", features = ["js"] }
 js-intern = "0.3.1"
-js-sys = "0.3.64"
+js-sys = "0.3.77"
 prost = { version = "0.12.3", default-features = false, features = [
     "prost-derive",
     "std",
@@ -77,7 +77,7 @@ wasm-bindgen-derive = "0.3.0"
 wasm-bindgen-futures = "0.4.41"
 
 [dependencies.web-sys]
-version = "0.3.64"
+version = "0.3.77"
 features = [
     "console",
     "Blob",

--- a/rust/perspective-js/src/rust/utils/browser.rs
+++ b/rust/perspective-js/src/rust/utils/browser.rs
@@ -34,6 +34,6 @@ pub mod global {
     }
 
     pub fn clipboard() -> web_sys::Clipboard {
-        navigator().clipboard().unwrap()
+        navigator().clipboard()
     }
 }

--- a/rust/perspective-python/src/client/proxy_session.rs
+++ b/rust/perspective-python/src/client/proxy_session.rs
@@ -25,11 +25,11 @@ pub struct ProxySession(perspective_client::ProxySession);
 
 #[pymethods]
 impl ProxySession {
-    #[new]
     /// Construct a proxy session from an AsyncClient or Client object and a
-    /// `handle_request`` callback.  The callback should ultimately invoke
+    /// `handle_request` callback.  The callback should ultimately invoke
     /// `handle_request` on another client, passing along the argument
     /// passed to it.
+    #[new]
     fn new(py: Python<'_>, client: Py<PyAny>, handle_request: Py<PyAny>) -> PyResult<Self> {
         let client = if let Ok(py_client) = client.downcast_bound::<AsyncClient>(py) {
             py_client.borrow().client.clone()
@@ -40,6 +40,7 @@ impl ProxySession {
                 "ProxySession::new() not passed a Perspective client",
             ));
         };
+
         let callback = {
             move |msg: &[u8]| {
                 let msg = msg.to_vec();
@@ -68,6 +69,11 @@ impl ProxySession {
 
     pub fn poll(&self, py: Python<'_>) -> PyResult<()> {
         self.0.poll().py_block_on(py).into_pyerr()?;
+        Ok(())
+    }
+
+    pub async fn poll_async(&self) -> PyResult<()> {
+        self.0.poll().await.into_pyerr()?;
         Ok(())
     }
 

--- a/rust/perspective-viewer/Cargo.toml
+++ b/rust/perspective-viewer/Cargo.toml
@@ -77,7 +77,7 @@ itertools = "0.10.1"
 js-intern = "0.3.1"
 
 # JavaScript stdlib bindings
-js-sys = "0.3.64"
+js-sys = "0.3.77"
 
 # Parse ExprTK for syntax highlighting.
 nom = "7.1.1"
@@ -119,7 +119,7 @@ wasm-bindgen-futures = "0.4.41"
 yew = { version = "0.21.0", features = ["csr"] }
 
 # Browser stdlib bindings
-web-sys.version = "0.3.64"
+web-sys.version = "0.3.77"
 
 # Browser stdlib bindings
 web-sys.features = [

--- a/rust/perspective-viewer/src/rust/components/form/debug.rs
+++ b/rust/perspective-viewer/src/rust/components/form/debug.rs
@@ -170,8 +170,8 @@ pub fn debug_panel(props: &DebugPanelProps) -> Html {
         (expr.clone(), select_all.callback()),
         move |_, (text, select_all)| {
             select_all.emit(());
-            let mut options = web_sys::BlobPropertyBag::new();
-            options.type_("text/plain");
+            let options = web_sys::BlobPropertyBag::new();
+            options.set_type("text/plain");
             let blob_txt = (JsValue::from((***text).clone())).clone();
             let blob_parts = js_sys::Array::from_iter([blob_txt].iter());
             let blob = web_sys::Blob::new_with_str_sequence_and_options(&blob_parts, &options);

--- a/rust/perspective-viewer/src/rust/custom_events.rs
+++ b/rust/perspective-viewer/src/rust/custom_events.rs
@@ -123,8 +123,8 @@ impl CustomEvents {
     }
 
     pub fn dispatch_column_style_changed(&self, config: &JsValue) {
-        let mut event_init = web_sys::CustomEventInit::new();
-        event_init.detail(config);
+        let event_init = web_sys::CustomEventInit::new();
+        event_init.set_detail(config);
         let event = web_sys::CustomEvent::new_with_event_init_dict(
             "perspective-column-style-change",
             &event_init,
@@ -134,8 +134,8 @@ impl CustomEvents {
     }
 
     pub fn dispatch_select(&self, view_window: Option<&ViewWindow>) -> ApiResult<()> {
-        let mut event_init = web_sys::CustomEventInit::new();
-        event_init.detail(&serde_wasm_bindgen::to_value(&view_window)?);
+        let event_init = web_sys::CustomEventInit::new();
+        event_init.set_detail(&serde_wasm_bindgen::to_value(&view_window)?);
         let event =
             web_sys::CustomEvent::new_with_event_init_dict("perspective-select", &event_init);
 
@@ -147,8 +147,8 @@ impl CustomEvents {
 
 impl CustomEventsDataRc {
     fn dispatch_settings_open_changed(&self, open: bool) {
-        let mut event_init = web_sys::CustomEventInit::new();
-        event_init.detail(&JsValue::from(open));
+        let event_init = web_sys::CustomEventInit::new();
+        event_init.set_detail(&JsValue::from(open));
         let event = web_sys::CustomEvent::new_with_event_init_dict(
             "perspective-toggle-settings",
             &event_init,
@@ -161,8 +161,8 @@ impl CustomEventsDataRc {
     }
 
     fn dispatch_column_settings_open_changed(&self, open: bool, column_name: Option<String>) {
-        let mut event_init = web_sys::CustomEventInit::new();
-        event_init.detail(&JsValue::from(
+        let event_init = web_sys::CustomEventInit::new();
+        event_init.set_detail(&JsValue::from(
             json!( {"open": open, "column_name": column_name} ),
         ));
         let event = web_sys::CustomEvent::new_with_event_init_dict(
@@ -174,8 +174,8 @@ impl CustomEventsDataRc {
     }
 
     fn dispatch_plugin_changed(&self, plugin: &JsPerspectiveViewerPlugin) {
-        let mut event_init = web_sys::CustomEventInit::new();
-        event_init.detail(plugin);
+        let event_init = web_sys::CustomEventInit::new();
+        event_init.set_detail(plugin);
         let event = web_sys::CustomEvent::new_with_event_init_dict(
             "perspective-plugin-update",
             &event_init,
@@ -191,8 +191,8 @@ impl CustomEventsDataRc {
                 && Some(&viewer_config) != self.last_dispatched.borrow().as_ref()
             {
                 let json_config = JsValue::from_serde_ext(&viewer_config)?;
-                let mut event_init = web_sys::CustomEventInit::new();
-                event_init.detail(&json_config);
+                let event_init = web_sys::CustomEventInit::new();
+                event_init.set_detail(&json_config);
                 let event = web_sys::CustomEvent::new_with_event_init_dict(
                     "perspective-config-update",
                     &event_init,

--- a/rust/perspective-viewer/src/rust/utils/browser/blob.rs
+++ b/rust/perspective-viewer/src/rust/utils/browser/blob.rs
@@ -29,8 +29,8 @@ impl AsBlob for js_sys::ArrayBuffer {
 impl AsBlob for js_sys::JsString {
     fn as_blob(&self) -> ApiResult<web_sys::Blob> {
         let array = std::iter::once(self).collect::<js_sys::Array>();
-        let mut options = web_sys::BlobPropertyBag::new();
-        options.type_("text/plain");
+        let options = web_sys::BlobPropertyBag::new();
+        options.set_type("text/plain");
         Ok(web_sys::Blob::new_with_str_sequence_and_options(
             &array, &options,
         )?)
@@ -40,8 +40,8 @@ impl AsBlob for js_sys::JsString {
 impl AsBlob for js_sys::Object {
     fn as_blob(&self) -> ApiResult<web_sys::Blob> {
         let array = std::iter::once(js_sys::JSON::stringify(self)?).collect::<js_sys::Array>();
-        let mut options = web_sys::BlobPropertyBag::new();
-        options.type_("text/plain");
+        let options = web_sys::BlobPropertyBag::new();
+        options.set_type("text/plain");
         Ok(web_sys::Blob::new_with_str_sequence_and_options(
             &array, &options,
         )?)

--- a/tools/perspective-bench/package.json
+++ b/tools/perspective-bench/package.json
@@ -28,6 +28,9 @@
         "zx": "^8.1.8"
     },
     "dependencies": {
+        "perspective-3-6-0": "npm:@finos/perspective@3.6.0",
+        "perspective-3-5-0": "npm:@finos/perspective@3.5.0",
+        "perspective-3-4-0": "npm:@finos/perspective@3.4.0",
         "perspective-3-3-0": "npm:@finos/perspective@3.3.0",
         "perspective-3-2-0": "npm:@finos/perspective@3.2.0",
         "perspective-3-1-0": "npm:@finos/perspective@3.1.0",


### PR DESCRIPTION
This PR fixes an issue which caused `Client` instances bound to a `ProxySession` to mis-route some messages due to re-used Message IDs. `ProxySession` is used by the `PerspectiveWidget` Jupyter widget to share a connection for both the Widget and local `Client`, and it relies on `msg_id` field to discriminate transport messages to each. These are now seeded randomly instead of starting at 0. The fix applied may still rarely have conflicts - but they would require a few unlikely conditions to occur in sequence, and eliminating conflicts completely would be quite a bit more difficult to implement.

A test is included based on the issue reported in https://github.com/tomjakubowski/perspective/tree/bug/session