### PR TITLE
Fix concurrent update/view creation segfault

### DIFF
--- a/rust/perspective-server/cpp/perspective/src/cpp/context_two.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/context_two.cpp
@@ -508,6 +508,7 @@ void
 t_ctx2::column_sort_by(const std::vector<t_sortspec>& sortby) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    m_column_sortby = sortby;
     m_ctraversal->sort_by(m_config, sortby, *(ctree()));
 }
 
@@ -576,6 +577,10 @@ t_ctx2::notify(const t_data_table& flattened) {
     }
     if (!m_sortby.empty()) {
         sort_by(m_sortby);
+    }
+
+    if (!m_column_sortby.empty()) {
+        column_sort_by(m_column_sortby);
     }
 }
 
@@ -650,6 +655,10 @@ t_ctx2::notify(
 
     if (!m_sortby.empty()) {
         sort_by(m_sortby);
+    }
+
+    if (!m_column_sortby.empty()) {
+        column_sort_by(m_column_sortby);
     }
 }
 

--- a/rust/perspective-server/cpp/perspective/src/cpp/server.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/server.cpp
@@ -184,6 +184,15 @@ make_context(
 
     auto pool = table->get_pool();
     auto gnode = table->get_gnode();
+
+    if (!sortspec.empty()) {
+        ctx2->sort_by(sortspec);
+    }
+
+    if (!col_sortspec.empty()) {
+        ctx2->column_sort_by(col_sortspec);
+    }
+
     pool->register_context(
         gnode->get_id(),
         name,
@@ -201,14 +210,6 @@ make_context(
         ctx2->set_depth(t_header::HEADER_COLUMN, column_pivot_depth - 1);
     } else {
         ctx2->set_depth(t_header::HEADER_COLUMN, column_pivots.size());
-    }
-
-    if (!sortspec.empty()) {
-        ctx2->sort_by(sortspec);
-    }
-
-    if (!col_sortspec.empty()) {
-        ctx2->column_sort_by(col_sortspec);
     }
 
     return ctx2;


### PR DESCRIPTION
This PR fixes a segfault that occurred rarely when a large, deeply pivotted `View` is created while its underlying `Table` is being updated, and adds a test (courtesy of @timkpaine)
