### PR TITLE
Fix Python sdist tests in CI

### DIFF
--- a/rust/perspective-python/perspective/tests/virtual_servers/test_duckdb.py
+++ b/rust/perspective-python/perspective/tests/virtual_servers/test_duckdb.py
@@ -11,14 +11,16 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import os
+import tempfile
+import urllib.request
+
 import pytest
 import duckdb
 
 from perspective import Client
 from perspective.virtual_servers.duckdb import DuckDBVirtualServer
 
-
-SUPERSTORE_PARQUET = os.path.join(
+_SUPERSTORE_LOCAL = os.path.join(
     os.path.dirname(__file__),
     "..",
     "..",
@@ -27,6 +29,22 @@ SUPERSTORE_PARQUET = os.path.join(
     "superstore-arrow",
     "superstore.parquet",
 )
+
+_SUPERSTORE_URL = (
+    "https://cdn.jsdelivr.net/npm/superstore-arrow@3.2.0/superstore.parquet"
+)
+
+
+def _get_superstore_parquet():
+    if os.path.exists(_SUPERSTORE_LOCAL):
+        return _SUPERSTORE_LOCAL
+    path = os.path.join(tempfile.gettempdir(), "superstore.parquet")
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(_SUPERSTORE_URL, path)
+    return path
+
+
+SUPERSTORE_PARQUET = _get_superstore_parquet()
 
 
 @pytest.fixture(scope="module")

--- a/rust/perspective-python/perspective/tests/virtual_servers/test_polars.py
+++ b/rust/perspective-python/perspective/tests/virtual_servers/test_polars.py
@@ -11,11 +11,13 @@
 #  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import os
+import tempfile
 import pytest
 import polars as pl
 
 from perspective import Client
 from perspective.virtual_servers.polars import PolarsVirtualServer
+import urllib
 
 
 def approx_json(expected):
@@ -26,7 +28,7 @@ def approx_json(expected):
     ]
 
 
-SUPERSTORE_PARQUET = os.path.join(
+_SUPERSTORE_LOCAL = os.path.join(
     os.path.dirname(__file__),
     "..",
     "..",
@@ -35,6 +37,22 @@ SUPERSTORE_PARQUET = os.path.join(
     "superstore-arrow",
     "superstore.parquet",
 )
+
+_SUPERSTORE_URL = (
+    "https://cdn.jsdelivr.net/npm/superstore-arrow@3.2.0/superstore.parquet"
+)
+
+
+def _get_superstore_parquet():
+    if os.path.exists(_SUPERSTORE_LOCAL):
+        return _SUPERSTORE_LOCAL
+    path = os.path.join(tempfile.gettempdir(), "superstore.parquet")
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(_SUPERSTORE_URL, path)
+    return path
+
+
+SUPERSTORE_PARQUET = _get_superstore_parquet()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR fixes a out-of-tree test suite dependency introduced in #3127, which added `superstore.parquet` from the NPM environment. This error was not caught in the PR because we do not run the `sdist` installation tests out-of-tree in the CI suite on PRs (only on master and tags).

[Full CI for this build](https://github.com/perspective-dev/perspective/actions/runs/22838405580/job/66242719796).