### PR TITLE
Fix `datetime` filters against numeric parameters

### DIFF
--- a/rust/perspective-js/test/js/filters.spec.js
+++ b/rust/perspective-js/test/js/filters.spec.js
@@ -395,7 +395,8 @@ const datetime_data_local = [
             });
 
             test("w == datetime as Date() object", async function () {
-                const table = await perspective.table(datetime_data);
+                const table = await perspective.table({ x: "datetime" });
+                await table.update(datetime_data);
                 expect(await table.schema()).toEqual({
                     x: "datetime",
                 });
@@ -413,8 +414,33 @@ const datetime_data_local = [
                 await table.delete();
             });
 
-            test.skip("w == datetime as US locale string", async function () {
-                const table = await perspective.table(datetime_data);
+            test("w == datetime as Number", async function () {
+                const table = await perspective.table({ x: "datetime" });
+                await table.update(datetime_data);
+                expect(await table.schema()).toEqual({
+                    x: "datetime",
+                });
+
+                const view = await table.view({
+                    filter: [["x", "==", +datetime_data[0]["x"]]],
+                });
+
+                expect(await view.num_rows()).toBe(1);
+                let data = await view.to_json();
+                data = data.map((d) => {
+                    d.x = new Date(d.x);
+                    return d;
+                });
+
+                expect(data).toEqual(datetime_data.slice(0, 1));
+                await view.delete();
+                await table.delete();
+            });
+
+            test("w == datetime as US locale string", async function () {
+                const table = await perspective.table({ x: "datetime" });
+                await table.update(datetime_data);
+
                 expect(await table.schema()).toEqual({
                     x: "datetime",
                 });

--- a/rust/perspective-python/perspective/tests/table/test_view.py
+++ b/rust/perspective-python/perspective/tests/table/test_view.py
@@ -1474,6 +1474,31 @@ class TestView(object):
             {"a": util.to_timestamp(datetime(2019, 7, 11, () * 1000)), "b": 4}
         ]
 
+    def test_view_filter_datetime_as_number_eq(self, util):
+        data = [
+            {"a": datetime(2019, 7, 11, 8, 15).timestamp(), "b": 2},
+            {"a": datetime(2019, 7, 11, 8, 16).timestamp(), "b": 4},
+        ]
+
+        tbl = Table({"a": "datetime", "b": "integer"})
+        tbl.update(data)
+        view = tbl.view(filter=[["a", "==", datetime(2019, 7, 11, 8, 15).timestamp()]])
+        assert view.to_records() == [
+            {"a": datetime(2019, 7, 11, 8, 15).timestamp(), "b": 2}
+        ]
+
+    def test_view_filter_datetime_as_number_neq(self, util):
+        data = [
+            {"a": datetime(2019, 7, 11, 8, 15).timestamp(), "b": 2},
+            {"a": datetime(2019, 7, 11, 8, 16).timestamp(), "b": 4},
+        ]
+        tbl = Table({"a": "datetime", "b": "integer"})
+        tbl.update(data)
+        view = tbl.view(filter=[["a", "!=", datetime(2019, 7, 11, 8, 15).timestamp()]])
+        assert view.to_records() == [
+            {"a": datetime(2019, 7, 11, 8, 16).timestamp(), "b": 4}
+        ]
+
     def test_view_filter_datetime_str_eq(self, util):
         data = [
             {"a": datetime(2019, 7, 11, 8, 15), "b": 2},

--- a/rust/perspective-server/cpp/perspective/src/cpp/server.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/server.cpp
@@ -1297,7 +1297,7 @@ coerce_to(const t_dtype dtype, const A& val) {
                 return scalar;
             }
             case DTYPE_TIME: {
-                t_time time{std::chrono::milliseconds((long)val).count()};
+                t_time time{std::chrono::milliseconds((long long)val).count()};
                 scalar.set(time);
                 return scalar;
             }


### PR DESCRIPTION
This PR fixes an integer overflow bug when a numeric type is used as a parameter for a`"datetime"` column filter in a `ViewConfig`, and corrects a few tests which should have caught this condition but were themselves bugged during the port to `3.x`.