### PR TITLE
Fix Windows CI

### DIFF
--- a/rust/perspective-client/build.rs
+++ b/rust/perspective-client/build.rs
@@ -63,10 +63,12 @@ fn prost_build() -> Result<()> {
             .compile_protos(&[proto_file], &[include_path])
             .unwrap();
 
-        std::fs::rename(
+        std::fs::copy(
             std::env::var("OUT_DIR").unwrap() + "/perspective.proto.rs",
             "src/rust/proto.rs",
         )?;
+
+        std::fs::remove_file(std::env::var("OUT_DIR").unwrap() + "/perspective.proto.rs")?;
     }
 
     Ok(())


### PR DESCRIPTION
This PR fixes Windows CI for Github Actions runners, which seem to have changed their disk layouts somewhat.