### PR TITLE
ci: Revert to mainline actions-setup-cmake

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -60,8 +60,7 @@ runs:
         # Sticking to 3.29 because of:
         # https://github.com/open-telemetry/opentelemetry-cpp/issues/2998
         - name: Setup cmake
-          # uses: jwlawson/actions-setup-cmake@v2
-          uses: tomjakubowski/actions-setup-cmake@v0-aarch64-test4
+          uses: jwlawson/actions-setup-cmake@v2
           with:
               cmake-version: "3.29.6"
 


### PR DESCRIPTION
The change we needed from my fork to support aarch64 Linux has been
merged:

<https://github.com/jwlawson/actions-setup-cmake/pull/83>

Reverting back away from my fork to the main repo for this action.