### PR TITLE
Fix thread safety of multiple `Server` instances in the same process

### DIFF
--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -1182,12 +1182,12 @@ bucket::operator()(t_parameter_list parameters) {
     t_scalar_view temp_val(gt_val);
     val.set(temp_val());
 
+    // Bucket by numeric value
+    t_scalar_view temp_unit2(gt_unit);
+    unit.set(temp_unit2());
+
     if (val.is_numeric()) {
         rval.m_type = DTYPE_FLOAT64;
-
-        // Bucket by numeric value
-        t_scalar_view temp_unit(gt_unit);
-        unit.set(temp_unit());
 
         // type-check
         if (!unit.is_numeric() || val.m_status == STATUS_CLEAR
@@ -1206,10 +1206,10 @@ bucket::operator()(t_parameter_list parameters) {
     }
 
     // Must be a datetime - second parameter is a string
-    t_string_view temp_string(gt_unit);
-    std::string unit_str = std::string(temp_string.begin(), temp_string.end());
+    const auto unit_str = std::string(unit.get<const char*>());
     char temp_unit = 0;
-    auto len = unit_str.size();
+    const auto len = unit_str.size();
+
     unsigned long multiplicity;
     t_date_bucket_unit date_unit;
     if (len == 0) {
@@ -1245,13 +1245,6 @@ bucket::operator()(t_parameter_list parameters) {
     // type-check multiplicity
     switch (date_unit) {
         case t_date_bucket_unit::SECONDS:
-            if (multiplicity != 1 && multiplicity != 5 && multiplicity != 10
-                && multiplicity != 15 && multiplicity != 20
-                && multiplicity != 30) {
-                rval.m_status = STATUS_CLEAR;
-                return rval;
-            }
-            break;
         case t_date_bucket_unit::MINUTES:
             if (multiplicity != 1 && multiplicity != 5 && multiplicity != 10
                 && multiplicity != 15 && multiplicity != 20
@@ -1270,11 +1263,6 @@ bucket::operator()(t_parameter_list parameters) {
             break;
         case t_date_bucket_unit::DAYS:
             // TODO: day multiplicity.
-            if (multiplicity != 1) {
-                rval.m_status = STATUS_CLEAR;
-                return rval;
-            }
-            break;
         case t_date_bucket_unit::WEEKS:
             // TODO: week multiplicity
             if (multiplicity != 1) {

--- a/cpp/perspective/src/cpp/server.cpp
+++ b/cpp/perspective/src/cpp/server.cpp
@@ -307,7 +307,7 @@ re_intern_strings(std::string&& expression) {
 static auto
 re_unintern_some_exprs(std::string&& expression) {
     static const RE2 interned_param(
-        "(?:bucket|match|match_all|search|indexof|replace|replace_all)\\("
+        "(?:match|match_all|search|indexof|replace|replace_all)\\("
         "(?:.*?,\\s*(intern\\(('.*?')\\)))"
     );
     static const RE2 intern_match("intern\\(('.*?')\\)");
@@ -1291,12 +1291,6 @@ coerce_to(const t_dtype dtype, const A& val) {
 
 std::vector<ProtoServerResp<ProtoServer::Response>>
 ProtoServer::_handle_request(std::uint32_t client_id, Request&& req) {
-    static bool is_init_expr = false;
-    if (!is_init_expr) {
-        t_computed_expression_parser::init();
-        is_init_expr = true;
-    }
-
     std::vector<ProtoServerResp<ProtoServer::Response>> proto_resp;
     // proto::Response resp_env;
 
@@ -1810,7 +1804,7 @@ ProtoServer::_handle_request(std::uint32_t client_id, Request&& req) {
                 t_regex_mapping& regex_mapping = *expression_regex_mapping;
 
                 std::shared_ptr<t_computed_expression> computed_expression =
-                    t_computed_expression_parser::precompute(
+                    m_computed_expression_parser.precompute(
                         expr.expression_alias,
                         expr.expression,
                         expr.parse_expression_string,

--- a/cpp/perspective/src/cpp/table.cpp
+++ b/cpp/perspective/src/cpp/table.cpp
@@ -13,6 +13,7 @@
 #include "perspective/arrow_loader.h"
 #include "perspective/base.h"
 #include "perspective/column.h"
+#include "perspective/computed_expression.h"
 #include "perspective/data_table.h"
 #include "perspective/raw_types.h"
 #include "perspective/schema.h"
@@ -49,6 +50,7 @@ Table::Table(
     m_limit(limit),
     m_index(std::move(index)),
     m_gnode_set(false) {
+
     validate_columns(m_column_names);
 }
 
@@ -152,7 +154,7 @@ Table::validate_expressions(
 
         const auto& column_ids = std::get<3>(expr);
 
-        t_dtype expression_dtype = t_computed_expression_parser::get_dtype(
+        t_dtype expression_dtype = m_computed_expression_parser.get_dtype(
             expression_alias,
             expression_string,
             parsed_expression_string,

--- a/cpp/perspective/src/include/perspective/server.h
+++ b/cpp/perspective/src/include/perspective/server.h
@@ -663,6 +663,7 @@ namespace server {
         static std::uint32_t m_client_id;
         bool m_realtime_mode;
         ServerResources m_resources;
+        t_computed_expression_parser m_computed_expression_parser;
     };
 
 } // namespace server

--- a/cpp/perspective/src/include/perspective/table.h
+++ b/cpp/perspective/src/include/perspective/table.h
@@ -11,6 +11,7 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 #pragma once
+#include "perspective/computed_expression.h"
 #include <perspective/first.h>
 #include <perspective/exports.h>
 #include <perspective/base.h>
@@ -268,6 +269,7 @@ private:
     std::shared_ptr<t_gnode> m_gnode;
     std::vector<std::string> m_column_names;
     std::vector<t_dtype> m_data_types;
+    t_computed_expression_parser m_computed_expression_parser;
 
     /**
      * @brief The row number at which we start to write into the Table.


### PR DESCRIPTION
This PR fixes a memory corruption issue which can be encountered in `perspective-python` or `perspective-rs` when:

1. Multiple `Server` instances exist in the same process, and
2. Both instances have `View` instances with `expressions` fields, and
3. `View` methods on each are called from separate threads concurrently

This has technically been an issue since Perspective  `v3.0`, but only because before this version, #1 in this list was not possible as there was no public API for instancing multiple Servers.