### PR TITLE
Fix Arrow decimal type conversion to float instead of integer

### DIFF
--- a/rust/perspective-python/perspective/tests/table/test_table_arrow.py
+++ b/rust/perspective-python/perspective/tests/table/test_table_arrow.py
@@ -185,7 +185,7 @@ class TestTableArrow(object):
         tbl = Table(arrow_data)
         assert tbl.size() == 10
         assert tbl.schema() == {
-            "a": "integer",
+            "a": "float",
         }
         assert tbl.view().to_columns() == {"a": data[0]}
 
@@ -389,7 +389,7 @@ class TestTableArrow(object):
         tbl = Table(arrow_data)
         assert tbl.size() == 10
         assert tbl.schema() == {
-            "a": "integer",
+            "a": "float",
         }
         assert tbl.view().to_columns() == {"a": data[0]}
 


### PR DESCRIPTION
## Summary

- Fixes Arrow Decimal128 columns being incorrectly converted to integers
- Values like `3.14` now display correctly instead of as their internal representation (e.g., `314`)
- Maps decimal Arrow types to `DTYPE_FLOAT64` and uses `Decimal128::ToDouble(scale)` for proper conversion

## Test plan

- [x] Updated existing decimal stream and legacy tests to expect "float" schema type
- [ ] Verify with reproduction code from issue:
  ```python
  import perspective
  import duckdb
  import pyarrow as pa
  import io
  
  table = duckdb.sql("SELECT 3.14::DECIMAL AS decimal_col, 3.14::FLOAT AS float_col").arrow()
  buffer = io.BytesIO()
  
  with pa.ipc.new_file(buffer, table.schema) as writer:
      writer.write_table(table)
  
  bytes_object = buffer.getvalue()
  
  perspective_table = perspective.Table(bytes_object)
  # Both columns should now show 3.14
  ```

Fixes #2582