### PR TITLE
Fix typo in docs for replace_all

### DIFF
--- a/rust/perspective-client/src/rust/config/expressions.rs
+++ b/rust/perspective-client/src/rust/config/expressions.rs
@@ -641,7 +641,7 @@ pub static COMPLETIONS: [CompletionItemSuggestion; 77] = [
     },
     CompletionItemSuggestion {
         label: "replace_all",
-        insert_text: "replace(${1:string}, ${2:pattern}, ${3:replacer})",
+        insert_text: "replace_all(${1:string}, ${2:pattern}, ${3:replacer})",
         documentation: "Replaces all non-overlapping matches of pattern in string with replacer, \
                         or return the original string if no replaces were made.",
     },
@@ -661,3 +661,17 @@ pub static COMPLETIONS: [CompletionItemSuggestion; 77] = [
         documentation: "Looks up a value in another column by index",
     },
 ];
+
+#[test]
+fn test_completions_insert_text_matches_label() {
+    for comp in COMPLETIONS {
+        let label = comp.label;
+        let insert_text = comp.insert_text;
+        assert!(
+            insert_text.starts_with(&label),
+            "insert_text for label {label} does not start with {label}:\n    {insert_text}",
+            label = label,
+            insert_text = insert_text
+        );
+    }
+}


### PR DESCRIPTION
I noticed while reading the expressions docs that `replace_all` was mistyped as `replace`.

https://docs.rs/perspective-client/latest/perspective_client/config/expressions/index.html#perspective-exprtk-extensions

This PR fixes that. I also added a pretty basic unit test which confirms that `insert_text`
starts with `label` for all of the `COMPLETIONS`.