### PR TITLE
Support a wider array of integers

### DIFF
--- a/rust/perspective-python/requirements.txt
+++ b/rust/perspective-python/requirements.txt
@@ -1,4 +1,5 @@
 pytest>=7.4.3
+maturin==1.6.0
 
 Faker==26.0.0
 ipywidgets==8.1.3

--- a/rust/perspective-server/cpp/perspective/src/cpp/server.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/server.cpp
@@ -1266,23 +1266,19 @@ coerce_to(const t_dtype dtype, const A& val) {
             case DTYPE_BOOL:
                 scalar.set(val == 1);
                 return scalar;
-            case DTYPE_UINT32:
-                scalar.set((std::uint32_t)val);
-                return scalar;
-            case DTYPE_UINT64:
-                scalar.set((std::uint64_t)val);
-                return scalar;
+            case DTYPE_UINT8:
+            case DTYPE_UINT16:
+            case DTYPE_INT8:
+            case DTYPE_INT16:
             case DTYPE_INT32:
-                scalar.set(val);
+                scalar.set(static_cast<std::int32_t>(val));
                 return scalar;
             case DTYPE_INT64:
-                scalar.set((std::int64_t)val);
-                return scalar;
+            case DTYPE_UINT32:
+            case DTYPE_UINT64:
             case DTYPE_FLOAT32:
-                scalar.set(static_cast<float>(val));
-                return scalar;
             case DTYPE_FLOAT64:
-                scalar.set(val);
+                scalar.set(static_cast<double>(val));
                 return scalar;
             case DTYPE_DATE: {
                 const auto time = static_cast<time_t>(val / 1000);
@@ -1302,7 +1298,9 @@ coerce_to(const t_dtype dtype, const A& val) {
                 return scalar;
             }
             default:
-                PSP_COMPLAIN_AND_ABORT("Unsupported double type");
+                std::stringstream ss;
+                ss << "Unsupported double type: " << dtype;
+                PSP_COMPLAIN_AND_ABORT(ss.str());
         }
     } else if constexpr (std::is_same_v<A, std::int32_t>) {
         return t_tscalar(val);


### PR DESCRIPTION
Currently arrow files may be sent to Perspective that use a variety of integer types that are not supported internally by Perspective. This PR allows these types by properly handling them on the server-side.

Look at the provided test to generate the appropriate arrow that fails on `master` but passes on this branch.
