### PR TITLE
New error UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,6 +2119,7 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "serde_bytes",
  "serde_json",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
  "ts-rs",
@@ -2213,6 +2214,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "strum 0.26.2",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
  "ts-rs",
@@ -2395,9 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "procss"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fd6979bf7b925902a304e2aecdb8689c9daab4b7b79ab96002da5bbcdfb46c"
+checksum = "4e49f7323a5d32db7e4e3fd55cac1d79b07bd144205806ea3075835d32d3fe79"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/packages/perspective-workspace/test/js/table.spec.js
+++ b/packages/perspective-workspace/test/js/table.spec.js
@@ -93,7 +93,7 @@ function tests(context, compare) {
         // NOTE This is the error message we expect when `restore()` is called
         // without a `Table`, subject to change.
         expect(result).toEqual(
-            "Error: Trying to draw the viewer with no table attached"
+            "Error: Failed to construct table from JsValue(undefined)"
         );
         await page.evaluate(async () => {
             await workspace.replaceTable(

--- a/rust/perspective-js/Cargo.toml
+++ b/rust/perspective-js/Cargo.toml
@@ -69,6 +69,7 @@ ts-rs = { version = "10.0.0", features = [
     "serde-json-impl",
     "no-serde-warnings",
 ] }
+thiserror = "1.0.55"
 tracing = { version = ">=0.1.36" }
 tracing-subscriber = "0.3.15"
 console_error_panic_hook = "0.1.6"

--- a/rust/perspective-js/src/rust/utils/errors.rs
+++ b/rust/perspective-js/src/rust/utils/errors.rs
@@ -11,112 +11,254 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 use std::fmt::Display;
+use std::rc::Rc;
 use std::string::FromUtf8Error;
 
-use perspective_client::ClientError;
+use perspective_client::{ClientError, ValidateExpressionsData};
+use thiserror::*;
 use wasm_bindgen::prelude::*;
 
-/// A bespoke error class for chaining a litany of various error types with the
-/// `?` operator.  
-///
-/// `anyhow`, `web_sys::JsError` are candidates for replacing
-/// this, but we'd need a way to get around syntacitc conveniences we get
-/// from avoiding orphan instance issues (e.g. converting `JsValue` to an error
-/// in `anyhow`).
-///
-/// We'd still like to implement this, but instead must independently implement
-/// the instance for each error, as otherwise `rustc` will complain that the
-/// `wasm_bindgen` authors may themselves implement `Error` for `JsValue`.
-///
-/// ```
-/// impl<T> From<T> for ApiError
-/// where
-///     T: std::error::Error,
-/// {
-///     fn from(x: T) -> Self {
-///         ApiError(JsValue::from(format!("{}", x)))
-///     }
-/// }
-/// ```
-#[derive(Clone, Debug)]
-pub struct ApiError(JsValue);
+#[macro_export]
+macro_rules! apierror {
+    ($msg:expr) => {{
+        use $crate::utils::errors::ApiErrorType::*;
+        let js_err_type = $msg;
+        let err = js_sys::Error::new(js_err_type.to_string().as_str());
+        let js_err = $crate::utils::errors::ApiError(
+            js_err_type,
+            $crate::utils::errors::JsBackTrace(std::rc::Rc::new(err.clone())),
+        );
+        js_err
+    }};
+}
+
+fn format_js_error(value: &JsValue) -> String {
+    if let Some(err) = value.dyn_ref::<js_sys::Error>() {
+        let msg = err.message().as_string().unwrap();
+        if let Ok(x) = js_sys::Reflect::get(value, &"stack".into()) {
+            format!("{}\n{}", msg, x.as_string().unwrap())
+        } else {
+            msg
+        }
+    } else {
+        value
+            .as_string()
+            .unwrap_or_else(|| format!("{:?}", value))
+            .to_string()
+    }
+}
+
+fn format_valid_exprs(recs: &ValidateExpressionsData) -> String {
+    recs.errors
+        .iter()
+        .map(|x| format!("\"{}\": {}", x.0, x.1.error_message))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// A bespoke error class for chaining a litany of error types with the `?`
+/// operator.  
+#[derive(Clone, Debug, Error)]
+pub enum ApiErrorType {
+    #[error("{}", format_js_error(.0))]
+    JsError(JsValue),
+
+    #[error("{}", format_js_error(.0))]
+    JsRawError(js_sys::Error),
+
+    #[error("Failed to construct table from {0:?}")]
+    TableError(JsValue),
+
+    #[error("{}", format_js_error(.0))]
+    ViewerPluginError(JsValue),
+
+    #[error("{0}")]
+    ExternalError(Rc<Box<dyn std::error::Error>>),
+
+    #[error("{0}")]
+    UnknownError(String),
+
+    #[error("{0}")]
+    ClientError(#[from] ClientError),
+
+    #[error("Cancelled")]
+    CancelledError(#[from] futures::channel::oneshot::Canceled),
+
+    #[error("{0}")]
+    SerdeJsonError(Rc<serde_json::Error>),
+
+    #[error("{0}")]
+    ProstError(#[from] prost::DecodeError),
+
+    #[error("Unknown column \"{0}\" in field `{0}`")]
+    InvalidViewerConfigError(&'static str, String),
+
+    #[error("Invalid `expressions` {}", format_valid_exprs(.0))]
+    InvalidViewerConfigExpressionsError(Rc<ValidateExpressionsData>),
+
+    #[error("No `Table` attached")]
+    NoTableError,
+
+    #[error(transparent)]
+    SerdeWasmBindgenError(Rc<serde_wasm_bindgen::Error>),
+
+    #[error(transparent)]
+    Utf8Error(#[from] FromUtf8Error),
+
+    #[error(transparent)]
+    StdIoError(Rc<std::io::Error>),
+
+    #[error(transparent)]
+    RmpSerdeEncodeError(Rc<rmp_serde::encode::Error>),
+
+    #[error(transparent)]
+    RmpSerdeDecodeError(Rc<rmp_serde::decode::Error>),
+
+    #[error(transparent)]
+    Base64DecodeError(#[from] base64::DecodeError),
+
+    #[error(transparent)]
+    ChronoParseError(#[from] chrono::ParseError),
+}
+
+#[derive(Clone, Debug, Error)]
+pub struct ApiError(pub ApiErrorType, pub JsBackTrace);
 
 impl ApiError {
     pub fn new<T: Display>(val: T) -> Self {
-        ApiError(JsValue::from(format!("{}", val)))
+        apierror!(UnknownError(format!("{}", val)))
     }
-}
 
-impl Display for ApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(msg) = self.0.as_string() {
-            write!(f, "{}", msg)
-        } else {
-            write!(f, "{:?}", self.0)
+    /// The error category
+    pub fn kind(&self) -> &'static str {
+        match self.0 {
+            ApiErrorType::JsError(..) => "[JsError]",
+            ApiErrorType::TableError(_) => "[TableError]",
+            ApiErrorType::ExternalError(_) => "[ExternalError]",
+            ApiErrorType::UnknownError(..) => "[UnknownError]",
+            ApiErrorType::ClientError(_) => "[ClientError]",
+            ApiErrorType::CancelledError(_) => "[CancelledError]",
+            ApiErrorType::SerdeJsonError(_) => "[SerdeJsonError]",
+            ApiErrorType::ProstError(_) => "[ProstError]",
+            ApiErrorType::InvalidViewerConfigError(..) => "[InvalidViewerConfigError]",
+            ApiErrorType::InvalidViewerConfigExpressionsError(_) => "[InvalidViewerConfigError]",
+            ApiErrorType::NoTableError => "[NoTableError]",
+            ApiErrorType::SerdeWasmBindgenError(_) => "[SerdeWasmBindgenError]",
+            ApiErrorType::Utf8Error(_) => "[FromUtf8Error]",
+            ApiErrorType::StdIoError(_) => "[StdIoError]",
+            ApiErrorType::RmpSerdeEncodeError(_) => "[RmpSerdeEncodeError]",
+            ApiErrorType::RmpSerdeDecodeError(_) => "[RmpSerdeDecodeError]",
+            ApiErrorType::Base64DecodeError(_) => "[Base64DecodeError]",
+            ApiErrorType::ChronoParseError(_) => "[ChronoParseError]",
+            ApiErrorType::ViewerPluginError(_) => "[ViewerPluginError]",
+            ApiErrorType::JsRawError(_) => "[JsRawError]",
         }
     }
+
+    /// The raw internal enum
+    pub fn inner(&self) -> &'_ ApiErrorType {
+        &self.0
+    }
+
+    /// The `Display` for this error
+    pub fn message(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// This error's stacktrace from when it was constructed.
+    pub fn stacktrace(&self) -> String {
+        js_sys::Reflect::get(&self.1.0, &"stack".into())
+            .unwrap()
+            .as_string()
+            .unwrap()
+            .to_string()
+    }
 }
 
-impl std::error::Error for ApiError {}
+unsafe impl Send for ApiError {}
+unsafe impl Sync for ApiError {}
 
-/// A common Rust error handling idion (see e.g. `anyhow::Result`)
-pub type ApiResult<T> = Result<T, ApiError>;
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T: Into<ApiErrorType>> From<T> for ApiError {
+    fn from(value: T) -> Self {
+        let value: ApiErrorType = value.into();
+        let err = js_sys::Error::new(value.to_string().as_str());
+        ApiError(value, JsBackTrace(Rc::new(err.clone())))
+    }
+}
 
 impl From<ApiError> for JsValue {
     fn from(err: ApiError) -> Self {
-        err.0
+        err.1.0.unchecked_ref::<JsValue>().clone()
+    }
+}
+
+impl From<serde_wasm_bindgen::Error> for ApiError {
+    fn from(value: serde_wasm_bindgen::Error) -> Self {
+        ApiErrorType::SerdeWasmBindgenError(Rc::new(value)).into()
+    }
+}
+
+impl From<std::io::Error> for ApiError {
+    fn from(value: std::io::Error) -> Self {
+        ApiErrorType::StdIoError(Rc::new(value)).into()
+    }
+}
+
+impl From<rmp_serde::decode::Error> for ApiError {
+    fn from(value: rmp_serde::decode::Error) -> Self {
+        ApiErrorType::RmpSerdeDecodeError(Rc::new(value)).into()
+    }
+}
+
+impl From<rmp_serde::encode::Error> for ApiError {
+    fn from(value: rmp_serde::encode::Error) -> Self {
+        ApiErrorType::RmpSerdeEncodeError(Rc::new(value)).into()
+    }
+}
+
+impl From<Box<dyn std::error::Error>> for ApiError {
+    fn from(value: Box<dyn std::error::Error>) -> Self {
+        ApiErrorType::ExternalError(Rc::new(value)).into()
+    }
+}
+
+impl From<serde_json::Error> for ApiError {
+    fn from(value: serde_json::Error) -> Self {
+        ApiErrorType::SerdeJsonError(Rc::new(value)).into()
     }
 }
 
 impl From<JsValue> for ApiError {
     fn from(err: JsValue) -> Self {
-        Self(err)
+        if err.is_instance_of::<js_sys::Error>() {
+            ApiErrorType::JsRawError(err.clone().unchecked_into()).into()
+        } else {
+            apierror!(JsError(err))
+        }
     }
 }
 
-macro_rules! define_api_error {
-    ($($t:ty),*) => {
-        $(
-            impl From<$t> for ApiError {
-                fn from(err: $t) -> Self {
-                    ApiError(JsError::new(format!("{}", err).as_str()).into())
-                }
-            }
-        )*
+impl From<String> for ApiError {
+    fn from(value: String) -> Self {
+        apierror!(UnknownError(value.to_owned()))
     }
 }
 
-define_api_error!(
-    Box<dyn std::error::Error>,
-    serde_wasm_bindgen::Error,
-    std::io::Error,
-    serde_json::Error,
-    rmp_serde::encode::Error,
-    rmp_serde::decode::Error,
-    &str,
-    String,
-    futures::channel::oneshot::Canceled,
-    base64::DecodeError,
-    chrono::ParseError,
-    prost::DecodeError,
-    FromUtf8Error
-);
-
-#[wasm_bindgen(inline_js = r#"
-export class PerspectiveViewNotFoundError extends Error {}
-"#)]
-unsafe extern "C" {
-    pub type PerspectiveViewNotFoundError;
-
-    #[wasm_bindgen(constructor)]
-    unsafe fn new() -> PerspectiveViewNotFoundError;
+impl From<&str> for ApiError {
+    fn from(value: &str) -> Self {
+        apierror!(UnknownError(value.to_owned()))
+    }
 }
 
-/// Explicit conversion methods for `ApiResult<T>`, for situations where
-/// error-casting through the `?` operator is insufficient.
+/// `ToApiError` handles complex cases that can't be into-d
 pub trait ToApiError<T> {
     fn into_apierror(self) -> ApiResult<T>;
-    // fn as_apierror(&self) -> ApiResult<&T>;
 }
 
 impl<T> ToApiError<T> for Option<T> {
@@ -131,13 +273,16 @@ impl ToApiError<JsValue> for Result<(), ApiResult<JsValue>> {
     }
 }
 
-impl From<perspective_client::ClientError> for ApiError {
-    fn from(value: ClientError) -> Self {
-        match value {
-            ClientError::ViewNotFound => {
-                ApiError(unsafe { PerspectiveViewNotFoundError::new() }.into())
-            },
-            err => ApiError(JsError::new(format!("{}", err).as_str()).into()),
-        }
+/// A common Rust error handling idiom (see e.g. `anyhow::Result`)
+pub type ApiResult<T> = Result<T, ApiError>;
+
+// Backtrace
+
+#[derive(Clone, Debug)]
+pub struct JsBackTrace(pub Rc<js_sys::Error>);
+
+impl std::fmt::Display for JsBackTrace {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
     }
 }

--- a/rust/perspective-js/src/rust/utils/local_poll_loop.rs
+++ b/rust/perspective-js/src/rust/utils/local_poll_loop.rs
@@ -10,7 +10,7 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-use futures::channel::mpsc::{unbounded, UnboundedSender};
+use futures::channel::mpsc::{UnboundedSender, unbounded};
 use futures::{Future, SinkExt, StreamExt};
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
@@ -18,9 +18,9 @@ use wasm_bindgen_futures::spawn_local;
 /// A useful abstraction for connecting `!Sync + !Send` callbacks (like
 /// `js_sys::Function`) to `Send + Sync` contexts (like the client loop).
 #[derive(Clone)]
-pub struct LocalPollLoop<R: Send + Sync + Clone + 'static>(UnboundedSender<R>);
+pub struct LocalPollLoop<R: Send + Sync + 'static>(UnboundedSender<R>);
 
-impl<R: Send + Sync + Clone + 'static> LocalPollLoop<R> {
+impl<R: Send + Sync + 'static> LocalPollLoop<R> {
     /// Create a new loop which accepts a `R: Send + Sync` intermediate state
     /// argument and calls the `!Send + !Sync` callback.
     pub fn new<F: Fn(R) -> Result<JsValue, JsValue> + 'static>(send: F) -> Self {

--- a/rust/perspective-viewer/Cargo.toml
+++ b/rust/perspective-viewer/Cargo.toml
@@ -38,7 +38,7 @@ default = []
 
 [build-dependencies]
 serde_json = { version = "1.0.59", features = ["raw_value"] }
-procss = { version = "0.1.16" }
+procss = { version = "0.1.17" }
 glob = "0.3.0"
 anyhow = "1.0.66"
 
@@ -95,6 +95,8 @@ serde_json = { version = "1.0.107", features = ["raw_value"] }
 
 # Faster struct serialize/deserialize
 serde-wasm-bindgen = "0.6.0"
+
+thiserror = { version = "1.0.55" }
 
 # specta = { version = "2.0.0-rc.9", features = ["typescript"] }
 ts-rs = { version = "10.0.0", features = [

--- a/rust/perspective-viewer/src/less/status-bar.less
+++ b/rust/perspective-viewer/src/less/status-bar.less
@@ -212,12 +212,46 @@
         }
 
         .error-dialog {
+            position: absolute;
+            z-index: 1;
+            width: 100%;
+            flex-direction: column;
+            max-height: 300px;
+            top: 0;
+            left: 0;
+            padding: 0px 0px 0px 50px;
             display: none;
+            white-space: pre-wrap;
+            color: var(--plugin--background);
+            background: var(--icon--color);
+            border-radius: var(--status-bar--border-radius);
+        }
+
+        .error-dialog-message {
+            align-items: center;
+            display: flex;
+            padding-right: 17px;
+            height: var(--status-bar--height, 48px);
+            min-height: var(--status-bar--height, 48px);
+        }
+
+        .error-dialog-stack {
+            font-size: 10px;
+            padding-right: 17px;
+            color: var(--inactive--color);
+            overflow-y: auto;
+            padding-bottom: 24px;
+        }
+
+        .section:hover .error-dialog {
+            display: flex;
         }
 
         div#status_reconnect {
+            z-index: 2;
             display: flex;
             align-items: center;
+            border-radius: var(--status-bar--border-radius);
             height: var(--status-bar--height, 48px);
             &.errored {
                 cursor: pointer;

--- a/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/inactive_column.rs
@@ -73,17 +73,20 @@ impl InactiveColumnProps {
 
         // Don't treat `None` at the end of the column list as columns, we'll refill
         // these later
-        let last_filled = columns.iter().rposition(|x| !x.is_none()).unwrap();
-        columns.truncate(last_filled + 1);
+        if let Some(last_filled) = columns.iter().rposition(|x| !x.is_none()) {
+            columns.truncate(last_filled + 1);
 
-        let mode = self.renderer.metadata().mode;
-        if (mode == ColumnSelectMode::Select) ^ shift {
-            columns.clear();
-        } else {
-            columns.retain(|x| x.as_ref() != Some(&name));
+            let mode = self.renderer.metadata().mode;
+            if (mode == ColumnSelectMode::Select) ^ shift {
+                columns.clear();
+            } else {
+                columns.retain(|x| x.as_ref() != Some(&name));
+            }
+
+            columns.push(Some(name));
         }
 
-        columns.push(Some(name));
+        // Do this outside the loop so errors dont just become noops
         self.apply_columns(
             columns
                 .into_iter()

--- a/rust/perspective-viewer/src/rust/components/error_message.rs
+++ b/rust/perspective-viewer/src/rust/components/error_message.rs
@@ -32,12 +32,13 @@ pub fn error_message(p: &ErrorMessageProps) -> yew::Html {
         |(set_error, session)| {
             let sub = session.table_errored.add_listener({
                 clone!(set_error);
-                move |y| set_error.set(y)
+                move |y| set_error.set(Some(y))
             });
 
             || drop(sub)
         },
     );
+
     html! {
         <>
             <LocalStyle href={css!("render-warning")} />

--- a/rust/perspective-viewer/src/rust/components/plugin_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/plugin_selector.rs
@@ -77,7 +77,7 @@ impl Component for PluginSelector {
         match msg {
             RendererSelectPlugin(_plugin_name) => true,
             ComponentSelectPlugin(plugin_name) => {
-                if ctx.props().session.get_error().is_none() {
+                if !ctx.props().session.is_errored() {
                     ctx.props()
                         .renderer
                         .update_plugin(&PluginUpdate::Update(plugin_name))

--- a/rust/perspective-viewer/src/rust/components/status_bar.rs
+++ b/rust/perspective-viewer/src/rust/components/status_bar.rs
@@ -205,7 +205,8 @@ impl Component for StatusBar {
 
         let is_menu = ctx.props().session.has_table()
             && (ctx.props().presentation.is_settings_open()
-                || ctx.props().presentation.get_title().is_some());
+                || (ctx.props().presentation.get_title().is_some()
+                    && !ctx.props().session.is_errored()));
 
         if !ctx.props().session.has_table() {
             is_updating_class_name.push("updating");

--- a/rust/perspective-viewer/src/rust/model/restore_and_render.rs
+++ b/rust/perspective-viewer/src/rust/model/restore_and_render.rs
@@ -87,6 +87,12 @@ pub trait RestoreAndRender: HasRenderer + HasSession + HasPresentation {
                 presentation.update_columns_configs(columns_config);
                 let columns_config = presentation.all_columns_configs();
                 plugin.restore(&plugin_update, Some(&columns_config))?;
+
+                // The previous call which acquired the lock errored, so skip this render
+                if let Some(error) = session.get_error() {
+                    return Err(error);
+                }
+
                 session.validate().await?.create_view().await
             });
 

--- a/rust/perspective-viewer/src/rust/model/update_and_render.rs
+++ b/rust/perspective-viewer/src/rust/model/update_and_render.rs
@@ -61,9 +61,13 @@ pub trait UpdateAndRender: HasRenderer + HasSession {
 
 #[tracing::instrument(level = "debug", skip(session, renderer))]
 async fn update_and_render(session: Session, renderer: Renderer) -> ApiResult<()> {
+    // The previous call which acquired the lock errored, so skip this render
+    if session.get_error().is_some() {
+        return Ok(());
+    }
+
     let view = session.validate().await?;
-    renderer.draw(view.create_view()).await?;
-    Ok(())
+    renderer.draw(view.create_view()).await
 }
 
 impl<T: HasRenderer + HasSession> UpdateAndRender for T {}

--- a/rust/perspective-viewer/src/rust/session/metadata.rs
+++ b/rust/perspective-viewer/src/rust/session/metadata.rs
@@ -16,6 +16,7 @@ use std::ops::{Deref, DerefMut};
 
 use perspective_client::ColumnType;
 use perspective_client::config::*;
+use perspective_js::apierror;
 
 use crate::components::viewer::ColumnLocator;
 use crate::*;
@@ -87,7 +88,9 @@ impl SessionMetadata {
         valid_recs: &perspective_client::ValidateExpressionsData,
     ) -> ApiResult<HashSet<String>> {
         if !valid_recs.errors.is_empty() {
-            return Err("Expressions invalid".into());
+            return Err(apierror!(InvalidViewerConfigExpressionsError(
+                valid_recs.clone().into(),
+            )));
         }
 
         let mut edited = self

--- a/rust/perspective-viewer/test/js/settings.spec.js
+++ b/rust/perspective-viewer/test/js/settings.spec.js
@@ -107,16 +107,10 @@ test.describe("Settings", () => {
             });
 
             const contents = await get_contents(page);
-            expect(errors).toEqual(["Error::Intentional Load Error"]);
-
-            consoleLogs.expectedLogs.push(
-                "error",
-                /Failed to apply config: Error: Trying to draw the viewer with no table attached/
-            );
-            consoleLogs.expectedLogs.push(
-                "error",
-                /Caught error: Error: Trying to draw the viewer with no table attached/
-            );
+            expect(errors).toEqual([
+                'Error::Failed to construct table from JsValue("Intentional Load Error")',
+            ]);
+            consoleLogs.expectedLogs.push("error", /Intentional Load Error/);
         });
     });
 });


### PR DESCRIPTION
This PR adds a new UX for capturing the error details on hover over the error status icon. Additionally, the `perspective_js::ApiError` error type has been upgraded to `thiserror` derived version, in order to support the new UX features:

* Instances of duplicated stack trace inlining have been removed.
* `String -> Rich error type -> String -> Rich error type -> ...` conversions flattened to use `ApiError` everywhere.
* Better stacktraces (in debug builds), better error messages with categories overall. 
* UI is no longer borked nor does it auto-reset (though dismissing the dialog will reset the viewer).
* Rust API has changed to take `ClientError`/`ApiError` for `Client::on_error` callbacks, which is an API breaking change (though this type implements `Display` also).

<img width="984" alt="Screenshot 2025-06-08 at 6 26 19 PM" src="https://github.com/user-attachments/assets/d5cca638-784f-41e2-ab88-5702ffe939c4" />
