### PR TITLE
fix: respect column_config date formatting in D3FC chart tooltips

### DIFF
--- a/packages/viewer-d3fc/src/ts/tooltip/generateHTML.ts
+++ b/packages/viewer-d3fc/src/ts/tooltip/generateHTML.ts
@@ -31,15 +31,23 @@ function addDataValues(tooltipDiv, values) {
             select(this)
                 .text(`${d.name}: `)
                 .append("b")
-                .text(formatNumber(d.value));
+                .text(formatValue(d.value));
         });
 }
 
-const formatNumber = (value) =>
-    value === null || value === undefined
-        ? "-"
-        : value.toLocaleString(undefined, {
-              style: "decimal",
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-          });
+const formatValue = (value) => {
+    if (value === null || value === undefined) {
+        return "-";
+    }
+    if (typeof value === "string") {
+        return value;
+    }
+    if (typeof value === "number") {
+        return value.toLocaleString(undefined, {
+            style: "decimal",
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        });
+    }
+    return String(value);
+};


### PR DESCRIPTION
## Summary
Fixes #3020

The Y Bar (and other D3FC chart) hover labels were not respecting the date formatting and timezone settings from `column_config`. The tooltip was using hardcoded formatting (`dateStyle: 'short', timeStyle: 'medium'`) and local timezone instead of the user-specified settings.

## Changes

### selectionData.ts
- Added `createDateFormatter()` function that reads `date_format` settings from `column_config`:
  - Supports `timeZone` setting (UTC or custom)
  - Supports `dateStyle` and `timeStyle` options
  - Supports custom format with individual components (year, month, day, hour, etc.)
- Updated `toValue()` to accept `columnConfig` parameter and format dates using the proper formatter
- Updated `getGroupValues()`, `getSplitValues()`, `getDataValues()` to lookup column config from `settings.columns_config` and pass it to `toValue()`

### generateHTML.ts
- Renamed `formatNumber` to `formatValue` and updated it to handle pre-formatted strings (dates now come as formatted strings)

## Testing
The fix follows the same pattern as `viewer-datagrid/src/js/data_listener/formatter_cache.js` which correctly handles column_config date formatting.