### PR TITLE
Publish `@perspective-dev/server` package in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -987,6 +987,9 @@ jobs:
               working-directory: ./rust/perspective-js
 
             - run: pnpm pack --pack-destination=../..
+              working-directory: ./rust/perspective-server
+
+            - run: pnpm pack --pack-destination=../..
               working-directory: ./rust/perspective-viewer
 
             - run: pnpm pack --pack-destination=../..

--- a/rust/perspective-server/package.json
+++ b/rust/perspective-server/package.json
@@ -15,5 +15,8 @@
         "pro_self_extracting_wasm": "catalog:",
         "typescript": "catalog:",
         "zx": "catalog:"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }


### PR DESCRIPTION
The `@perspective-dev/server` package did not exist in `3.x` as its contents were inlined into what is now `@perspective-dev/client`. In order to simplify the build we've now just made this package public, which exclusively contains the `dist/was/perspective-server.wasm` server WebAsssembly module. This PR adds the `@perspective-dev/server` module to CI.