### PR TITLE
Add a failing test for updating a table with a headerless CSV.

### DIFF
--- a/rust/perspective-python/perspective/tests/table/test_exception.py
+++ b/rust/perspective-python/perspective/tests/table/test_exception.py
@@ -63,3 +63,13 @@ class TestException(object):
             tbl.view(group_by=["b"])
 
         assert str(ex.value) == "Abort(): Invalid column 'b' found in View group_by.\n"
+
+    def test_exception_from_csv_update_with_no_header(self):
+        tbl = Table({ "stringcol": "string" })
+        data = "rowval  \n another row val"
+        errored = False
+        try:
+            tbl.update(data)
+        except:
+            errored = True
+        assert errored


### PR DESCRIPTION
This PR adds a test that crashes the test suite. It does not provide a fix, so the PR is marked as a draft for now.

Currently Perspective aborts in the C++ by updating a table with a CSV that has no header.

```py
tbl = Table({ "stringcol": "string" })
tbl.update("rowval  \n another row val")
```

Results in `Fatal Python error: Aborted`

This bug also occurs in Rust, see the example in the below comment
