### PR TITLE
Fix view conflation test timeout

### DIFF
--- a/rust/perspective-viewer/src/rust/model/intersection_observer.rs
+++ b/rust/perspective-viewer/src/rust/model/intersection_observer.rs
@@ -38,8 +38,9 @@ impl IntersectionObserverHandle {
     ) -> Self {
         clone!(session, renderer, presentation);
         let _callback = Closure::new(move |xs: js_sys::Array| {
+            // https://stackoverflow.com/questions/53862160/intersectionobserver-multiple-entries
             let intersect = xs
-                .get(0)
+                .pop()
                 .unchecked_into::<IntersectionObserverEntry>()
                 .is_intersecting();
 
@@ -49,6 +50,7 @@ impl IntersectionObserverHandle {
                 session,
                 renderer,
             };
+
             ApiFuture::spawn(state.set_pause(intersect));
         });
 

--- a/rust/perspective-viewer/src/rust/renderer/registry.rs
+++ b/rust/perspective-viewer/src/rust/renderer/registry.rs
@@ -102,7 +102,14 @@ pub impl LocalKey<Rc<RefCell<Vec<PluginRecord>>>> {
                     .unwrap_or_else(|| "Custom".to_owned()),
                 priority: plugin_inst.priority().unwrap_or_default(),
             };
+
             let mut plugins = plugin.borrow_mut();
+            if let Some(first) = plugins.first()
+                && first.tag_name.as_str() == "perspective-viewer-plugin"
+            {
+                plugins.clear();
+            }
+
             plugins.push(record);
             plugins.sort_by(|a, b| Ord::cmp(&b.priority, &a.priority));
         });
@@ -121,7 +128,7 @@ fn register_default() {
                 name: "Debug".to_owned(),
                 category: "Custom".to_owned(),
                 tag_name: "perspective-viewer-plugin".to_owned(),
-                priority: 0,
+                priority: -1,
             })
         }
     })

--- a/rust/perspective-viewer/test/html/superstore_lazy_viewer.html
+++ b/rust/perspective-viewer/test/html/superstore_lazy_viewer.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+    <head>
+        <script type="module" src="/node_modules/@perspective-dev/viewer/dist/cdn/perspective-viewer.js"></script>
+        <script type="module" src="/node_modules/@perspective-dev/test/load-viewer.js"></script>
+        <link rel="stylesheet" href="../css/demo.css" />
+        <link rel="stylesheet" href="/node_modules/@perspective-dev/viewer/dist/css/pro.css" />
+        <link rel="stylesheet" href="/node_modules/@fontsource/roboto-mono/400.css" />
+    </head>
+    <body></body>
+</html>

--- a/tools/test/load-viewer.js
+++ b/tools/test/load-viewer.js
@@ -1,0 +1,22 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import "/node_modules/@perspective-dev/viewer/dist/cdn/perspective-viewer.js";
+import perspective from "/node_modules/@perspective-dev/client/dist/cdn/perspective.js";
+
+async function load() {
+    const worker = await perspective.worker();
+    window.__TEST_WORKER__ = worker;
+}
+
+await load();
+window.__TEST_PERSPECTIVE_READY__ = true;


### PR DESCRIPTION
This PR fixes a flapping test which correctly detected a very non-test race condition in `<perspective-viewer>`'s internal `IntersectionObserver` handling logic, which pulled batched intersect events backwards (apparently).