### PR TITLE
perspective-workspace: safer isVisible() callbacks

### DIFF
--- a/packages/workspace/src/ts/workspace/commands.ts
+++ b/packages/workspace/src/ts/workspace/commands.ts
@@ -154,9 +154,9 @@ export const createCommands = (
         isVisible: (args) => {
             const target_widget = workspace.getWidgetByName(
                 args.target_widget_name as string,
-            )!;
+            );
 
-            return target_widget.title.label !== "";
+            return target_widget?.title.label !== "";
         },
         label: (args) => {
             const target_widget = workspace.getWidgetByName(
@@ -194,9 +194,9 @@ export const createCommands = (
         isVisible: (args) => {
             const widget = workspace.getWidgetByName(
                 args.widget_name as string,
-            )!;
+            );
 
-            return widget.parent! === (workspace.get_dock_panel() as Widget)
+            return widget?.parent === (workspace.get_dock_panel() as Widget)
                 ? true
                 : false;
         },
@@ -220,8 +220,10 @@ export const createCommands = (
             ),
         // iconClass: "menu-duplicate",
         isVisible: (args) => {
-            return workspace.getWidgetByName(args.widget_name as string)!
-                .parent! === (workspace.get_dock_panel() as Widget)
+            const parent = workspace.getWidgetByName(
+                args.widget_name as string,
+            )?.parent;
+            return parent === (workspace.get_dock_panel() as Widget)
                 ? true
                 : false;
         },


### PR DESCRIPTION
I've been seeing "cannot read properties of null" errors in these isVisible() callbacks while developing a React application which wraps `<perspective-workspace>`.   The error message details suggest getWidgetByName() is returning null at some point.

Make these isVisible() callbacks safer with the null coalescing operator, to avoid null 'dereferences' when `getWidgetByName()` returns null.  In this case, the command is considered not visible.

I didn't pin down reliable repro steps. Although from a look at this code's context, it might be related to a viewer widget being deleted from the workspace, or perhaps the viewer being renamed, while at the same time Lumino is rendering workspace commands (such as in the context menu).

### Pull Request Checklist

-   [ ] Description which clearly states what problems the PR solves.
-   [ ] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [ ] Include new tests that fail without this PR but passes with it.
-   [ ] Include any relevent Documentation changes related to this change.
-   [ ] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [ ] Reviewed PR commit history to remove unnecessary changes.
-   [ ] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
