### PR TITLE
Upgrade toolchain

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ bundle = "run -p perspective-bundle"
 
 [build]
 # rustflags = ["--cfg=web_sys_unstable_apis", "--cfg=pyo3_disable_reference_pool"]
-rustflags = ["--cfg=web_sys_unstable_apis"]
+rustflags = ["--cfg=web_sys_unstable_apis", "-Csymbol-mangling-version=v0"]
 target-dir = "rust/target"
 
 [target.wasm32-unknown-unknown]

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -116,14 +116,14 @@ runs:
           shell: bash
           run: echo "MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)" >> $GITHUB_ENV
 
-        # Use python 3.9 from manylinu
-        - run: echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
+        # Use python 3.12 from manylinu
+        - run: echo "/opt/python/cp311-cp311/bin" >> $GITHUB_PATH
           shell: bash
           if: ${{ runner.os == 'Linux' }}
 
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v5
-          if: ${{ inputs.python == 'true' && runner.os != 'Linux' }}
+          if: ${{ inputs.python == 'true' && inputs.manylinux == 'false' }}
           with:
               python-version: ${{ matrix.python-version }}
               cache: "pip"
@@ -145,7 +145,7 @@ runs:
           uses: dtolnay/rust-toolchain@nightly
           if: ${{ inputs.rust == 'true' && inputs.arch != 'aarch64' }}
           with:
-              toolchain: nightly-2025-02-01
+              toolchain: nightly-2026-01-01
               targets: wasm32-unknown-unknown
               components: rustfmt, clippy, rust-src
 
@@ -153,7 +153,7 @@ runs:
           uses: dtolnay/rust-toolchain@nightly
           if: ${{ inputs.rust == 'true' && inputs.arch == 'aarch64' && runner.os == 'macOS' }}
           with:
-              toolchain: nightly-2025-02-01
+              toolchain: nightly-2026-01-01
               targets: aarch64-apple-darwin
               components: rust-src
 
@@ -161,7 +161,7 @@ runs:
           uses: dtolnay/rust-toolchain@nightly
           if: ${{ inputs.rust == 'true' && inputs.arch == 'aarch64' && runner.os == 'Linux' }}
           with:
-              toolchain: nightly-2025-02-01
+              toolchain: nightly-2026-01-01
               targets: aarch64-unknown-linux-gnu
               components: rust-src
 
@@ -199,7 +199,7 @@ runs:
         - name: Install Python dependencies
           shell: bash
           if: ${{ inputs.python == 'true' && inputs.manylinux == 'true' }}
-          run: /opt/python/cp39-cp39/bin/python -m pip install -r rust/perspective-python/requirements.txt
+          run: /opt/python/cp311-cp311/bin/python -m pip install -r rust/perspective-python/requirements.txt
 
         - name: manylinux deps
           shell: bash
@@ -225,4 +225,3 @@ runs:
         #   if: ${{ runner.os == 'Linux' }}
         #   run: |
         #       rm -rf /__t/*
-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
                 os:
                     - ubuntu-22.04
                 python-version:
-                    - 3.9
+                    - 3.11
                 node-version: [22.x]
 
         steps:
@@ -124,7 +124,7 @@ jobs:
                 os:
                     - ubuntu-22.04
                 python-version:
-                    - 3.9
+                    - 3.11
                 node-version: [22.x]
 
         steps:
@@ -192,16 +192,16 @@ jobs:
                     - aarch64
                     - x86_64
                 python-version:
-                    - 3.9
+                    - 3.11
                 node-version: [22.x]
                 include:
                     - os: ubuntu-22.04
                       arch: x86_64
-                      python-version: 3.9
+                      python-version: 3.11
                       container: quay.io/pypa/manylinux_2_28_x86_64
                     - os: ubuntu-22.04-arm
                       arch: aarch64
-                      python-version: 3.9
+                      python-version: 3.11
                       container: quay.io/pypa/manylinux_2_28_aarch64
                 is-release:
                     - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
@@ -394,7 +394,7 @@ jobs:
                 arch:
                     - x86_64
                 python-version:
-                    - 3.9
+                    - 3.11
                 node-version: [22.x]
         steps:
             - name: Checkout
@@ -442,7 +442,7 @@ jobs:
                 arch:
                     - x86_64
                 python-version:
-                    - 3.9
+                    - 3.11
                 node-version: [22.x]
         steps:
             - name: Checkout
@@ -509,7 +509,7 @@ jobs:
                     - aarch64
                     - x86_64
                 python-version:
-                    - 3.9
+                    - 3.11
                 node-version: [22.x]
                 is-release:
                     - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
@@ -620,7 +620,7 @@ jobs:
                 os:
                     - ubuntu-22.04
                 python-version:
-                    - 3.9
+                    - 3.11
                 node-version: [22.x]
 
         steps:
@@ -672,8 +672,8 @@ jobs:
                     - x86_64
                     - aarch64
                 python-version:
-                    - 3.9
-                    # - 3.12
+                    - 3.11
+                    # - 3.11
                 node-version: [22.x]
                 is-release:
                     - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
@@ -733,7 +733,7 @@ jobs:
                 arch:
                     - x86_64
                 python-version:
-                    - 3.9
+                    - 3.11
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -788,8 +788,8 @@ jobs:
                   # Maturin got this wrong: the packages should be in .dist-info/licenses/
                   # Newer versions of Maturin will fix it, so search for either location.
                   # https://github.com/PyO3/maturin/pull/862 https://github.com/PyO3/maturin/pull/2181
-                  grep -E '.dist-info/(license|license_files)/LICENSE.md' wheel_installed_files.txt
-                  grep -E '.dist-info/(license|license_files)/LICENSE_THIRDPARTY_cargo.yml' wheel_installed_files.txt
+                  grep -E '.dist-info/(licenses|license|license_files)/LICENSE.md' wheel_installed_files.txt
+                  grep -E '.dist-info/(licenses|license|license_files)/LICENSE_THIRDPARTY_cargo.yml' wheel_installed_files.txt
 
             - name: Verify labextension
               shell: bash
@@ -822,7 +822,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-22.04]
-                python-version: [3.9]
+                python-version: [3.11]
                 node-version: [22.x]
                 arch: [x86_64]
         steps:
@@ -961,11 +961,11 @@ jobs:
 
             - uses: actions/download-artifact@v4
               with:
-                  name: perspective-python-dist-aarch64-macos-14-3.9
+                  name: perspective-python-dist-aarch64-macos-14-3.11
 
             - uses: actions/download-artifact@v4
               with:
-                  name: perspective-python-dist-aarch64-ubuntu-22.04-arm-3.9
+                  name: perspective-python-dist-aarch64-ubuntu-22.04-arm-3.11
 
             # - uses: actions/download-artifact@v4
             #   with:
@@ -973,15 +973,15 @@ jobs:
 
             - uses: actions/download-artifact@v4
               with:
-                  name: perspective-python-dist-x86_64-windows-2022-3.9
+                  name: perspective-python-dist-x86_64-windows-2022-3.11
 
             - uses: actions/download-artifact@v4
               with:
-                  name: perspective-python-dist-x86_64-ubuntu-22.04-3.9
+                  name: perspective-python-dist-x86_64-ubuntu-22.04-3.11
 
             - uses: actions/download-artifact@v4
               with:
-                  name: perspective-python-dist-wasm32-emscripten-3.9
+                  name: perspective-python-dist-wasm32-emscripten-3.11
 
             - uses: actions/download-artifact@v4
               with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,17 +102,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -216,12 +196,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -258,16 +232,17 @@ dependencies = [
 
 [[package]]
 name = "cargo-bundle-licenses"
-version = "2.3.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f242965642b4551a3d16e8af3c2c92b5899bc001c2526bbc281eba4ba9e6a37"
+checksum = "250a2335d1c5ef791cfc90bee35c87cc7893e826e5b2342138f56bee44f3b4b5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "clap",
  "env_logger",
  "git-version",
  "home",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "regex",
  "serde",
@@ -275,33 +250,33 @@ dependencies = [
  "serde_yaml",
  "slug",
  "spdx",
- "structopt",
- "strum 0.24.1",
- "thiserror 1.0.69",
+ "strum 0.27.2",
+ "thiserror 2.0.17",
  "toml",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.27",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -337,21 +312,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width 0.1.14",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
@@ -369,7 +329,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -522,7 +482,7 @@ version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f29a879d35f7906e3c9b77d7a1005a6a0787d330c09dfe4ffb5f617728cb44"
 dependencies = [
- "clap 4.5.53",
+ "clap",
  "codespan-reporting 0.13.1",
  "indexmap 2.12.1",
  "proc-macro2",
@@ -630,16 +590,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
+name = "env_filter"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1125,15 +1095,6 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -1146,26 +1107,17 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1229,12 +1181,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1358,17 +1304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi 0.5.2",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,10 +1328,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "jobserver"
@@ -1448,7 +1416,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "libc",
 ]
 
@@ -1666,7 +1634,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1751,7 +1719,7 @@ dependencies = [
 name = "perspective-bundle"
 version = "0.0.0"
 dependencies = [
- "clap 4.5.53",
+ "clap",
  "wasm-bindgen-cli-support",
  "wasm-opt",
 ]
@@ -1966,6 +1934,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2335,7 +2312,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2403,7 +2380,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2556,11 +2533,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2667,9 +2644,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.10.9"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
+checksum = "41cf87c0efffc158b9dde4d6e0567a43e4383adc4c949e687a2039732db2f23a"
 dependencies = [
  "smallvec",
 ]
@@ -2682,48 +2659,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
 
 [[package]]
 name = "strum"
@@ -2732,6 +2676,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2757,6 +2710,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.111",
 ]
 
@@ -2836,15 +2801,6 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width 0.1.14",
-]
 
 [[package]]
 name = "thiserror"
@@ -2978,14 +2934,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
- "serde",
+ "indexmap 2.12.1",
+ "serde_core",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -2993,8 +2952,14 @@ name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3004,11 +2969,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.12.1",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -3032,7 +3010,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -3184,12 +3162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,12 +3202,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -3478,7 +3444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
 dependencies = [
  "ahash",
- "bitflags 2.10.0",
+ "bitflags",
  "hashbrown 0.14.5",
  "indexmap 2.12.1",
  "semver 1.0.27",
@@ -3491,7 +3457,7 @@ version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.12.1",
  "semver 1.0.27",
@@ -3609,15 +3575,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -3651,22 +3608,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
@@ -3675,7 +3616,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.53.1",
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
@@ -3687,12 +3628,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3708,12 +3643,6 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
@@ -3726,21 +3655,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -3756,12 +3673,6 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
@@ -3771,12 +3682,6 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3792,12 +3697,6 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
@@ -3807,12 +3706,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3828,6 +3721,12 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "wit-bindgen"
@@ -3869,7 +3768,7 @@ dependencies = [
  "anyhow",
  "basic-toml",
  "bumpalo",
- "clap 4.5.53",
+ "clap",
  "codespan-reporting 0.11.1",
  "diffy",
  "dirs",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
         }
     },
     "type": "module",
-    "emscripten": "3.1.58",
+    "emscripten": "4.0.9",
     "llvm": "17.0.6",
-    "pyodide": "0.27.1",
+    "pyodide": "0.29.3",
     "engines": {
         "node": ">=16 <23"
     },

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -11,6 +11,6 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 [toolchain]
-channel = "nightly-2025-02-01"
+channel = "nightly-2026-01-01"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["wasm32-unknown-unknown", "wasm32-unknown-emscripten"]

--- a/rust/lint/Cargo.toml
+++ b/rust/lint/Cargo.toml
@@ -22,6 +22,9 @@ name = "lint"
 path = "main.rs"
 bench = false
 
+[features]
+default = []
+
 [dependencies]
-yew-fmt = { version = "0.6.1", artifact = "bin" }
+yew-fmt = { version = "0.6.3", artifact = "bin", optional = true }
 glob = "0.3.1"

--- a/rust/lint/main.rs
+++ b/rust/lint/main.rs
@@ -37,12 +37,16 @@ pub fn main() {
         .chain(args)
         .collect::<Vec<_>>();
 
-    let exit_code = std::process::Command::new(env!("CARGO_BIN_FILE_YEW_FMT"))
-        .args(yewfmt_args)
-        .spawn()
-        .expect("Could not spawn process")
-        .wait()
-        .expect("Process did not start");
+    if let Some(cmd) = option_env!("CARGO_BIN_FILE_YEW_FMT") {
+        let exit_code = std::process::Command::new(cmd)
+            .args(yewfmt_args)
+            .spawn()
+            .expect("Could not spawn process")
+            .wait()
+            .expect("Process did not start");
 
-    std::process::exit(exit_code.code().unwrap())
+        std::process::exit(exit_code.code().unwrap())
+    } else {
+        std::process::exit(1)
+    }
 }

--- a/rust/metadata/Cargo.toml
+++ b/rust/metadata/Cargo.toml
@@ -22,7 +22,7 @@ path = "main.rs"
 bench = false
 
 [dependencies.cargo-bundle-licenses]
-version = "2.0.0"
+version = "4.2.0"
 artifact = ["bin"]
 
 [dependencies.ts-rs]

--- a/rust/perspective-js/src/rust/utils/console_logger.rs
+++ b/rust/perspective-js/src/rust/utils/console_logger.rs
@@ -170,10 +170,10 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WasmLogger {
     }
 
     fn on_record(&self, id: &tracing::Id, values: &tracing::span::Record<'_>, ctx: Context<'_, S>) {
-        if let Some(span_ref) = ctx.span(id) {
-            if let Some(debug_record) = span_ref.extensions_mut().get_mut::<LogLineBuffer>() {
-                values.record(debug_record);
-            }
+        if let Some(span_ref) = ctx.span(id)
+            && let Some(debug_record) = span_ref.extensions_mut().get_mut::<LogLineBuffer>()
+        {
+            values.record(debug_record);
         }
     }
 

--- a/rust/perspective-python/Cargo.toml
+++ b/rust/perspective-python/Cargo.toml
@@ -42,7 +42,7 @@ rustdoc-args = ["--html-in-header", "docs/index.html"]
 
 [features]
 default = []
-abi3 = ["pyo3/abi3-py39"]
+abi3 = ["pyo3/abi3-py311"]
 external-cpp = ["perspective-server/external-cpp"]
 generate-proto = ["perspective-client/generate-proto"]
 protobuf-src = ["perspective-client/protobuf-src"]

--- a/rust/perspective-python/requirements-pyodide.txt
+++ b/rust/perspective-python/requirements-pyodide.txt
@@ -1,5 +1,5 @@
 # Requirements for testing pyodide
 pytest==8.2.2
 pytest-playwright==0.5.2
-pytest-pyodide==0.58.4
+pytest-pyodide==0.58.6
 pytest-timeout==2.3.1

--- a/rust/perspective-python/requirements.txt
+++ b/rust/perspective-python/requirements.txt
@@ -1,14 +1,12 @@
 pytest>=7.4.3
-maturin==1.6.0
-
 Faker==26.0.0
 ipywidgets==8.1.3
 jupyterlab==4.2.3
 jupyterlab_git==0.50.1
-maturin==1.6.0
-numpy==2.0.0
+maturin==1.10.2
+numpy==2.2.6
 packaging==24.1
-pandas==2.2.2
+pandas==2.3.0
 pdoc==15.0.3
 polars==1.13.1
 pyarrow==21
@@ -22,4 +20,4 @@ tornado==6.4.1
 traitlets==5.14.3
 websocket-client==1.8.0
 widgetsnbextension==4.0.11
-wheel==0.43.0
+wheel==0.46.3

--- a/rust/perspective-python/test.mjs
+++ b/rust/perspective-python/test.mjs
@@ -48,7 +48,7 @@ if (process.env.PSP_PYODIDE) {
             // with --timeout_method=signal, tests hang.  seems like the
             // pytest-pyodide webserver fixture does not shut down
             "--timeout_method=thread",
-            // ...process.argv.slice(2),
+            ...process.argv.slice(2),
         ],
         execOpts,
     );
@@ -59,7 +59,7 @@ if (process.env.PSP_PYODIDE) {
             "perspective/tests",
             "-W error",
             "--timeout=300",
-            // ...process.argv.slice(2),
+            ...process.argv.slice(2),
         ],
         execOpts,
     );

--- a/rust/perspective-server/build.rs
+++ b/rust/perspective-server/build.rs
@@ -24,10 +24,9 @@ fn main() -> Result<(), std::io::Error> {
 
     if std::option_env!("PSP_DISABLE_CPP").is_none()
         && std::env::var("CARGO_FEATURE_DISABLE_CPP").is_err()
+        && let Some(artifact_dir) = cmake_build()?
     {
-        if let Some(artifact_dir) = cmake_build()? {
-            cmake_link_deps(&artifact_dir)?;
-        }
+        cmake_link_deps(&artifact_dir)?;
     }
 
     Ok(())

--- a/rust/perspective-server/cpp/perspective/CMakeLists.txt
+++ b/rust/perspective-server/cpp/perspective/CMakeLists.txt
@@ -210,6 +210,10 @@ if(NOT DEFINED PSP_WASM_EXCEPTIONS AND NOT PSP_PYTHON_BUILD)
     set(PSP_WASM_EXCEPTIONS ON)
 endif()
 
+if(PSP_PYODIDE)
+    set(PSP_WASM_EXCEPTIONS ON)
+endif()
+
 set(DEBUG_LEVEL "0")
 if(PSP_HEAP_INSTRUMENTS)
     set(DEBUG_LEVEL "3")
@@ -347,17 +351,12 @@ endif()
 set(RAPIDJSON_BUILD_TESTS OFF CACHE BOOL "Disable rapidjson tests")
 
 if(PSP_PYODIDE)
-    set(RELOCATABLE_FLAGS " -sRELOCATABLE=1 -sSIDE_MODULE=2 ")
+    set(RELOCATABLE_FLAGS " -sRELOCATABLE=1 -sSIDE_MODULE=2 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm \ ")
     string(APPEND CMAKE_EXE_LINKER_FLAGS "${RELOCATABLE_FLAGS} -sWASM_BIGINT=1 ")
     string(APPEND CMAKE_C_FLAGS "${RELOCATABLE_FLAGS}")
     string(APPEND CMAKE_CXX_FLAGS "${RELOCATABLE_FLAGS}")
-endif()
-
-if(PSP_PYODIDE)
     string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden")
-endif()
 
-if (PSP_PYODIDE AND NOT PSP_WASM_EXCEPTIONS)
     # Emscripten exceptions
     string(APPEND CMAKE_CXX_FLAGS " -fexceptions")
 endif()

--- a/rust/perspective-viewer/src/rust/components/column_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/column_dropdown.rs
@@ -91,19 +91,19 @@ impl Component for ColumnDropDown {
             },
             ColumnDropDownMsg::ItemDown => {
                 self.selected += 1;
-                if let Some(ref values) = self.values {
-                    if self.selected >= values.len() {
-                        self.selected = 0;
-                    }
+                if let Some(ref values) = self.values
+                    && self.selected >= values.len()
+                {
+                    self.selected = 0;
                 }
 
                 true
             },
             ColumnDropDownMsg::ItemUp => {
-                if let Some(ref values) = self.values {
-                    if self.selected < 1 {
-                        self.selected = values.len();
-                    }
+                if let Some(ref values) = self.values
+                    && self.selected < 1
+                {
+                    self.selected = values.len();
                 }
 
                 self.selected -= 1;

--- a/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
+++ b/rust/perspective-viewer/src/rust/components/column_selector/filter_column.rs
@@ -514,18 +514,18 @@ impl FilterColumnProps {
             }
         };
 
-        if let Some(input) = filter_input {
-            if &input != filter_column.term() {
-                *filter_column.term_mut() = input;
-                let update = ViewConfigUpdate {
-                    filter: Some(filters),
-                    ..ViewConfigUpdate::default()
-                };
+        if let Some(input) = filter_input
+            && &input != filter_column.term()
+        {
+            *filter_column.term_mut() = input;
+            let update = ViewConfigUpdate {
+                filter: Some(filters),
+                ..ViewConfigUpdate::default()
+            };
 
-                self.update_and_render(update)
-                    .map(ApiFuture::spawn)
-                    .unwrap_or_log();
-            }
+            self.update_and_render(update)
+                .map(ApiFuture::spawn)
+                .unwrap_or_log();
         }
     }
 }

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar.rs
@@ -156,7 +156,7 @@ impl Component for ColumnSettingsPanel {
     }
 
     fn update(&mut self, ctx: &yew::prelude::Context<Self>, msg: Self::Message) -> bool {
-        let result = match msg {
+        match msg {
             ColumnSettingsPanelMsg::SetExprValue(val) => {
                 if self.expr_value != val {
                     self.expr_value = val;
@@ -241,9 +241,7 @@ impl Component for ColumnSettingsPanel {
                     false
                 }
             },
-        };
-
-        result
+        }
     }
 
     fn view(&self, ctx: &yew::prelude::Context<Self>) -> Html {

--- a/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/symbol/row_selector.rs
+++ b/rust/perspective-viewer/src/rust/components/column_settings_sidebar/style_tab/symbol/row_selector.rs
@@ -55,15 +55,15 @@ pub fn row_selector(props: &RowSelectorProps) -> Html {
 
     let inner = if props.selected_row.is_none() || props.focused {
         let mut pairs = props.pairs.clone();
-        if let Some(ref rowval) = props.selected_row {
-            if let Some((i, _)) = pairs.iter().find_position(|pair| {
+        if let Some(ref rowval) = props.selected_row
+            && let Some((i, _)) = pairs.iter().find_position(|pair| {
                 pair.key
                     .as_ref()
                     .map(|keyval| keyval == rowval)
                     .unwrap_or_default()
-            }) {
-                pairs.remove(i);
-            }
+            })
+        {
+            pairs.remove(i);
         }
 
         let exclude: HashSet<_> = pairs

--- a/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/dragdrop_list.rs
@@ -213,10 +213,11 @@ where
                     .position(|x| x.1.1.as_ref().unwrap().props.get_item() == *column);
 
                 valid_duplicate_drag = is_duplicate.is_some() && !ctx.props().allow_duplicates;
-                if let Some(duplicate) = is_duplicate {
-                    if !is_append && (!ctx.props().allow_duplicates || is_self_move) {
-                        columns.remove(duplicate);
-                    }
+                if let Some(duplicate) = is_duplicate
+                    && !is_append
+                    && (!ctx.props().allow_duplicates || is_self_move)
+                {
+                    columns.remove(duplicate);
                 }
 
                 // If inserting into the middle of the list, use

--- a/rust/perspective-viewer/src/rust/components/containers/select.rs
+++ b/rust/perspective-viewer/src/rust/components/containers/select.rs
@@ -100,12 +100,12 @@ where
                             ctx.props().on_select.emit(self.selected.clone());
                             return true;
                         }
-                    } else if code.as_str() == "ArrowDown" {
-                        if let Some(x) = find_nth(idx + 1, &ctx.props().values) {
-                            self.selected = x.clone();
-                            ctx.props().on_select.emit(self.selected.clone());
-                            return true;
-                        }
+                    } else if code.as_str() == "ArrowDown"
+                        && let Some(x) = find_nth(idx + 1, &ctx.props().values)
+                    {
+                        self.selected = x.clone();
+                        ctx.props().on_select.emit(self.selected.clone());
+                        return true;
                     }
                 }
 

--- a/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/filter_dropdown.rs
@@ -87,19 +87,19 @@ impl Component for FilterDropDown {
             },
             FilterDropDownMsg::ItemDown => {
                 self.selected += 1;
-                if let Some(ref values) = self.values {
-                    if self.selected >= values.len() {
-                        self.selected = 0;
-                    }
+                if let Some(ref values) = self.values
+                    && self.selected >= values.len()
+                {
+                    self.selected = 0;
                 };
 
                 true
             },
             FilterDropDownMsg::ItemUp => {
-                if let Some(ref values) = self.values {
-                    if self.selected < 1 {
-                        self.selected = values.len();
-                    }
+                if let Some(ref values) = self.values
+                    && self.selected < 1
+                {
+                    self.selected = values.len();
                 };
 
                 self.selected -= 1;

--- a/rust/perspective-viewer/src/rust/components/function_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/components/function_dropdown.rs
@@ -88,19 +88,19 @@ impl Component for FunctionDropDown {
             },
             FunctionDropDownMsg::ItemDown => {
                 self.selected += 1;
-                if let Some(ref values) = self.values {
-                    if self.selected >= values.len() {
-                        self.selected = 0;
-                    }
+                if let Some(ref values) = self.values
+                    && self.selected >= values.len()
+                {
+                    self.selected = 0;
                 };
 
                 true
             },
             FunctionDropDownMsg::ItemUp => {
-                if let Some(ref values) = self.values {
-                    if self.selected < 1 {
-                        self.selected = values.len();
-                    }
+                if let Some(ref values) = self.values
+                    && self.selected < 1
+                {
+                    self.selected = values.len();
                 }
 
                 self.selected -= 1;

--- a/rust/perspective-viewer/src/rust/components/modal.rs
+++ b/rust/perspective-viewer/src/rust/components/modal.rs
@@ -82,10 +82,10 @@ where
                 true
             },
             ModalMsg::SubMsg(msg) => {
-                if let Some(child) = &ctx.props().child {
-                    if let Some(link) = child.props.weak_link().borrow().as_ref() {
-                        link.send_message(msg);
-                    }
+                if let Some(child) = &ctx.props().child
+                    && let Some(link) = child.props.weak_link().borrow().as_ref()
+                {
+                    link.send_message(msg);
                 }
 
                 false

--- a/rust/perspective-viewer/src/rust/custom_elements/filter_dropdown.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/filter_dropdown.rs
@@ -93,10 +93,10 @@ impl FilterDropDownElement {
                         FilterDropDownMsg::SetValues(values),
                     ]);
 
-                    if let Some(x) = self.target.borrow().clone() {
-                        if !self.modal.is_open() {
-                            ApiFuture::spawn(self.modal.clone().open(x, None))
-                        }
+                    if let Some(x) = self.target.borrow().clone()
+                        && !self.modal.is_open()
+                    {
+                        ApiFuture::spawn(self.modal.clone().open(x, None))
                     }
                 }
             },

--- a/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
+++ b/rust/perspective-viewer/src/rust/custom_elements/viewer.rs
@@ -939,10 +939,8 @@ impl PerspectiveViewerElement {
                 .cloned();
 
             changed = presentation.set_theme_name(reset_theme.as_deref()).await? || changed;
-            if changed {
-                if let Some(view) = session.get_view() {
-                    return renderer.restyle_all(&view).await;
-                }
+            if changed && let Some(view) = session.get_view() {
+                return renderer.restyle_all(&view).await;
             }
 
             Ok(JsValue::UNDEFINED)

--- a/rust/perspective-viewer/src/rust/presentation.rs
+++ b/rust/perspective-viewer/src/rust/presentation.rs
@@ -243,10 +243,10 @@ impl Presentation {
     /// A `bool` indicating whether the internal state changed.
     pub async fn set_theme_name(&self, theme: Option<&str>) -> ApiResult<bool> {
         let (themes, selected) = self.get_selected_theme_config().await?;
-        if let Some(x) = selected {
-            if themes.get(x).map(|x| x.as_str()) == theme {
-                return Ok(false);
-            }
+        if let Some(x) = selected
+            && themes.get(x).map(|x| x.as_str()) == theme
+        {
+            return Ok(false);
         }
 
         let index = if let Some(theme) = theme {

--- a/tools/bench/python_suite.mjs
+++ b/tools/bench/python_suite.mjs
@@ -44,8 +44,6 @@ const CLIENT_VERSION = {
     "2.4.0": "perspective-2-4-0",
     "2.3.2": "perspective-2-3-0",
     "2.3.1": "perspective-2-3-0",
-    "2.2.0": "perspective-2-2-0",
-    "2.1.4": "perspective-2-1-0",
 };
 
 fs.mkdirSync(path.join(__dirname, "./dist"), { recursive: true });

--- a/tools/scripts/lint.mjs
+++ b/tools/scripts/lint.mjs
@@ -30,7 +30,7 @@ export async function lint_js(is_fix = false) {
     const dirty = is_fix ? ["--allow-dirty"] : [];
     const staged = is_fix ? ["--allow-staged"] : [];
     const fix = is_fix ? ["--fix"] : [];
-    await $`cargo build -p perspective-lint`.verbose();
+    await $`cargo build -p perspective-lint --features=yew-fmt`.verbose();
     await $`cargo clippy ${fix} ${dirty} ${staged} -p perspective-viewer -- -Dwarnings`.verbose();
     await $`RUSTFMT="rust/target/debug/lint" cargo fmt ${check}`.verbose();
 }

--- a/tools/scripts/workspace.mjs
+++ b/tools/scripts/workspace.mjs
@@ -39,7 +39,7 @@ export function getRustWheelsDir() {
 }
 export function getEmscriptenWheelPath() {
     const pspVersion = getWorkspacePackageJson().version.replace("-", ".");
-    const wheeljunk = "cp39-abi3-emscripten_3_1_58_wasm32";
+    const wheeljunk = "cp311-abi3-emscripten_4_0_9_wasm32";
     return path.join(
         rustWheelsDir,
         `perspective_python-${pspVersion}-${wheeljunk}.whl`,


### PR DESCRIPTION
This PR upgrades:

* Python minimum required version to `3.11` (from `3.9`)
* Rust toolchain to `nightly-2026-01-01` (from `nightly-2025-02-01`)
* Emscripten to `4.0.9` (from (`3.1.58`)
* Maturin to `1.10.2` (from `1.6.0`)
* Pyodide to `0.29.3` (from `0.27.1`)

