### PR TITLE
fix: increase join aggregate size limit from 280 to 65536 chars

### DIFF
--- a/rust/perspective-server/cpp/perspective/src/cpp/sparse_tree.cpp
+++ b/rust/perspective-server/cpp/perspective/src/cpp/sparse_tree.cpp
@@ -35,8 +35,8 @@
 
 namespace perspective {
 
-// Tweet length
-const t_uindex MAX_JOIN_SIZE = 280;
+// Maximum size for join aggregate strings (64KB)
+const t_uindex MAX_JOIN_SIZE = 65536;
 
 t_tscalar
 get_dominant(std::vector<t_tscalar>& values) {


### PR DESCRIPTION
## Summary
Fixes #3088

The `join` aggregate function was truncating long content due to a 280 character limit (originally labeled as "Tweet length"). This was causing issues where:
- Grouped rows with long text content would have empty or truncated aggregated values
- The limit was too restrictive for many real-world use cases

## Changes
- Increased `MAX_JOIN_SIZE` from 280 to 65536 (64KB) in `sparse_tree.cpp`
- Updated the comment to reflect the new purpose

## Testing
This change allows the `join` aggregate to handle much longer content without truncation.