### PR TITLE
Provide perspective token in JupyterLab to ensure proper ordering of other extensions

### DIFF
--- a/docs/md/how_to/python/jupyterlab.md
+++ b/docs/md/how_to/python/jupyterlab.md
@@ -59,3 +59,27 @@ Perspective also exposes a JS-only `mimerender-extension`. This lets you view
 this by right clicking one of these files and `Open With->CSVPerspective` (or
 `JSONPerspective` or `ArrowPerspective`). Perspective will also install itself
 as the default handler for opening `.arrow` files. -->
+
+## Depending on Perspective in your own JupyterLab Widget
+
+Perspective provides a [token for integration with JupyterLab's federated dependency model](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#plugins-interacting-with-each-other).
+This allows your plugin to simply depend on Perspective for initialization.
+
+In your plugin code:
+
+```javascript
+import {IPerspective} from "@finos/perspective-jupyterlab";
+
+export const MyCoolPlugin = {
+  activate,
+  id: "my-cool-plugin",
+  requires: [IPerspective],
+  autoStart: true,
+};
+
+// to use perspective, simply import. No initialization required
+import perspective from "@finos/perspective";
+```
+
+And remember to add `perspective-python` as a python dependency, to ensure
+the Perspective JupyterLab extension is installed.

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -31,6 +31,7 @@
         "@jupyter-widgets/base": ">2 <5",
         "@jupyterlab/application": ">2 <5",
         "@lumino/application": "<3",
+        "@lumino/coreutils": "<3",
         "@lumino/widgets": "<3"
     },
     "devDependencies": {

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -55,10 +55,6 @@
                 "bundled": true,
                 "singleton": true
             },
-            "@finos/perspective-jupyterlab": {
-                "bundled": true,
-                "singleton": true
-            },
             "@finos/perspective-viewer": {
                 "bundled": true,
                 "singleton": true

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -50,6 +50,22 @@
             "@jupyter-widgets/base": {
                 "bundled": false,
                 "singleton": true
+            },
+            "@finos/perspective": {
+                "bundled": true,
+                "singleton": true
+            },
+            "@finos/perspective-viewer": {
+                "bundled": true,
+                "singleton": true
+            },
+            "@finos/perspective-viewer-d3fc": {
+                "bundled": true,
+                "singleton": true
+            },
+            "@finos/perspective-viewer-datagrid": {
+                "bundled": true,
+                "singleton": true
             }
         },
         "discovery": {

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -55,6 +55,10 @@
                 "bundled": true,
                 "singleton": true
             },
+            "@finos/perspective-jupyterlab": {
+                "bundled": true,
+                "singleton": true
+            },
             "@finos/perspective-viewer": {
                 "bundled": true,
                 "singleton": true
@@ -64,6 +68,10 @@
                 "singleton": true
             },
             "@finos/perspective-viewer-datagrid": {
+                "bundled": true,
+                "singleton": true
+            },
+            "@finos/perspective-viewer-openlayers": {
                 "bundled": true,
                 "singleton": true
             }

--- a/packages/perspective-jupyterlab/src/js/index.js
+++ b/packages/perspective-jupyterlab/src/js/index.js
@@ -22,6 +22,7 @@ await Promise.all([
 ]);
 
 export * from "./model";
+export { IPerspective } from "./plugin";
 export * from "./version";
 export * from "./view";
 export * from "./widget";

--- a/packages/perspective-jupyterlab/src/js/plugin.js
+++ b/packages/perspective-jupyterlab/src/js/plugin.js
@@ -11,12 +11,18 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import { IJupyterWidgetRegistry } from "@jupyter-widgets/base";
-import { Token } from "@lumino/coreutils";
 import { PerspectiveModel } from "./model";
+import {
+    IPerspective,
+    IPerspectiveJupyterlab,
+    IPerspectiveViewer,
+    IPerspectiveViewerD3fc,
+    IPerspectiveViewerDatagrid,
+    IPerspectiveViewerOpenlayers,
+} from "./tokens";
 import { PerspectiveView } from "./view";
 import { PERSPECTIVE_VERSION } from "./version";
 const EXTENSION_ID = "@finos/perspective-jupyterlab";
-export const IPerspective = new Token(EXTENSION_ID);
 
 /**
  * PerspectiveJupyterPlugin Defines the Jupyterlab plugin, and registers `PerspectiveModel` and `PerspectiveView`
@@ -26,7 +32,14 @@ export const PerspectiveJupyterPlugin = {
     id: EXTENSION_ID,
     // @ts-ignore
     requires: [IJupyterWidgetRegistry],
-    provides: [IPerspective],
+    provides: [
+        IPerspective,
+        IPerspectiveJupyterlab,
+        IPerspectiveViewer,
+        IPerspectiveViewerD3fc,
+        IPerspectiveViewerDatagrid,
+        IPerspectiveViewerOpenlayers,
+    ],
     activate: (app, registry) => {
         registry.registerWidget({
             name: EXTENSION_ID,

--- a/packages/perspective-jupyterlab/src/js/plugin.js
+++ b/packages/perspective-jupyterlab/src/js/plugin.js
@@ -11,10 +11,12 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import { IJupyterWidgetRegistry } from "@jupyter-widgets/base";
+import { Token } from "@lumino/coreutils";
 import { PerspectiveModel } from "./model";
 import { PerspectiveView } from "./view";
 import { PERSPECTIVE_VERSION } from "./version";
 const EXTENSION_ID = "@finos/perspective-jupyterlab";
+export const IPerspective = new Token(EXTENSION_ID);
 
 /**
  * PerspectiveJupyterPlugin Defines the Jupyterlab plugin, and registers `PerspectiveModel` and `PerspectiveView`
@@ -24,6 +26,7 @@ export const PerspectiveJupyterPlugin = {
     id: EXTENSION_ID,
     // @ts-ignore
     requires: [IJupyterWidgetRegistry],
+    provides: [IPerspective],
     activate: (app, registry) => {
         registry.registerWidget({
             name: EXTENSION_ID,

--- a/packages/perspective-jupyterlab/src/js/tokens.js
+++ b/packages/perspective-jupyterlab/src/js/tokens.js
@@ -10,36 +10,19 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import perspective from "@finos/perspective";
-import perspective_viewer from "@finos/perspective-viewer";
+import { Token } from "@lumino/coreutils";
 
-import server_wasm from "@finos/perspective/dist/wasm/perspective-server.wasm";
-import client_wasm from "@finos/perspective-viewer/dist/wasm/perspective-viewer.wasm";
-
-await Promise.all([
-    perspective_viewer.init_client(client_wasm),
-    perspective.init_server(server_wasm),
-]);
-
-export * from "./model";
-export * from "./tokens";
-export * from "./version";
-export * from "./view";
-export * from "./widget";
-
-import "@finos/perspective-viewer-datagrid";
-import "@finos/perspective-viewer-d3fc";
-import "@finos/perspective-viewer-openlayers";
-
-// NOTE: only expose the widget here
-import { PerspectiveJupyterPlugin } from "./plugin";
-
-let plugins = [PerspectiveJupyterPlugin];
-
-// Conditionally import renderers if running in jupyterlab only
-if (window && window._JUPYTERLAB) {
-    const { PerspectiveRenderers } = await import("./renderer");
-    plugins.push(PerspectiveRenderers);
-}
-
-export default plugins;
+export const IPerspective = new Token("@finos/perspective");
+export const IPerspectiveJupyterlab = new Token(
+    "@finos/perspective-jupyterlab",
+);
+export const IPerspectiveViewer = new Token("@finos/perspective-viewer");
+export const IPerspectiveViewerD3fc = new Token(
+    "@finos/perspective-viewer-d3fc",
+);
+export const IPerspectiveViewerDatagrid = new Token(
+    "@finos/perspective-viewer-datagrid",
+);
+export const IPerspectiveViewerOpenlayers = new Token(
+    "@finos/perspective-viewer-openlayers",
+);

--- a/packages/perspective-jupyterlab/webpack.config.js
+++ b/packages/perspective-jupyterlab/webpack.config.js
@@ -11,6 +11,8 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 const CopyPlugin = require("copy-webpack-plugin");
+const { ModuleFederationPlugin } = webpack.container;
+const packageData = require("./package.json");
 
 module.exports = {
     experiments: {
@@ -19,6 +21,19 @@ module.exports = {
     plugins: [
         new CopyPlugin({
             patterns: [{ from: "./install.json", to: "../install.json" }],
+        }),
+        new ModuleFederationPlugin({
+            library: {
+                type: "var",
+                name: ["PERSPECTIVE"],
+            },
+            name: "PERSPECTIVE",
+            shared: packageData.jupyterlab.sharedPackages
+                .filter((pkg) => pkg.startsWith("@finos/perspective"))
+                .reduce((obj, pkg) => {
+                    obj[pkg] = { singleton: true };
+                    return obj;
+                }, {}),
         }),
     ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,6 +614,9 @@ importers:
       '@lumino/application':
         specifier: <3
         version: 2.4.4
+      '@lumino/coreutils':
+        specifier: <3
+        version: 2.2.1
       '@lumino/widgets':
         specifier: <3
         version: 2.7.1


### PR DESCRIPTION
JupyterLab has a [mechanism for having plugins depend on other plugins](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#plugins-interacting-with-each-other).

Since perspective registers custom elements (see #3056), this change lets other Jupyter extensions "depend" on `@finos/perspective-jupyterlab` by doing:

```javascript
import {IPerspective} from "@finos/perspective-jupyterlab";

export const MyCoolPlugin = {
  activate,
  id: "my-cool-plugin",
  requires: [IPerspective],
  autoStart: true,
};
```

This then ensures that `@finos/perspective-jupyterlab` gets activated before `MyCoolPlugin`, ensuring that custom webcomponents and wasm loading occurs. Downstream plugins like `MyCoolPlugin` can then just do:

```javascript
import perspective from "@finos/perspective";
```

without any additional initialization. 

Fixes #3056 

I'm open to adding tests but its just a constant, not sure what the best mechanism for doing so is.
~~We can also add developer docs if we want, happy to write them.~~ done

### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [ ] Include new tests that fail without this PR but passes with it.
-   [x] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
