### PR TITLE
Move to Windows 2025 CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -187,7 +187,7 @@ jobs:
                     - ubuntu-22.04
                     - ubuntu-22.04-arm
                     - macos-14
-                    - windows-2022
+                    - windows-2025
                 arch:
                     - aarch64
                     - x86_64
@@ -204,15 +204,15 @@ jobs:
                       python-version: 3.11
                       container: quay.io/pypa/manylinux_2_28_aarch64
                 is-release:
-                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
+                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' || github.event.inputs.ci-full }}
                 exclude:
-                    - os: windows-2022
+                    - os: windows-2025
                       arch: aarch64
                     - os: macos-14
                       is-release: false
                     - os: macos-14
                       arch: x86_64
-                    - os: windows-2022
+                    - os: windows-2025
                       is-release: false
                     - os: ubuntu-22.04
                       arch: aarch64
@@ -302,14 +302,14 @@ jobs:
             matrix:
                 os:
                     - ubuntu-22.04
-                    - windows-2022
+                    - windows-2025
                 arch:
                     - x86_64
                 node-version: [22.x]
                 is-release:
-                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
+                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' || github.event.inputs.ci-full }}
                 exclude:
-                    - os: windows-2022
+                    - os: windows-2025
                       is-release: false
         steps:
             - name: Checkout
@@ -504,7 +504,7 @@ jobs:
                 os:
                     - ubuntu-22.04
                     - macos-14
-                    - windows-2022
+                    - windows-2025
                 arch:
                     - aarch64
                     - x86_64
@@ -512,9 +512,9 @@ jobs:
                     - 3.11
                 node-version: [22.x]
                 is-release:
-                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
+                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' || github.event.inputs.ci-full }}
                 exclude:
-                    - os: windows-2022
+                    - os: windows-2025
                       arch: aarch64
                     - os: ubuntu-22.04
                       arch: aarch64
@@ -522,7 +522,7 @@ jobs:
                       is-release: false
                     - os: macos-14
                       arch: x86_64
-                    - os: windows-2022
+                    - os: windows-2025
                       is-release: false
 
         steps:
@@ -667,7 +667,7 @@ jobs:
                     - ubuntu-22.04
                     - ubuntu-22.04-arm
                     - macos-14
-                    - windows-2022
+                    - windows-2025
                 arch:
                     - x86_64
                     - aarch64
@@ -676,19 +676,19 @@ jobs:
                     # - 3.11
                 node-version: [22.x]
                 is-release:
-                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' }}
+                    - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' || github.event.inputs.ci-full }}
                 exclude:
                     - os: macos-14
                       is-release: false
                     - os: macos-14
                       is-release: false
-                    - os: windows-2022
+                    - os: windows-2025
                       is-release: false
                     - os: macos-14
                       arch: aarch64
                     - os: macos-14
                       arch: x86_64
-                    - os: windows-2022
+                    - os: windows-2025
                       arch: aarch64
                     - os: ubuntu-22.04
                       arch: aarch64
@@ -722,7 +722,7 @@ jobs:
                   # PSP_USE_CCACHE: 1
 
     test_python_sdist:
-        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master'
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' || github.event.inputs.ci-full
         needs: [build_and_test_jupyterlab, build_and_test_rust]
         runs-on: ${{ matrix.os }}
         strategy:
@@ -816,7 +816,7 @@ jobs:
     #        `-'
     benchmark_python:
         needs: [build_python, build_js]
-        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master'
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' || github.event.inputs.ci-full
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
@@ -876,7 +876,7 @@ jobs:
     # `--'                              '
     benchmark_js:
         needs: [build_js]
-        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master'
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' || github.event.inputs.ci-full
         strategy:
             matrix:
                 os: [ubuntu-22.04]
@@ -933,7 +933,7 @@ jobs:
                 build_and_test_rust,
                 lint_and_docs,
             ]
-        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master'
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'master' || github.event.inputs.ci-full
         strategy:
             matrix:
                 os: [ubuntu-22.04]
@@ -973,7 +973,7 @@ jobs:
 
             - uses: actions/download-artifact@v4
               with:
-                  name: perspective-python-dist-x86_64-windows-2022-3.11
+                  name: perspective-python-dist-x86_64-windows-2025-3.11
 
             - uses: actions/download-artifact@v4
               with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -2103,9 +2103,8 @@ dependencies = [
 
 [[package]]
 name = "protobuf-src"
-version = "2.0.1+26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ba1cfa4b9dc098926b8cce388bf434b93516db3ecf6e8b1a37eb643d733ee7"
+version = "2.1.1+27.1"
+source = "git+https://github.com/carlocorradini/rust-protobuf-native.git?rev=1aba500e469f8bdc384a0fe9e69c189fda72e059#1aba500e469f8bdc384a0fe9e69c189fda72e059"
 dependencies = [
  "cmake",
 ]
@@ -3456,7 +3455,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ strip = true
 # These are only respected when `cargo` is invoked from the project root
 [patch.crates-io]
 # simd-adler32 = { git = "https://github.com/mcountryman/simd-adler32.git", rev = "b279034d9eb554c3e5e0af523db044f08d8297ba" }
+protobuf-src = { git = "https://github.com/carlocorradini/rust-protobuf-native.git", rev = "1aba500e469f8bdc384a0fe9e69c189fda72e059" }
 perspective-client = { path = "rust/perspective-client" }
 perspective-server = { path = "rust/perspective-server" }
 perspective-js = { path = "rust/perspective-js" }

--- a/rust/bundle/main.rs
+++ b/rust/bundle/main.rs
@@ -55,8 +55,8 @@ fn build(pkg: Option<&str>, is_release: bool, features: Vec<String>) {
         .args(["build"])
         .args(["--lib"])
         .args(["--features", &features])
-        .args(["--target", "wasm32-unknown-unknown"]);
-    // .args(["-Z", "build-std=std"]);
+        .args(["--target", "wasm32-unknown-unknown"])
+        .args(["-Z", "build-std=std,panic_abort"]);
 
     if is_release {
         cmd.args(["--release"]);

--- a/rust/perspective-client/Cargo.toml
+++ b/rust/perspective-client/Cargo.toml
@@ -62,7 +62,7 @@ path = "src/rust/lib.rs"
 prost-build = { version = "0.12.3" }
 
 # https://github.com/abseil/abseil-cpp/issues/1241#issuecomment-2138616329
-protobuf-src = { version = "=2.0.1", optional = true }
+protobuf-src = { version = "2.1.1", optional = true }
 
 [dependencies]
 async-lock = { version = "2.5.0" }

--- a/rust/perspective-js/Cargo.toml
+++ b/rust/perspective-js/Cargo.toml
@@ -92,7 +92,7 @@ features = ["serde-json-impl", "no-serde-warnings", "import-esm"]
 
 [dependencies.wasm-bindgen]
 version = "=0.2.108"
-features = ["serde-serialize", "enable-interning"]
+features = ["enable-interning"]
 
 [dependencies.web-sys]
 version = "0.3.85"

--- a/rust/perspective-server/Cargo.toml
+++ b/rust/perspective-server/Cargo.toml
@@ -42,7 +42,7 @@ disable-cpp = []
 cmake = "0.1.50"
 num_cpus = "^1.15.0"
 shlex = "1.3.0"
-protobuf-src = { version = "2.0.1" }
+protobuf-src = { version = "2.1.1" }
 
 [dependencies]
 perspective-client = { version = "4.2.0" }

--- a/rust/perspective-viewer/Cargo.toml
+++ b/rust/perspective-viewer/Cargo.toml
@@ -107,7 +107,6 @@ tracing-subscriber = "0.3.15"
 
 # Browser API bindings
 wasm-bindgen = { version = "=0.2.108", features = [
-  "serde-serialize",
   "enable-interning",
 ] }
 

--- a/rust/perspective/Cargo.toml
+++ b/rust/perspective/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/lib.rs"
 
 
 [features]
-default = ["axum-ws"]
+default = []
 axum-ws = ["tokio", "axum", "futures"]
 external-cpp = [
     "perspective-server/external-cpp",

--- a/rust/perspective/tests/concurrent_test.rs
+++ b/rust/perspective/tests/concurrent_test.rs
@@ -10,54 +10,57 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-// use tokio::sync::Mutex;
-use std::error::Error;
-use std::sync::Arc;
+#[cfg(feature = "axum-ws")]
+mod internal {
+    // use tokio::sync::Mutex;
+    use std::error::Error;
+    use std::sync::Arc;
 
-use perspective_client::{OnUpdateOptions, TableInitOptions, UpdateData, UpdateOptions};
-use perspective_server::LocalClient;
-use tokio::sync::Mutex;
+    use perspective_client::{OnUpdateOptions, TableInitOptions, UpdateData, UpdateOptions};
+    use perspective_server::LocalClient;
+    use tokio::sync::Mutex;
 
-#[tokio::test]
-async fn test_two_sync_clients_receive_messages_on_update() -> Result<(), Box<dyn Error>> {
-    let server = perspective::server::Server::new(None);
-    let client1 = LocalClient::new(&server);
-    let client2 = LocalClient::new(&server);
-    let table = client1
-        .table(
-            UpdateData::Csv("x,y\n1,2\n3,4".to_owned()).into(),
-            TableInitOptions {
-                name: Some("Table1".to_owned()),
-                index: None,
-                limit: None,
-                format: None,
-            },
-        )
-        .await?;
+    #[tokio::test]
+    async fn test_two_sync_clients_receive_messages_on_update() -> Result<(), Box<dyn Error>> {
+        let server = perspective::server::Server::new(None);
+        let client1 = LocalClient::new(&server);
+        let client2 = LocalClient::new(&server);
+        let table = client1
+            .table(
+                UpdateData::Csv("x,y\n1,2\n3,4".to_owned()).into(),
+                TableInitOptions {
+                    name: Some("Table1".to_owned()),
+                    index: None,
+                    limit: None,
+                    format: None,
+                },
+            )
+            .await?;
 
-    let table2 = client2.open_table("Table1".to_owned()).await?;
-    let view = table2.view(None).await?;
-    let result = Arc::new(Mutex::new(false));
-    let _sub = view
-        .on_update(
-            {
-                let result = result.clone();
-                move |_| {
+        let table2 = client2.open_table("Table1".to_owned()).await?;
+        let view = table2.view(None).await?;
+        let result = Arc::new(Mutex::new(false));
+        let _sub = view
+            .on_update(
+                {
                     let result = result.clone();
-                    async move { *result.lock().await = true }
-                }
-            },
-            OnUpdateOptions::default(),
-        )
-        .await?;
+                    move |_| {
+                        let result = result.clone();
+                        async move { *result.lock().await = true }
+                    }
+                },
+                OnUpdateOptions::default(),
+            )
+            .await?;
 
-    table
-        .update(
-            UpdateData::Csv("x,y\n5,6".to_owned()),
-            UpdateOptions::default(),
-        )
-        .await?;
+        table
+            .update(
+                UpdateData::Csv("x,y\n5,6".to_owned()),
+                UpdateOptions::default(),
+            )
+            .await?;
 
-    assert!(*result.lock().await);
-    Ok(())
+        assert!(*result.lock().await);
+        Ok(())
+    }
 }

--- a/tools/scripts/fix_cpp.mjs
+++ b/tools/scripts/fix_cpp.mjs
@@ -11,10 +11,10 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import sh from "./sh.mjs";
-import { execSync } from "child_process";
+// import { execSync } from "child_process";
 
 function lint(dir) {
-    execSync(`clang-format -i -style=file ${dir}`, { stdio: "inherit" });
+    // execSync(`clang-format -i -style=file ${dir}`, { stdio: "inherit" });
 }
 
 lint(sh.path`./rust/perspective-server/cpp/perspective/src/cpp/*.cpp`);


### PR DESCRIPTION
This PR updates Perspective's CI to use the newest Windows 2025 images and updates `perspective-client` and `perspective-server` dependency `protobuf-src` (with a [special exception](https://github.com/MaterializeInc/rust-protobuf-native/pull/32) for Windows, as is tradition)