### PR TITLE
Fix windows Python builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-src"
-version = "2.1.1+27.1"
+version = "2.0.1+26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6217c3504da19b85a3a4b2e9a5183d635822d83507ba0986624b5c05b83bfc40"
+checksum = "f8ba1cfa4b9dc098926b8cce388bf434b93516db3ecf6e8b1a37eb643d733ee7"
 dependencies = [
  "cmake",
 ]

--- a/rust/perspective-client/Cargo.toml
+++ b/rust/perspective-client/Cargo.toml
@@ -57,7 +57,7 @@ path = "src/rust/lib.rs"
 [build-dependencies]
 prost-build = { version = "0.12.3" }
 # https://github.com/abseil/abseil-cpp/issues/1241#issuecomment-2138616329
-protobuf-src = { version = "2.1.1", optional = true }
+protobuf-src = { version = "=2.0.1", optional = true }
 
 [dependencies]
 async-lock = { version = "2.5.0" }


### PR DESCRIPTION
This PR fixes a regression in Windows Python build CI related to bundling the `protoc` compiler.

[Full CI build w/windows](https://github.com/perspective-dev/perspective/actions/runs/21221307702)