### PR TITLE
fix(workspace): Add missing d3fc CSS variables for chart plugins

### DIFF
--- a/packages/viewer-d3fc/src/ts/series/colorStyles.ts
+++ b/packages/viewer-d3fc/src/ts/series/colorStyles.ts
@@ -60,7 +60,11 @@ export const initialiseStyles = (
 };
 
 const getOpacityFromColor = (color) => {
-    return d3.color(color).opacity;
+    if (!color) {
+        return 1.0; // Default to fully opaque when color is undefined
+    }
+    const parsed = d3.color(color);
+    return parsed ? parsed.opacity : 1.0;
 };
 
 const stepAsColor = (value, opacity) => {

--- a/packages/workspace/src/themes/pro-dark.less
+++ b/packages/workspace/src/themes/pro-dark.less
@@ -39,6 +39,7 @@ perspective-workspace perspective-viewer[settings] {
 perspective-workspace {
     @include perspective-workspace-pro-base;
     @include perspective-viewer-pro-dark--colors;
+    @include perspective-viewer-pro-dark--d3fc;  // Fix: Add d3fc CSS variables for chart plugins
 
     background-color: #000202;
     color: white;

--- a/packages/workspace/src/themes/pro.less
+++ b/packages/workspace/src/themes/pro.less
@@ -21,6 +21,7 @@ perspective-indicator[theme="Pro Light"] {
 perspective-workspace {
     @include perspective-workspace-pro-base;
     @include perspective-viewer-pro--colors;
+    @include perspective-viewer-pro--d3fc;  // Fix: Add d3fc CSS variables for chart plugins
     background-color: #dadada;
 }
 


### PR DESCRIPTION
## Summary

Fixes #3101

Chart plugins (Y Line, Y Bar, Y Area, X Bar, etc.) crash when used inside `<perspective-workspace>` with the error:

```
Cannot read properties of null (reading 'opacity')
TypeError: Cannot read properties of null (reading 'opacity')
    at colorStyles.ts:63:26
```

## Root Cause

The workspace theme files (`pro.less` and `pro-dark.less`) were missing the d3fc CSS variable definitions. The `perspective-viewer` themes include `@include perspective-viewer-pro--d3fc` which defines variables like `--d3fc-series`, but the workspace themes only included `perspective-viewer-pro--colors`.

When `colorStyles.ts` tries to read `--d3fc-series` via `getComputedStyle()`, it gets an empty string, which causes `d3.color(null)` to return `null`, and accessing `.opacity` on `null` throws the error.

## Changes

1. **`packages/workspace/src/themes/pro.less`**: Add `@include perspective-viewer-pro--d3fc`
2. **`packages/workspace/src/themes/pro-dark.less`**: Add `@include perspective-viewer-pro-dark--d3fc`
3. **`packages/viewer-d3fc/src/ts/series/colorStyles.ts`**: Add defensive null check in `getOpacityFromColor()` as additional protection

## Testing

Before fix: Charts crash immediately when rendering in workspace
After fix: Charts render correctly with proper colors

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the [CONTRIBUTING](https://github.com/perspective-dev/perspective/blob/master/CONTRIBUTING.md) document