### PR TITLE
Fix compatibility with recent crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
  "axum-core",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -162,12 +162,6 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -657,12 +651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,7 +842,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
- "fallible-iterator 0.2.0",
+ "fallible-iterator",
  "indexmap 1.9.3",
  "stable_deref_trait",
 ]
@@ -959,7 +947,7 @@ dependencies = [
  "gloo-events",
  "gloo-utils",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_urlencoded",
  "thiserror 1.0.69",
  "wasm-bindgen",
@@ -1373,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1527,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "minicov"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -1711,7 +1699,7 @@ version = "4.1.1"
 dependencies = [
  "async-lock",
  "axum",
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "futures",
  "indexmap 2.12.1",
  "perspective-client",
@@ -1748,7 +1736,6 @@ dependencies = [
  "prost-types",
  "protobuf-src",
  "rand",
- "rand-unique",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1774,9 +1761,9 @@ dependencies = [
  "perspective-client",
  "prost",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "tracing-subscriber",
  "ts-rs",
@@ -1813,7 +1800,7 @@ dependencies = [
  "pollster",
  "pyo3",
  "pyo3-async-runtimes",
- "pyo3-build-config 0.22.6",
+ "pyo3-build-config",
  "python-config-rs",
  "pythonize",
  "serde",
@@ -1848,14 +1835,14 @@ version = "4.1.1"
 dependencies = [
  "anyhow",
  "async-lock",
- "base64 0.13.1",
+ "base64",
  "chrono",
  "console_error_panic_hook",
  "derivative",
  "extend",
  "futures",
  "glob",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "js-sys",
  "macro_rules_attribute",
  "nom",
@@ -1863,7 +1850,7 @@ dependencies = [
  "perspective-js",
  "procss",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "strum 0.26.3",
  "thiserror 1.0.69",
@@ -2046,17 +2033,17 @@ dependencies = [
 
 [[package]]
 name = "procss"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e49f7323a5d32db7e4e3fd55cac1d79b07bd144205806ea3075835d32d3fe79"
+checksum = "5aab2f146f9f527c7e31c6d2cc8d57765686aa4cee61e4aad1077a12574a3291"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64",
  "console_error_panic_hook",
  "js-sys",
  "mockall",
  "nom",
- "serde-wasm-bindgen 0.4.5",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -2134,7 +2121,7 @@ dependencies = [
  "memoffset",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.25.1",
+ "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
  "serde",
@@ -2168,22 +2155,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
-dependencies = [
- "once_cell",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "pyo3-build-config"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
- "target-lexicon 0.13.3",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -2193,7 +2170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
- "pyo3-build-config 0.25.1",
+ "pyo3-build-config",
 ]
 
 [[package]]
@@ -2216,7 +2193,7 @@ checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config 0.25.1",
+ "pyo3-build-config",
  "quote",
  "syn 2.0.111",
 ]
@@ -2263,16 +2240,6 @@ checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
  "rand_core",
-]
-
-[[package]]
-name = "rand-unique"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a83e1f91c1c954a1ade65d6402d5e6c8172586b888355cee1835ef1340368dfd"
-dependencies = [
- "num-traits",
- "rand",
 ]
 
 [[package]]
@@ -2461,17 +2428,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2769,12 +2725,6 @@ checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-lexicon"
@@ -3273,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3288,12 +3238,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03794299fa80bda34aef2784a496c6440fbc75fb1977c4e05750ddcd617e5a09"
+checksum = "2be60cf36510aa4702ce189517229c3091f4a322a5ec2665a7737ea5956c2b3a"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "leb128",
  "log",
  "rustc-demangle",
@@ -3328,11 +3278,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -3341,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3351,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3364,18 +3315,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.56"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
+checksum = "45649196a53b0b7a15101d845d44d2dda7374fc1b5b5e2bbf58b7577ff4b346d"
 dependencies = [
  "async-trait",
  "cast",
@@ -3390,18 +3341,25 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.56"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
+checksum = "f579cdd0123ac74b94e1a4a72bd963cf30ebac343f2df347da0b8df24cdebed2"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
 
 [[package]]
 name = "wasm-encoder"
@@ -3468,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/rust-axum/Cargo.toml
+++ b/examples/rust-axum/Cargo.toml
@@ -16,8 +16,20 @@ version = "4.1.1"
 edition = "2024"
 publish = false
 
+[features]
+default = []
+
+# TODO(texodus): Due to feature unification and `wasm_bindgen_futures`
+# requirements for `Send` bounds interacting poorly with `rust-analyzer`,
+# this cannot require the "axum-ws" feature by defualt without impacting
+# developer sanity. In a stand-alone project outside the perspective repo, this
+# hack is not necessary.
+#
+# This feature flag is passed on the CLI by `package.json` instead.
+_hack = ["perspective/axum-ws"]
+
 [dependencies]
-perspective = { version = "4.1.1" }
+perspective = { version = "4.1.1", default-features = false }
 axum = { version = ">=0.8,<0.9", features = ["ws"] }
 futures = "0.3"
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/rust-axum/package.json
+++ b/examples/rust-axum/package.json
@@ -4,10 +4,12 @@
     "version": "4.1.1",
     "description": "An example of a Rust/Axum virtual Perspective server",
     "scripts": {
-        "start": "cargo run --target=$(rustc -vV | sed -n 's|host: ||p')"
+        "start": "cargo run --target=$(rustc -vV | sed -n 's|host: ||p') --features=_hack"
     },
     "keywords": [],
     "license": "Apache-2.0",
-    "dependencies": {},
+    "dependencies": {
+        "superstore-arrow": "catalog:"
+    },
     "devDependencies": {}
 }

--- a/examples/rust-axum/src/main.rs
+++ b/examples/rust-axum/src/main.rs
@@ -12,21 +12,29 @@
 
 use std::fs::File;
 use std::io::Read;
+#[cfg(feature = "_hack")]
 use std::net::SocketAddr;
 
+#[cfg(feature = "_hack")]
 use axum::Router;
+#[cfg(feature = "_hack")]
 use axum::routing::get_service;
 use perspective::client::{TableInitOptions, UpdateData};
 use perspective::server::Server;
-use tower_http::services::{ServeDir, ServeFile};
-use tower_http::trace::TraceLayer;
+#[cfg(feature = "_hack")]
+use tower_http::{
+    services::{ServeDir, ServeFile},
+    trace::TraceLayer,
+};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::layer;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry;
 
-const ROOT_PATH: &str = "../..";
+const ROOT_PATH: &str = ".";
 const ARROW_FILE_PATH: &str = "node_modules/superstore-arrow/superstore.arrow";
+
+#[cfg(feature = "_hack")]
 const SERVER_ADDRESS: &str = "0.0.0.0:3000";
 
 /// A local error synonym for this module only.
@@ -51,18 +59,22 @@ async fn load_server_arrow(server: &Server) -> Result<(), AppError> {
 /// simple Perspective application. The app's HTML, etc., assets are served
 /// from the root, while the app's embedded WebAssembly [`perspective::Client`]
 /// will connect to this server over a WebSocket via the path `/ws`.
-async fn start_web_server_and_block(server: Server) -> Result<(), AppError> {
-    let app = Router::new()
-        .route("/", get_service(ServeFile::new("src/index.html")))
-        .route("/ws", perspective::axum::websocket_handler())
-        .fallback_service(ServeDir::new(ROOT_PATH))
-        .with_state(server)
-        .layer(TraceLayer::new_for_http());
+async fn start_web_server_and_block(_server: Server) -> Result<(), AppError> {
+    #[cfg(feature = "_hack")]
+    {
+        let app = Router::new()
+            .route("/", get_service(ServeFile::new("src/index.html")))
+            .route("/ws", perspective::axum::websocket_handler())
+            .fallback_service(ServeDir::new(ROOT_PATH))
+            .with_state(_server)
+            .layer(TraceLayer::new_for_http());
 
-    let service = app.into_make_service_with_connect_info::<SocketAddr>();
-    let listener = tokio::net::TcpListener::bind(SERVER_ADDRESS).await?;
-    tracing::info!("listening on {}", listener.local_addr()?);
-    axum::serve(listener, service).await?;
+        let service = app.into_make_service_with_connect_info::<SocketAddr>();
+        let listener = tokio::net::TcpListener::bind(SERVER_ADDRESS).await?;
+        tracing::info!("listening on {}", listener.local_addr()?);
+        axum::serve(listener, service).await?;
+    }
+
     Ok(())
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: '=1.52.0'
       version: 1.52.0
     '@prospective.co/procss':
-      specifier: 0.1.17
-      version: 0.1.17
+      specifier: 0.1.18
+      version: 0.1.18
     '@types/chroma-js':
       specifier: ^3.1.2
       version: 3.1.2
@@ -620,7 +620,11 @@ importers:
         specifier: 'catalog:'
         version: 14.1.1
 
-  examples/rust-axum: {}
+  examples/rust-axum:
+    dependencies:
+      superstore-arrow:
+        specifier: 'catalog:'
+        version: 3.2.0
 
   examples/vite-example:
     dependencies:
@@ -848,7 +852,7 @@ importers:
         version: link:../../tools/test
       '@prospective.co/procss':
         specifier: 'catalog:'
-        version: 0.1.17
+        version: 0.1.18
       '@types/d3':
         specifier: 'catalog:'
         version: 7.4.3
@@ -879,7 +883,7 @@ importers:
         version: link:../../tools/test
       '@prospective.co/procss':
         specifier: 'catalog:'
-        version: 0.1.17
+        version: 0.1.18
       '@types/chroma-js':
         specifier: 'catalog:'
         version: 3.1.2
@@ -925,7 +929,7 @@ importers:
         version: link:../../tools/test
       '@prospective.co/procss':
         specifier: 'catalog:'
-        version: 0.1.17
+        version: 0.1.18
 
   packages/workspace:
     dependencies:
@@ -971,7 +975,7 @@ importers:
         version: link:../../rust/perspective-viewer
       '@prospective.co/procss':
         specifier: 'catalog:'
-        version: 0.1.17
+        version: 0.1.18
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.20
@@ -1113,7 +1117,7 @@ importers:
         version: 1.52.0
       '@prospective.co/procss':
         specifier: 'catalog:'
-        version: 0.1.17
+        version: 0.1.18
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.26
@@ -3324,6 +3328,9 @@ packages:
 
   '@prospective.co/procss@0.1.17':
     resolution: {integrity: sha512-jZCbEji9gTgJIJ41a0VQQV8GARUNKp9ils8/6347fbNkGBtA3cRwhQfRAxnqc0dhyo6pTSjMSflqop5ToIiSwQ==}
+
+  '@prospective.co/procss@0.1.18':
+    resolution: {integrity: sha512-odl+Vd/Lm2XdkB223/eghsGS4A5x5q8D9f/vCei2Wb/ljyLCGFWvP7w4Dtglid9xpvDCpJZtogeZASLcitMxug==}
 
   '@puppeteer/browsers@2.10.12':
     resolution: {integrity: sha512-mP9iLFZwH+FapKJLeA7/fLqOlSUwYpMwjR1P5J23qd4e7qGJwecJccJqHYrjw33jmIZYV4dtiTHPD/J+1e7cEw==}
@@ -12485,6 +12492,8 @@ snapshots:
   '@polka/url@1.0.0-next.29': {}
 
   '@prospective.co/procss@0.1.17': {}
+
+  '@prospective.co/procss@0.1.18': {}
 
   '@puppeteer/browsers@2.10.12':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,7 @@ catalog:
     "@jupyterlab/builder": "^4"
     "@playwright/experimental-ct-react": "=1.52.0"
     "@playwright/test": "=1.52.0"
-    "@prospective.co/procss": "0.1.17"
+    "@prospective.co/procss": "0.1.18"
     "@types/d3": "^7.4.3"
     "@types/lodash": "^4.17.20"
     "@types/node": ">=22"

--- a/rust/bundle/Cargo.toml
+++ b/rust/bundle/Cargo.toml
@@ -23,7 +23,7 @@ bench = false
 
 [dependencies]
 clap = { version = "4.4.8", features = ["derive"] }
-wasm-bindgen-cli-support = "0.2.106"
+wasm-bindgen-cli-support = "*"
 
 # https://github.com/brson/wasm-opt-rs/issues/154
 wasm-opt = { version = "0.116.1", default-features = false }

--- a/rust/perspective-client/Cargo.toml
+++ b/rust/perspective-client/Cargo.toml
@@ -60,6 +60,7 @@ path = "src/rust/lib.rs"
 
 [build-dependencies]
 prost-build = { version = "0.12.3" }
+
 # https://github.com/abseil/abseil-cpp/issues/1241#issuecomment-2138616329
 protobuf-src = { version = "=2.0.1", optional = true }
 
@@ -70,10 +71,11 @@ indexmap = { version = "2.2.6", features = ["serde"] }
 itertools = { version = "0.10.1" }
 paste = { version = "1.0.12" }
 prost-types = { version = "0.12.3" }
-getrandom = { version = "0.3", features = ["wasm_js"] }
+
+# `rand` dependency that needs features unified.
+getrandom = { version = "0", features = ["wasm_js"] }
 num-traits = "0.2.19"
-rand = { version = "=0.9.1" }
-rand-unique = { version = "0.2.0" }
+rand = { version = ">=0.9,<1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = { version = "0.11" }
 serde_json = { version = "1.0.107", features = ["raw_value"] }

--- a/rust/perspective-client/src/rust/utils/rand_sequence.rs
+++ b/rust/perspective-client/src/rust/utils/rand_sequence.rs
@@ -1,0 +1,87 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+//! This implementation liberally borrows from the excellent
+//! [`rand-unique`](https://github.com/hoxxep/rand-unique) crate, MIT licensed.
+//! Unlike `rand-unique`, this hacked up version only implements u32 (for wasm),
+//! but is compatible with `rand>0.8` and ~20kb smaller (in wasm).
+
+const INIT_BASE: u32 = 0x682f0161;
+const INIT_OFFSET: u32 = 0x46790905;
+const PRIME: u32 = 4294967291;
+const INTERMEDIATE_XOR: u32 = 0x5bf03635;
+
+#[derive(Debug, Clone)]
+pub struct RandomSequence {
+    start_index: u32,
+    current_index: u32,
+    intermediate_offset: u32,
+    ended: bool,
+}
+
+impl RandomSequence {
+    pub fn new(seed_base: u32, seed_offset: u32) -> Self {
+        let start_index = permute_qpr(permute_qpr(seed_base).wrapping_add(INIT_BASE));
+        let intermediate_offset = permute_qpr(permute_qpr(seed_offset).wrapping_add(INIT_OFFSET));
+        RandomSequence {
+            start_index,
+            current_index: 0,
+            intermediate_offset,
+            ended: false,
+        }
+    }
+}
+
+impl Iterator for RandomSequence {
+    type Item = u32;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.start_index.wrapping_add(self.current_index);
+        let inner_residue = permute_qpr(index).wrapping_add(self.intermediate_offset);
+        let next = permute_qpr(inner_residue ^ INTERMEDIATE_XOR);
+        self.current_index = match self.current_index.checked_add(1) {
+            Some(v) => {
+                self.ended = false;
+                v
+            },
+            None => {
+                if !self.ended {
+                    self.ended = true;
+                    self.current_index
+                } else {
+                    return None;
+                }
+            },
+        };
+
+        Some(next)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (u32::MAX as usize - self.current_index as usize, None)
+    }
+}
+
+fn permute_qpr(x: u32) -> u32 {
+    if x >= PRIME {
+        return x;
+    }
+
+    let residue = ((x as u64 * x as u64) % PRIME as u64) as u32;
+    if x <= PRIME >> 1 {
+        residue
+    } else {
+        PRIME - residue
+    }
+}

--- a/rust/perspective-js/Cargo.toml
+++ b/rust/perspective-js/Cargo.toml
@@ -70,12 +70,12 @@ derivative = "2.2.0"
 extend = "1.1.2"
 futures = "0.3.28"
 getrandom = { version = "0.2", features = ["js"] }
-indexmap = "2.2.6"
-js-sys = "0.3.77"
+indexmap = "2.12.1"
+js-sys = "0.3.85"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.107", features = ["raw_value"] }
 serde-wasm-bindgen = "0.6.0"
-thiserror = "1.0.55"
+thiserror = "2.0.17"
 tracing = { version = ">=0.1.36" }
 tracing-subscriber = "0.3.15"
 wasm-bindgen-derive = "0.3.0"
@@ -91,11 +91,11 @@ version = "11.0.1"
 features = ["serde-json-impl", "no-serde-warnings", "import-esm"]
 
 [dependencies.wasm-bindgen]
-version = "=0.2.106"
+version = "=0.2.108"
 features = ["serde-serialize", "enable-interning"]
 
 [dependencies.web-sys]
-version = "0.3.77"
+version = "0.3.85"
 features = [
     "console",
     "Document",

--- a/rust/perspective-python/Cargo.toml
+++ b/rust/perspective-python/Cargo.toml
@@ -53,7 +53,7 @@ crate-type = ["cdylib"]
 [build-dependencies]
 cmake = "0.1.50"
 num_cpus = "^1.16.0"
-pyo3-build-config = "0.22.6"
+pyo3-build-config = "0.25.1"
 python-config-rs = "0.1.2"
 
 [dependencies]
@@ -65,7 +65,7 @@ macro_rules_attribute = "0.2.2"
 async-lock = "2.5.0"
 pollster = "0.3.0"
 extend = "1.1.2"
-indexmap = "2.2.6"
+indexmap = "2.12.1"
 futures = "0.3.28"
 serde = { version = "1.0" }
 pyo3 = { version = "0.25.1", features = [

--- a/rust/perspective-viewer/Cargo.toml
+++ b/rust/perspective-viewer/Cargo.toml
@@ -40,7 +40,7 @@ trace-allocator = ["perspective-js/trace-allocator"]
 
 [build-dependencies]
 serde_json = { version = "1.0.59", features = ["raw_value"] }
-procss = { version = "0.1.17" }
+procss = { version = "0.1.18" }
 glob = "0.3.0"
 anyhow = "1.0.66"
 
@@ -55,7 +55,7 @@ perspective-js = { version = "4.1.1" }
 async-lock = "2.5.0"
 
 # Encode HTML export
-base64 = "0.13.0"
+base64 = "0.22.1"
 
 console_error_panic_hook = "0.1.6"
 
@@ -72,10 +72,10 @@ extend = "1.1.2"
 futures = "0.3.31"
 
 # General iterator improvements
-itertools = "0.10.1"
+itertools = "0.14.0"
 
 # JavaScript stdlib bindings
-js-sys = "0.3.82"
+js-sys = "0.3.85"
 
 macro_rules_attribute = "0.2.2"
 
@@ -106,7 +106,7 @@ tracing = { version = ">=0.1.36" }
 tracing-subscriber = "0.3.15"
 
 # Browser API bindings
-wasm-bindgen = { version = "=0.2.106", features = [
+wasm-bindgen = { version = "=0.2.108", features = [
   "serde-serialize",
   "enable-interning",
 ] }
@@ -121,7 +121,7 @@ wasm-bindgen-futures = "0.4.41"
 yew = { version = "0.22.0", features = ["csr"] }
 
 # Browser stdlib bindings
-web-sys.version = "0.3.77"
+web-sys.version = "0.3.85"
 
 # Browser stdlib bindings
 web-sys.features = [

--- a/rust/perspective-viewer/src/rust/model/copy_export.rs
+++ b/rust/perspective-viewer/src/rust/model/copy_export.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashSet;
 
+use base64::prelude::*;
 use futures::join;
 use itertools::Itertools;
 use perspective_client::ViewWindow;
@@ -59,7 +60,7 @@ pub trait CopyExportModel:
         let mut config = config?;
         config.settings = false;
         let js_config = serde_json::to_string(&config)?;
-        let html = export_app::render(&base64::encode(arrow), &js_config, &plugins);
+        let html = export_app::render(&BASE64_STANDARD.encode(arrow), &js_config, &plugins);
         Ok(js_sys::JsString::from(html.trim()).into())
     }
 

--- a/rust/perspective/Cargo.toml
+++ b/rust/perspective/Cargo.toml
@@ -41,9 +41,9 @@ async-lock = "2.5.0"
 perspective-client = { version = "4.1.1" }
 perspective-server = { version = "4.1.1" }
 tracing = { version = ">=0.1.36" }
-axum = { version = ">=0.8,<0.9", features = ["ws"], optional = true }
-fallible-iterator = "0.3.0"
-indexmap = "2.2.6"
+axum = { version = ">=0.7,<0.9", features = ["ws"], optional = true }
+fallible-iterator = "0.2.0"
+indexmap = "2.12.1"
 serde = { version = "1.0" }
 serde_json = { version = "1.0.107" }
 tokio = { version = "~1", features = ["full"], optional = true }

--- a/rust/perspective/src/lib.rs
+++ b/rust/perspective/src/lib.rs
@@ -54,6 +54,7 @@
 
 #[cfg(feature = "axum-ws")]
 pub mod axum;
+#[cfg(feature = "axum-ws")]
 pub mod virtual_server;
 
 pub use perspective_client::proto;

--- a/rust/perspective/src/virtual_server.rs
+++ b/rust/perspective/src/virtual_server.rs
@@ -66,7 +66,6 @@ where
                                             ConnectInfo(addr): ConnectInfo<SocketAddr>|
            -> axum::response::Response {
         tracing::info!("{addr} Connected.");
-
         ws.on_upgrade(move |mut socket| async move {
             if let Err(msg) = process_message_loop(&mut socket, handler).await {
                 tracing::error!("Internal error {}", msg);


### PR DESCRIPTION
This PR fixes cargo dependency conflicts caused by multiple versions of the same crate coexisting in the workspace, and updates some pinned dependencies to their latest compatible versions.

- Eliminate duplicate crate versions in `Cargo.lock` by unifying `base64`, `serde-wasm-bindgen`, `fallible-iterator`, `pyo3-build-config`, and `target-lexicon` to single versions across the workspace.
- Remove `rand-unique` dependency from `perspective-client`, avoiding version conflicts with `rand`/`getrandom`.
- Loosen version pins for `rand`, `getrandom`, `axum`, and `wasm-bindgen-cli-support`.
- Bump dependency versions for `wasm-bindgen` 0.2.106 -> 0.2.108, `js-sys`/`web-sys` 0.3.83 -> 0.3.85, `base64` 0.13 -> 0.22, `itertools` 0.10 -> 0.14,  `thiserror` 1.x -> 2.x (in `perspective-js`), `procss` 0.1.17 -> 0.1.18, `pyo3-build-config` 0.22 -> 0.25.
- Fix `rust-axum` example to work around Cargo feature unification issues with `wasm_bindgen_futures` `Send` bounds when building inside the perspective workspace.