### PR TITLE
Fix `perspective_viewer::restore` calls blurring

### DIFF
--- a/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
@@ -16,7 +16,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::str::FromStr;
 
-use ::perspective_js::utils::global;
 use ::perspective_js::{Table, View};
 use futures::future::join;
 use js_sys::*;
@@ -399,7 +398,6 @@ impl PerspectiveViewerElement {
     /// ```
     pub fn restore(&self, update: JsValue) -> ApiFuture<()> {
         tracing::info!("Restoring ViewerConfig");
-        global::document().blur_active_element();
         let this = self.clone();
         ApiFuture::new(async move {
             let decoded_update = ViewerConfigUpdate::decode(&update)?;
@@ -790,7 +788,6 @@ impl PerspectiveViewerElement {
     /// ```
     #[wasm_bindgen]
     pub fn toggleConfig(&self, force: Option<bool>) -> ApiFuture<JsValue> {
-        global::document().blur_active_element();
         let root = self.root.clone();
         ApiFuture::new(async move {
             let force = force.map(SettingsUpdate::Update);

--- a/rust/perspective-viewer/src/rust/utils/browser/mod.rs
+++ b/rust/perspective-viewer/src/rust/utils/browser/mod.rs
@@ -12,7 +12,6 @@
 
 mod blob;
 mod download;
-mod focus;
 mod request_animation_frame;
 mod selection;
 
@@ -21,6 +20,5 @@ mod tests;
 
 pub use blob::*;
 pub use download::*;
-pub use focus::*;
 pub use request_animation_frame::*;
 pub use selection::*;

--- a/rust/perspective-viewer/test/html/superstore_with_input.html
+++ b/rust/perspective-viewer/test/html/superstore_with_input.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="module" src="/node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-test/load-viewer-csv.js"></script>
+        <link rel="stylesheet" href="../css/demo.css" />
+        <link rel="stylesheet" href="/node_modules/@finos/perspective-viewer/dist/css/pro.css" />
+        <link rel="stylesheet" href="/node_modules/@fontsource/roboto-mono/400.css" />
+        <style>
+            perspective-viewer {
+                top: 50px !important;
+            }
+        </style>
+    </head>
+    <body>
+        <input />
+        <perspective-viewer></perspective-viewer>
+    </body>
+</html>


### PR DESCRIPTION
This PR fixes a small bug which causes Perspective to steal focus via `document.activeElement.blur()` when DOM-reconstructing API methods are called, like `perspective_viewer::restore`. This was done intentionally to make sure that modal windows and dropdowns rooted in the UI are dismissed before their parent widgets are removed, but this behavior is no longer necessary for this case. A test has also been added to assert focus is not stolen.
