### PR TITLE
Fix Workspace.removeTable()

### DIFF
--- a/packages/perspective-viewer-datagrid/index.d.ts
+++ b/packages/perspective-viewer-datagrid/index.d.ts
@@ -16,7 +16,7 @@ declare global {
     interface CustomElementRegistry {
         get(
             tagName: "perspective-viewer-datagrid"
-        ): HTMLPerspectiveViewerDatagridPluginElement;
+        ): typeof HTMLPerspectiveViewerDatagridPluginElement;
 
         // TODO is this needed?
         whenDefined(tagName: "perspective-viewer-datagrid"): Promise<void>;

--- a/packages/perspective-workspace/src/ts/utils/observable_map.ts
+++ b/packages/perspective-workspace/src/ts/utils/observable_map.ts
@@ -25,12 +25,8 @@ export class ObservableMap<K, V> extends Map<K, V> {
     }
 
     delete(name: K) {
-        const result = this._delete_listener?.(name);
-        if (result) {
-            return super.delete(name);
-        } else {
-            return false;
-        }
+        this._delete_listener?.(name);
+        return super.delete(name);
     }
 
     addSetListener(listener: (name: K, val: V) => void) {

--- a/packages/perspective-workspace/test/js/table.spec.js
+++ b/packages/perspective-workspace/test/js/table.spec.js
@@ -111,6 +111,27 @@ function tests(context, compare) {
             `${context}-replace-table-works-with-errored-table.txt`
         );
     });
+
+    test("removeTable() smoke test", async ({ page }) => {
+        const tables = await page.evaluate(async () => {
+            const table = await window.__WORKER__.table("x\n1\n");
+            const workspace = document.getElementById("workspace");
+            await workspace.addTable("temptable", table);
+            return Array.from(workspace.tables.keys());
+        });
+
+        expect(tables).toEqual(["superstore", "temptable"]);
+        const result = await page.evaluate(async () => {
+            return await workspace.removeTable("temptable");
+        });
+        expect(result).toBe(true);
+
+        const tablesAfterRemove = await page.evaluate(async () => {
+            const workspace = document.getElementById("workspace");
+            return Array.from(workspace.tables.keys());
+        });
+        expect(tablesAfterRemove).toEqual(["superstore"]);
+    });
 }
 
 test.describe("Workspace table functions", () => {


### PR DESCRIPTION
A recent change to the workspace/viewer error handling resulted in the workspace
removeTable() method always failing.  This fixes the bug and adds a smoke/regression
test.

Also includes a Typescript fix for types in the custom elements registry.

-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [x] Include new tests that fail without this PR but passes with it.
-   [x] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
