### PR TITLE
fix(jupyterlab): update @jupyter-widgets/base constraint for ipywidgets 8.x

### DIFF
--- a/packages/jupyterlab/package.json
+++ b/packages/jupyterlab/package.json
@@ -29,7 +29,7 @@
         "@perspective-dev/viewer": "workspace:",
         "@perspective-dev/client": "workspace:",
         "@perspective-dev/server": "workspace:",
-        "@jupyter-widgets/base": ">2 <5",
+        "@jupyter-widgets/base": ">2 <7",
         "@jupyterlab/application": ">2 <5",
         "@lumino/application": "<3",
         "@lumino/widgets": "<3"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
     # Dependencies
     "@d3fc/d3fc-chart": "5.1.9"
     "@d3fc/d3fc-element": "6.2.0"
-    "@jupyter-widgets/base": ">2 <5"
+    "@jupyter-widgets/base": ">2 <7"
     "@jupyterlab/application": ">2 <5"
     "@lumino/application": "<3"
     "@lumino/widgets": "<3"


### PR DESCRIPTION
## Summary

So I was trying to get Perspective running in JupyterLab 4 and kept hitting this wall where the widget just... wouldn't load. Dug into the browser console and found the culprit - there's a version constraint on `@jupyter-widgets/base` that's rejecting version 6.x.

The thing is, ipywidgets 8.x has been the stable release since October 2022. It ships `@jupyter-widgets/base` 6.0.11, but the current constraint in the jupyterlab package is `">2 <5"` - which obviously doesn't include 6.x.

Two-line fix: bump the upper bound from `<5` to `<7`.

## Changes

- `packages/jupyterlab/package.json`: `@jupyter-widgets/base` from `">2 <5"` to `">2 <7"`
- `pnpm-workspace.yaml`: same change in the catalog entry

## Did it work?

Ran through the semver math to make sure I wasn't breaking existing setups:

- `6.0.11` (ipywidgets 8.x) satisfies `">2 <7"` - yep
- `4.1.7` (ipywidgets 7.x) still satisfies `">2 <7"` - still works

Then spun up a fresh Docker container (node:20 devcontainer) to validate the dependency resolution in isolation:

- `pnpm install` resolved all 1805 packages with no version conflicts
- The workspace catalog and package.json constraints played nice together

So both ipywidgets 7.x and 8.x environments should be happy now.

## Related issues

This is adjacent to #2060 (Support ipywidgets 8) and #2307 (Support JupyterLab 4) - those got closed but this specific version constraint issue slipped through.

## Test plan

- [x] Semver validation for both ipywidgets versions
- [x] Docker container: `pnpm install` succeeds (1805 packages)
- [ ] CI validates full build
