### PR TITLE
Fix `null` handling for cast ExprTK functions

### DIFF
--- a/cpp/perspective/src/cpp/computed_function.cpp
+++ b/cpp/perspective/src/cpp/computed_function.cpp
@@ -1973,6 +1973,10 @@ to_string::operator()(t_parameter_list parameters) {
 
     t_generic_type& gt = parameters[0];
     t_scalar_view temp(gt);
+    if (temp().get_dtype() == DTYPE_NONE) {
+        return rval;
+    }
+
     val.set(temp());
 
     if (!val.is_valid()) {
@@ -2011,6 +2015,10 @@ to_integer::operator()(t_parameter_list parameters) {
 
     t_generic_type& gt = parameters[0];
     t_scalar_view temp(gt);
+    if (temp().get_dtype() == DTYPE_NONE) {
+        return rval;
+    }
+
     val.set(temp());
 
     if (!val.is_valid()) {
@@ -2059,8 +2067,11 @@ to_float::operator()(t_parameter_list parameters) {
 
     t_generic_type& gt = parameters[0];
     t_scalar_view temp(gt);
-    val.set(temp());
+    if (temp().get_dtype() == DTYPE_NONE) {
+        return rval;
+    }
 
+    val.set(temp());
     if (!val.is_valid()) {
         return rval;
     }
@@ -2101,6 +2112,10 @@ to_boolean::operator()(t_parameter_list parameters) {
 
     const t_generic_type& gt = parameters[0];
     t_scalar_view temp(gt);
+    if (temp().get_dtype() == DTYPE_NONE) {
+        return rval;
+    }
+
     val.set(temp());
 
     // handles STATUS_VALID, so no need to check separately
@@ -2169,6 +2184,10 @@ make_datetime::operator()(t_parameter_list parameters) {
 
     t_generic_type& gt = parameters[0];
     t_scalar_view temp(gt);
+    if (temp().get_dtype() == DTYPE_NONE) {
+        return rval;
+    }
+
     t_tscalar temp_scalar;
 
     temp_scalar.set(temp());

--- a/docs/md/explanation/architecture/client_server.md
+++ b/docs/md/explanation/architecture/client_server.md
@@ -1,6 +1,6 @@
 # Client/Server replicated
 
-<img src="./architecture.sub2.svg" />
+<img src="./architecture.sub3.svg" />
 
 _For medium-sized, real-time, synchronized and/or editable data sets with many
 concurrent users._

--- a/docs/md/explanation/architecture/server_only.md
+++ b/docs/md/explanation/architecture/server_only.md
@@ -1,6 +1,6 @@
 # Server-only
 
-<img src="./architecture.sub3.svg" />
+<img src="./architecture.sub2.svg" />
 
 _For extremely large datasets with a small number of concurrent users._
 

--- a/rust/perspective-js/test/js/expressions/numeric.spec.js
+++ b/rust/perspective-js/test/js/expressions/numeric.spec.js
@@ -1258,6 +1258,45 @@ function validate_binary_operations(output, expressions, operator) {
                 await table.delete();
             });
 
+            test("null", async function () {
+                const table = await perspective.table({
+                    a: "integer",
+                    b: "float",
+                });
+
+                const view = await table.view({
+                    expressions: [
+                        "float(null)",
+                        "string(null)",
+                        "integer(null)",
+                    ].reduce((x, y) => Object.assign(x, { [y]: y }), {}),
+                });
+
+                await table.update({
+                    a: [1, null, null, 4],
+                    b: [null, 2.5, null, 4.5],
+                });
+
+                const result = await view.to_columns();
+                expect(result["float(null)"]).toEqual([null, null, null, null]);
+                expect(result["string(null)"]).toEqual([
+                    null,
+                    null,
+                    null,
+                    null,
+                ]);
+
+                expect(result["integer(null)"]).toEqual([
+                    null,
+                    null,
+                    null,
+                    null,
+                ]);
+
+                await view.delete();
+                await table.delete();
+            });
+
             test("percent_of", async function () {
                 const table = await perspective.table({
                     a: "integer",

--- a/rust/perspective-js/test/js/leaks.spec.js
+++ b/rust/perspective-js/test/js/leaks.spec.js
@@ -48,8 +48,8 @@ async function leak_test(test, num_iterations = 10_000) {
 
     const final_used = (await perspective.system_info()).used_size;
     expect((await perspective.system_info()).heap_size).toEqual(start);
-    expect(final_used / start_used).toBeGreaterThanOrEqual(0.8);
-    expect(final_used / start_used).toBeLessThanOrEqual(1.5);
+    expect(Number(final_used) / Number(start_used)).toBeGreaterThanOrEqual(0.8);
+    expect(Number(final_used) / Number(start_used)).toBeLessThanOrEqual(1.5);
 }
 
 /**


### PR DESCRIPTION
This PR modifies the behavior of the `null` literal in ExprTK expressions to preserve `null` when being cast e.g. `float(null)`, which is required to satisfy the type checker for e.g. branching. A test has been added for this case - I don't think this can be called a regression since it's always been the case, but it is at least a bug.