### PR TITLE
Fix `split_by` support for rollups in generic SQL

### DIFF
--- a/rust/perspective-client/src/rust/virtual_server/data.rs
+++ b/rust/perspective-client/src/rust/virtual_server/data.rs
@@ -204,9 +204,7 @@ impl VirtualDataSlice {
         if name.starts_with("__ROW_PATH_") {
             let group_by_index: u32 = name[11..name.len() - 2].parse()?;
             let max_grouping_id = 2_i32.pow((self.0.group_by.len() as u32) - group_by_index) - 1;
-            if grouping_id.map(|x| x as i32).unwrap_or(i32::MAX) < max_grouping_id
-                || !self.0.split_by.is_empty()
-            {
+            if grouping_id.map(|x| x as i32).unwrap_or(i32::MAX) < max_grouping_id {
                 if !self.contains_key("__ROW_PATH__") {
                     self.insert(
                         "__ROW_PATH__".to_owned(),

--- a/rust/perspective-client/src/rust/virtual_server/generic_sql_model/table_make_view.rs
+++ b/rust/perspective-client/src/rust/virtual_server/generic_sql_model/table_make_view.rs
@@ -1,0 +1,416 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+use crate::config::{Aggregate, Sort, SortDir, ViewConfig};
+
+fn aggregate_to_string(agg: &Aggregate) -> String {
+    match agg {
+        Aggregate::SingleAggregate(name) => name.clone(),
+        Aggregate::MultiAggregate(name, _args) => name.clone(),
+    }
+}
+
+fn sort_dir_to_string(dir: &SortDir) -> &'static str {
+    match dir {
+        SortDir::None => "",
+        SortDir::Asc | SortDir::ColAsc | SortDir::AscAbs | SortDir::ColAscAbs => "ASC",
+        SortDir::Desc | SortDir::ColDesc | SortDir::DescAbs | SortDir::ColDescAbs => "DESC",
+    }
+}
+
+fn is_col_sort(dir: &SortDir) -> bool {
+    matches!(
+        dir,
+        SortDir::ColAsc | SortDir::ColDesc | SortDir::ColAscAbs | SortDir::ColDescAbs
+    )
+}
+
+enum QueryOrientation {
+    Flat,
+    Grouped,
+    Pivoted,
+    GroupedAndPivoted,
+}
+
+/// Precomputed context for building a SQL view query from a [`ViewConfig`].
+///
+/// Holds the resolved column names, grouping function, and row-path aliases
+/// needed to emit the correct `SELECT`, `GROUP BY`, `PIVOT`, `ORDER BY`, and
+/// `WINDOW` clauses for every combination of `group_by` / `split_by`.
+pub(crate) struct ViewQueryContext<'a> {
+    table: &'a str,
+    config: &'a ViewConfig,
+    group_col_names: Vec<String>,
+    grouping_fn: &'a str,
+    row_path_aliases: Vec<String>,
+}
+
+impl<'a> ViewQueryContext<'a> {
+    /// Creates a new query context by resolving expressions, the grouping
+    /// function, and row-path aliases from the given model and config.
+    pub(crate) fn new(
+        model: &'a super::GenericSQLVirtualServerModel,
+        table: &'a str,
+        config: &'a ViewConfig,
+    ) -> Self {
+        let expressions = &config.expressions.0;
+        let col_name_resolve = |col: &str| -> String {
+            expressions
+                .get(col)
+                .cloned()
+                .unwrap_or_else(|| format!("\"{}\"", col))
+        };
+
+        let grouping_fn = model.0.grouping_fn.as_deref().unwrap_or("GROUPING_ID");
+        let group_col_names: Vec<String> = config
+            .group_by
+            .iter()
+            .map(|c| col_name_resolve(c))
+            .collect();
+
+        let row_path_aliases: Vec<String> = (0..config.group_by.len())
+            .map(|i| format!("__ROW_PATH_{}__", i))
+            .collect();
+
+        Self {
+            table,
+            config,
+            group_col_names,
+            grouping_fn,
+            row_path_aliases,
+        }
+    }
+
+    /// Builds the inner `SELECT` query (without the outer `CREATE TABLE`
+    /// wrapper) for the four `group_by` x `split_by` combinations, appending
+    /// `WINDOW` and `ORDER BY` clauses as needed.
+    pub(crate) fn build_query(&self) -> String {
+        let where_sql = self.where_sql();
+        let order_by = self.order_by_clauses();
+        let windows = self.window_clauses();
+        let mut query = match self.query_orientation() {
+            QueryOrientation::Flat => {
+                let select = self.select_clauses().join(", ");
+                format!("SELECT {} FROM {}{}", select, self.table, where_sql)
+            },
+            QueryOrientation::Grouped => {
+                let mut clauses = self.select_clauses();
+                clauses.extend(self.row_path_select_clauses());
+                clauses.push(self.grouping_id_clause());
+                format!(
+                    "SELECT {} FROM {}{} GROUP BY ROLLUP({})",
+                    clauses.join(", "),
+                    self.table,
+                    where_sql,
+                    self.group_col_names.join(", ")
+                )
+            },
+            QueryOrientation::Pivoted => {
+                let select = self.select_clauses();
+                let pivot_using: Vec<String> = self
+                    .config
+                    .columns
+                    .iter()
+                    .flatten()
+                    .map(|col| {
+                        let escaped = col.replace('"', "\"\"").replace('_', "-");
+                        format!("first(\"{}\") as \"{}\"", escaped, escaped)
+                    })
+                    .collect();
+
+                let split_cols: String = self
+                    .config
+                    .split_by
+                    .iter()
+                    .map(|c| format!("\"{}\"", c))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                format!(
+                    "SELECT * EXCLUDE (__ROW_NUM__) FROM (PIVOT (SELECT {}, {}, ROW_NUMBER() OVER \
+                     () as __ROW_NUM__ FROM {}{}) ON {} USING {} GROUP BY __ROW_NUM__)",
+                    select.join(", "),
+                    split_cols,
+                    self.table,
+                    where_sql,
+                    self.pivot_on_expr(),
+                    pivot_using.join(", "),
+                )
+            },
+            QueryOrientation::GroupedAndPivoted => {
+                let groups_joined = self.group_col_names.join(", ");
+                let split_cols_joined = self.pivot_on_expr();
+                let mut inner_clauses = self.select_clauses();
+                inner_clauses.extend(self.row_path_select_clauses());
+                inner_clauses.push(self.grouping_id_clause());
+                for sb_col in &self.config.split_by {
+                    inner_clauses.push(self.col_name(sb_col));
+                }
+
+                for (sidx, Sort(sort_col, sort_dir)) in self.config.sort.iter().enumerate() {
+                    if *sort_dir != SortDir::None && !is_col_sort(sort_dir) {
+                        let agg = self.get_aggregate(sort_col);
+                        inner_clauses.push(format!(
+                            "sum({}({})) OVER (PARTITION BY {}({}), {}) AS __SORT_{}__",
+                            agg,
+                            self.col_name(sort_col),
+                            self.grouping_fn,
+                            groups_joined,
+                            groups_joined,
+                            sidx,
+                        ));
+                    }
+                }
+
+                let inner_query = format!(
+                    "SELECT {} FROM {}{} GROUP BY ROLLUP({}), {}",
+                    inner_clauses.join(", "),
+                    self.table,
+                    where_sql,
+                    groups_joined,
+                    split_cols_joined,
+                );
+
+                let pivot_using = self.select_clauses().join(", ");
+                let mut row_id_cols = self.row_path_aliases.clone();
+                row_id_cols.push("__GROUPING_ID__".to_string());
+                for (sidx, Sort(_, sort_dir)) in self.config.sort.iter().enumerate() {
+                    if *sort_dir != SortDir::None && !is_col_sort(sort_dir) {
+                        row_id_cols.push(format!("__SORT_{}__", sidx));
+                    }
+                }
+
+                format!(
+                    "SELECT * FROM (PIVOT ({}) ON {} USING {} GROUP BY {})",
+                    inner_query,
+                    self.pivot_on_expr(),
+                    pivot_using,
+                    row_id_cols.join(", ")
+                )
+            },
+        };
+
+        if !windows.is_empty() {
+            query = format!("{} WINDOW {}", query, windows.join(", "));
+        }
+
+        if !order_by.is_empty() {
+            query = format!("{} ORDER BY {}", query, order_by.join(", "));
+        }
+
+        query
+    }
+
+    fn query_orientation(&self) -> QueryOrientation {
+        match (
+            self.config.group_by.is_empty(),
+            self.config.split_by.is_empty(),
+        ) {
+            (true, true) => QueryOrientation::Flat,
+            (false, true) => QueryOrientation::Grouped,
+            (true, false) => QueryOrientation::Pivoted,
+            (false, false) => QueryOrientation::GroupedAndPivoted,
+        }
+    }
+
+    fn col_name(&self, col: &str) -> String {
+        self.config
+            .expressions
+            .0
+            .get(col)
+            .cloned()
+            .unwrap_or_else(|| format!("\"{}\"", col))
+    }
+
+    fn get_aggregate(&self, col: &str) -> String {
+        self.config
+            .aggregates
+            .get(col)
+            .map(aggregate_to_string)
+            .unwrap_or_else(|| "any_value".to_string())
+    }
+
+    fn select_clauses(&self) -> Vec<String> {
+        let mut clauses = Vec::new();
+        if !self.config.group_by.is_empty() {
+            for col in self.config.columns.iter().flatten() {
+                let agg = self.get_aggregate(col);
+                let escaped = col.replace('"', "\"\"").replace("_", "-");
+                clauses.push(format!(
+                    "{}({}) as \"{}\"",
+                    agg,
+                    self.col_name(col),
+                    escaped
+                ));
+            }
+        } else if !self.config.columns.is_empty() {
+            for col in self.config.columns.iter().flatten() {
+                let escaped = col.replace('"', "\"\"").replace("_", "-");
+                clauses.push(format!("{} as \"{}\"", self.col_name(col), escaped));
+            }
+        }
+
+        clauses
+    }
+
+    fn where_sql(&self) -> String {
+        let clauses: Vec<String> = self
+            .config
+            .filter
+            .iter()
+            .filter_map(|flt| {
+                super::GenericSQLVirtualServerModel::filter_term_to_sql(flt.term()).map(
+                    |term_lit| format!("{} {} {}", self.col_name(flt.column()), flt.op(), term_lit),
+                )
+            })
+            .collect();
+
+        if clauses.is_empty() {
+            String::new()
+        } else {
+            format!(" WHERE {}", clauses.join(" AND "))
+        }
+    }
+
+    fn pivot_on_expr(&self) -> String {
+        self.config
+            .split_by
+            .iter()
+            .map(|c| format!("\"{}\"", c))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    fn grouping_id_clause(&self) -> String {
+        format!(
+            "{}({}) AS __GROUPING_ID__",
+            self.grouping_fn,
+            self.group_col_names.join(", ")
+        )
+    }
+
+    fn row_path_select_clauses(&self) -> Vec<String> {
+        self.config
+            .group_by
+            .iter()
+            .enumerate()
+            .map(|(i, col)| format!("{} as __ROW_PATH_{}__", self.col_name(col), i))
+            .collect()
+    }
+
+    fn order_by_clauses(&self) -> Vec<String> {
+        let mut clauses = Vec::new();
+        if !self.config.group_by.is_empty() {
+            for gidx in 0..self.config.group_by.len() {
+                if !self.config.split_by.is_empty() {
+                    let shift = self.config.group_by.len() - 1 - gidx;
+                    if shift > 0 {
+                        clauses.push(format!("(__GROUPING_ID__ >> {}) DESC", shift));
+                    } else {
+                        clauses.push("__GROUPING_ID__ DESC".to_string());
+                    }
+                } else {
+                    let groups_up_to = self.config.group_by[..=gidx]
+                        .iter()
+                        .map(|c| self.col_name(c))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    clauses.push(format!("{}({}) DESC", self.grouping_fn, groups_up_to));
+                }
+
+                let is_leaf = gidx >= self.config.group_by.len() - 1;
+                for (sidx, Sort(sort_col, sort_dir)) in self.config.sort.iter().enumerate() {
+                    if *sort_dir == SortDir::None || is_col_sort(sort_dir) {
+                        continue;
+                    }
+
+                    let dir = sort_dir_to_string(sort_dir);
+                    if !self.config.split_by.is_empty() {
+                        if is_leaf {
+                            clauses.push(format!("__SORT_{}__ {}", sidx, dir));
+                        } else {
+                            clauses.push(format!(
+                                "first(__SORT_{}__) OVER __WINDOW_{}__ {}",
+                                sidx, gidx, dir
+                            ));
+                        }
+                    } else {
+                        let agg = self.get_aggregate(sort_col);
+                        if is_leaf {
+                            clauses.push(format!("{}({}) {}", agg, self.col_name(sort_col), dir));
+                        } else {
+                            clauses.push(format!(
+                                "first({}({})) OVER __WINDOW_{}__ {}",
+                                agg,
+                                self.col_name(sort_col),
+                                gidx,
+                                dir
+                            ));
+                        }
+                    }
+                }
+
+                clauses.push(format!("{} ASC", self.row_path_aliases[gidx]));
+            }
+        } else {
+            for Sort(sort_col, sort_dir) in &self.config.sort {
+                if *sort_dir != SortDir::None && !is_col_sort(sort_dir) {
+                    let dir = sort_dir_to_string(sort_dir);
+                    clauses.push(format!("{} {}", self.col_name(sort_col), dir));
+                }
+            }
+        }
+
+        clauses
+    }
+
+    fn window_clauses(&self) -> Vec<String> {
+        if self.config.sort.is_empty() || self.config.group_by.len() <= 1 {
+            return Vec::new();
+        }
+
+        let mut clauses = Vec::new();
+        for gidx in 0..(self.config.group_by.len() - 1) {
+            let partition = self.row_path_aliases[..=gidx].join(", ");
+            if !self.config.split_by.is_empty() {
+                let shift = self.config.group_by.len() - 1 - gidx;
+                let grouping_expr = if shift > 0 {
+                    format!("(__GROUPING_ID__ >> {})", shift)
+                } else {
+                    "__GROUPING_ID__".to_string()
+                };
+
+                let order = self.row_path_aliases.join(", ");
+                clauses.push(format!(
+                    "__WINDOW_{}__ AS (PARTITION BY {}, {} ORDER BY {})",
+                    gidx, grouping_expr, partition, order,
+                ));
+            } else {
+                let sub_groups = self.config.group_by[..=gidx]
+                    .iter()
+                    .map(|c| self.col_name(c))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                clauses.push(format!(
+                    "__WINDOW_{}__ AS (PARTITION BY {}({}), {} ORDER BY {})",
+                    gidx,
+                    self.grouping_fn,
+                    sub_groups,
+                    partition,
+                    self.group_col_names.join(", ")
+                ));
+            }
+        }
+
+        clauses
+    }
+}

--- a/rust/perspective-client/src/rust/virtual_server/generic_sql_model/tests.rs
+++ b/rust/perspective-client/src/rust/virtual_server/generic_sql_model/tests.rs
@@ -1,0 +1,361 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ ██████ ██████ ██████       █      █      █      █      █ █▄  ▀███ █       ┃
+// ┃ ▄▄▄▄▄█ █▄▄▄▄▄ ▄▄▄▄▄█  ▀▀▀▀▀█▀▀▀▀▀ █ ▀▀▀▀▀█ ████████▌▐███ ███▄  ▀█ █ ▀▀▀▀▀ ┃
+// ┃ █▀▀▀▀▀ █▀▀▀▀▀ █▀██▀▀ ▄▄▄▄▄ █ ▄▄▄▄▄█ ▄▄▄▄▄█ ████████▌▐███ █████▄   █ ▄▄▄▄▄ ┃
+// ┃ █      ██████ █  ▀█▄       █ ██████      █      ███▌▐███ ███████▄ █       ┃
+// ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+// ┃ Copyright (c) 2017, the Perspective Authors.                              ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃ This file is part of the Perspective library, distributed under the terms ┃
+// ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+use std::collections::HashMap;
+
+use super::*;
+use crate::config::Aggregate;
+
+#[test]
+fn test_get_hosted_tables() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    assert_eq!(builder.get_hosted_tables().unwrap(), "SHOW ALL TABLES");
+}
+
+#[test]
+fn test_table_schema() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    assert_eq!(
+        builder.table_schema("my_table").unwrap(),
+        "DESCRIBE my_table"
+    );
+}
+
+#[test]
+fn test_table_size() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    assert_eq!(
+        builder.table_size("my_table").unwrap(),
+        "SELECT COUNT(*) FROM my_table"
+    );
+}
+
+#[test]
+fn test_view_delete() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    assert_eq!(
+        builder.view_delete("my_view").unwrap(),
+        "DROP TABLE IF EXISTS my_view"
+    );
+}
+
+#[test]
+fn test_table_make_view_simple() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("col1".to_string()), Some("col2".to_string())];
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(sql.starts_with("CREATE TABLE dest_view AS"));
+    assert!(sql.contains("\"col1\""));
+    assert!(sql.contains("\"col2\""));
+}
+
+#[test]
+fn test_table_make_view_with_group_by() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("value".to_string())];
+    config.group_by = vec!["category".to_string()];
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(sql.contains("GROUP BY ROLLUP"));
+    assert!(sql.contains("__ROW_PATH_0__"));
+    assert!(sql.contains("__GROUPING_ID__"));
+}
+
+#[test]
+fn test_table_make_view_with_group_by_and_split_by() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("value".to_string())];
+    config.group_by = vec!["category".to_string()];
+    config.split_by = vec!["quarter".to_string()];
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(sql.contains("GROUP BY ROLLUP"), "expected ROLLUP: {}", sql);
+    assert!(sql.contains("PIVOT"), "expected PIVOT: {}", sql);
+    assert!(
+        sql.contains("__ROW_PATH_0__"),
+        "expected __ROW_PATH_0__: {}",
+        sql
+    );
+
+    assert!(
+        sql.contains("__GROUPING_ID__"),
+        "expected __GROUPING_ID__: {}",
+        sql
+    );
+}
+
+#[test]
+fn test_table_make_view_with_sort_group_by_and_split_by() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("value".to_string())];
+    config.group_by = vec!["category".to_string()];
+    config.split_by = vec!["quarter".to_string()];
+    config.sort = vec![Sort("value".to_string(), SortDir::Asc)];
+    config.aggregates = HashMap::from([(
+        "value".to_string(),
+        Aggregate::SingleAggregate("sum".to_string()),
+    )]);
+
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(sql.contains("__SORT_0__"), "expected __SORT_0__: {}", sql);
+    assert!(
+        sql.contains("__GROUPING_ID__, __SORT_0__"),
+        "expected __SORT_0__ in GROUP BY: {}",
+        sql
+    );
+
+    assert!(
+        sql.contains("__SORT_0__ ASC"),
+        "expected __SORT_0__ ASC in ORDER BY: {}",
+        sql
+    );
+
+    assert!(
+        !sql.contains("sum(\"value\") ASC"),
+        "should not have raw aggregate in ORDER BY: {}",
+        sql
+    );
+}
+
+#[test]
+fn test_table_make_view_with_sort_multi_group_by_and_split_by() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("value".to_string())];
+    config.group_by = vec!["region".to_string(), "category".to_string()];
+    config.split_by = vec!["quarter".to_string()];
+    config.sort = vec![Sort("value".to_string(), SortDir::Asc)];
+    config.aggregates = HashMap::from([(
+        "value".to_string(),
+        Aggregate::SingleAggregate("sum".to_string()),
+    )]);
+
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(
+        sql.contains("PARTITION BY (__GROUPING_ID__ >> 1)"),
+        "expected shifted __GROUPING_ID__ in WINDOW: {}",
+        sql
+    );
+
+    assert!(
+        sql.contains("first(__SORT_0__) OVER __WINDOW_0__"),
+        "expected first(__SORT_0__) OVER __WINDOW_0__: {}",
+        sql
+    );
+
+    assert!(
+        !sql.contains("GROUPING_ID(\"region\")"),
+        "should not have GROUPING_ID function in WINDOW: {}",
+        sql
+    );
+}
+
+#[test]
+fn test_table_make_view_with_sort_and_group_by_no_split_by() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("value".to_string())];
+    config.group_by = vec!["category".to_string()];
+    config.sort = vec![Sort("value".to_string(), SortDir::Asc)];
+    config.aggregates = HashMap::from([(
+        "value".to_string(),
+        Aggregate::SingleAggregate("sum".to_string()),
+    )]);
+
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(
+        sql.contains("sum(\"value\") ASC"),
+        "expected raw aggregate in ORDER BY: {}",
+        sql
+    );
+
+    assert!(
+        !sql.contains("__SORT_0__"),
+        "should not have __SORT_0__ without split_by: {}",
+        sql
+    );
+}
+
+#[test]
+fn test_table_make_view_col_sort_excludes_row_order_by() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("value".to_string())];
+    config.group_by = vec!["category".to_string()];
+    config.split_by = vec!["quarter".to_string()];
+    config.sort = vec![Sort("value".to_string(), SortDir::ColAsc)];
+    config.aggregates = HashMap::from([(
+        "value".to_string(),
+        Aggregate::SingleAggregate("sum".to_string()),
+    )]);
+
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(
+        !sql.contains("__SORT_0__"),
+        "col sort should not produce __SORT_0__: {}",
+        sql
+    );
+
+    assert!(
+        !sql.contains("sum(\"value\") ASC"),
+        "col sort should not produce row ORDER BY: {}",
+        sql
+    );
+
+    assert!(sql.contains("PIVOT"), "should still have PIVOT: {}", sql);
+}
+
+#[test]
+fn test_table_make_view_mixed_row_and_col_sort() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.columns = vec![Some("value".to_string()), Some("qty".to_string())];
+    config.group_by = vec!["category".to_string()];
+    config.split_by = vec!["quarter".to_string()];
+    config.sort = vec![
+        Sort("value".to_string(), SortDir::ColDesc),
+        Sort("qty".to_string(), SortDir::Asc),
+    ];
+
+    config.aggregates = HashMap::from([
+        (
+            "value".to_string(),
+            Aggregate::SingleAggregate("sum".to_string()),
+        ),
+        (
+            "qty".to_string(),
+            Aggregate::SingleAggregate("sum".to_string()),
+        ),
+    ]);
+
+    let sql = builder
+        .table_make_view("source_table", "dest_view", &config)
+        .unwrap();
+
+    assert!(
+        !sql.contains("__SORT_0__"),
+        "col sort (idx 0) should not produce __SORT_0__: {}",
+        sql
+    );
+
+    assert!(
+        sql.contains("__SORT_1__"),
+        "row sort (idx 1) should produce __SORT_1__: {}",
+        sql
+    );
+}
+
+#[test]
+fn test_view_get_data_col_sort_ascending() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.sort = vec![Sort("value".to_string(), SortDir::ColAsc)];
+    let viewport = ViewPort {
+        start_row: Some(0),
+        end_row: Some(100),
+        start_col: Some(0),
+        end_col: None,
+    };
+
+    let mut schema = IndexMap::new();
+    schema.insert("C_value".to_string(), ColumnType::Float);
+    schema.insert("A_value".to_string(), ColumnType::Float);
+    schema.insert("B_value".to_string(), ColumnType::Float);
+    let sql = builder
+        .view_get_data("my_view", &config, &viewport, &schema)
+        .unwrap();
+
+    let a_pos = sql.find("\"A_value\"").unwrap();
+    let b_pos = sql.find("\"B_value\"").unwrap();
+    let c_pos = sql.find("\"C_value\"").unwrap();
+    assert!(
+        a_pos < b_pos && b_pos < c_pos,
+        "col asc should order columns A < B < C: {}",
+        sql
+    );
+}
+
+#[test]
+fn test_view_get_data_col_sort_descending() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let mut config = ViewConfig::default();
+    config.sort = vec![Sort("value".to_string(), SortDir::ColDesc)];
+    let viewport = ViewPort {
+        start_row: Some(0),
+        end_row: Some(100),
+        start_col: Some(0),
+        end_col: None,
+    };
+
+    let mut schema = IndexMap::new();
+    schema.insert("A_value".to_string(), ColumnType::Float);
+    schema.insert("C_value".to_string(), ColumnType::Float);
+    schema.insert("B_value".to_string(), ColumnType::Float);
+    let sql = builder
+        .view_get_data("my_view", &config, &viewport, &schema)
+        .unwrap();
+
+    let a_pos = sql.find("\"A_value\"").unwrap();
+    let b_pos = sql.find("\"B_value\"").unwrap();
+    let c_pos = sql.find("\"C_value\"").unwrap();
+    assert!(
+        c_pos < b_pos && b_pos < a_pos,
+        "col desc should order columns C > B > A: {}",
+        sql
+    );
+}
+
+#[test]
+fn test_view_get_data() {
+    let builder = GenericSQLVirtualServerModel::new(GenericSQLVirtualServerModelArgs::default());
+    let config = ViewConfig::default();
+    let viewport = ViewPort {
+        start_row: Some(0),
+        end_row: Some(100),
+        start_col: Some(0),
+        end_col: Some(5),
+    };
+
+    let mut schema = IndexMap::new();
+    schema.insert("col1".to_string(), ColumnType::String);
+    schema.insert("col2".to_string(), ColumnType::Integer);
+    let sql = builder
+        .view_get_data("my_view", &config, &viewport, &schema)
+        .unwrap();
+
+    assert!(sql.contains("SELECT"));
+    assert!(sql.contains("FROM my_view"));
+    assert!(sql.contains("LIMIT 100 OFFSET 0"));
+}

--- a/rust/perspective-client/src/rust/virtual_server/server.rs
+++ b/rust/perspective-client/src/rust/virtual_server/server.rs
@@ -91,7 +91,7 @@ impl<T: VirtualServerHandler> VirtualServer<T> {
                 tracing::error!("{}", err);
                 Ok(respond!(msg, ServerError {
                     message: err.to_string(),
-                    status_code: 1
+                    status_code: 0
                 }))
             },
         }

--- a/rust/perspective-js/src/rust/utils/futures.rs
+++ b/rust/perspective-js/src/rust/utils/futures.rs
@@ -90,12 +90,7 @@ where
     Result<T, JsValue>: IntoJsResult + 'static,
 {
     fn from(fut: ApiFuture<T>) -> Self {
-        future_to_promise(async move {
-            match fut.0.await.ignore_view_delete()? {
-                Some(x) => Ok(x).into_js_result(),
-                None => Err("View not found".into()).into_js_result(),
-            }
-        })
+        future_to_promise(async move { Ok(fut.0.await?).into_js_result() })
     }
 }
 

--- a/rust/perspective-viewer/src/rust/components/status_indicator.rs
+++ b/rust/perspective-viewer/src/rust/components/status_indicator.rs
@@ -164,6 +164,9 @@ impl Reducible for StatusIconState {
                 StatusIconStateAction::Increment | StatusIconStateAction::Decrement,
             ) => StatusIconState::Loading,
             (_, StatusIconStateAction::Increment) => Self::Updating(1),
+            (StatusIconState::Errored(x, y, z), _) => {
+                StatusIconState::Errored(x.clone(), y.clone(), z)
+            },
             (_, StatusIconStateAction::Decrement) => StatusIconState::Normal,
         };
 


### PR DESCRIPTION
This PR re-implements the `split_by` SQL for Perspective's DuckDB/Postgres/Generic Virtual Server, such that rollups are preserved. The test suite has been expanded to cover this feature, and old DuckDB test have been re-written with tighter assertions.