### PR TITLE
Update column paths when the colun set changes in `perspective-viewer-datagrid`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.2",
  "itertools 0.10.5",
+ "num-traits",
  "paste",
  "prost",
  "prost-build",

--- a/packages/perspective-viewer-datagrid/src/js/custom_elements/datagrid.js
+++ b/packages/perspective-viewer-datagrid/src/js/custom_elements/datagrid.js
@@ -123,6 +123,14 @@ export class HTMLPerspectiveViewerDatagridPluginElement extends HTMLElement {
     async update(view) {
         if (this.model === undefined) {
             await this.draw(view);
+        } else if (this.model._config.split_by?.length > 0) {
+            const dimensions = await view.dimensions();
+            this.model._num_rows = dimensions.num_view_rows;
+            // if (this.model._column_paths.length !== dimensions.num_view_columns) {
+            // await this.draw(view);
+            // } else {
+            await this.regular_table.draw();
+            // }
         } else {
             this.model._num_rows = await view.num_rows();
             await this.regular_table.draw();

--- a/rust/generate-metadata/main.rs
+++ b/rust/generate-metadata/main.rs
@@ -73,7 +73,7 @@ pub fn generate_type_bindings_js() -> Result<(), Box<dyn Error>> {
     UpdateOptions::export_all_to(&path)?;
     DeleteOptions::export_all_to(&path)?;
     ViewWindow::export_all_to(&path)?;
-    SystemInfo::export_all_to(&path)?;
+    SystemInfo::<f64>::export_all_to(&path)?;
     Ok(())
 }
 

--- a/rust/generate-metadata/main.rs
+++ b/rust/generate-metadata/main.rs
@@ -32,8 +32,8 @@ use std::fs;
 
 use perspective_client::config::*;
 use perspective_client::{
-    DeleteOptions, OnUpdateData, OnUpdateOptions, SystemInfo, TableInitOptions, UpdateOptions,
-    ViewWindow,
+    ColumnWindow, DeleteOptions, OnUpdateData, OnUpdateOptions, SystemInfo, TableInitOptions,
+    UpdateOptions, ViewWindow,
 };
 use perspective_viewer::config::ViewerConfigUpdate;
 use ts_rs::TS;
@@ -64,6 +64,7 @@ fn generate_exprtk_docs() -> Result<(), Box<dyn Error>> {
 #[doc(hidden)]
 pub fn generate_type_bindings_js() -> Result<(), Box<dyn Error>> {
     let path = std::env::current_dir()?.join("../perspective-js/src/ts/ts-rs");
+    ColumnWindow::export_all_to(&path)?;
     ViewWindow::export_all_to(&path)?;
     TableInitOptions::export_all_to(&path)?;
     ViewConfigUpdate::export_all_to(&path)?;

--- a/rust/perspective-client/Cargo.toml
+++ b/rust/perspective-client/Cargo.toml
@@ -65,6 +65,7 @@ itertools = { version = "0.10.1" }
 paste = { version = "1.0.12" }
 prost-types = { version = "0.12.3" }
 getrandom = { version = "0.3", features = ["wasm_js"] }
+num-traits = "0.2.19"
 rand = { version = "=0.9.1" }
 rand-unique = { version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/perspective-client/perspective.proto
+++ b/rust/perspective-client/perspective.proto
@@ -420,7 +420,10 @@ message ViewToArrowResp {
     bytes arrow = 1;
 }
 
-message ViewColumnPathsReq {}
+message ViewColumnPathsReq {
+    optional uint32 start_col = 1;
+    optional uint32 end_col = 2;
+}
 
 // // TODO This is a better paths representations but its not compatible with
 // // the legacy API. Let's do this when we can fix the API.

--- a/rust/perspective-client/src/rust/lib.rs
+++ b/rust/perspective-client/src/rust/lib.rs
@@ -53,7 +53,9 @@ pub use crate::table::{
     DeleteOptions, ExprValidationResult, Table, TableInitOptions, TableReadFormat, UpdateOptions,
 };
 pub use crate::table_data::{TableData, UpdateData};
-pub use crate::view::{OnUpdateData, OnUpdateMode, OnUpdateOptions, View, ViewWindow};
+pub use crate::view::{
+    ColumnWindow, OnUpdateData, OnUpdateMode, OnUpdateOptions, View, ViewWindow,
+};
 
 pub type ClientError = utils::ClientError;
 pub type ExprValidationError = crate::proto::table_validate_expr_resp::ExprValidationError;

--- a/rust/perspective-client/src/rust/view.rs
+++ b/rust/perspective-client/src/rust/view.rs
@@ -69,6 +69,15 @@ pub struct Dimensions {
     pub num_table_columns: usize,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TS, PartialEq)]
+pub struct ColumnWindow {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_col: Option<f32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_col: Option<f32>,
+}
+
 /// Options for serializing a window of data from a [`View`].
 ///
 /// Some fields of [`ViewWindow`] are only applicable to specific methods of
@@ -239,8 +248,12 @@ impl View {
     ///
     /// A column path shows the columns that a given cell belongs to after
     /// pivots are applied.
-    pub async fn column_paths(&self) -> ClientResult<Vec<String>> {
-        let msg = self.client_message(ClientReq::ViewColumnPathsReq(ViewColumnPathsReq {}));
+    pub async fn column_paths(&self, window: ColumnWindow) -> ClientResult<Vec<String>> {
+        let msg = self.client_message(ClientReq::ViewColumnPathsReq(ViewColumnPathsReq {
+            start_col: window.start_col.map(|x| x as u32),
+            end_col: window.end_col.map(|x| x as u32),
+        }));
+
         match self.client.oneshot(&msg).await? {
             ClientResp::ViewColumnPathsResp(ViewColumnPathsResp { paths }) => {
                 // Ok(paths.into_iter().map(|x| x.path).collect())

--- a/rust/perspective-js/build.js
+++ b/rust/perspective-js/build.js
@@ -142,9 +142,6 @@ async function build_all() {
         "inherit",
         "inherit"
     );
-
-    await cpy("target/themes/*", "dist/css");
-    await cpy("target/themes/*", "dist/css");
 }
 
 build_all();

--- a/rust/perspective-js/src/rust/client.rs
+++ b/rust/perspective-js/src/rust/client.rs
@@ -477,7 +477,7 @@ impl Client {
             .map(|x| x.now() as u64);
 
         info.timestamp = timestamp;
-        let record = JsValue::from_serde_ext(&info)?;
+        let record = JsValue::from_serde_ext(&info.cast::<f64>())?;
         Ok(record.unchecked_into())
     }
 }

--- a/rust/perspective-js/src/rust/lib.rs
+++ b/rust/perspective-js/src/rust/lib.rs
@@ -42,6 +42,7 @@ pub use crate::table_data::*;
 #[wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
 export type * from "../../src/ts/ts-rs/ViewWindow.d.ts";
+export type * from "../../src/ts/ts-rs/ColumnWindow.d.ts";
 export type * from "../../src/ts/ts-rs/TableInitOptions.d.ts";
 export type * from "../../src/ts/ts-rs/ViewConfigUpdate.d.ts";
 export type * from "../../src/ts/ts-rs/ViewOnUpdateResp.d.ts";
@@ -50,6 +51,7 @@ export type * from "../../src/ts/ts-rs/UpdateOptions.d.ts";
 export type * from "../../src/ts/ts-rs/DeleteOptions.d.ts";
 export type * from "../../src/ts/ts-rs/SystemInfo.d.ts";
 
+import type {ColumnWindow} from "../../src/ts/ts-rs/ColumnWindow.d.ts";
 import type {ViewWindow} from "../../src/ts/ts-rs/ViewWindow.d.ts";
 import type {TableInitOptions} from "../../src/ts/ts-rs/TableInitOptions.d.ts";
 import type {ViewConfigUpdate} from "../../src/ts/ts-rs/ViewConfigUpdate.d.ts";

--- a/rust/perspective-js/src/rust/utils/serde.rs
+++ b/rust/perspective-js/src/rust/utils/serde.rs
@@ -32,7 +32,6 @@ where
     {
         t.serialize(
             &serde_wasm_bindgen::Serializer::new()
-                .serialize_large_number_types_as_bigints(true)
                 .serialize_maps_as_objects(true)
                 .serialize_missing_as_null(true),
         )

--- a/rust/perspective-js/src/rust/view.rs
+++ b/rust/perspective-js/src/rust/view.rs
@@ -11,7 +11,9 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 use js_sys::{Array, ArrayBuffer, Function, Object};
-use perspective_client::{OnUpdateData, OnUpdateOptions, ViewWindow, assert_view_api};
+use perspective_client::{
+    ColumnWindow, OnUpdateData, OnUpdateOptions, ViewWindow, assert_view_api,
+};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 
@@ -24,6 +26,10 @@ unsafe extern "C" {
     #[wasm_bindgen(typescript_type = "ViewWindow")]
     #[derive(Clone)]
     pub type JsViewWindow;
+
+    #[wasm_bindgen(typescript_type = "ColumnWindow")]
+    #[derive(Clone)]
+    pub type JsColumnWindow;
 
     #[wasm_bindgen(method, setter, js_name = "formatted")]
     pub fn set_formatted(this: &JsViewWindow, x: bool);
@@ -79,8 +85,9 @@ impl View {
     /// A column path shows the columns that a given cell belongs to after
     /// pivots are applied.
     #[wasm_bindgen]
-    pub async fn column_paths(&self) -> ApiResult<JsValue> {
-        let columns = self.0.column_paths().await?;
+    pub async fn column_paths(&self, window: Option<JsColumnWindow>) -> ApiResult<JsValue> {
+        let window = window.into_serde_ext::<Option<ColumnWindow>>()?;
+        let columns = self.0.column_paths(window.unwrap_or_default()).await?;
         Ok(JsValue::from_serde_ext(&columns)?)
     }
 

--- a/rust/perspective-js/src/ts/wasm/engine.ts
+++ b/rust/perspective-js/src/ts/wasm/engine.ts
@@ -148,7 +148,7 @@ export class PerspectiveSession {
             polled,
             async (msg: ApiResponse) => {
                 if (msg.client_id === 0) {
-                    console.error("Poll error");
+                    await this.client_map.get(this.client_id)!(msg.data);
                 } else {
                     await this.client_map.get(msg.client_id)!(msg.data);
                 }

--- a/rust/perspective-js/test/js/aggregates.spec.js
+++ b/rust/perspective-js/test/js/aggregates.spec.js
@@ -152,7 +152,7 @@ const std = (nums) => {
                 },
             });
             const paths = await view.column_paths();
-            expect(paths).toEqual(["__ROW_PATH__", "y", "z"]);
+            expect(paths).toEqual(["y", "z"]);
             const answer = [
                 { __ROW_PATH__: [], y: "c", z: true },
                 { __ROW_PATH__: [false], y: "d", z: false },
@@ -174,7 +174,7 @@ const std = (nums) => {
                 },
             });
             const paths = await view.column_paths();
-            expect(paths).toEqual(["__ROW_PATH__", "y", "z"]);
+            expect(paths).toEqual(["y", "z"]);
             const answer = [
                 { __ROW_PATH__: [], y: 4, z: 4 },
                 { __ROW_PATH__: [false], y: 2, z: 2 },

--- a/rust/perspective-js/test/js/expressions/functionality.spec.js
+++ b/rust/perspective-js/test/js/expressions/functionality.spec.js
@@ -2385,14 +2385,7 @@ import perspective from "../perspective_client";
             });
 
             let paths = await view.column_paths();
-            expect(paths).toEqual([
-                "__ROW_PATH__",
-                "w",
-                "x",
-                "y",
-                "z",
-                "column",
-            ]);
+            expect(paths).toEqual(["w", "x", "y", "z", "column"]);
 
             await view.delete();
 
@@ -2404,7 +2397,6 @@ import perspective from "../perspective_client";
 
             for (const expected of expected_paths) {
                 const output = expected.slice();
-                output.unshift("__ROW_PATH__");
                 view = await table.view({
                     group_by: ["y"],
                     expressions: { column: '"w" + "x"' },
@@ -2417,7 +2409,6 @@ import perspective from "../perspective_client";
 
             for (const expected of expected_paths) {
                 const output = expected.slice();
-                output.unshift("__ROW_PATH__");
                 view = await table.view({
                     group_by: ["column"],
                     expressions: { column: '"w" + "x"' },
@@ -2448,7 +2439,7 @@ import perspective from "../perspective_client";
             let view = await table.view(config);
 
             let paths = await view.column_paths();
-            expect(paths).toEqual(["__ROW_PATH__", "w", "x", "y", "z", "1234"]);
+            expect(paths).toEqual(["w", "x", "y", "z", "1234"]);
 
             await view.delete();
 
@@ -2460,7 +2451,6 @@ import perspective from "../perspective_client";
 
             for (const expected of expected_paths) {
                 const output = expected.slice();
-                output.unshift("__ROW_PATH__");
                 view = await table.view({
                     ...config,
                     columns: expected,
@@ -2472,7 +2462,6 @@ import perspective from "../perspective_client";
 
             for (const expected of expected_paths) {
                 const output = expected.slice();
-                output.unshift("__ROW_PATH__");
                 view = await table.view({
                     ...config,
                     columns: expected,

--- a/rust/perspective-js/test/js/group_by.spec.js
+++ b/rust/perspective-js/test/js/group_by.spec.js
@@ -1056,7 +1056,7 @@ const std = (nums) => {
                 group_by: ["x"],
             });
             const paths = await view.column_paths();
-            expect(paths).toEqual(["__ROW_PATH__", "x", "y", "z"]);
+            expect(paths).toEqual(["x", "y", "z"]);
             view.delete();
             table.delete();
         });
@@ -1083,13 +1083,7 @@ const std = (nums) => {
                 },
             });
             const paths = await view.column_paths();
-            expect(paths).toEqual([
-                "__ROW_PATH__",
-                "2345",
-                "1234",
-                "x",
-                "1.23456789",
-            ]);
+            expect(paths).toEqual(["2345", "1234", "x", "1.23456789"]);
             view.delete();
             table.delete();
         });
@@ -1101,7 +1095,7 @@ const std = (nums) => {
                 columns: ["z", "y", "x"],
             });
             const paths = await view.column_paths();
-            expect(paths).toEqual(["__ROW_PATH__", "z", "y", "x"]);
+            expect(paths).toEqual(["z", "y", "x"]);
             view.delete();
             table.delete();
         });
@@ -1113,7 +1107,7 @@ const std = (nums) => {
                 group_by: ["x"],
             });
             const paths = await view.column_paths();
-            expect(paths).toEqual(["__ROW_PATH__", "x"]);
+            expect(paths).toEqual(["x"]);
             view.delete();
             table.delete();
         });
@@ -1126,7 +1120,6 @@ const std = (nums) => {
             });
             const paths = await view.column_paths();
             expect(paths).toEqual([
-                "__ROW_PATH__",
                 "a|x",
                 "a|y",
                 "a|z",
@@ -1153,7 +1146,6 @@ const std = (nums) => {
             });
             const paths = await view.column_paths();
             expect(paths).toEqual([
-                "__ROW_PATH__",
                 "a|z",
                 "a|y",
                 "a|x",
@@ -1179,7 +1171,7 @@ const std = (nums) => {
                 split_by: ["y"],
             });
             const paths = await view.column_paths();
-            expect(paths).toEqual(["__ROW_PATH__", "a|x", "b|x", "c|x", "d|x"]);
+            expect(paths).toEqual(["a|x", "b|x", "c|x", "d|x"]);
             view.delete();
             table.delete();
         });
@@ -1196,7 +1188,6 @@ const std = (nums) => {
             const view = await table.view({ group_by: ["y"], split_by: ["z"] });
             const paths = await view.column_paths();
             expect(paths).toEqual([
-                "__ROW_PATH__",
                 "2019-04-11|w",
                 "2019-04-11|x",
                 "2019-04-11|y",

--- a/rust/perspective-js/test/js/sort.spec.js
+++ b/rust/perspective-js/test/js/sort.spec.js
@@ -426,7 +426,7 @@ const data3 = {
                     sort: [["x", "col desc"]],
                 });
                 const paths = await view.column_paths();
-                expect(paths).toEqual(["__ROW_PATH__", "false|w", "true|w"]);
+                expect(paths).toEqual(["false|w", "true|w"]);
                 view.delete();
                 table.delete();
             });
@@ -443,7 +443,7 @@ const data3 = {
                     ],
                 });
                 const paths = await view.column_paths();
-                expect(paths).toEqual(["__ROW_PATH__", "false|w", "true|w"]);
+                expect(paths).toEqual(["false|w", "true|w"]);
                 view.delete();
                 table.delete();
             });
@@ -758,7 +758,7 @@ const data3 = {
                     ],
                 });
                 const paths = await view.column_paths();
-                expect(paths).toEqual(["__ROW_PATH__", "x|z", "y|z"]);
+                expect(paths).toEqual(["x|z", "y|z"]);
                 const expected = {
                     __ROW_PATH__: [[], ["a"], ["b"], ["c"]],
                     "x|z": [7, 3, null, 4],
@@ -786,7 +786,7 @@ const data3 = {
                     ],
                 });
                 const paths = await view.column_paths();
-                expect(paths).toEqual(["__ROW_PATH__", "y|z", "x|z"]);
+                expect(paths).toEqual(["y|z", "x|z"]);
                 const expected = {
                     __ROW_PATH__: [[], ["c"], ["b"], ["a"]],
                     "y|z": [3, null, 3, null],
@@ -811,7 +811,7 @@ const data3 = {
                     sort: [["x", "desc"]],
                 });
                 const paths = await view.column_paths();
-                expect(paths).toEqual(["__ROW_PATH__", "a|z", "b|z", "c|z"]);
+                expect(paths).toEqual(["a|z", "b|z", "c|z"]);
                 const expected = {
                     __ROW_PATH__: [[], ["x"], ["y"]],
                     "a|z": [3, 3, null],

--- a/rust/perspective-python/perspective/tests/table/test_column_paths.py
+++ b/rust/perspective-python/perspective/tests/table/test_column_paths.py
@@ -1,0 +1,89 @@
+#  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+#  ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+#  ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+#  ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+#  ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+#  ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+#  ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+#  ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+#  ┃ This file is part of the Perspective library, distributed under the terms ┃
+#  ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+#  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import perspective as psp
+
+client = psp.Server().new_local_client()
+
+
+class TestViewColumnPaths(object):
+    def test_column_paths(self, superstore):
+        tbl = client.table(superstore)
+        view = tbl.view()
+        paths = view.column_paths()
+        assert paths == [
+            "index",
+            "Row ID",
+            "Order ID",
+            "Order Date",
+            "Ship Date",
+            "Ship Mode",
+            "Customer ID",
+            "Segment",
+            "Country",
+            "City",
+            "State",
+            "Postal Code",
+            "Region",
+            "Product ID",
+            "Category",
+            "Sub-Category",
+            "Sales",
+            "Quantity",
+            "Discount",
+            "Profit",
+        ]
+
+        view.delete()
+        tbl.delete()
+
+    def test_column_paths_split_by(self, superstore):
+        tbl = client.table(superstore)
+        view = tbl.view(group_by=["State"], columns=["Sales"], split_by=["Ship Mode"])
+        paths = view.column_paths()
+        assert paths == [
+            "First Class|Sales",
+            "Second Class|Sales",
+            "Standard Class|Sales",
+        ]
+
+        view.delete()
+        tbl.delete()
+
+    def test_column_paths_split_by_range(self, superstore):
+        tbl = client.table(superstore)
+        view = tbl.view(group_by=["State"], columns=["Sales"], split_by=["Ship Mode"])
+        paths = view.column_paths(start_col=1)
+        assert paths == [
+            "Second Class|Sales",
+            "Standard Class|Sales",
+        ]
+
+        view.delete()
+        view = tbl.view(group_by=["State"], columns=["Sales"], split_by=["Ship Mode"])
+        paths = view.column_paths(start_col=1, end_col=2)
+        assert paths == [
+            "Second Class|Sales",
+            "Standard Class|Sales",
+        ]
+
+        view.delete()
+        tbl = client.table(superstore)
+        view = tbl.view(group_by=["State"], columns=["Sales"], split_by=["Ship Mode"])
+        paths = view.column_paths(end_col=1)
+        assert paths == [
+            "First Class|Sales",
+            "Second Class|Sales",
+        ]
+
+        view.delete()
+        tbl.delete()

--- a/rust/perspective-python/perspective/tests/table/test_view.py
+++ b/rust/perspective-python/perspective/tests/table/test_view.py
@@ -119,14 +119,14 @@ class TestView(object):
         tbl = Table(data)
         view = tbl.view(group_by=["a"])
         paths = view.column_paths()
-        assert paths == ["__ROW_PATH__", "a", "b"]
+        assert paths == ["a", "b"]
 
     def test_view_column_path_one_numeric_names(self):
         data = {"a": [1, 2, 3], "b": [1.5, 2.5, 3.5], "1234": [5, 6, 7]}
         tbl = Table(data)
         view = tbl.view(group_by=["a"], columns=["b", "1234", "a"])
         paths = view.column_paths()
-        assert paths == ["__ROW_PATH__", "b", "1234", "a"]
+        assert paths == ["b", "1234", "a"]
 
     def test_view_column_path_two(self):
         data = {"a": [1, 2, 3], "b": [1.5, 2.5, 3.5]}
@@ -134,7 +134,6 @@ class TestView(object):
         view = tbl.view(group_by=["a"], split_by=["b"])
         paths = view.column_paths()
         assert paths == [
-            "__ROW_PATH__",
             "1.5|a",
             "1.5|b",
             "2.5|a",
@@ -245,7 +244,7 @@ class TestView(object):
             )
         )
         view = table.view(columns=["-0.1", "-0.05", "0.0", "0.1"], group_by=["str"])
-        assert view.column_paths() == ["__ROW_PATH__", "-0.1", "-0.05", "0.0", "0.1"]
+        assert view.column_paths() == ["-0.1", "-0.05", "0.0", "0.1"]
 
     def test_view_aggregate_order_with_columns(self):
         """If `columns` is provided, order is always guaranteed."""
@@ -257,7 +256,7 @@ class TestView(object):
             aggregates={"d": "avg", "c": "avg", "b": "last", "a": "last"},
         )
 
-        order = ["__ROW_PATH__", "a", "b", "c", "d"]
+        order = ["a", "b", "c", "d"]
         assert view.column_paths() == order
 
     def test_view_df_aggregate_order_with_columns(self):
@@ -272,7 +271,7 @@ class TestView(object):
             aggregates={"d": "avg", "c": "avg", "b": "last", "a": "last"},
         )
 
-        order = ["__ROW_PATH__", "index", "d", "a", "c", "b"]
+        order = ["index", "d", "a", "c", "b"]
         assert view.column_paths() == order
 
     def test_view_aggregates_with_no_columns(self):
@@ -281,7 +280,7 @@ class TestView(object):
         view = tbl.view(
             group_by=["a"], aggregates={"c": "avg", "a": "last"}, columns=[]
         )
-        assert view.column_paths() == ["__ROW_PATH__"]
+        assert view.column_paths() == []
         assert view.to_records() == [
             {"__ROW_PATH__": []},
             {"__ROW_PATH__": [1]},
@@ -297,8 +296,7 @@ class TestView(object):
         cols = tbl.columns()
         view = tbl.view(group_by=["a"], aggregates={"c": "avg", "a": "last"})
 
-        order = ["__ROW_PATH__"] + cols
-        assert view.column_paths() == order
+        assert view.column_paths() == cols
 
         # check that default aggregates have been applied
         result = view.to_columns()

--- a/rust/perspective-python/src/client/client_sync.rs
+++ b/rust/perspective-python/src/client/client_sync.rs
@@ -487,8 +487,13 @@ impl View {
     ///
     /// A column path shows the columns that a given cell belongs to after
     /// pivots are applied.
-    pub fn column_paths(&self, py: Python<'_>) -> PyResult<Vec<String>> {
-        self.0.column_paths().py_block_on(py)
+    #[pyo3(signature = (**window))]
+    pub fn column_paths(
+        &self,
+        py: Python<'_>,
+        window: Option<Py<PyDict>>,
+    ) -> PyResult<Vec<String>> {
+        self.0.column_paths(window).py_block_on(py)
     }
 
     /// Renders this [`View`] as a column-oriented JSON string. Useful if you

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/server.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/server.h
@@ -230,6 +230,10 @@ namespace server {
         virtual std::vector<std::vector<std::string>> column_paths() const = 0;
 
         [[nodiscard]]
+        virtual std::vector<std::vector<std::string>>
+        column_paths_range(t_uindex start_col, t_uindex end_col) const = 0;
+
+        [[nodiscard]]
         virtual std::map<std::string, std::string>
         expression_schema() const = 0;
 
@@ -427,6 +431,26 @@ namespace server {
             std::vector<std::vector<std::string>> out;
             std::vector<std::vector<t_tscalar>> column_paths =
                 m_view->column_paths();
+
+            for (const auto& path : column_paths) {
+                std::vector<std::string> path_str;
+                path_str.reserve(path.size());
+                for (const auto& scalar : path) {
+                    path_str.push_back(scalar.to_string());
+                }
+                out.push_back(path_str);
+            }
+
+            return out;
+        }
+
+        [[nodiscard]]
+        std::vector<std::vector<std::string>>
+        column_paths_range(t_uindex start_col, t_uindex end_col)
+            const override {
+            std::vector<std::vector<std::string>> out;
+            std::vector<std::vector<t_tscalar>> column_paths =
+                m_view->column_paths_range(start_col, end_col);
 
             for (const auto& path : column_paths) {
                 std::vector<std::string> path_str;

--- a/rust/perspective-server/cpp/perspective/src/include/perspective/view.h
+++ b/rust/perspective-server/cpp/perspective/src/include/perspective/view.h
@@ -119,6 +119,13 @@ public:
     std::vector<std::vector<t_tscalar>>
     column_names(bool skip = false, std::int32_t depth = 0) const;
 
+    std::vector<std::vector<t_tscalar>> column_names_range(
+        bool skip = false,
+        std::int32_t depth = 0,
+        t_uindex start_col = 0,
+        t_uindex end_col = 0
+    ) const;
+
     /**
      * @brief The aggregated column names of this View, showing the columns that
      * have been composed through the addition of a pivot as they appear in the
@@ -130,6 +137,9 @@ public:
      * @return std::vector<std::vector<t_tscalar>>>
      */
     std::vector<std::vector<t_tscalar>> column_paths() const;
+
+    std::vector<std::vector<t_tscalar>>
+    column_paths_range(t_uindex start_col, t_uindex end_col) const;
 
     std::vector<std::vector<std::string>> column_paths_string() const;
 

--- a/rust/perspective-viewer/src/rust/lib.rs
+++ b/rust/perspective-viewer/src/rust/lib.rs
@@ -54,6 +54,7 @@ use crate::utils::define_web_component;
 const TS_APPEND_CONTENT: &'static str = r#"
 import type {
     TableInitOptions, 
+    ColumnWindow,
     ViewWindow, 
     OnUpdateOptions,
     UpdateOptions,


### PR DESCRIPTION
This PR fixes `perspective-viewer-datagrid` to handle `split_by` columns which change due to a `Table::update` call which introduces a new value (or removes all instances of an existing one).

In order to implement this fix without requiring the datagrid to fetch _all_ column names for each tick, two breaking API changes are introduced as well:
* `View::column_paths` now takes optional `ColumnWindow` `start_col` and `end_col` bounds.
* `View::column_paths` now no longer returns `__ROW_PATH__` as an output column when a `group_by` is applied (though this column is still in the output data).

https://github.com/user-attachments/assets/32a9e140-29f2-4966-9a68-020c708a7cdb

