### PR TITLE
Nightly versions

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -179,6 +179,13 @@ runs:
           if: ${{ inputs.javascript == 'false' || inputs.playwright == 'false'}}
           run: pnpm install --ignore-scripts
 
+        - name: Template version
+          shell: bash
+          if: ${{ !startsWith(github.ref_name, 'v') }}
+          run: |
+              git config --global --add safe.directory $GITHUB_WORKSPACE
+              node tools/perspective-scripts/version.mjs --nightly
+
         - name: Install Python dependencies
           shell: bash
           if: ${{ inputs.python == 'true' && inputs.manylinux == 'false'  }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
                   PACKAGE: "perspective-metadata"
 
             - name: Lint
-              run: pnpm run lint
+              run: pnpm run lint --nightly
 
             # - name: Docs Build
             #   run: pnpm run docs
@@ -155,7 +155,7 @@ jobs:
             - name: WebAssembly Build
               run: pnpm run build --ci
               env:
-                  PACKAGE: "perspective-cpp,perspective,perspective-viewer,perspective-viewer-datagrid,perspective-viewer-d3fc,perspective-viewer-openlayers,perspective-workspace,perspective-cli"
+                  PACKAGE: "perspective-cpp,perspective,perspective-viewer,perspective-viewer-datagrid,perspective-viewer-d3fc,perspective-viewer-openlayers,perspective-workspace,perspective-cli,perspective-react"
                   # PSP_USE_CCACHE: 1
 
             - uses: actions/upload-artifact@v4
@@ -170,6 +170,7 @@ jobs:
                       packages/perspective-viewer-openlayers/dist
                       packages/perspective-cli/dist
                       packages/perspective-workspace/dist
+                      packages/perspective-react/dist
 
     # ,-,---.       .    .  .-,--.     .  .
     #  '|___/ . . . |  ,-|   '|__/ . . |- |-. ,-. ,-.
@@ -627,7 +628,7 @@ jobs:
             - name: Run Tests
               run: pnpm run test
               env:
-                  PACKAGE: "perspective-cpp,perspective,perspective-viewer,perspective-viewer-datagrid,perspective-viewer-d3fc,perspective-viewer-openlayers,perspective-workspace,perspective-cli"
+                  PACKAGE: "perspective-cpp,perspective,perspective-viewer,perspective-viewer-datagrid,perspective-viewer-d3fc,perspective-viewer-openlayers,perspective-workspace,perspective-cli,perspective-react"
                   # PSP_USE_CCACHE: 1
 
     # ,--,--'      .   .-,--.     .  .
@@ -990,6 +991,9 @@ jobs:
 
             - run: pnpm pack --pack-destination=../..
               working-directory: ./packages/perspective-workspace
+
+            - run: pnpm pack --pack-destination=../..
+              working-directory: ./packages/perspective-react
 
             - run: pnpm pack --pack-destination=../..
               working-directory: ./packages/perspective-cli

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ applications.
 -   [`@finos/perspective`, JavaScript Client API](https://docs.rs/perspective-js/latest/perspective_js/)
 -   [`@finos/perspective-viewer`, JavaScript UI API](https://docs.rs/perspective-viewer/latest/perspective_viewer/)
 -   [`perspective-python`, Python API](https://docs.rs/perspective-python/latest/perspective_python/)
--   [`perspective`, Rust API](https://docs.rs/perspective-rs/latest/perspective_rs/)
+-   [`perspective`, Rust API](https://docs.rs/perspective/latest/perspective/)
 
 ### Examples
 
@@ -64,7 +64,6 @@ applications.
 <td><a href="https://www.youtube.com/watch?v=v5Y5ftlGNhU"><img width="240" src="https://img.youtube.com/vi/v5Y5ftlGNhU/0.jpg" /></a></td>
 <td><a href="https://www.youtube.com/watch?v=lDpIu4dnp78"><img width="240" src="https://img.youtube.com/vi/lDpIu4dnp78/0.jpg" /></a></td>
 <td><a href="https://www.youtube.com/watch?v=IO-HJsGdleE"><img width="240"  src="https://img.youtube.com/vi/IO-HJsGdleE/0.jpg" /></a></td>
-
 </tr>
 <tr>
 <td><a href="https://github.com/texodus"><code>@texodus</code></a></td>

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "@finos/perspective-viewer-openlayers": "workspace:^",
         "@finos/perspective-workspace": "workspace:^",
         "@fontsource/roboto-mono": "4.5.10",
+        "@iarna/toml": "toml-1.0.0-rc.1",
         "@playwright/test": "^1.52.0",
         "@playwright/experimental-ct-react": "1.52.0",
         "@types/ws": "^8.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@fontsource/roboto-mono':
         specifier: 4.5.10
         version: 4.5.10
+      '@iarna/toml':
+        specifier: toml-1.0.0-rc.1
+        version: 3.0.0
       '@playwright/experimental-ct-react':
         specifier: 1.52.0
         version: 1.52.0(@types/node@22.10.5)(jiti@1.21.6)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(vite@6.3.3(@types/node@22.10.5)(jiti@1.21.6)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2))
@@ -3401,6 +3404,9 @@ packages:
   '@humanwhocodes/retry@0.4.1':
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
+
+  '@iarna/toml@3.0.0':
+    resolution: {integrity: sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -14048,6 +14054,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.1':
     optional: true
+
+  '@iarna/toml@3.0.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/tools/perspective-scripts/lint_headers.mjs
+++ b/tools/perspective-scripts/lint_headers.mjs
@@ -79,7 +79,14 @@ async function check(is_write, pattern, comment) {
 
         const expected_header = header_text(default_comment);
         let seen_whitespace = false;
-        if (!contents.startsWith(expected_header)) {
+        // Nightly builds modify the version of metadata scripts in place to
+        // tag the nightly, so lint will fail if we don't make an exception
+        // for these files.
+        const is_nightly =
+            process.argv.indexOf("--nightly") > -1 &&
+            match.indexOf("Cargo.toml") > -1;
+
+        if (!contents.startsWith(expected_header) && !is_nightly) {
             console.error(`Missing header in file ${match}`);
             while (
                 contents.length > 0 &&

--- a/tools/perspective-scripts/workspace.mjs
+++ b/tools/perspective-scripts/workspace.mjs
@@ -38,7 +38,7 @@ export function getRustWheelsDir() {
     return rustWheelsDir;
 }
 export function getEmscriptenWheelPath() {
-    const pspVersion = getWorkspacePackageJson().version;
+    const pspVersion = getWorkspacePackageJson().version.replace("-", ".");
     const wheeljunk = "cp39-abi3-emscripten_3_1_58_wasm32";
     return path.join(
         rustWheelsDir,


### PR DESCRIPTION
This PR modifies the project's CI workflow to template `package.json`, `pyproject.toml` and `Cargo.toml` metadata files with a timestamped version of the latest commit, e.g. `3.6.1-dev123123123` for nightly builds. There is no impact to the published artifacts nor the workflow for tag/release/dev builds.
